### PR TITLE
proc/test: fix flakyness of TestCallConcurrent

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4306,8 +4306,8 @@ func TestCallConcurrent(t *testing.T) {
 	withTestProcess("teststepconcurrent", t, func(p proc.Process, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture, 24)
 		assertNoError(proc.Continue(p), t, "Continue()")
-		//_, err := p.ClearBreakpoint(bp.Addr)
-		//assertNoError(err, t, "ClearBreakpoint() returned an error")
+		_, err := p.ClearBreakpoint(bp.Addr)
+		assertNoError(err, t, "ClearBreakpoint() returned an error")
 
 		gid1 := p.SelectedGoroutine().ID
 		t.Logf("starting injection in %d / %d", p.SelectedGoroutine().ID, p.CurrentThread().ThreadID())
@@ -4319,9 +4319,6 @@ func TestCallConcurrent(t *testing.T) {
 		if curbp := curthread.Breakpoint(); curbp.Breakpoint == nil || curbp.ID != bp.ID || returned {
 			return
 		}
-
-		_, err := p.ClearBreakpoint(bp.Addr)
-		assertNoError(err, t, "ClearBreakpoint() returned an error")
 
 		for {
 			returned = testCallConcurrentCheckReturns(p, t, gid1)


### PR DESCRIPTION
```
proc/test: fix flakyness of TestCallConcurrent

Remove the breakpoint set in TestCallConcurrent so that it doesn't
interfere with the call injection protocol.
The fact that it can is a bug but that bug is better addressed after
PRs #1503 and #1504 are merged, this keeps tests happy in the meantime.

Fixes #1542

```
