### PR TITLE
service: decorate symbolic constant values with their numerical value

### DIFF
--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"go/constant"
 	"go/printer"
 	"go/token"
@@ -143,8 +144,9 @@ func ConvertVar(v *proc.Variable) *Variable {
 		case reflect.String, reflect.Func:
 			r.Value = constant.StringVal(v.Value)
 		default:
-			r.Value = v.ConstDescr()
-			if r.Value == "" {
+			if cd := v.ConstDescr(); cd != "" {
+				r.Value = fmt.Sprintf("%s (%s)", cd, v.Value.String())
+			} else {
 				r.Value = v.Value.String()
 			}
 		}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1031,9 +1031,9 @@ func TestPackageRenames(t *testing.T) {
 
 func TestConstants(t *testing.T) {
 	testcases := []varTest{
-		{"a", true, "constTwo", "", "main.ConstType", nil},
-		{"b", true, "constThree", "", "main.ConstType", nil},
-		{"c", true, "bitZero|bitOne", "", "main.BitFieldType", nil},
+		{"a", true, "constTwo (2)", "", "main.ConstType", nil},
+		{"b", true, "constThree (3)", "", "main.ConstType", nil},
+		{"c", true, "bitZero|bitOne (3)", "", "main.BitFieldType", nil},
 		{"d", true, "33", "", "main.BitFieldType", nil},
 		{"e", true, "10", "", "main.ConstType", nil},
 		{"f", true, "0", "", "main.BitFieldType", nil},


### PR DESCRIPTION
```
service: decorate symbolic constant values with their numerical value

When we resolve a numerical value to a symbolic constant also report
the numerical value, for clarity.

Fixes #1516

```
