### PR TITLE
Stop target process immediately after execve.

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -30,9 +30,9 @@ func WithTestProcess(name string, t *testing.T, fn testfunc) {
 	}
 	defer os.Remove("./" + base)
 
-	p, err := proctl.AttachBinary("./" + base)
+	p, err := proctl.Launch([]string{"./" + base})
 	if err != nil {
-		t.Fatal("NewDebugProcess():", err)
+		t.Fatal("Launch():", err)
 	}
 
 	defer p.Process.Kill()


### PR DESCRIPTION
The current way of launching to be debugged processes is kind of racy. They are
started and then get sent a SIGSTOP. This results in the target being stopped
at a more or less arbitrary point. There is explicit support for launching to
be traced processes in os/exec. By setting SysProcAttr.Ptrace we can make the
target process stop immediately after the execve.
