### PR TITLE
pkg/proc: Disable default compression on DWZ test

### DIFF
--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -103,7 +103,8 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	tmpfile := filepath.Join(os.TempDir(), fmt.Sprintf("%s.%s", name, hex.EncodeToString(r)))
 
 	buildFlags := []string{"build"}
-	if ver, _ := goversion.Parse(runtime.Version()); runtime.GOOS == "windows" && ver.Major > 0 && !ver.AfterOrEqual(goversion.GoVersion{1, 9, -1, 0, 0, ""}) {
+	var ver goversion.GoVersion
+	if ver, _ = goversion.Parse(runtime.Version()); runtime.GOOS == "windows" && ver.Major > 0 && !ver.AfterOrEqual(goversion.GoVersion{1, 9, -1, 0, 0, ""}) {
 		// Work-around for https://github.com/golang/go/issues/13154
 		buildFlags = append(buildFlags, "-ldflags=-linkmode internal")
 	}
@@ -124,6 +125,11 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	}
 	if flags&BuildModePIE != 0 {
 		buildFlags = append(buildFlags, "-buildmode=pie")
+	}
+	if ver.AfterOrEqual(goversion.GoVersion{1, 11, -1, 0, 0, ""}) {
+		if flags&EnableDWZCompression != 0 {
+			buildFlags = append(buildFlags, "-ldflags=-compressdwarf=false")
+		}
 	}
 	if path != "" {
 		buildFlags = append(buildFlags, name+".go")


### PR DESCRIPTION
When compression is applied by default running the DWZ tool on the
resulting binary will crash.

The actual default compression code will look and see if compression
makes any difference and if so replace the normal `.debug_*` section
with `.zdebug_*`. This is why it may not have been hit before. On one of
my workstations I build with 1.12rc1 and no compression happens, but on
a Fedora VM I build and the binary results in compressed DWARF sections.

Adding this flag will make this test more consistent overall.