### PR TITLE
proc: catch fatal runtime errors

### DIFF
--- a/_fixtures/testdeadlock.go
+++ b/_fixtures/testdeadlock.go
@@ -1,0 +1,12 @@
+package main
+
+func main() {
+	ch1 := make(chan string)
+	ch2 := make(chan string)
+	go func() {
+		<-ch1
+		ch2 <- "done"
+	}()
+	<-ch2
+	ch1 <- "done"
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4196,3 +4196,21 @@ func TestIssue1469(t *testing.T) {
 		}
 	})
 }
+
+func TestDeadlockBreakpoint(t *testing.T) {
+	if buildMode == "pie" {
+		t.Skip("See https://github.com/golang/go/issues/29322")
+	}
+	deadlockBp := proc.FatalThrow
+	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
+		deadlockBp = proc.UnrecoveredPanic
+	}
+	withTestProcess("testdeadlock", t, func(p proc.Process, fixture protest.Fixture) {
+		assertNoError(proc.Continue(p), t, "Continue()")
+
+		bp := p.CurrentThread().Breakpoint()
+		if bp.Breakpoint == nil || bp.Name != deadlockBp {
+			t.Fatalf("did not stop at deadlock breakpoint %v", bp)
+		}
+	})
+}


### PR DESCRIPTION
```
proc: catch fatal runtime errors

Like we do with unrecovered panics, create a default breakpoint to
catch runtime errors that will cause the program to terminate.
Primarily intended to give users the opportunity to examine the state
of a deadlocked process.

```
