### PR TITLE
service/api: use %q instead of %s for types in writeStructTo

### DIFF
--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -158,7 +158,7 @@ func (v *Variable) writeArrayTo(buf io.Writer, newlines, includeType bool, inden
 
 func (v *Variable) writeStructTo(buf io.Writer, newlines, includeType bool, indent string) {
 	if int(v.Len) != len(v.Children) && len(v.Children) == 0 {
-		fmt.Fprintf(buf, "(*%s)(0x%x)", v.Type, v.Addr)
+		fmt.Fprintf(buf, "(*%q)(0x%x)", v.Type, v.Addr)
 		return
 	}
 


### PR DESCRIPTION
```
service/api: use %q instead of %s for types in writeStructTo

Type names need to be quoted when that expression is evaluated, by
printing them quoted the user can just copy and paste the output.

```
