### PR TITLE
[WIP] Add capability to jump to location in order skip execution of some instructions

### DIFF
--- a/_fixtures/testsetexecpoint.go
+++ b/_fixtures/testsetexecpoint.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+)
+
+func demo1() {
+	fmt.Println("line 1")
+	fmt.Println("line 2")
+	fmt.Println("line 3")
+	fmt.Println("line 4")
+}
+
+func demo2() {
+	fmt.Println("line 5")
+	fmt.Println("line 6")
+	fmt.Println("line 7")
+	fmt.Println("line 8")
+}
+
+func demo3() {
+	fmt.Println("line 9")
+	fmt.Println("line 10")
+	fmt.Println("line 11")
+	fmt.Println("line 12")
+}
+
+func main() {
+	demo1()
+	demo2()
+	demo3()
+}

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -73,6 +73,16 @@ type Breakpoint struct {
 	TotalHitCount uint64 `json:"totalHitCount"`
 }
 
+// ExecutionPoint addresses a location at which process execution will jump to.
+type ExecutionPoint struct {
+	// Addr is the address of the breakpoint.
+	Addr uint64 `json:"addr"`
+	// File is the source file for the breakpoint.
+	File string `json:"file"`
+	// Line is a line in File for the breakpoint.
+	Line int `json:"line"`
+}
+
 func ValidBreakpointName(name string) error {
 	if _, err := strconv.Atoi(name); err == nil {
 		return errors.New("breakpoint name can not be a number")

--- a/service/client.go
+++ b/service/client.go
@@ -52,6 +52,8 @@ type Client interface {
 	GetBreakpointByName(name string) (*api.Breakpoint, error)
 	// CreateBreakpoint creates a new breakpoint.
 	CreateBreakpoint(*api.Breakpoint) (*api.Breakpoint, error)
+	// SetExecutionPoint will jump the execution point.
+	SetExecutionPoint(*api.ExecutionPoint) error
 	// ListBreakpoints gets all breakpoints.
 	ListBreakpoints() ([]*api.Breakpoint, error)
 	// ClearBreakpoint deletes a breakpoint by ID.

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -181,6 +181,11 @@ func (c *RPCClient) CreateBreakpoint(breakPoint *api.Breakpoint) (*api.Breakpoin
 	return &out.Breakpoint, err
 }
 
+func (c *RPCClient) SetExecutionPoint(executionPoint *api.ExecutionPoint) error {
+	out := SetExecutionPointOut{}
+	return c.call("SetExecutionPoint", SetExecutionPointIn{*executionPoint}, &out)
+}
+
 func (c *RPCClient) ListBreakpoints() ([]*api.Breakpoint, error) {
 	var out ListBreakpointsOut
 	err := c.call("ListBreakpoints", ListBreakpointsIn{}, &out)

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -214,6 +214,17 @@ func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpoi
 	return nil
 }
 
+type SetExecutionPointIn struct {
+	ExecutionPoint api.ExecutionPoint
+}
+
+type SetExecutionPointOut struct{}
+
+// SetExecutionPoint will jump the execution point.
+func (s *RPCServer) SetExecutionPoint(arg SetExecutionPointIn, out *SetExecutionPointOut) error {
+	return s.debugger.SetExecutionPoint(&arg.ExecutionPoint)
+}
+
 type ClearBreakpointIn struct {
 	Id   int
 	Name string


### PR DESCRIPTION
This currently is a more or less work in progress, it depends on the feature set we want to support this feature. In my opinion, this could be flagged as an experimental feature and if the user has an issue then it's their fault. Maybe it's not a 100% good statement to have. There are cases where this could be useful to have and a user that understands how to use it, will be able to use it to the full extent.

I've tested this only on Windows, I'll let the integration test do the job on the other systems.

Cross function jumping works as well, but only in the toy example below, I have no clue how the runtime will be affected by this. 

Fixes #1045