### PR TITLE
proc: support childless compile units in loadDebugInfoMaps

### DIFF
--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -263,7 +263,9 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugLineBytes []byte, wg 
 				}
 			}
 			bi.compileUnits = append(bi.compileUnits, cu)
-			cu.endOffset = bi.loadDebugInfoMapsCompileUnit(ctxt, image, reader, cu)
+			if entry.Children {
+				cu.endOffset = bi.loadDebugInfoMapsCompileUnit(ctxt, image, reader, cu)
+			}
 
 		case dwarf.TagPartialUnit:
 			reader.SkipChildren()


### PR DESCRIPTION
```
proc: support childless compile units in loadDebugInfoMaps

Childless compile units would confuse loadDebugInfoMaps.
No test because I don't know what causes go to invoke GNU As in such a
way that it produces a childless compile unit.

Fixes #1572
```