### PR TITLE
Refactor member variable evaluation so it works in all cases

### DIFF
--- a/_fixtures/testvariables.go
+++ b/_fixtures/testvariables.go
@@ -7,6 +7,12 @@ type FooBar struct {
 	Bur string
 }
 
+// same member names, different order / types
+type FooBar2 struct {
+	Bur int
+	Baz string
+}
+
 func barfoo() {
 	a1 := "bur"
 	fmt.Println(a1)
@@ -21,6 +27,7 @@ func foobar(baz string, bar FooBar) {
 		a5  = []int{1, 2, 3, 4, 5}
 		a6  = FooBar{Baz: 8, Bur: "word"}
 		a7  = &FooBar{Baz: 5, Bur: "strum"}
+		a8  = FooBar2{Bur: 10, Baz: "feh"}
 		neg = -1
 		i8  = int8(1)
 		f32 = float32(1.2)
@@ -28,7 +35,7 @@ func foobar(baz string, bar FooBar) {
 	)
 
 	barfoo()
-	fmt.Println(a1, a2, a3, a4, a5, a6, a7, baz, neg, i8, f32, i32, bar)
+	fmt.Println(a1, a2, a3, a4, a5, a6, a7, a8, baz, neg, i8, f32, i32, bar)
 }
 
 func main() {

--- a/dwarf/reader/reader.go
+++ b/dwarf/reader/reader.go
@@ -60,7 +60,44 @@ func (reader *Reader) SeekToFunction(pc uint64) (*dwarf.Entry, error) {
 	return nil, fmt.Errorf("unable to find function context")
 }
 
-// NextScopeVariable moves the reader to the next debug entry that describes a local variable
+// SeekToType moves the reader to the type specified by the entry,
+// optionally resolving typedefs and pointer types. If the reader is set
+// to a struct type the NextMemberVariable call can be used to walk all member data
+func (reader *Reader) SeekToType(entry *dwarf.Entry, resolveTypedefs bool, resolvePointerTypes bool) (*dwarf.Entry, error) {
+	offset, ok := entry.Val(dwarf.AttrType).(dwarf.Offset)
+	if !ok {
+		return nil, fmt.Errorf("entry does not have a type attribute")
+	}
+
+	// Seek to the first type offset
+	reader.Seek(offset)
+
+	// Walk the types to the base
+	for typeEntry, err := reader.Next(); typeEntry != nil; typeEntry, err = reader.Next() {
+		if err != nil {
+			return nil, err
+		}
+
+		if typeEntry.Tag == dwarf.TagTypedef && !resolveTypedefs {
+			return typeEntry, nil
+		}
+
+		if typeEntry.Tag == dwarf.TagPointerType && !resolvePointerTypes {
+			return typeEntry, nil
+		}
+
+		offset, ok = typeEntry.Val(dwarf.AttrType).(dwarf.Offset)
+		if !ok {
+			return typeEntry, nil
+		}
+
+		reader.Seek(offset)
+	}
+
+	return nil, fmt.Errorf("no type entry found")
+}
+
+// NextScopeVariable moves the reader to the next debug entry that describes a local variable and returns the entry
 func (reader *Reader) NextScopeVariable() (*dwarf.Entry, error) {
 	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
 		if err != nil {
@@ -76,6 +113,30 @@ func (reader *Reader) NextScopeVariable() (*dwarf.Entry, error) {
 		}
 
 		if entry.Tag == dwarf.TagVariable || entry.Tag == dwarf.TagFormalParameter {
+			return entry, nil
+		}
+	}
+
+	// No more items
+	return nil, nil
+}
+
+// NextMememberVariable moves the reader to the next debug entry that describes a member variable and returns the entry
+func (reader *Reader) NextMemberVariable() (*dwarf.Entry, error) {
+	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
+		if err != nil {
+			return nil, err
+		}
+
+		// All member variables will be at the same depth
+		reader.SkipChildren()
+
+		// End of the current depth
+		if entry.Tag == 0 {
+			break
+		}
+
+		if entry.Tag == dwarf.TagMember {
 			return entry, nil
 		}
 	}

--- a/proctl/variables_test.go
+++ b/proctl/variables_test.go
@@ -42,16 +42,19 @@ func TestVariableEvaluation(t *testing.T) {
 		{"a5", "len: 5 cap: 5 [1 2 3 4 5]", "struct []int"},
 		{"a6", "main.FooBar {Baz: 8, Bur: word}", "main.FooBar"},
 		{"a7", "*main.FooBar {Baz: 5, Bur: strum}", "*main.FooBar"},
+		{"a8", "main.FooBar2 {Bur: 10, Baz: feh}", "main.FooBar2"},
 		{"baz", "bazburzum", "struct string"},
 		{"neg", "-1", "int"},
 		{"i8", "1", "int8"},
 		{"f32", "1.2", "float32"},
 		{"a6.Baz", "8", "int"},
+		{"a8.Baz", "feh", "struct string"},
+		{"a8", "main.FooBar2 {Bur: 10, Baz: feh}", "main.FooBar2"}, // reread variable after member
 		{"i32", "[2]int32 [1 2]", "[2]int32"},
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 30)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 37)
 
 		_, err := p.Break(uintptr(pc))
 		assertNoError(err, t, "Break() returned an error")
@@ -76,7 +79,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 30)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 37)
 
 		_, err := p.Break(uintptr(pc))
 		assertNoError(err, t, "Break() returned an error")
@@ -91,7 +94,7 @@ func TestVariableFunctionScoping(t *testing.T) {
 		assertNoError(err, t, "Unable to find variable a1")
 
 		// Move scopes, a1 exists here by a2 does not
-		pc, _, _ = p.GoSymTable.LineToPC(fp, 12)
+		pc, _, _ = p.GoSymTable.LineToPC(fp, 18)
 
 		_, err = p.Break(uintptr(pc))
 		assertNoError(err, t, "Break() returned an error")
@@ -147,6 +150,7 @@ func TestLocalVariables(t *testing.T) {
 				{"a5", "len: 5 cap: 5 [1 2 3 4 5]", "struct []int"},
 				{"a6", "main.FooBar {Baz: 8, Bur: word}", "main.FooBar"},
 				{"a7", "*main.FooBar {Baz: 5, Bur: strum}", "*main.FooBar"},
+				{"a8", "main.FooBar2 {Bur: 10, Baz: feh}", "main.FooBar2"},
 				{"f32", "1.2", "float32"},
 				{"i32", "[2]int32 [1 2]", "[2]int32"},
 				{"i8", "1", "int8"},
@@ -158,7 +162,7 @@ func TestLocalVariables(t *testing.T) {
 	}
 
 	withTestProcess(executablePath, t, func(p *DebuggedProcess) {
-		pc, _, _ := p.GoSymTable.LineToPC(fp, 30)
+		pc, _, _ := p.GoSymTable.LineToPC(fp, 37)
 
 		_, err := p.Break(uintptr(pc))
 		assertNoError(err, t, "Break() returned an error")


### PR DESCRIPTION
Fixes the issue with conflicting member names, all member names will now resolve correctly.  Added tests to ensure it stays that way.

Expanded the new reader with functions for seeking to a type record and iterating member variables.

Fixed an insidious bug causing debug data to be overwritten in memory (see line note)
