### PR TITLE
Documentation: update recommended compiler flags for 'exec' command

### DIFF
--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -10,7 +10,8 @@ Execute a precompiled binary and begin a debug session.
 This command will cause Delve to exec the binary and immediately attach to it to
 begin a new debug session. Please note that if the binary was not compiled with
 optimizations disabled, it may be difficult to properly debug it. Please
-consider compiling debugging binaries with -gcflags="-N -l".
+consider compiling debugging binaries with -gcflags="all=-N -l" on Go 1.10
+or later, -gcflags="-N -l" on earlier versions of Go.
 
 ```
 dlv exec <path/to/binary>

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -172,7 +172,8 @@ session.`,
 This command will cause Delve to exec the binary and immediately attach to it to
 begin a new debug session. Please note that if the binary was not compiled with
 optimizations disabled, it may be difficult to properly debug it. Please
-consider compiling debugging binaries with -gcflags="-N -l".`,
+consider compiling debugging binaries with -gcflags="all=-N -l" on Go 1.10
+or later, -gcflags="-N -l" on earlier versions of Go.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("you must provide a path to a binary")


### PR DESCRIPTION
```
Documentation: update recommended compiler flags for 'exec' command

On Go 1.10 -gcflags='all=-N -l' should be preferred, update the
documentation of 'exec' command to reflect this.

```
