### PR TITLE
proc: Update map reading code for Go 1.12

### DIFF
--- a/_fixtures/issue1531.go
+++ b/_fixtures/issue1531.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type W struct {
+	x int
+	y int
+}
+
+func main() {
+	testMaps()
+}
+
+func testMaps() {
+
+	m := make(map[string]W)
+
+	m["t"] = W{}
+	m["s"] = W{}
+	m["r"] = W{}
+	m["v"] = W{}
+
+	mm := map[string]W{
+		"r": {},
+		"s": {},
+		"t": {},
+		"v": {},
+	}
+
+	delete(mm, "s")
+	delete(m, "t")
+	runtime.Breakpoint()
+	fmt.Println(m, mm)
+}


### PR DESCRIPTION
```
proc: Update map reading code for Go 1.12

Go 1.12 introduced a change to the internal map representation where
empty map cells can be marked with a tophash value of 1 instead of just
0.

Fixes #1531

```
