### PR TITLE
proc: increase maximum string length when loading string for binary ops

### DIFF
--- a/_fixtures/issue1615.go
+++ b/_fixtures/issue1615.go
@@ -1,0 +1,21 @@
+package main
+
+var strings = []string{
+	"one",
+	"two",
+	"three",
+	"four",
+	"projects/my-gcp-project-id-string/locations/us-central1/queues/my-task-queue-name",
+	"five",
+	"six",
+}
+
+func f(s string) {
+	// ...
+}
+
+func main() {
+	for _, s := range strings {
+		f(s)
+	}
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4448,3 +4448,19 @@ func TestIssue1601(t *testing.T) {
 		evalVariable(p, t, "C.globalq")
 	})
 }
+
+func TestIssue1615(t *testing.T) {
+	// A breakpoint condition that tests for string equality with a constant string shouldn't fail with 'string too long for comparison' error
+
+	withTestProcess("issue1615", t, func(p proc.Process, fixture protest.Fixture) {
+		bp := setFileBreakpoint(p, t, fixture, 19)
+		bp.Cond = &ast.BinaryExpr{
+			Op: token.EQL,
+			X:  &ast.Ident{Name: "s"},
+			Y:  &ast.BasicLit{Kind: token.STRING, Value: `"projects/my-gcp-project-id-string/locations/us-central1/queues/my-task-queue-name"`},
+		}
+
+		assertNoError(proc.Continue(p), t, "Continue")
+		assertLineNumber(p, t, 19, "")
+	})
+}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -163,6 +163,7 @@ type LoadConfig struct {
 
 var loadSingleValue = LoadConfig{false, 0, 64, 0, 0, 0}
 var loadFullValue = LoadConfig{true, 1, 64, 64, -1, 0}
+var loadFullValueLongerStrings = LoadConfig{true, 1, 1024 * 1024, 64, -1, 0}
 
 // G status, from: src/runtime/runtime2.go
 const (


### PR DESCRIPTION
```
proc: increase maximum string length when loading string for binary ops

Increases the maximum string length from 64 to 1MB when loading strings
for a binary operator, also delays the loading until it's necessary.

This ensures that comparison between strings will always succeed in
reasonable situations.

Fixes #1615

```
