### PR TITLE
cmd/dlv: add Go version check

### DIFF
--- a/Documentation/usage/dlv.md
+++ b/Documentation/usage/dlv.md
@@ -28,6 +28,7 @@ Pass flags to the program you are debugging using `--`, for example:
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -28,6 +28,7 @@ dlv attach pid [executable]
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_connect.md
+++ b/Documentation/usage/dlv_connect.md
@@ -23,6 +23,7 @@ dlv connect addr
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_core.md
+++ b/Documentation/usage/dlv_core.md
@@ -29,6 +29,7 @@ dlv core <executable> <core>
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -34,6 +34,7 @@ dlv debug [package]
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -29,6 +29,7 @@ dlv exec <path/to/binary>
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_replay.md
+++ b/Documentation/usage/dlv_replay.md
@@ -27,6 +27,7 @@ dlv replay [trace directory]
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_run.md
+++ b/Documentation/usage/dlv_run.md
@@ -23,6 +23,7 @@ dlv run
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -34,6 +34,7 @@ dlv test [package]
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -38,6 +38,7 @@ dlv trace [package] regexp
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -23,6 +23,7 @@ dlv version
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
  (default "default")
       --build-flags string   Build flags, to be passed to the compiler.
+      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
   -l, --listen string        Debugging server listen address. (default "localhost:0")

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -1,0 +1,28 @@
+package goversion
+
+import (
+	"fmt"
+)
+
+var (
+	minSupportedVersionOfGoMinor = 10
+	maxSupportedVersionOfGoMinor = 12
+	goTooOldErr                  = fmt.Errorf("Version of Go is too old for this version of Delve (minimum supported version 1.%d, suppress this error with --check-go-version=false)", minSupportedVersionOfGoMinor)
+	dlvTooOldErr                 = fmt.Errorf("Version of Delve is too old for this version of Go (maximum supported version 1.%d, suppress this error with --check-go-version=false)", maxSupportedVersionOfGoMinor)
+)
+
+// Compatible checks that the version specified in the producer string is compatible with
+// this version of delve.
+func Compatible(producer string) error {
+	ver := parseProducer(producer)
+	if ver.IsDevel() {
+		return nil
+	}
+	if !ver.AfterOrEqual(GoVersion{1, minSupportedVersionOfGoMinor, -1, 0, 0, ""}) {
+		return goTooOldErr
+	}
+	if ver.AfterOrEqual(GoVersion{1, maxSupportedVersionOfGoMinor + 1, -1, 0, 0, ""}) {
+		return dlvTooOldErr
+	}
+	return nil
+}

--- a/pkg/goversion/go_version.go
+++ b/pkg/goversion/go_version.go
@@ -167,12 +167,17 @@ const producerVersionPrefix = "Go cmd/compile "
 // ProducerAfterOrEqual checks that the DW_AT_producer version is
 // major.minor or a later version, or a development version.
 func ProducerAfterOrEqual(producer string, major, minor int) bool {
-	if strings.HasPrefix(producer, producerVersionPrefix) {
-		producer = producer[len(producerVersionPrefix):]
-	}
-	ver, _ := Parse(producer)
+	ver := parseProducer(producer)
 	if ver.IsDevel() {
 		return true
 	}
 	return ver.AfterOrEqual(GoVersion{major, minor, -1, 0, 0, ""})
+}
+
+func parseProducer(producer string) GoVersion {
+	if strings.HasPrefix(producer, producerVersionPrefix) {
+		producer = producer[len(producerVersionPrefix):]
+	}
+	ver, _ := Parse(producer)
+	return ver
 }

--- a/service/config.go
+++ b/service/config.go
@@ -39,6 +39,11 @@ type Config struct {
 	// Foreground lets target process access stdin.
 	Foreground bool
 
+	// CheckGoVersion is true if the debugger should check the version of Go
+	// used to compile the executable and refuse to work on incompatible
+	// versions.
+	CheckGoVersion bool
+
 	// DisconnectChan will be closed by the server when the client disconnects
 	DisconnectChan chan<- struct{}
 }

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -122,6 +122,7 @@ func (s *ServerImpl) Run() error {
 		Backend:              s.config.Backend,
 		Foreground:           s.config.Foreground,
 		DebugInfoDirectories: s.config.DebugInfoDirectories,
+		CheckGoVersion:       s.config.CheckGoVersion,
 	},
 		s.config.ProcessArgs); err != nil {
 		return err

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -60,9 +60,10 @@ func withTestClient2Extended(name string, t *testing.T, fn func(c service.Client
 	}
 	fixture := protest.BuildFixture(name, buildFlags)
 	server := rpccommon.NewServer(&service.Config{
-		Listener:    listener,
-		ProcessArgs: []string{fixture.Path},
-		Backend:     testBackend,
+		Listener:       listener,
+		ProcessArgs:    []string{fixture.Path},
+		Backend:        testBackend,
+		CheckGoVersion: true,
 	})
 	if err := server.Run(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
```
cmd/dlv: add Go version check

Before doing anything check that the version of Go is compatible with
the current version of Delve.
This will improve the error message in the case that  another change as
disruptive as Go1.11 dwarf compression, happens.

```
