### PR TITLE
Allow launching target process with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The debugger can be launched in three ways:
 * Provide the name of the program you want to debug, and the debugger will launch it for you.
 
 	```
-	$ dlv -proc path/to/program
+	$ dlv path/to/program
 	```
 
 * Provide the pid of a currently running process, and the debugger will attach and begin the session.

--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -33,7 +33,6 @@ func main() {
 
 	var (
 		pid     int
-		proc    string
 		run     bool
 		printv  bool
 		err     error
@@ -43,12 +42,11 @@ func main() {
 	)
 
 	flag.IntVar(&pid, "pid", 0, "Pid of running process to attach to.")
-	flag.StringVar(&proc, "proc", "", "Path to process to run and debug.")
 	flag.BoolVar(&run, "run", false, "Compile program and begin debug session.")
 	flag.BoolVar(&printv, "v", false, "Print version number and exit.")
 	flag.Parse()
 
-	if flag.NFlag() == 0 {
+	if flag.NFlag() == 0 && len(flag.Args()) == 0 {
 		flag.Usage()
 		os.Exit(0)
 	}
@@ -77,8 +75,8 @@ func main() {
 		if err != nil {
 			die(1, "Could not attach to process:", err)
 		}
-	case proc != "":
-		dbgproc, err = proctl.Launch(append([]string{proc}, flag.Args()...))
+	default:
+		dbgproc, err = proctl.Launch(flag.Args())
 		if err != nil {
 			die(1, "Could not launch program:", err)
 		}


### PR DESCRIPTION
Pass extra commandline arguments to the target process so that:

`dlv -run -- -opt some_arg another_arg`
launches
`./debug -opt some_arg another_arg`

and 

`dlv -proc cmd -opt arg`
launches
`cmd -opt arg`

The second commit removes the '-proc' option and makes it the default, so that

`dlv -proc cmd -opt arg`
becomes 
`dlv cmd -opt arg`
