### PR TITLE
proc,service: remove support for locspec '<fnname>:0'

### DIFF
--- a/Documentation/api/ClientHowto.md
+++ b/Documentation/api/ClientHowto.md
@@ -177,8 +177,7 @@ as valid.
 
 If you want to let your users specify a breakpoint on a function selected
 from a list of all functions you should specify the name of the function in
-the FunctionName field of Breakpoint and set Line to -1. *Do not omit Line,
-do not set Line to 0*.
+the FunctionName field of Breakpoint.
 
 If you want to support the [same language as dlv's break and trace commands](//github.com/go-delve/Delve/tree/master/Documentation/cli/locspec.md)
  you should call RPCServer.FindLocation and

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -55,7 +55,7 @@ func assertNoError(err error, t testing.TB, s string) {
 }
 
 func setFunctionBreakpoint(p proc.Process, t *testing.T, fname string) *proc.Breakpoint {
-	addr, err := proc.FindFunctionLocation(p, fname, true, 0)
+	addr, err := proc.FindFunctionLocation(p, fname, 0)
 	assertNoError(err, t, fmt.Sprintf("FindFunctionLocation(%s)", fname))
 	bp, err := p.SetBreakpoint(addr, proc.UserBreakpoint, nil)
 	assertNoError(err, t, fmt.Sprintf("SetBreakpoint(%#x) function %s", addr, fname))

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -395,11 +395,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 		}
 		addr, err = proc.FindFileLocation(d.target, fileName, requestedBp.Line)
 	case len(requestedBp.FunctionName) > 0:
-		if requestedBp.Line >= 0 {
-			addr, err = proc.FindFunctionLocation(d.target, requestedBp.FunctionName, false, requestedBp.Line)
-		} else {
-			addr, err = proc.FindFunctionLocation(d.target, requestedBp.FunctionName, true, 0)
-		}
+		addr, err = proc.FindFunctionLocation(d.target, requestedBp.FunctionName, requestedBp.Line)
 	default:
 		addr = requestedBp.Addr
 	}

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -250,7 +250,7 @@ func (loc *RegexLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr st
 	}
 	r := make([]api.Location, 0, len(matches))
 	for i := range matches {
-		addr, err := proc.FindFunctionLocation(d.target, matches[i], true, 0)
+		addr, err := proc.FindFunctionLocation(d.target, matches[i], 0)
 		if err == nil {
 			r = append(r, api.Location{PC: addr})
 		}
@@ -385,11 +385,7 @@ func (loc *NormalLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr s
 		}
 		addr, err = proc.FindFileLocation(d.target, candidateFiles[0], loc.LineOffset)
 	} else { // len(candidateFUncs) == 1
-		if loc.LineOffset < 0 {
-			addr, err = proc.FindFunctionLocation(d.target, candidateFuncs[0], true, 0)
-		} else {
-			addr, err = proc.FindFunctionLocation(d.target, candidateFuncs[0], false, loc.LineOffset)
-		}
+		addr, err = proc.FindFunctionLocation(d.target, candidateFuncs[0], loc.LineOffset)
 	}
 
 	if err != nil {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -222,9 +222,7 @@ type CreateBreakpointOut struct {
 //
 // - If arg.Breakpoint.FunctionName is not an empty string
 // the breakpoint will be created on the specified function:line
-// location. Note that setting a breakpoint on a function's entry point
-// (line == 0) can have surprising consequences, it is advisable to
-// use line = -1 instead which will skip the prologue.
+// location.
 //
 // - Otherwise the value specified by arg.Breakpoint.Addr will be used.
 func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpointOut) error {

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -1001,56 +1001,6 @@ func Test1ClientServer_CondBreakpoint(t *testing.T) {
 	})
 }
 
-func Test1SkipPrologue(t *testing.T) {
-	withTestClient1("locationsprog2", t, func(c *rpc1.RPCClient) {
-		<-c.Continue()
-
-		afunction := findLocationHelper(t, c, "main.afunction", false, 1, 0)[0]
-		findLocationHelper(t, c, "*fn1", false, 1, afunction)
-		findLocationHelper(t, c, "locationsprog2.go:8", false, 1, afunction)
-
-		afunction0 := findLocationHelper(t, c, "main.afunction:0", false, 1, 0)[0]
-
-		if afunction == afunction0 {
-			t.Fatal("Skip prologue failed")
-		}
-	})
-}
-
-func Test1SkipPrologue2(t *testing.T) {
-	withTestClient1("callme", t, func(c *rpc1.RPCClient) {
-		callme := findLocationHelper(t, c, "main.callme", false, 1, 0)[0]
-		callmeZ := findLocationHelper(t, c, "main.callme:0", false, 1, 0)[0]
-		findLocationHelper(t, c, "callme.go:5", false, 1, callme)
-		if callme == callmeZ {
-			t.Fatal("Skip prologue failed")
-		}
-
-		callme2 := findLocationHelper(t, c, "main.callme2", false, 1, 0)[0]
-		callme2Z := findLocationHelper(t, c, "main.callme2:0", false, 1, 0)[0]
-		findLocationHelper(t, c, "callme.go:12", false, 1, callme2)
-		if callme2 == callme2Z {
-			t.Fatal("Skip prologue failed")
-		}
-
-		callme3 := findLocationHelper(t, c, "main.callme3", false, 1, 0)[0]
-		callme3Z := findLocationHelper(t, c, "main.callme3:0", false, 1, 0)[0]
-		ver, _ := goversion.Parse(runtime.Version())
-		if ver.Major < 0 || ver.AfterOrEqual(goversion.GoVer18Beta) {
-			findLocationHelper(t, c, "callme.go:19", false, 1, callme3)
-		} else {
-			// callme3 does not have local variables therefore the first line of the
-			// function is immediately after the prologue
-			// This is only true before 1.8 where frame pointer chaining introduced a
-			// bit of prologue even for functions without local variables
-			findLocationHelper(t, c, "callme.go:19", false, 1, callme3Z)
-		}
-		if callme3 == callme3Z {
-			t.Fatal("Skip prologue failed")
-		}
-	})
-}
-
 func Test1Issue419(t *testing.T) {
 	// Calling service/rpc.(*Client).Halt could cause a crash because both Halt and Continue simultaneously
 	// try to read 'runtime.g' and debug/dwarf.Data.Type is not thread safe

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1063,7 +1063,7 @@ func TestConstants(t *testing.T) {
 }
 
 func setFunctionBreakpoint(p proc.Process, fname string) (*proc.Breakpoint, error) {
-	addr, err := proc.FindFunctionLocation(p, fname, true, 0)
+	addr, err := proc.FindFunctionLocation(p, fname, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -1181,7 +1181,7 @@ func TestCallFunction(t *testing.T) {
 	}
 
 	withTestProcess("fncall", t, func(p proc.Process, fixture protest.Fixture) {
-		_, err := proc.FindFunctionLocation(p, "runtime.debugCallV1", true, 0)
+		_, err := proc.FindFunctionLocation(p, "runtime.debugCallV1", 0)
 		if err != nil {
 			t.Skip("function calls not supported on this version of go")
 		}


### PR DESCRIPTION
```
proc,service: remove support for locspec '<fnname>:0'

The location specified '<fnname>:0' could be used to set a breakpoint
on the entry point of the function (as opposed to locspec '<fnname>'
which sets it after the prologue).
Setting a breakpoint on an entry point is almost never useful, the way
this feature was implemented could cause it to be used accidentally and
there are other ways to accomplish the same task (by setting a
breakpoint on the PC address directly).

```
