### PR TITLE
Don't panic in `threads` if there is no info for pc

### DIFF
--- a/proctl/threads_linux_amd64.go
+++ b/proctl/threads_linux_amd64.go
@@ -56,7 +56,11 @@ func (thread *ThreadContext) PrintInfo() error {
 		return err
 	}
 	f, l, fn := thread.Process.GoSymTable.PCToLine(pc)
-	fmt.Printf("Thread %d at %#v %s:%d %s\n", thread.Id, pc, f, l, fn.Name)
+	if fn != nil {
+		fmt.Printf("Thread %d at %#v %s:%d %s\n", thread.Id, pc, f, l, fn.Name)
+	} else {
+		fmt.Printf("Thread %d at %#v\n", thread.Id, pc)
+	}
 	return nil
 }
 


### PR DESCRIPTION
`threads` currently panics in proctl.ThreadContext.PrintInfo when PCToLine
can't find any info for the current pc.

```
$ ./dlv -run
Type 'help' for list of commands.
dlv> threads
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x8 pc=0x47f00b]

goroutine 1 [running, locked to thread]:
github.com/derekparker/delve/proctl.(*ThreadContext).PrintInfo(0xc20800a5a0, 0x0, 0x0)
        src/github.com/derekparker/delve/proctl/threads_linux_amd64.go:59 +0x29b
[...]
```
