### PR TITLE
documentation: update idea plugin url

### DIFF
--- a/Documentation/EditorIntegration.md
+++ b/Documentation/EditorIntegration.md
@@ -13,7 +13,7 @@ The following editor plugins for delve are available:
 * [JetBrains Goland](https://www.jetbrains.com/go)
 
 **IntelliJ IDEA**
-* [Golang Plugin for IntelliJ IDEA](https://github.com/go-lang-plugin-org/go-lang-idea-plugin)
+* [Golang Plugin for IntelliJ IDEA](https://plugins.jetbrains.com/plugin/9568-go)
 
 **LiteIDE**
 * [LiteIDE](https://github.com/visualfc/liteide)


### PR DESCRIPTION
The old URL pointed to the deprecated OSS plugin.  The new URL points to the official plugin, which uses the same code GoLand is based on.