### PR TITLE
proc: add LocationCover method to BinaryInfo

### DIFF
--- a/pkg/dwarf/dwarfbuilder/info.go
+++ b/pkg/dwarf/dwarfbuilder/info.go
@@ -143,6 +143,9 @@ func (b *Builder) Attr(attr dwarf.Attr, val interface{}) {
 	case uint16:
 		tag.form = append(tag.form, DW_FORM_data2)
 		binary.Write(&b.info, binary.LittleEndian, x)
+	case uint64:
+		tag.form = append(tag.form, DW_FORM_data8)
+		binary.Write(&b.info, binary.LittleEndian, x)
 	case Address:
 		tag.form = append(tag.form, DW_FORM_addr)
 		binary.Write(&b.info, binary.LittleEndian, x)
@@ -230,6 +233,12 @@ func (b *Builder) makeAbbrevTable() []byte {
 	}
 
 	return abbrev.Bytes()
+}
+
+func (b *Builder) AddCompileUnit(name string, lowPC uint64) dwarf.Offset {
+	r := b.TagOpen(dwarf.TagCompileUnit, name)
+	b.Attr(dwarf.AttrLowpc, lowPC)
+	return r
 }
 
 // AddSubprogram adds a subprogram declaration to debug_info, must call

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -61,9 +61,11 @@ type BinaryInfo struct {
 	packageMap map[string]string
 
 	frameEntries frame.FrameDescriptionEntries
-	compileUnits []*compileUnit
-	types        map[string]dwarfRef
-	packageVars  []packageVar // packageVars is a list of all global/package variables in debug_info, sorted by address
+
+	compileUnits []*compileUnit // compileUnits is sorted by increasing DWARF offset
+
+	types       map[string]dwarfRef
+	packageVars []packageVar // packageVars is a list of all global/package variables in debug_info, sorted by address
 
 	gStructOffset uint64
 
@@ -112,7 +114,7 @@ type compileUnit struct {
 	optimized          bool                // this compile unit is optimized
 	producer           string              // producer attribute
 
-	startOffset, endOffset dwarf.Offset // interval of offsets contained in this compile unit
+	offset dwarf.Offset // offset of the entry describing the compile unit
 
 	image *Image // parent image of this compilation unit.
 }
@@ -608,6 +610,45 @@ func (bi *BinaryInfo) locationExpr(entry reader.Entry, attr dwarf.Attr, pc uint6
 	return instr, descr.String(), nil
 }
 
+// LocationCovers returns the list of PC addresses that is covered by the
+// location attribute 'attr' of entry 'entry'.
+func (bi *BinaryInfo) LocationCovers(entry *dwarf.Entry, attr dwarf.Attr) ([][2]uint64, error) {
+	a := entry.Val(attr)
+	if a == nil {
+		return nil, fmt.Errorf("attribute %s not found", attr)
+	}
+	if _, isblock := a.([]byte); isblock {
+		return [][2]uint64{[2]uint64{0, ^uint64(0)}}, nil
+	}
+
+	off, ok := a.(int64)
+	if !ok {
+		return nil, fmt.Errorf("attribute %s of unsupported type %T", attr, a)
+	}
+	cu := bi.findCompileUnitForOffset(entry.Offset)
+	if cu == nil {
+		return nil, errors.New("could not find compile unit")
+	}
+
+	image := cu.image
+	base := cu.lowPC
+	if image == nil || image.loclist.data == nil {
+		return nil, errors.New("malformed executable")
+	}
+
+	r := [][2]uint64{}
+	image.loclist.Seek(int(off))
+	var e loclistEntry
+	for image.loclist.Next(&e) {
+		if e.BaseAddressSelection() {
+			base = e.highpc
+			continue
+		}
+		r = append(r, [2]uint64{e.lowpc + base, e.highpc + base})
+	}
+	return r, nil
+}
+
 // Location returns the location described by attribute attr of entry.
 // This will either be an int64 address or a slice of Pieces for locations
 // that don't correspond to a single memory address (registers, composite
@@ -662,12 +703,13 @@ func (bi *BinaryInfo) findCompileUnit(pc uint64) *compileUnit {
 }
 
 func (bi *BinaryInfo) findCompileUnitForOffset(off dwarf.Offset) *compileUnit {
-	for _, cu := range bi.compileUnits {
-		if off >= cu.startOffset && off < cu.endOffset {
-			return cu
-		}
+	i := sort.Search(len(bi.compileUnits), func(i int) bool {
+		return bi.compileUnits[i].offset >= off
+	})
+	if i > 0 {
+		i--
 	}
-	return nil
+	return bi.compileUnits[i]
 }
 
 // Producer returns the value of DW_AT_producer.


### PR DESCRIPTION
```
proc: add LocationCover method to BinaryInfo

Also fixes findCompileUnitForOffset which was broken in some edge cases
(when looking up an offset inside the last child of the compilation
unit) which don't happen in normal executables (we only look up types, and those
are always direct childs of compile units).

```
