### PR TITLE
proc: fix panic when calling Ancestors on a parked goroutine

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4280,7 +4280,7 @@ func TestAncestors(t *testing.T) {
 		_, err := setFunctionBreakpoint(p, "main.testgoroutine")
 		assertNoError(err, t, "setFunctionBreakpoint()")
 		assertNoError(proc.Continue(p), t, "Continue()")
-		as, err := p.SelectedGoroutine().Ancestors(1000)
+		as, err := proc.Ancestors(p, p.SelectedGoroutine(), 1000)
 		assertNoError(err, t, "Ancestors")
 		t.Logf("ancestors: %#v\n", as)
 		if len(as) != 1 {

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -659,8 +659,8 @@ func (g *G) StartLoc() Location {
 var errTracebackAncestorsDisabled = errors.New("tracebackancestors is disabled")
 
 // Ancestors returns the list of ancestors for g.
-func (g *G) Ancestors(n int) ([]Ancestor, error) {
-	scope := globalScope(g.Thread.BinInfo(), g.Thread.BinInfo().Images[0], g.Thread)
+func Ancestors(p Process, g *G, n int) ([]Ancestor, error) {
+	scope := globalScope(p.BinInfo(), p.BinInfo().Images[0], p.CurrentThread())
 	tbav, err := scope.EvalExpression("runtime.debug.tracebackancestors", loadSingleValue)
 	if err == nil && tbav.Unreadable == nil && tbav.Kind == reflect.Int {
 		tba, _ := constant.Int64Val(tbav.Value)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -991,7 +991,7 @@ func (d *Debugger) Ancestors(goroutineID, numAncestors, depth int) ([]api.Ancest
 		return nil, errors.New("no selected goroutine")
 	}
 
-	ancestors, err := g.Ancestors(numAncestors)
+	ancestors, err := proc.Ancestors(d.target, g, numAncestors)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```
proc: fix panic when calling Ancestors on a parked goroutine

Fixes #1568

```
