### PR TITLE
proc/gdbserial: do not return floating point regs when not requested

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -284,7 +284,7 @@ func (a *AMD64) RegistersToDwarfRegisters(regs Registers, staticBase uint64) op.
 		}
 	}
 
-	for _, reg := range regs.Slice() {
+	for _, reg := range regs.Slice(true) {
 		for dwarfReg, regName := range amd64DwarfToName {
 			if regName == reg.Name {
 				dregs[dwarfReg] = op.DwarfRegisterFromBytes(reg.Bytes)

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -242,7 +242,7 @@ func TestCore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't get current thread registers: %v", err)
 	}
-	regslice := regs.Slice()
+	regslice := regs.Slice(true)
 	for _, reg := range regslice {
 		t.Logf("%s = %s", reg.Name, reg.Value)
 	}
@@ -311,13 +311,13 @@ func TestCoreFpRegisters(t *testing.T) {
 		{"XMM8", "0x4059999a404ccccd4059999a404ccccd"},
 	}
 
-	for _, reg := range regs.Slice() {
+	for _, reg := range regs.Slice(true) {
 		t.Logf("%s = %s", reg.Name, reg.Value)
 	}
 
 	for _, regtest := range regtests {
 		found := false
-		for _, reg := range regs.Slice() {
+		for _, reg := range regs.Slice(true) {
 			if reg.Name == regtest.name {
 				found = true
 				if !strings.HasPrefix(reg.Value, regtest.value) {

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -227,7 +227,8 @@ type gdbRegisterInfo struct {
 	Name    string `xml:"name,attr"`
 	Bitsize int    `xml:"bitsize,attr"`
 	Offset  int
-	Regnum  int `xml:"regnum,attr"`
+	Regnum  int    `xml:"regnum,attr"`
+	Group   string `xml:"group,attr"`
 }
 
 // readTargetXml reads target.xml file from stub using qXfer:features:read,

--- a/pkg/proc/linutil/regs.go
+++ b/pkg/proc/linutil/regs.go
@@ -51,7 +51,7 @@ type AMD64PtraceRegs struct {
 }
 
 // Slice returns the registers as a list of (name, value) pairs.
-func (r *AMD64Registers) Slice() []proc.Register {
+func (r *AMD64Registers) Slice(floatingPoint bool) []proc.Register {
 	var regs = []struct {
 		k string
 		v uint64
@@ -92,7 +92,9 @@ func (r *AMD64Registers) Slice() []proc.Register {
 			out = proc.AppendQwordReg(out, reg.k, reg.v)
 		}
 	}
-	out = append(out, r.Fpregs...)
+	if floatingPoint {
+		out = append(out, r.Fpregs...)
+	}
 	return out
 }
 

--- a/pkg/proc/native/registers_darwin_amd64.go
+++ b/pkg/proc/native/registers_darwin_amd64.go
@@ -42,7 +42,7 @@ type Regs struct {
 	fpregs []proc.Register
 }
 
-func (r *Regs) Slice() []proc.Register {
+func (r *Regs) Slice(floatingPoint bool) []proc.Register {
 	var regs = []struct {
 		k string
 		v uint64
@@ -78,7 +78,9 @@ func (r *Regs) Slice() []proc.Register {
 			out = proc.AppendQwordReg(out, reg.k, reg.v)
 		}
 	}
-	out = append(out, r.fpregs...)
+	if floatingPoint {
+		out = append(out, r.fpregs...)
+	}
 	return out
 }
 

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -23,7 +23,7 @@ type Registers interface {
 	// GAddr returns the address of the G variable if it is known, 0 and false otherwise
 	GAddr() (uint64, bool)
 	Get(int) (uint64, error)
-	Slice() []Register
+	Slice(floatingPoint bool) []Register
 	// Copy returns a copy of the registers that is guaranteed not to change
 	// when the registers of the associated thread change.
 	Copy() Registers

--- a/pkg/proc/registers_amd64.go
+++ b/pkg/proc/registers_amd64.go
@@ -79,7 +79,7 @@ func GetDwarfRegister(regs Registers, i int) []byte {
 		return buf.Bytes()
 	}
 	if regname, ok := dwarfToName[i]; ok {
-		regslice := regs.Slice()
+		regslice := regs.Slice(true)
 		for _, reg := range regslice {
 			if reg.Name == regname {
 				return reg.Bytes

--- a/pkg/proc/winutil/regs.go
+++ b/pkg/proc/winutil/regs.go
@@ -74,7 +74,7 @@ func NewAMD64Registers(context *CONTEXT, TebBaseAddress uint64, floatingPoint bo
 }
 
 // Slice returns the registers as a list of (name, value) pairs.
-func (r *AMD64Registers) Slice() []proc.Register {
+func (r *AMD64Registers) Slice(floatingPoint bool) []proc.Register {
 	var regs = []struct {
 		k string
 		v uint64
@@ -103,7 +103,7 @@ func (r *AMD64Registers) Slice() []proc.Register {
 		{"TLS", r.tls},
 	}
 	outlen := len(regs)
-	if r.fltSave != nil {
+	if r.fltSave != nil && floatingPoint {
 		outlen += 6 + 8 + 2 + 16
 	}
 	out := make([]proc.Register, 0, outlen)
@@ -114,7 +114,7 @@ func (r *AMD64Registers) Slice() []proc.Register {
 			out = proc.AppendQwordReg(out, reg.k, reg.v)
 		}
 	}
-	if r.fltSave != nil {
+	if r.fltSave != nil && floatingPoint {
 		out = proc.AppendWordReg(out, "CW", r.fltSave.ControlWord)
 		out = proc.AppendWordReg(out, "SW", r.fltSave.StatusWord)
 		out = proc.AppendWordReg(out, "TW", uint16(r.fltSave.TagWord))

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -847,3 +847,19 @@ func TestTruncateStacktrace(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue1493(t *testing.T) {
+	// The 'regs' command without the '-a' option should only return
+	// general purpose registers.
+	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
+		r := term.MustExec("regs")
+		nr := len(strings.Split(r, "\n"))
+		t.Logf("regs: %s", r)
+		ra := term.MustExec("regs -a")
+		nra := len(strings.Split(ra, "\n"))
+		t.Logf("regs -a: %s", ra)
+		if nr > nra/2 {
+			t.Fatalf("'regs' returned too many registers (%d) compared to 'regs -a' (%d)", nr, nra)
+		}
+	})
+}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -830,7 +830,7 @@ func (d *Debugger) Registers(threadID int, floatingPoint bool) (api.Registers, e
 	if err != nil {
 		return nil, err
 	}
-	return api.ConvertRegisters(regs.Slice()), err
+	return api.ConvertRegisters(regs.Slice(floatingPoint)), err
 }
 
 func convertVars(pv []*proc.Variable) []api.Variable {


### PR DESCRIPTION
```
proc/gdbserial: do not return floating point regs when not requested

Fixes #1493

```
