### PR TITLE
godwarf: fix nil pointer reading recursive types involving an array

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -93,6 +93,14 @@ type truncatedMap struct {
 	v []map[string]astruct
 }
 
+type Cache struct {
+	blocks [2000]Block
+}
+
+type Block struct {
+	cache *Cache
+}
+
 func main() {
 	i1 := 1
 	i2 := 2
@@ -191,6 +199,7 @@ func main() {
 	mapinf["inf"] = mapinf
 	var bencharr [64]benchstruct
 	var benchparr [64]*benchstruct
+	var issue1578 Block
 	mainMenu := Menu{
 		{Name: "home", Route: "/", Active: 1},
 		{Name: "About", Route: "/about", Active: 1},
@@ -273,5 +282,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, bytearray, runearray, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4, iface2map)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, bytearray, runearray, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4, iface2map, issue1578)
 }

--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -433,6 +433,9 @@ func (t *TypedefType) sizeIntl(recCheck recCheck) int64 {
 		return t.CommonType.ByteSize
 	}
 	defer release()
+	if t.Type == nil {
+		return 0
+	}
 	return t.Type.sizeIntl(recCheck)
 }
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -810,6 +810,8 @@ func TestEvalExpression(t *testing.T) {
 		{"as2.NonPointerRecieverMethod", false, "main.astruct.NonPointerRecieverMethod", "main.astruct.NonPointerRecieverMethod", "func()", nil},
 
 		{`iface2map.(data)`, false, "…", "…", "map[string]interface {}", nil},
+
+		{"issue1578", false, "main.Block {cache: *main.Cache nil}", "main.Block {cache: *main.Cache nil}", "main.Block", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())


### PR DESCRIPTION
```
godwarf: fix nil pointer reading recursive types involving an array

Fixes #1578

```
