### PR TITLE
proc: allow simultaneous call injection to multiple goroutines

### DIFF
--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -80,7 +80,7 @@ func uintExprCheck(t *testing.T, scope *proc.EvalScope, expr string, tgt uint64)
 }
 
 func dwarfExprCheck(t *testing.T, mem proc.MemoryReadWriter, regs op.DwarfRegisters, bi *proc.BinaryInfo, testCases map[string]uint16, fn *proc.Function) *proc.EvalScope {
-	scope := &proc.EvalScope{Location: proc.Location{PC: 0x40100, Fn: fn}, Regs: regs, Mem: mem, Gvar: nil, BinInfo: bi}
+	scope := &proc.EvalScope{Location: proc.Location{PC: 0x40100, Fn: fn}, Regs: regs, Mem: mem, BinInfo: bi}
 	for name, value := range testCases {
 		uintExprCheck(t, scope, name, uint64(value))
 	}
@@ -213,7 +213,7 @@ func TestDwarfExprLoclist(t *testing.T) {
 	mem := newFakeMemory(defaultCFA, uint16(before), uint16(after))
 	regs := linutil.AMD64Registers{Regs: &linutil.AMD64PtraceRegs{}}
 
-	scope := &proc.EvalScope{Location: proc.Location{PC: 0x40100, Fn: mainfn}, Regs: dwarfRegisters(bi, &regs), Mem: mem, Gvar: nil, BinInfo: bi}
+	scope := &proc.EvalScope{Location: proc.Location{PC: 0x40100, Fn: mainfn}, Regs: dwarfRegisters(bi, &regs), Mem: mem, BinInfo: bi}
 
 	uintExprCheck(t, scope, "a", before)
 	scope.PC = 0x40800
@@ -247,7 +247,7 @@ func TestIssue1419(t *testing.T) {
 
 	mem := newFakeMemory(defaultCFA)
 
-	scope := &proc.EvalScope{Location: proc.Location{PC: 0x40100, Fn: mainfn}, Regs: op.DwarfRegisters{}, Mem: mem, Gvar: nil, BinInfo: bi}
+	scope := &proc.EvalScope{Location: proc.Location{PC: 0x40100, Fn: mainfn}, Regs: op.DwarfRegisters{}, Mem: mem, BinInfo: bi}
 
 	va, err := scope.EvalExpression("a", normalLoadConfig)
 	assertNoError(err, t, "EvalExpression(a)")

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -214,10 +214,10 @@ func (scope *EvalScope) evalAST(t ast.Expr) (*Variable, error) {
 		// try to interpret the selector as a package variable
 		if maybePkg, ok := node.X.(*ast.Ident); ok {
 			if maybePkg.Name == "runtime" && node.Sel.Name == "curg" {
-				if scope.Gvar == nil {
+				if scope.g == nil {
 					return nilVariable, nil
 				}
-				return scope.Gvar.clone(), nil
+				return scope.g.variable.clone(), nil
 			} else if maybePkg.Name == "runtime" && node.Sel.Name == "frameoff" {
 				return newConstant(constant.MakeInt64(scope.frameOffset), scope.Mem), nil
 			} else if v, err := scope.findGlobal(maybePkg.Name + "." + node.Sel.Name); err == nil {

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/go-delve/delve/pkg/dwarf/godwarf"
 	"github.com/go-delve/delve/pkg/dwarf/op"
@@ -105,7 +106,7 @@ type callContext struct {
 	// To signal that evaluation is completed a value will be written to
 	// continueRequest having cont == false and the return values in ret.
 	continueRequest   chan<- continueRequest
-	continueCompleted <-chan struct{}
+	continueCompleted <-chan *G
 }
 
 type continueRequest struct {
@@ -114,9 +115,9 @@ type continueRequest struct {
 	ret  *Variable
 }
 
-func (callCtx *callContext) doContinue() {
+func (callCtx *callContext) doContinue() *G {
 	callCtx.continueRequest <- continueRequest{cont: true}
-	<-callCtx.continueCompleted
+	return <-callCtx.continueCompleted
 }
 
 func (callCtx *callContext) doReturn(ret *Variable, err error) {
@@ -129,12 +130,21 @@ func (callCtx *callContext) doReturn(ret *Variable, err error) {
 // EvalExpressionWithCalls is like EvalExpression but allows function calls in 'expr'.
 // Because this can only be done in the current goroutine, unlike
 // EvalExpression, EvalExpressionWithCalls is not a method of EvalScope.
-func EvalExpressionWithCalls(p Process, expr string, retLoadCfg LoadConfig, checkEscape bool) error {
+func EvalExpressionWithCalls(p Process, g *G, expr string, retLoadCfg LoadConfig, checkEscape bool) error {
 	bi := p.BinInfo()
 	if !p.Common().fncallEnabled {
 		return errFuncCallUnsupportedBackend
 	}
-	if p.Common().continueCompleted != nil {
+
+	// check that the target goroutine is running
+	if g == nil {
+		return errNoGoroutine
+	}
+	if g.Status != Grunning || g.Thread == nil {
+		return errGoroutineNotRunning
+	}
+
+	if callinj := p.Common().fncallForG[g.ID]; callinj != nil && callinj.continueCompleted != nil {
 		return errFuncCallInProgress
 	}
 
@@ -143,22 +153,13 @@ func EvalExpressionWithCalls(p Process, expr string, retLoadCfg LoadConfig, chec
 		return errFuncCallUnsupported
 	}
 
-	// check that the selected goroutine is running
-	g := p.SelectedGoroutine()
-	if g == nil {
-		return errNoGoroutine
-	}
-	if g.Status != Grunning || g.Thread == nil {
-		return errGoroutineNotRunning
-	}
-
-	scope, err := GoroutineScope(p.CurrentThread())
+	scope, err := GoroutineScope(g.Thread)
 	if err != nil {
 		return err
 	}
 
 	continueRequest := make(chan continueRequest)
-	continueCompleted := make(chan struct{})
+	continueCompleted := make(chan *G)
 
 	scope.callCtx = &callContext{
 		p:                 p,
@@ -168,8 +169,10 @@ func EvalExpressionWithCalls(p Process, expr string, retLoadCfg LoadConfig, chec
 		continueCompleted: continueCompleted,
 	}
 
-	p.Common().continueRequest = continueRequest
-	p.Common().continueCompleted = continueCompleted
+	p.Common().fncallForG[g.ID] = &callInjection{
+		continueCompleted,
+		continueRequest,
+	}
 
 	go scope.EvalExpression(expr, retLoadCfg)
 
@@ -178,35 +181,35 @@ func EvalExpressionWithCalls(p Process, expr string, retLoadCfg LoadConfig, chec
 		return Continue(p)
 	}
 
-	return finishEvalExpressionWithCalls(p, contReq, ok)
+	return finishEvalExpressionWithCalls(p, g, contReq, ok)
 }
 
-func finishEvalExpressionWithCalls(p Process, contReq continueRequest, ok bool) error {
+func finishEvalExpressionWithCalls(p Process, g *G, contReq continueRequest, ok bool) error {
+	fncallLog("stashing return values for %d in thread=%d\n", g.ID, g.Thread.ThreadID())
 	var err error
 	if !ok {
 		err = errors.New("internal error EvalExpressionWithCalls didn't return anything")
 	} else if contReq.err != nil {
 		if fpe, ispanic := contReq.err.(fncallPanicErr); ispanic {
-			p.CurrentThread().Common().returnValues = []*Variable{fpe.panicVar}
+			g.Thread.Common().returnValues = []*Variable{fpe.panicVar}
 		} else {
 			err = contReq.err
 		}
 	} else if contReq.ret == nil {
-		p.CurrentThread().Common().returnValues = nil
+		g.Thread.Common().returnValues = nil
 	} else if contReq.ret.Addr == 0 && contReq.ret.DwarfType == nil {
 		// this is a variable returned by a function call with multiple return values
 		r := make([]*Variable, len(contReq.ret.Children))
 		for i := range contReq.ret.Children {
 			r[i] = &contReq.ret.Children[i]
 		}
-		p.CurrentThread().Common().returnValues = r
+		g.Thread.Common().returnValues = r
 	} else {
-		p.CurrentThread().Common().returnValues = []*Variable{contReq.ret}
+		g.Thread.Common().returnValues = []*Variable{contReq.ret}
 	}
 
-	p.Common().continueRequest = nil
-	close(p.Common().continueCompleted)
-	p.Common().continueCompleted = nil
+	close(p.Common().fncallForG[g.ID].continueCompleted)
+	delete(p.Common().fncallForG, g.ID)
 	return err
 }
 
@@ -240,22 +243,13 @@ func (scope *EvalScope) evalFunctionCall(node *ast.CallExpr) (*Variable, error) 
 		return nil, errFuncCallUnsupported
 	}
 
-	// check that the selected goroutine is running
-	g := p.SelectedGoroutine()
-	if g == nil {
-		return nil, errNoGoroutine
-	}
-	if g.Status != Grunning || g.Thread == nil {
-		return nil, errGoroutineNotRunning
-	}
-
 	// check that there are at least 256 bytes free on the stack
-	regs, err := g.Thread.Registers(true)
+	regs, err := scope.g.Thread.Registers(true)
 	if err != nil {
 		return nil, err
 	}
 	regs = regs.Copy()
-	if regs.SP()-256 <= g.stacklo {
+	if regs.SP()-256 <= scope.g.stacklo {
 		return nil, errNotEnoughStack
 	}
 	_, err = regs.Get(int(x86asm.RAX))
@@ -273,41 +267,38 @@ func (scope *EvalScope) evalFunctionCall(node *ast.CallExpr) (*Variable, error) 
 		return nil, err
 	}
 
-	if err := callOP(bi, g.Thread, regs, dbgcallfn.Entry); err != nil {
+	if err := callOP(bi, scope.g.Thread, regs, dbgcallfn.Entry); err != nil {
 		return nil, err
 	}
 	// write the desired argument frame size at SP-(2*pointer_size) (the extra pointer is the saved PC)
-	if err := writePointer(bi, g.Thread, regs.SP()-3*uint64(bi.Arch.PtrSize()), uint64(fncall.argFrameSize)); err != nil {
+	if err := writePointer(bi, scope.g.Thread, regs.SP()-3*uint64(bi.Arch.PtrSize()), uint64(fncall.argFrameSize)); err != nil {
 		return nil, err
 	}
 
-	fncallLog("function call initiated %v frame size %d\n", fncall.fn, fncall.argFrameSize)
+	fncallLog("function call initiated %v frame size %d", fncall.fn, fncall.argFrameSize)
 
-	spoff := int64(scope.Regs.Uint64Val(scope.Regs.SPRegNum)) - int64(g.stackhi)
-	bpoff := int64(scope.Regs.Uint64Val(scope.Regs.BPRegNum)) - int64(g.stackhi)
-	fboff := scope.Regs.FrameBase - int64(g.stackhi)
+	spoff := int64(scope.Regs.Uint64Val(scope.Regs.SPRegNum)) - int64(scope.g.stackhi)
+	bpoff := int64(scope.Regs.Uint64Val(scope.Regs.BPRegNum)) - int64(scope.g.stackhi)
+	fboff := scope.Regs.FrameBase - int64(scope.g.stackhi)
 
 	for {
-		scope.callCtx.doContinue()
+		scope.g = scope.callCtx.doContinue()
 
-		g = p.SelectedGoroutine()
-		if g != nil {
-			// adjust the value of registers inside scope
-			for regnum := range scope.Regs.Regs {
-				switch uint64(regnum) {
-				case scope.Regs.PCRegNum, scope.Regs.SPRegNum, scope.Regs.BPRegNum:
-					// leave these alone
-				default:
-					// every other register is dirty and unrecoverable
-					scope.Regs.Regs[regnum] = nil
-				}
+		// adjust the value of registers inside scope
+		for regnum := range scope.Regs.Regs {
+			switch uint64(regnum) {
+			case scope.Regs.PCRegNum, scope.Regs.SPRegNum, scope.Regs.BPRegNum:
+				// leave these alone
+			default:
+				// every other register is dirty and unrecoverable
+				scope.Regs.Regs[regnum] = nil
 			}
-
-			scope.Regs.Regs[scope.Regs.SPRegNum].Uint64Val = uint64(spoff + int64(g.stackhi))
-			scope.Regs.Regs[scope.Regs.BPRegNum].Uint64Val = uint64(bpoff + int64(g.stackhi))
-			scope.Regs.FrameBase = fboff + int64(g.stackhi)
-			scope.Regs.CFA = scope.frameOffset + int64(g.stackhi)
 		}
+
+		scope.Regs.Regs[scope.Regs.SPRegNum].Uint64Val = uint64(spoff + int64(scope.g.stackhi))
+		scope.Regs.Regs[scope.Regs.BPRegNum].Uint64Val = uint64(bpoff + int64(scope.g.stackhi))
+		scope.Regs.FrameBase = fboff + int64(scope.g.stackhi)
+		scope.Regs.CFA = scope.frameOffset + int64(scope.g.stackhi)
 
 		finished := funcCallStep(scope, &fncall)
 		if finished {
@@ -464,14 +455,13 @@ type funcCallArg struct {
 // funcCallEvalArgs evaluates the arguments of the function call, copying
 // the into the argument frame starting at argFrameAddr.
 func funcCallEvalArgs(scope *EvalScope, fncall *functionCallState, argFrameAddr uint64) error {
-	g := scope.callCtx.p.SelectedGoroutine()
-	if g == nil {
+	if scope.g == nil {
 		// this should never happen
 		return errNoGoroutine
 	}
 
 	if fncall.receiver != nil {
-		err := funcCallCopyOneArg(g, scope, fncall, fncall.receiver, &fncall.formalArgs[0], argFrameAddr)
+		err := funcCallCopyOneArg(scope, fncall, fncall.receiver, &fncall.formalArgs[0], argFrameAddr)
 		if err != nil {
 			return err
 		}
@@ -487,7 +477,7 @@ func funcCallEvalArgs(scope *EvalScope, fncall *functionCallState, argFrameAddr 
 		}
 		actualArg.Name = exprToString(fncall.expr.Args[i])
 
-		err = funcCallCopyOneArg(g, scope, fncall, actualArg, formalArg, argFrameAddr)
+		err = funcCallCopyOneArg(scope, fncall, actualArg, formalArg, argFrameAddr)
 		if err != nil {
 			return err
 		}
@@ -496,10 +486,10 @@ func funcCallEvalArgs(scope *EvalScope, fncall *functionCallState, argFrameAddr 
 	return nil
 }
 
-func funcCallCopyOneArg(g *G, scope *EvalScope, fncall *functionCallState, actualArg *Variable, formalArg *funcCallArg, argFrameAddr uint64) error {
+func funcCallCopyOneArg(scope *EvalScope, fncall *functionCallState, actualArg *Variable, formalArg *funcCallArg, argFrameAddr uint64) error {
 	if scope.callCtx.checkEscape {
 		//TODO(aarzilli): only apply the escapeCheck to leaking parameters.
-		if err := escapeCheck(actualArg, formalArg.name, g); err != nil {
+		if err := escapeCheck(actualArg, formalArg.name, scope.g); err != nil {
 			return fmt.Errorf("cannot use %s as argument %s in function %s: %v", actualArg.Name, formalArg.name, fncall.fn.Name, err)
 		}
 	}
@@ -631,7 +621,7 @@ func funcCallStep(callScope *EvalScope, fncall *functionCallState) bool {
 	p := callScope.callCtx.p
 	bi := p.BinInfo()
 
-	thread := p.CurrentThread()
+	thread := callScope.g.Thread
 	regs, err := thread.Registers(false)
 	if err != nil {
 		fncall.err = err
@@ -651,7 +641,7 @@ func funcCallStep(callScope *EvalScope, fncall *functionCallState) bool {
 				fnname = loc.Fn.Name
 			}
 		}
-		fncallLog("function call interrupt rax=%#x (PC=%#x in %s)\n", rax, pc, fnname)
+		fncallLog("function call interrupt gid=%d thread=%d rax=%#x (PC=%#x in %s)", callScope.g.ID, thread.ThreadID(), rax, pc, fnname)
 	}
 
 	switch rax {
@@ -868,4 +858,50 @@ func (scope *EvalScope) allocString(v *Variable) error {
 	v.Base = uintptr(mallocv.Children[0].Addr)
 	_, err = scope.Mem.WriteMemory(v.Base, []byte(constant.StringVal(v.Value)))
 	return err
+}
+
+func isCallInjectionStop(loc *Location) bool {
+	if loc.Fn == nil {
+		return false
+	}
+	return strings.HasPrefix(loc.Fn.Name, debugCallFunctionNamePrefix1) || strings.HasPrefix(loc.Fn.Name, debugCallFunctionNamePrefix2)
+}
+
+// callInjectionProtocol is the function called from Continue to progress
+// the injection protocol for all threads.
+// Returns true if a call injection terminated
+func callInjectionProtocol(p Process, threads []Thread) (done bool, err error) {
+	if len(p.Common().fncallForG) == 0 {
+		// we aren't injecting any calls, no need to check the threads.
+		return false, nil
+	}
+	for _, thread := range threads {
+		loc, err := thread.Location()
+		if err != nil {
+			continue
+		}
+		if !isCallInjectionStop(loc) {
+			continue
+		}
+
+		g, err := GetG(thread)
+		if err != nil {
+			return done, fmt.Errorf("could not determine running goroutine for thread %#x currently executing the function call injection protocol: %v", thread.ThreadID(), err)
+		}
+		callinj := p.Common().fncallForG[g.ID]
+		if callinj == nil || callinj.continueCompleted == nil {
+			return false, fmt.Errorf("could not recover call injection state for goroutine %d", g.ID)
+		}
+		fncallLog("step for injection on goroutine %d thread=%d (location %s)", g.ID, thread.ThreadID(), loc.Fn.Name)
+		callinj.continueCompleted <- g
+		contReq, ok := <-callinj.continueRequest
+		if !contReq.cont {
+			err := finishEvalExpressionWithCalls(p, g, contReq, ok)
+			if err != nil {
+				return done, err
+			}
+			done = true
+		}
+	}
+	return done, nil
 }

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -197,7 +197,7 @@ func finishEvalExpressionWithCalls(p Process, g *G, contReq continueRequest, ok 
 		}
 	} else if contReq.ret == nil {
 		g.Thread.Common().returnValues = nil
-	} else if contReq.ret.Addr == 0 && contReq.ret.DwarfType == nil {
+	} else if contReq.ret.Addr == 0 && contReq.ret.DwarfType == nil && contReq.ret.Kind == reflect.Invalid {
 		// this is a variable returned by a function call with multiple return values
 		r := make([]*Variable, len(contReq.ret.Children))
 		for i := range contReq.ret.Children {

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -117,17 +117,21 @@ type CommonProcess struct {
 	allGCache     []*G
 	fncallEnabled bool
 
+	fncallForG map[int]*callInjection
+}
+
+type callInjection struct {
 	// if continueCompleted is not nil it means we are in the process of
 	// executing an injected function call, see comments throughout
 	// pkg/proc/fncall.go for a description of how this works.
-	continueCompleted chan<- struct{}
+	continueCompleted chan<- *G
 	continueRequest   <-chan continueRequest
 }
 
 // NewCommonProcess returns a struct with fields common across
 // all process implementations.
 func NewCommonProcess(fncallEnabled bool) CommonProcess {
-	return CommonProcess{fncallEnabled: fncallEnabled}
+	return CommonProcess{fncallEnabled: fncallEnabled, fncallForG: make(map[int]*callInjection)}
 }
 
 // ClearAllGCache clears the cached contents of the cache for runtime.allgs.

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -218,7 +218,7 @@ type EvalScope struct {
 	Location
 	Regs    op.DwarfRegisters
 	Mem     MemoryReadWriter // Target's memory
-	Gvar    *Variable
+	g       *G
 	BinInfo *BinaryInfo
 
 	frameOffset int64
@@ -250,7 +250,7 @@ func (err *IsNilErr) Error() string {
 }
 
 func globalScope(bi *BinaryInfo, image *Image, mem MemoryReadWriter) *EvalScope {
-	return &EvalScope{Location: Location{}, Regs: op.DwarfRegisters{StaticBase: image.StaticBase}, Mem: mem, Gvar: nil, BinInfo: bi, frameOffset: 0}
+	return &EvalScope{Location: Location{}, Regs: op.DwarfRegisters{StaticBase: image.StaticBase}, Mem: mem, g: nil, BinInfo: bi, frameOffset: 0}
 }
 
 func (scope *EvalScope) newVariable(name string, addr uintptr, dwarfType godwarf.Type, mem MemoryReadWriter) *Variable {

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1035,7 +1035,7 @@ func (c *Commands) call(t *Term, ctx callContext, args string) error {
 		unsafe = true
 		args = args[len(unsafePrefix):]
 	}
-	state, err := exitedToError(t.client.Call(args, unsafe))
+	state, err := exitedToError(t.client.Call(ctx.Scope.GoroutineID, args, unsafe))
 	c.frame = 0
 	if err != nil {
 		printcontextNoState(t)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -304,7 +304,7 @@ type DebuggerCommand struct {
 	// command.
 	ThreadID int `json:"threadID,omitempty"`
 	// GoroutineID is used to specify which thread to use with the SwitchGoroutine
-	// command.
+	// and Call commands.
 	GoroutineID int `json:"goroutineID,omitempty"`
 	// When ReturnInfoLoadConfig is not nil it will be used to load the value
 	// of any return variables.

--- a/service/client.go
+++ b/service/client.go
@@ -39,7 +39,7 @@ type Client interface {
 	// StepOut continues to the return address of the current function
 	StepOut() (*api.DebuggerState, error)
 	// Call resumes process execution while making a function call.
-	Call(expr string, unsafe bool) (*api.DebuggerState, error)
+	Call(goroutineID int, expr string, unsafe bool) (*api.DebuggerState, error)
 
 	// SingleStep will step a single cpu instruction.
 	StepInstruction() (*api.DebuggerState, error)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -598,7 +598,14 @@ func (d *Debugger) Command(command *api.DebuggerCommand) (*api.DebuggerState, er
 		if command.ReturnInfoLoadConfig == nil {
 			return nil, errors.New("can not call function with nil ReturnInfoLoadConfig")
 		}
-		err = proc.EvalExpressionWithCalls(d.target, command.Expr, *api.LoadConfigToProc(command.ReturnInfoLoadConfig), !command.UnsafeCall)
+		g := d.target.SelectedGoroutine()
+		if command.GoroutineID > 0 {
+			g, err = proc.FindGoroutine(d.target, command.GoroutineID)
+			if err != nil {
+				return nil, err
+			}
+		}
+		err = proc.EvalExpressionWithCalls(d.target, g, command.Expr, *api.LoadConfigToProc(command.ReturnInfoLoadConfig), !command.UnsafeCall)
 	case api.Rewind:
 		d.log.Debug("rewinding")
 		if err := d.target.Direction(proc.Backward); err != nil {

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -148,9 +148,9 @@ func (c *RPCClient) StepOut() (*api.DebuggerState, error) {
 	return &out.State, err
 }
 
-func (c *RPCClient) Call(expr string, unsafe bool) (*api.DebuggerState, error) {
+func (c *RPCClient) Call(goroutineID int, expr string, unsafe bool) (*api.DebuggerState, error) {
 	var out CommandOut
-	err := c.call("Command", api.DebuggerCommand{Name: api.Call, ReturnInfoLoadConfig: c.retValLoadCfg, Expr: expr, UnsafeCall: unsafe}, &out)
+	err := c.call("Command", api.DebuggerCommand{Name: api.Call, ReturnInfoLoadConfig: c.retValLoadCfg, Expr: expr, UnsafeCall: unsafe, GoroutineID: goroutineID}, &out)
 	return &out.State, err
 }
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1555,7 +1555,7 @@ func TestClientServerFunctionCall(t *testing.T) {
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
 		beforeCallFn := state.CurrentThread.Function.Name()
-		state, err := c.Call("call1(one, two)", false)
+		state, err := c.Call(-1, "call1(one, two)", false)
 		assertNoError(err, t, "Call()")
 		t.Logf("returned to %q", state.CurrentThread.Function.Name())
 		if state.CurrentThread.Function.Name() != beforeCallFn {
@@ -1598,7 +1598,7 @@ func TestClientServerFunctionCallBadPos(t *testing.T) {
 		assertNoError(state.Err, t, "Continue()")
 
 		c.SetReturnValuesLoadConfig(&normalLoadConfig)
-		state, err = c.Call("main.call1(main.zero, main.zero)", false)
+		state, err = c.Call(-1, "main.call1(main.zero, main.zero)", false)
 		if err == nil || err.Error() != "call not at safe point" {
 			t.Fatalf("wrong error or no error: %v", err)
 		}
@@ -1612,7 +1612,7 @@ func TestClientServerFunctionCallPanic(t *testing.T) {
 		c.SetReturnValuesLoadConfig(&normalLoadConfig)
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
-		state, err := c.Call("callpanic()", false)
+		state, err := c.Call(-1, "callpanic()", false)
 		assertNoError(err, t, "Call()")
 		t.Logf("at: %s:%d", state.CurrentThread.File, state.CurrentThread.Line)
 		if state.CurrentThread.ReturnValues == nil {
@@ -1638,7 +1638,7 @@ func TestClientServerFunctionCallStacktrace(t *testing.T) {
 		c.SetReturnValuesLoadConfig(&api.LoadConfig{false, 0, 2048, 0, 0})
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
-		state, err := c.Call("callstacktrace()", false)
+		state, err := c.Call(-1, "callstacktrace()", false)
 		assertNoError(err, t, "Call()")
 		t.Logf("at: %s:%d", state.CurrentThread.File, state.CurrentThread.Line)
 		if state.CurrentThread.ReturnValues == nil {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1225,7 +1225,7 @@ func testCallFunction(t *testing.T, p proc.Process, tc testCaseCallFunction) {
 		checkEscape = false
 	}
 	t.Logf("call %q", tc.expr)
-	err := proc.EvalExpressionWithCalls(p, callExpr, pnormalLoadConfig, checkEscape)
+	err := proc.EvalExpressionWithCalls(p, p.SelectedGoroutine(), callExpr, pnormalLoadConfig, checkEscape)
 	if tc.err != nil {
 		t.Logf("\terr = %v\n", err)
 		if err == nil {

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1156,6 +1156,10 @@ func TestCallFunction(t *testing.T) {
 		// Escape tests
 
 		{"escapeArg(&a2)", nil, errors.New("cannot use &a2 as argument pa2 in function main.escapeArg: stack object passed to escaping pointer: pa2")},
+
+		// Issue 1577
+		{"1+2", []string{`::3`}, nil},
+		{`"de"+"mo"`, []string{`::"demo"`}, nil},
 	}
 
 	var testcases112 = []testCaseCallFunction{


### PR DESCRIPTION
```
proc: fix EvalExpressionWithCalls for constant expressions

The lack of address of constant expressions would confuse EvalExpressionWithCalls

Fixes #1577

proc: allow simultaneous call injection to multiple goroutines

Changes the call injection code so that we can have multiple call
injections going on at the same time as long as they happen on distinct
goroutines.

```
