### PR TITLE
proc: simplify partial unit support

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -123,20 +123,6 @@ type dwarfRef struct {
 	offset     dwarf.Offset
 }
 
-type partialUnitConstant struct {
-	name  string
-	typ   dwarf.Offset
-	value int64
-}
-
-type partialUnit struct {
-	entry     *dwarf.Entry
-	types     map[string]dwarf.Offset
-	variables []packageVar
-	constants []partialUnitConstant
-	functions []Function
-}
-
 // inlinedFn represents a concrete inlined function, e.g.
 // an entry for the generated code of an inlined function.
 type inlinedFn struct {


### PR DESCRIPTION
```
proc: simplify partial unit support

Instead of reading partial units as we see them skip them entirely and
then re-read them when they are imported, directly into the destination
compile unit.

This avoids a lot of duplicate code in the loadDebugInfoMaps function
and will simplify implementing logical breakpoints and support for the
new DW_AT_go_package_name attribute added in Go 1.13.

```
