### PR TITLE
godwarf: support recursive types involving C qualifiers and typedefs

### DIFF
--- a/_fixtures/issue1601.go
+++ b/_fixtures/issue1601.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"runtime"
+)
+
+/*
+typedef struct Qst Q1;
+typedef const Q1 Q;
+struct Qst {
+	Q *q;
+};
+
+const Q1 globalq;
+*/
+import "C"
+
+func main() {
+	runtime.Breakpoint()
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4410,3 +4410,11 @@ func TestPluginStepping(t *testing.T) {
 		{contNext, "plugin2.go:26"},
 		{contNext, "plugintest2.go:42"}})
 }
+
+func TestIssue1601(t *testing.T) {
+	//Tests that recursive types involving C qualifiers and typedefs are parsed correctly
+	withTestProcess("issue1601", t, func(p proc.Process, fixture protest.Fixture) {
+		assertNoError(proc.Continue(p), t, "Continue")
+		evalVariable(p, t, "C.globalq")
+	})
+}


### PR DESCRIPTION
```
godwarf: support recursive types involving C qualifiers and typedefs

Backports debug/dwarf commit: 535741a69a1300d1fe2800778b99c8a1b75d7fdd
CL: https://go-review.googlesource.com/18459

The x/debug/dwarf that we used for dwarf/godwarf/type.go was forked
from debug/dwarf long before this commit.

Original description:

Currently readType simultaneously constructs a type graph and resolves
the sizes of the types. However, these two operations are
fundamentally at odds: the order we parse a cyclic structure in may be
different than the order we need to resolve type sizes in. As a
result, it's possible that when readType attempts to resolve the size
of a typedef, it may dereference a nil Type field of another typedef
retrieved from the type cache that's only partially constructed.

To fix this, we delay resolving typedef sizes until the end of the
readType recursion, when the full type graph is constructed.

Fixes #1601

```
