### PR TITLE
go.mod: add Go version to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/go-delve/delve
 
+go 1.10
+
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cosiner/argv v0.0.0-20170225145430-13bacc38a0a5


### PR DESCRIPTION
```
go.mod: add Go version to go.mod

Go 1.13 insists on adding a go version to go.mod, add one that makes
sense.

```
