### PR TITLE
Pause execution and return to CLI on ^C

### DIFF
--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 
 	"runtime"
 	"strings"
@@ -72,6 +73,15 @@ func main() {
 		if err != nil {
 			die(1, "Could not start debugging process:", err)
 		}
+
+		ch := make(chan os.Signal)
+		signal.Notify(ch, syscall.SIGINT)
+
+		go func() {
+			for _ = range ch {
+				dbgproc.RequestManualStop()
+			}
+		}()
 
 		return dbgproc
 	}


### PR DESCRIPTION
Consider this a feature request with a prototype, I guess, because I get the following when I actually try to use this:

```
dlv> continue
new thread spawned 12773
new thread spawned 12774
^CStopped at: :269
Command failed: open : no such file or directory
dlv> 
```

Is this just what happens when it stops in the runtime guts rather than go-land?
