### PR TITLE
cmd/dlv: Change name for binary dlv auto compiles

### DIFF
--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -19,7 +19,7 @@ dlv debug [package]
 ### Options
 
 ```
-      --output string   Output path for the binary. (default "debug")
+      --output string   Output path for the binary. (default "./__debug_bin")
 ```
 
 ### Options inherited from parent commands

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -171,7 +171,7 @@ package name and Delve will compile that package instead, and begin a new debug
 session.`,
 		Run: debugCmd,
 	}
-	debugCommand.Flags().String("output", "debug", "Output path for the binary.")
+	debugCommand.Flags().String("output", "./__debug_bin", "Output path for the binary.")
 	RootCommand.AddCommand(debugCommand)
 
 	// 'exec' subcommand.

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -123,7 +123,7 @@ func testOutput(t *testing.T, dlvbin, output string, delveCmds []string) (stdout
 	buildtestdir := filepath.Join(protest.FindFixturesDir(), "buildtest")
 
 	c := []string{dlvbin, "debug"}
-	debugbin := filepath.Join(buildtestdir, "debug")
+	debugbin := filepath.Join(buildtestdir, "__debug_bin")
 	if output != "" {
 		c = append(c, "--output", output)
 		if filepath.IsAbs(output) {


### PR DESCRIPTION
Prevent conflicts by choosing a name that is extremely unlikely to
conflict with any actual package a user may have in their code.

Fixes #580