### PR TITLE
proc: added *BinaryInfo.AllPCsForFileLine for faster bulk queries

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -406,6 +406,20 @@ func (bi *BinaryInfo) AllPCsForFileLine(filename string, lineno int) []uint64 {
 	return r
 }
 
+// AllPCsForFileLines returns a map providing all PC addresses for filename and each line in linenos
+func (bi *BinaryInfo) AllPCsForFileLines(filename string, linenos []int) map[int][]uint64 {
+	r := make(map[int][]uint64)
+	for _, line := range linenos {
+		r[line] = make([]uint64, 0, 1)
+	}
+	for _, cu := range bi.compileUnits {
+		if cu.lineInfo.Lookup[filename] != nil {
+			cu.lineInfo.AllPCsForFileLines(filename, r)
+		}
+	}
+	return r
+}
+
 // PCToFunc returns the function containing the given PC address
 func (bi *BinaryInfo) PCToFunc(pc uint64) *Function {
 	i := sort.Search(len(bi.Functions), func(i int) bool {


### PR DESCRIPTION
Support for bulk queries makes the DWARF quality checker
run much more efficiently (replace quadratic cost with
linear). See https://github.com/dr2chase/dwarf-goodness .

