### PR TITLE
proc: flag variables that have a 'fake' address

### DIFF
--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -746,6 +746,9 @@ func funcCallStep(callScope *EvalScope, fncall *functionCallState) bool {
 		}
 
 		loadValues(fncall.retvars, callScope.callCtx.retLoadCfg)
+		for _, v := range fncall.retvars {
+			v.Flags |= VariableFakeAddress
+		}
 
 	case debugCallAXReadPanic:
 		// read panic value from stack
@@ -755,11 +758,6 @@ func funcCallStep(callScope *EvalScope, fncall *functionCallState) bool {
 			break
 		}
 		fncall.panicvar.Name = "~panic"
-		fncall.panicvar.loadValue(callScope.callCtx.retLoadCfg)
-		if fncall.panicvar.Unreadable != nil {
-			fncall.err = fmt.Errorf("could not get panic: %v", fncall.panicvar.Unreadable)
-			break
-		}
 
 	default:
 		// Got an unknown AX value, this is probably bad but the safest thing
@@ -785,6 +783,7 @@ func readTopstackVariable(thread Thread, regs Registers, typename string, loadCf
 	if v.Unreadable != nil {
 		return nil, v.Unreadable
 	}
+	v.Flags |= VariableFakeAddress
 	return v, nil
 }
 

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -71,6 +71,12 @@ const (
 	VariableArgument
 	// VariableReturnArgument means this variable is a function return value
 	VariableReturnArgument
+	// VariableFakeAddress means the address of this variable is either fake
+	// (i.e. the variable is partially or completely stored in a CPU register
+	// and doesn't have a real address) or possibly no longer availabe (because
+	// the variable is the return value of a function call and allocated on a
+	// frame that no longer exists)
+	VariableFakeAddress
 )
 
 // Variable represents a variable. It contains the address, name,
@@ -1050,6 +1056,9 @@ func (scope *EvalScope) extractVarInfoFromEntry(varEntry *dwarf.Entry) (*Variabl
 	}
 
 	v := scope.newVariable(n, uintptr(addr), t, mem)
+	if pieces != nil {
+		v.Flags |= VariableFakeAddress
+	}
 	v.LocationExpr = descr
 	v.DeclLine, _ = entry.Val(dwarf.AttrDeclLine).(int64)
 	if err != nil {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -214,6 +214,13 @@ const (
 
 	// VariableReturnArgument means this variable is a function return value
 	VariableReturnArgument
+
+	// VariableFakeAddress means the address of this variable is either fake
+	// (i.e. the variable is partially or completely stored in a CPU register
+	// and doesn't have a real address) or possibly no longer availabe (because
+	// the variable is the return value of a function call and allocated on a
+	// frame that no longer exists)
+	VariableFakeAddress
 )
 
 // Variable describes a variable.


### PR DESCRIPTION
```
proc: flag variables that have a 'fake' address

Add variables flag to mark variables that are allocated on a register
(and have no address) and variables that we read as result of a
function call (and are allocated on a stack that no longer exists when
we show them to the user).

```
