### PR TITLE
Pretty printing for time, math and option to format numbers in hex

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -29,6 +29,7 @@ Command | Description
 [next](#next) | Step over to next source line.
 [on](#on) | Executes a command when a breakpoint is hit.
 [print](#print) | Evaluate an expression.
+[printf](#printf) | Evaluate an expression, allowing the user to specify formatting options.
 [regs](#regs) | Print contents of CPU registers.
 [restart](#restart) | Restart process from a checkpoint or event.
 [rewind](#rewind) | Run backwards until breakpoint or program termination.
@@ -50,7 +51,12 @@ Command | Description
 ## args
 Print function arguments.
 
-	[goroutine <n>] [frame <m>] args [-v] [<regex>]
+	[goroutine <n>] [frame <m>] args [-v] [-x] [-o] [-n]  [<regex>]
+	
+	-v	more information about each package variable will be shown
+	-x	print numbers in hexadecimal
+	-o	print numbers in octal
+	-n	disables pretty printing of some built in types
 
 If regex is specified only function arguments with a name matching it will be returned. If -v is specified more information about each function argument will be shown.
 
@@ -278,7 +284,12 @@ Aliases: ls l
 ## locals
 Print local variables.
 
-	[goroutine <n>] [frame <m>] locals [-v] [<regex>]
+	[goroutine <n>] [frame <m>] locals [-v] [-x] [-o] [-n]  [<regex>]
+	
+	-v	more information about each package variable will be shown
+	-x	print numbers in hexadecimal
+	-o	print numbers in octal
+	-n	disables pretty printing of some built in types
 
 The name of variables that are shadowed in the current scope will be shown in parenthesis.
 
@@ -306,6 +317,19 @@ Evaluate an expression.
 See [Documentation/cli/expr.md](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md) for a description of supported expressions.
 
 Aliases: p
+
+## printf
+Evaluate an expression, allowing the user to specify formatting options.
+		
+	[goroutine <n>] [frame <m>] printf [-x] [-o] [-n] <expression>
+	
+	-v	more information about each package variable will be shown
+	-x	print numbers in hexadecimal
+	-o	print numbers in octal
+	-n	disables pretty printing of some built in types
+
+See [Documentation/cli/expr.md](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md) for a description of supported expressions.
+
 
 ## regs
 Print contents of CPU registers.
@@ -417,7 +441,12 @@ Move the current frame up by <m>. The second form runs the command on the given 
 ## vars
 Print package variables.
 
-	vars [-v] [<regex>]
+	vars [-v] [-x] [-o] [-n] [<regex>]
+	
+	-v	more information about each package variable will be shown
+	-x	print numbers in hexadecimal
+	-o	print numbers in octal
+	-n	disables pretty printing of some built in types
 
 If regex is specified only package variables with a name matching it will be returned. If -v is specified more information about each package variable will be shown.
 

--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"go/constant"
 	"math"
+	"math/big"
 	"runtime"
+	"time"
 	"unsafe"
 )
 
@@ -250,6 +252,13 @@ func main() {
 	runearray := [4]rune{116, 232, 115, 116}
 
 	longstr := "very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"
+	tim1 := time.Unix(233431200, 0)
+	bigint := big.NewInt(int64(^uint64(0) >> 1))
+	bigint.Mul(bigint, bigint)
+	bigrat := new(big.Rat).SetFrac(bigint, big.NewInt(5))
+	bigfloat := new(big.Float).SetRat(bigrat)
+	bigfloat2 := new(big.Float).SetInf(true)
+	bigfloat3 := big.NewFloat(1.0)
 
 	var nilstruct *astruct = nil
 
@@ -273,5 +282,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, bytearray, runearray, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4, iface2map)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, bytearray, runearray, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4, iface2map, tim1, bigint, bigfloat, bigfloat2, bigfloat3)
 }

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -863,3 +863,26 @@ func TestIssue1493(t *testing.T) {
 		}
 	})
 }
+
+func TestPrintf(t *testing.T) {
+	ver, _ := goversion.Parse(runtime.Version())
+	withTestTerminal("testvariables2", t, func(term *FakeTerminal) {
+		term.MustExec("continue")
+		if out := term.MustExec("printf -x i1"); out != "0x1\n" {
+			t.Fatalf("bad hexadecimal output: %q", out)
+		}
+		if out := term.MustExec("goroutine 1 printf -x i1"); out != "0x1\n" {
+			t.Fatalf("bad hexadecimal output (with scope prefix): %q", out)
+		}
+		if ver.Major < 0 || ver.AfterOrEqual(goversion.GoVersion{1, 9, -1, 0, 0, ""}) {
+			// time.Time structure changed in 1.9, delve only provides pretty
+			// formatting for time.Time in 1.9 or later.
+			if out := term.MustExec("p tim1"); out != "time.Time(1977-05-25T18:00:00Z)\n" {
+				t.Fatalf("bad time formatting: %q", out)
+			}
+		}
+		if out := term.MustExec("printf -n tim1"); out == "time.Time(1977-05-25T18:00:00Z)\n" {
+			t.Fatalf("bad time formatting (with special formatting disabled): %q", out)
+		}
+	})
+}

--- a/service/debugger/prettyprint.go
+++ b/service/debugger/prettyprint.go
@@ -1,0 +1,244 @@
+package debugger
+
+import (
+	"fmt"
+	"go/constant"
+	"math/big"
+	"time"
+
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/service/api"
+)
+
+func FormatAndConvertVar(v *proc.Variable, arch proc.Arch) *api.Variable {
+	r, hasChildren := api.ConvertOneVar(v)
+
+	switch r.RealType {
+	case "time.Time":
+		r.Value = formatTime(v)
+	case "math/big.Int":
+		r.Value = formatBigInt(v, arch)
+	case "math/big.Float":
+		r.Value = formatBigFloat(v, arch)
+	case "math/big.Rat":
+		r.Value = formatBigRat(v, arch)
+	}
+
+	if hasChildren {
+		r.Children = make([]api.Variable, len(v.Children))
+
+		for i := range v.Children {
+			r.Children[i] = *FormatAndConvertVar(&v.Children[i], arch)
+		}
+	}
+	return r
+}
+
+const (
+	timeTimeWallHasMonotonicBit uint64 = (1 << 63) // hasMonotonic bit of time.Time.wall
+
+	maxAddSeconds time.Duration = (time.Duration(^uint64(0)>>1) / time.Second) * time.Second // maximum number of seconds that can be added with (time.Time).Add, measured in nanoseconds
+
+	wallNsecShift = 30 // size of the nanoseconds field of time.Time.wall
+
+	unixTimestampOfWallEpoch = -2682288000 // number of seconds between the unix epoch and the epoch for time.Time.wall (1 jan 1885)
+)
+
+func fieldVariable(v *proc.Variable, name string) *proc.Variable {
+	for i := range v.Children {
+		if child := &v.Children[i]; child.Name == name {
+			return child
+		}
+	}
+	return nil
+}
+
+// formatTime returns formatted value of a time.Time variable.
+// See $GOROOT/src/time/time.go for a description of time.Time internals.
+func formatTime(v *proc.Variable) string {
+	wallv := fieldVariable(v, "wall")
+	extv := fieldVariable(v, "ext")
+	if wallv == nil || extv == nil || wallv.Unreadable != nil || extv.Unreadable != nil || wallv.Value == nil || extv.Value == nil {
+		return ""
+	}
+
+	wall, _ := constant.Uint64Val(wallv.Value)
+	ext, _ := constant.Int64Val(extv.Value)
+	_ = ext
+
+	hasMonotonic := (wall & timeTimeWallHasMonotonicBit) != 0
+	if hasMonotonic {
+		// the 33-bit field of wall holds a 33-bit unsigned wall
+		// seconds since Jan 1 year 1885, and ext holds a signed 64-bit monotonic
+		// clock reading, nanoseconds since process start
+		sec := int64(wall << 1 >> (wallNsecShift + 1)) // seconds since 1 Jan 1885
+		t := time.Unix(sec+unixTimestampOfWallEpoch, 0).UTC()
+		return fmt.Sprintf("time.Time(%s, %+d)", t.Format(time.RFC3339), ext)
+	} else {
+		// the full signed 64-bit wall seconds since Jan 1 year 1 is stored in ext
+		var t time.Time
+		for ext > int64(maxAddSeconds/time.Second) {
+			t = t.Add(maxAddSeconds)
+			ext -= int64(maxAddSeconds / time.Second)
+		}
+		t = t.Add(time.Duration(ext) * time.Second)
+		return t.Format(time.RFC3339)
+	}
+}
+
+var len8tab = [256]uint8{
+	0x00, 0x01, 0x02, 0x02, 0x03, 0x03, 0x03, 0x03, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04,
+	0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05,
+	0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06,
+	0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06,
+	0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07,
+	0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07,
+	0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07,
+	0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+	0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08,
+}
+
+// len64 is a copy of math/bits.Len64 copied here for backwards
+// compatibility.
+func len64(x uint64) (n int) {
+	if x >= 1<<32 {
+		x >>= 32
+		n = 32
+	}
+	if x >= 1<<16 {
+		x >>= 16
+		n += 16
+	}
+	if x >= 1<<8 {
+		x >>= 8
+		n += 8
+	}
+	return n + int(len8tab[x])
+}
+
+// readNat reads a math/big.nat slice.
+func readNat(absv *proc.Variable, arch proc.Arch) (n *big.Int, bitsize int64) {
+	// _B here tracks _B in $GOROOT/src/math/big/arith.go
+	_B := big.NewInt(1)
+	_B.Lsh(_B, uint(arch.PtrSize()*8))
+
+	ptrbits := arch.PtrSize() * 8
+	bitsize = int64((len(absv.Children) - 1) * ptrbits)
+
+	n = big.NewInt(0)
+	x := big.NewInt(0)
+	for i := len(absv.Children) - 1; i >= 0; i-- {
+		n.Mul(n, _B)
+		ix, _ := constant.Uint64Val(absv.Children[i].Value)
+		if i == len(absv.Children)-1 {
+			bitsize += int64(len64(ix))
+		}
+		x.SetUint64(ix)
+		n.Add(n, x)
+	}
+	return n, bitsize
+}
+
+func asBigInt(v *proc.Variable, arch proc.Arch) *big.Int {
+	negv := fieldVariable(v, "neg")
+	absv := fieldVariable(v, "abs")
+
+	if negv == nil || negv.Value == nil || negv.Unreadable != nil || absv == nil || absv.Unreadable != nil || absv.Len != int64(len(absv.Children)) {
+		return nil
+	}
+
+	n, _ := readNat(absv, arch)
+	if n == nil {
+		return nil
+	}
+	if constant.BoolVal(negv.Value) {
+		n.Mul(n, big.NewInt(-1))
+	}
+	return n
+}
+
+// formatBigInt returns the formatted value of a math/big.Int variable.
+// See $GOROOT/src/math/big/int.go and $GOROOT/stc/math/big/nat.go for a
+// description of math/big.Int internals.
+func formatBigInt(v *proc.Variable, arch proc.Arch) string {
+	n := asBigInt(v, arch)
+	if n == nil {
+		return ""
+	}
+	return n.String()
+}
+
+// formatBigRat returne sthe formatted value of a math/big.Rat variable.
+// See $GOROOT/src/math/big/rat.go for a description of math/big.Rat internals.
+func formatBigRat(v *proc.Variable, arch proc.Arch) string {
+	nomv := fieldVariable(v, "a")
+	denomv := fieldVariable(v, "b")
+
+	if nomv == nil || nomv.Unreadable != nil || int64(len(nomv.Children)) != nomv.Len || denomv == nil || denomv.Unreadable != nil || int64(len(denomv.Children)) != denomv.Len {
+		return ""
+	}
+
+	nom := asBigInt(nomv, arch)
+	denom := asBigInt(denomv, arch)
+
+	if nom == nil || denom == nil {
+		return ""
+	}
+
+	return nom.String() + "/" + denom.String()
+}
+
+// formatBigFloat returns the formatted value of a math/big.Float variable.
+// See $GOROOT/src/math/big/float.go for a description of math/big.Float internals.
+func formatBigFloat(v *proc.Variable, arch proc.Arch) string {
+	//TODO: implement
+	negv := fieldVariable(v, "neg")
+	mantv := fieldVariable(v, "mant")
+	expv := fieldVariable(v, "exp")
+	formv := fieldVariable(v, "form")
+	precv := fieldVariable(v, "prec")
+
+	for _, vv := range []*proc.Variable{negv, expv, formv, precv} {
+		if vv == nil || vv.Unreadable != nil || vv.Value == nil {
+			return ""
+		}
+	}
+	if mantv == nil || mantv.Unreadable != nil || mantv.Len != int64(len(mantv.Children)) {
+		return ""
+	}
+
+	form, _ := constant.Int64Val(formv.Value)
+	exp, _ := constant.Int64Val(expv.Value)
+	prec, _ := constant.Int64Val(precv.Value)
+
+	// see type math/big.form in $GOROOT/src/math/big/float.go
+	switch form {
+	case 0: // zero
+		return "0"
+	case 2: // infinite
+		if constant.BoolVal(negv.Value) {
+			return "-inf"
+		}
+		return "+inf"
+	}
+
+	mant, mantbits := readNat(mantv, arch)
+	if mant == nil {
+		return ""
+	}
+
+	if constant.BoolVal(negv.Value) {
+		mant.Mul(mant, big.NewInt(-1))
+	}
+
+	x := new(big.Float).SetMantExp(new(big.Float).SetInt(mant), int(exp-mantbits))
+	x.SetPrec(uint(prec))
+	return x.String()
+}

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -690,7 +690,7 @@ func Test1ClientServer_EvalVariable(t *testing.T) {
 		var1, err := c.EvalVariable(api.EvalScope{-1, 0, 0}, "a1")
 		assertNoError(err, t, "EvalVariable")
 
-		t.Logf("var1: %s", var1.SinglelineString())
+		t.Logf("var1: %s", var1.SinglelineString(0))
 
 		if var1.Value != "foofoofoofoofoofoo" {
 			t.Fatalf("Wrong variable value: %s", var1.Value)
@@ -995,7 +995,7 @@ func Test1ClientServer_CondBreakpoint(t *testing.T) {
 		nvar, err := c.EvalVariable(api.EvalScope{-1, 0, 0}, "n")
 		assertNoError(err, t, "EvalVariable()")
 
-		if nvar.SinglelineString() != "7" {
+		if nvar.SinglelineString(0) != "7" {
 			t.Fatalf("Stopped on wrong goroutine %s\n", nvar.Value)
 		}
 	})
@@ -1105,7 +1105,7 @@ func Test1Issue406(t *testing.T) {
 		assertNoError(state.Err, t, "Continue()")
 		v, err := c.EvalVariable(api.EvalScope{-1, 0, 0}, "cfgtree")
 		assertNoError(err, t, "EvalVariable()")
-		vs := v.MultilineString("")
+		vs := v.MultilineString("", 0)
 		t.Logf("cfgtree formats to: %s\n", vs)
 	})
 }

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -758,7 +758,7 @@ func TestClientServer_EvalVariable(t *testing.T) {
 		var1, err := c.EvalVariable(api.EvalScope{-1, 0, 0}, "a1", normalLoadConfig)
 		assertNoError(err, t, "EvalVariable")
 
-		t.Logf("var1: %s", var1.SinglelineString())
+		t.Logf("var1: %s", var1.SinglelineString(0))
 
 		if var1.Value != "foofoofoofoofoofoo" {
 			t.Fatalf("Wrong variable value: %s", var1.Value)
@@ -1071,7 +1071,7 @@ func TestClientServer_CondBreakpoint(t *testing.T) {
 		nvar, err := c.EvalVariable(api.EvalScope{-1, 0, 0}, "n", normalLoadConfig)
 		assertNoError(err, t, "EvalVariable()")
 
-		if nvar.SinglelineString() != "7" {
+		if nvar.SinglelineString(0) != "7" {
 			t.Fatalf("Stopped on wrong goroutine %s\n", nvar.Value)
 		}
 	})
@@ -1183,7 +1183,7 @@ func TestIssue406(t *testing.T) {
 		assertNoError(state.Err, t, "Continue()")
 		v, err := c.EvalVariable(api.EvalScope{-1, 0, 0}, "cfgtree", normalLoadConfig)
 		assertNoError(err, t, "EvalVariable()")
-		vs := v.MultilineString("")
+		vs := v.MultilineString("", 0)
 		t.Logf("cfgtree formats to: %s\n", vs)
 	})
 }


### PR DESCRIPTION
```
proc: pretty printing for some std library types

Adds pretty printing for time.Time, math/big.Int, math/big.Float and
math/big.Rat.

This is implemented in proc instead of the pretty printer so that other
(non-go) clients can take advantage of it.

Fixes #999

terminal,prettyprint: add option to format numbers in hex/oct

Add a fmt prefix for commands that print variables to let the user
select betwen decimal, octal and hexadecimal number formatting.

Fixes #1038

```
