### PR TITLE
terminal: prompt to kill remote if process exited

### DIFF
--- a/pkg/terminal/terminal_test.go
+++ b/pkg/terminal/terminal_test.go
@@ -1,6 +1,8 @@
 package terminal
 
 import (
+	"errors"
+	"net/rpc"
 	"runtime"
 	"testing"
 
@@ -82,6 +84,24 @@ func TestSubstitutePath(t *testing.T) {
 		res := New(nil, &config.Config{SubstitutePath: subRules}).substitutePath(c.path)
 		if c.res != res {
 			t.Errorf("terminal.SubstitutePath(%q) => %q, want %q", c.path, res, c.res)
+		}
+	}
+}
+
+func TestIsErrProcessExited(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		result bool
+	}{
+		{"empty error", errors.New(""), false},
+		{"non-ServerError", errors.New("Process 33122 has exited with status 0"), false},
+		{"ServerError with zero status", rpc.ServerError("Process 33122 has exited with status 0"), true},
+		{"ServerError with non-zero status", rpc.ServerError("Process 2 has exited with status 25"), true},
+	}
+	for _, test := range tests {
+		if isErrProcessExited(test.err) != test.result {
+			t.Error(test.name)
 		}
 	}
 }


### PR DESCRIPTION
Fix #1617 by modifying the terminal to prompt the user to kill the remote headless instance if the remote process has exited.
```sh
$ dlv connect :59090
Type 'help' for list of commands.
(dlv) c
Process 36365 has exited with status 0
(dlv) exit
Remote process has exited. Would you like to kill the headless instance? [Y/n] y
```

There doesn't seem to be a clean way to determine whether `GetClient()` returned an error because `ErrProcessExited` on the remote or for some other reason.