### PR TITLE
proc,debugger,terminal: read goroutine ancestors

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -357,11 +357,13 @@ If regex is specified only the source files matching it will be returned.
 ## stack
 Print stack trace.
 
-	[goroutine <n>] [frame <m>] stack [<depth>] [-full] [-offsets] [-defer]
+	[goroutine <n>] [frame <m>] stack [<depth>] [-full] [-offsets] [-defer] [-a <n>] [-adepth <depth>]
 
 	-full		every stackframe is decorated with the value of its local variables and arguments.
 	-offsets	prints frame offset of each frame.
 	-defer		prints deferred function call stack for each frame.
+	-a <n>		prints stacktrace of n ancestors of the selected goroutine (target process must have tracebackancestors enabled)
+	-adepth <depth>	configures depth of ancestor stacktrace
 
 
 Aliases: bt

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -447,3 +447,11 @@ type Checkpoint struct {
 type Image struct {
 	Path string
 }
+
+// Ancestor represents a goroutine ancestor
+type Ancestor struct {
+	ID    int64
+	Stack []Stackframe
+
+	Unreadable string
+}

--- a/service/client.go
+++ b/service/client.go
@@ -100,6 +100,9 @@ type Client interface {
 	// Returns stacktrace
 	Stacktrace(goroutineID int, depth int, readDefers bool, cfg *api.LoadConfig) ([]api.Stackframe, error)
 
+	// Returns ancestor stacktraces
+	Ancestors(goroutineID int, numAncestors int, depth int) ([]api.Ancestor, error)
+
 	// Returns whether we attached to a running process or not
 	AttachedToExistingProcess() bool
 

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -310,6 +310,12 @@ func (c *RPCClient) Stacktrace(goroutineId, depth int, readDefers bool, cfg *api
 	return out.Locations, err
 }
 
+func (c *RPCClient) Ancestors(goroutineID int, numAncestors int, depth int) ([]api.Ancestor, error) {
+	var out AncestorsOut
+	err := c.call("Ancestors", AncestorsIn{goroutineID, numAncestors, depth}, &out)
+	return out.Ancestors, err
+}
+
 func (c *RPCClient) AttachedToExistingProcess() bool {
 	out := new(AttachedToExistingProcessOut)
 	c.call("AttachedToExistingProcess", AttachedToExistingProcessIn{}, out)

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -174,10 +174,24 @@ func (s *RPCServer) Stacktrace(arg StacktraceIn, out *StacktraceOut) error {
 	}
 	var err error
 	out.Locations, err = s.debugger.Stacktrace(arg.Id, arg.Depth, arg.Defers, api.LoadConfigToProc(cfg))
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
+}
+
+type AncestorsIn struct {
+	GoroutineID  int
+	NumAncestors int
+	Depth        int
+}
+
+type AncestorsOut struct {
+	Ancestors []api.Ancestor
+}
+
+// Ancestors returns the stacktraces for the ancestors of a goroutine.
+func (s *RPCServer) Ancestors(arg AncestorsIn, out *AncestorsOut) error {
+	var err error
+	out.Ancestors, err = s.debugger.Ancestors(arg.GoroutineID, arg.NumAncestors, arg.Depth)
+	return err
 }
 
 type ListBreakpointsIn struct {


### PR DESCRIPTION
```
proc,debugger,terminal: read goroutine ancestors

Add options to the stack command to read the goroutine ancestors.
Ancestor tracking was added to Go 1.12 with CL:
https://go-review.googlesource.com/c/go/+/70993/

Implements #1491

```
