### PR TITLE
doc/readme: Fix 'Github' spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/9e9edx1qlp3145j5/branch/master?svg=true)](https://ci.appveyor.com/project/go-delve/delve)
 [![Join the chat at https://gitter.im/go-delve/delve](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/go-delve/delve?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The Github issue tracker is for **bugs** only. Please use the [developer mailing list](https://groups.google.com/forum/#!forum/delve-dev) for any feature proposals and discussions.
+The GitHub issue tracker is for **bugs** only. Please use the [developer mailing list](https://groups.google.com/forum/#!forum/delve-dev) for any feature proposals and discussions.
 
 ### About Delve
 


### PR DESCRIPTION
It is "GitHub", not "Github"