### PR TITLE
proc: trivial typo fix

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -45,7 +45,7 @@ type BinaryInfo struct {
 	LookupFunc map[string]*Function
 
 	// Images is a list of loaded shared libraries (also known as
-	// shared objects on linux or DLLs on windws).
+	// shared objects on linux or DLLs on windows).
 	Images []*Image
 
 	ElfDynamicSection ElfDynamicSection


### PR DESCRIPTION
Just noticed it while looking through the DWARF parsing code.