### PR TITLE
updated the gcflags that needs to be used [documentation]

### DIFF
--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -10,7 +10,7 @@ Execute a precompiled binary and begin a debug session.
 This command will cause Delve to exec the binary and immediately attach to it to
 begin a new debug session. Please note that if the binary was not compiled with
 optimizations disabled, it may be difficult to properly debug it. Please
-consider compiling debugging binaries with -gcflags="-N -l".
+consider compiling debugging binaries with -gcflags="all=-N -l".
 
 ```
 dlv exec <path/to/binary>


### PR DESCRIPTION
as described here: https://github.com/derekparker/delve/issues/1124#issuecomment-366500430
-gcflags="-N -l" is not enough. -gcflags="all=-N -l" is necessary.