### PR TITLE
service: return an error when a client calls an unknown method

### DIFF
--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -278,6 +278,7 @@ func (s *ServerImpl) serveJSONCodec(conn io.ReadWriteCloser) {
 		mtype, ok := s.methodMaps[s.config.APIVersion-1][req.ServiceMethod]
 		if !ok {
 			s.log.Errorf("rpc: can't find method %s", req.ServiceMethod)
+			s.sendResponse(sending, &req, &rpc.Response{}, nil, codec, fmt.Sprintf("unknown method: %s", req.ServiceMethod))
 			continue
 		}
 


### PR DESCRIPTION
```
service: return an error when a client calls an unknown method

Without this a client calling an method on a version of Delve that
doesn't have that method (for example because it's old) will never get
a response back.

```
