### PR TITLE
Add trimpath flags and support LDFLAGS

### DIFF
--- a/scripts/make.go
+++ b/scripts/make.go
@@ -236,11 +236,17 @@ func buildFlags() []string {
 	if err != nil {
 		log.Fatal(err)
 	}
+	gctrimpath := "-gcflags=all=-trimpath=${PWD}"
+	asmtrimpath := "-asmflags=all=-trimpath=${PWD}"
 	ldFlags := "-X main.Build=" + strings.TrimSpace(string(buildSHA))
 	if runtime.GOOS == "darwin" {
 		ldFlags = "-s " + ldFlags
 	}
-	return []string{fmt.Sprintf("-ldflags=%s", ldFlags)}
+	extldFlags := os.Getenv("LDFLAGS")
+	if extldFlags != "" {
+		ldFlags = ldFlags + fmt.Sprintf(" -extldflags %s", extldFlags)
+	}
+	return []string{gctrimpath, asmtrimpath, fmt.Sprintf("-ldflags='%s'", ldFlags)}
 }
 
 func testFlags() []string {


### PR DESCRIPTION
Reproducible builds requires any unique paths to be trimmed out. So we
add the trimpaths for gcflags and asmflags to achieve this.

The second issue is the lack of support for `LDFLAGS` a lot of
distributions and build systems export to enable important compile
settings such as RELRO.