### PR TITLE
proc: do not crash if executable doesn't have a PT_TLS section

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -756,6 +756,10 @@ func (bi *BinaryInfo) setGStructOffsetElf(exe *elf.File, wg *sync.WaitGroup) {
 			break
 		}
 	}
+	if tls == nil {
+		bi.gStructOffset = ^uint64(8) + 1 // -8
+		return
+	}
 	memsz := tls.Memsz
 
 	memsz = (memsz + uint64(bi.Arch.PtrSize()) - 1) & ^uint64(bi.Arch.PtrSize()-1) // align to pointer-sized-boundary


### PR DESCRIPTION
```
proc: do not crash if executable doesn't have a PT_TLS section

Fixes #1481

```
