### PR TITLE
terminal/command: permit '-c' flag in 'exit' when attached to a process

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1919,8 +1919,8 @@ func (ere ExitRequestError) Error() string {
 
 func exitCommand(t *Term, ctx callContext, args string) error {
 	if args == "-c" {
-		if !t.client.IsMulticlient() {
-			return errors.New("not connected to an --accept-multiclient server")
+		if !t.client.IsMulticlient() && !t.client.AttachedToExistingProcess() {
+			return errors.New("not attached to a process or connected to an --accept-multiclient server")
 		}
 		t.quitContinue = true
 	}


### PR DESCRIPTION
This change permits the '-c' flag to be used in the 'exit' command which enables --init scripts which are run in a terminal to exit without prompting the user.

Informs #1540.