### PR TITLE
proc/native/linux: call postExit when process is killed by SIGINT

### DIFF
--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -321,6 +321,7 @@ func (dbp *Process) trapWaitInternal(pid int, halt bool) (*Thread, error) {
 		// TODO(dp) alert user about unexpected signals here.
 		if err := th.resumeWithSig(int(status.StopSignal())); err != nil {
 			if err == sys.ESRCH {
+				dbp.postExit()
 				return nil, proc.ErrProcessExited{Pid: dbp.pid}
 			}
 			return nil, err


### PR DESCRIPTION
```
proc/native/linux: call postExit when process is killed by SIGINT

If we return ErrProcessExited we should also set exited to true.

```
