### PR TITLE
proc/linutil: Fix register bitmasks

### DIFF
--- a/pkg/proc/linutil/regs.go
+++ b/pkg/proc/linutil/regs.go
@@ -132,9 +132,9 @@ func (r *AMD64Registers) GAddr() (uint64, bool) {
 func (r *AMD64Registers) Get(n int) (uint64, error) {
 	reg := x86asm.Reg(n)
 	const (
-		mask8  = 0x000f
-		mask16 = 0x00ff
-		mask32 = 0xffff
+		mask8  = 0x000000ff
+		mask16 = 0x0000ffff
+		mask32 = 0xffffffff
 	)
 
 	switch reg {

--- a/pkg/proc/linutil/regs_test.go
+++ b/pkg/proc/linutil/regs_test.go
@@ -1,0 +1,60 @@
+package linutil
+
+import (
+	"testing"
+
+	"golang.org/x/arch/x86/x86asm"
+)
+
+func TestAMD64Get(t *testing.T) {
+	val := uint64(0xffffffffdeadbeef)
+	regs := AMD64Registers{
+		Regs: &AMD64PtraceRegs{
+			Rax: val,
+		},
+	}
+	// Test AL, low 8 bits of RAX
+	al, err := regs.Get(int(x86asm.AL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if al != 0xef {
+		t.Fatalf("expected %#v, got %#v\n", 0xef, al)
+	}
+
+	// Test AH, high 8 bits of RAX
+	ah, err := regs.Get(int(x86asm.AH))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ah != 0xBE {
+		t.Fatalf("expected %#v, got %#v\n", 0xbe, ah)
+	}
+
+	// Test AX, lower 16 bits of RAX
+	ax, err := regs.Get(int(x86asm.AX))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ax != 0xBEEF {
+		t.Fatalf("expected %#v, got %#v\n", 0xbeef, ax)
+	}
+
+	// Test EAX, lower 32 bits of RAX
+	eax, err := regs.Get(int(x86asm.EAX))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eax != 0xDEADBEEF {
+		t.Fatalf("expected %#v, got %#v\n", 0xdeadbeef, eax)
+	}
+
+	// Test RAX, full 64 bits of register
+	rax, err := regs.Get(int(x86asm.RAX))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rax != val {
+		t.Fatalf("expected %#v, got %#v\n", val, rax)
+	}
+}


### PR DESCRIPTION
The bitmasks for transforming a 64-bit register into it's lower-bit
counterparts (e.g. RAX -> EAX -> AX -> AH/AL) were incorrect. This patch
fixes the bitmasks and adds an additional test.