### PR TITLE
service/api: add quotes around types when needed in prettyprint.go

### DIFF
--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 )
 
 const (
@@ -52,7 +53,11 @@ func (v *Variable) writeTo(buf io.Writer, top, newlines, includeType bool, inden
 		if v.Type == "" || len(v.Children) == 0 {
 			fmt.Fprint(buf, "nil")
 		} else if v.Children[0].OnlyAddr && v.Children[0].Addr != 0 {
-			fmt.Fprintf(buf, "(%s)(0x%x)", v.Type, v.Children[0].Addr)
+			if strings.Contains(v.Type, "/") {
+				fmt.Fprintf(buf, "(%q)(%#x)", v.Type, v.Children[0].Addr)
+			} else {
+				fmt.Fprintf(buf, "(%s)(%#x)", v.Type, v.Children[0].Addr)
+			}
 		} else {
 			fmt.Fprint(buf, "*")
 			v.Children[0].writeTo(buf, false, newlines, includeType, indent)
@@ -61,7 +66,7 @@ func (v *Variable) writeTo(buf io.Writer, top, newlines, includeType bool, inden
 		if len(v.Children) == 0 {
 			fmt.Fprintf(buf, "unsafe.Pointer(nil)")
 		} else {
-			fmt.Fprintf(buf, "unsafe.Pointer(0x%x)", v.Children[0].Addr)
+			fmt.Fprintf(buf, "unsafe.Pointer(%#x)", v.Children[0].Addr)
 		}
 	case reflect.String:
 		v.writeStringTo(buf)
@@ -107,7 +112,11 @@ func (v *Variable) writeTo(buf io.Writer, top, newlines, includeType bool, inden
 				v.Children[0].writeTo(buf, false, newlines, !includeType, indent)
 			}
 		} else if data.OnlyAddr {
-			fmt.Fprintf(buf, "*(*%q)(0x%x)", v.Type, v.Addr)
+			if strings.Contains(v.Type, "/") {
+				fmt.Fprintf(buf, "*(*%q)(%#x)", v.Type, v.Addr)
+			} else {
+				fmt.Fprintf(buf, "*(*%s)(%#x)", v.Type, v.Addr)
+			}
 		} else {
 			v.Children[0].writeTo(buf, false, newlines, !includeType, indent)
 		}
@@ -158,7 +167,11 @@ func (v *Variable) writeArrayTo(buf io.Writer, newlines, includeType bool, inden
 
 func (v *Variable) writeStructTo(buf io.Writer, newlines, includeType bool, indent string) {
 	if int(v.Len) != len(v.Children) && len(v.Children) == 0 {
-		fmt.Fprintf(buf, "(*%s)(0x%x)", v.Type, v.Addr)
+		if strings.Contains(v.Type, "/") {
+			fmt.Fprintf(buf, "(*%q)(%#x)", v.Type, v.Addr)
+		} else {
+			fmt.Fprintf(buf, "(*%s)(%#x)", v.Type, v.Addr)
+		}
 		return
 	}
 


### PR DESCRIPTION
```
service/api: add quotes around types when needed in prettyprint.go

Type names need to be quoted when that expression is evaluated, by
printing them quoted the user can just copy and paste the output.

```
