### PR TITLE
Improvements to ListGoroutines

### DIFF
--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -578,7 +578,9 @@ func GoroutinesInfo(dbp Process, start, count int) ([]*G, int, error) {
 			allg = append(allg, g)
 		}
 	}
-	dbp.Common().allGCache = allg
+	if start == 0 {
+		dbp.Common().allGCache = allg
+	}
 
 	return allg, -1, nil
 }

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -518,6 +518,11 @@ type ListGoroutinesOut struct {
 }
 
 // ListGoroutines lists all goroutines.
+// If Count is specified ListGoroutines will return at the first Count
+// goroutines and an index in Nextg, that can be passed as the Start
+// parameter, to get more goroutines from ListGoroutines.
+// Passing a value of Start that wasn't returned by ListGoroutines will skip
+// an undefined number of goroutines.
 func (s *RPCServer) ListGoroutines(arg ListGoroutinesIn, out *ListGoroutinesOut) error {
 	gs, nextg, err := s.debugger.Goroutines(arg.Start, arg.Count)
 	if err != nil {


### PR DESCRIPTION
```
service: make ListGoroutines return all running goroutines when
Start==0

Change ListGoroutines API call so that it tries to fit all running
goroutines in the ListGoroutines(Start=0) results.

Users are more likely to be interested in running goroutines, with this
change a frontend that just calls ListGoroutines(Start=0, Count=n) is
guaranteed to show all running goroutines to its users (as long as
there aren't more than n running goroutines).

proc: improve performance of FindGoroutine in normal circumstances

FindGoroutine can be slow when there are many goroutines running. This
can not be fixed in the general case, however:

1. Instead of getting the entire list of goroutines at once just get a
few at a time and return as soon as we find the one we want.

2. Since FindGoroutine is mostly called by ConvertEvalScope and users
are more likely to request informations about a goroutine running on a
thread, look within the threads first.

proc: fix GoroutinesInfo cache

The allg cache was corrupted when the count parameter was actually
reached.

Fix the bug and add a test for this.

```
