### PR TITLE
add max-variable-recurse parameter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	// MaxArrayValues is the maximum number of array items that the commands
 	// print, locals, args and vars should read (in verbose mode).
 	MaxArrayValues *int `yaml:"max-array-values,omitempty"`
-	// MaxVariableRecurse is output evaluation depth of of nested struct members, array and
+	// MaxVariableRecurse is output evaluation depth of nested struct members, array and
 	// slice items and dereference pointers
 	MaxVariableRecurse *int `yaml:"max-variable-recurse,omitempty"`
 
@@ -220,7 +220,7 @@ substitute-path:
 # max-string-len: 64
 
 # Output evaluation.
-# max-variable-recurse 1
+# max-variable-recurse: 1
 
 # Uncomment the following line to make the whatis command also print the DWARF location expression of its argument.
 # show-location-expr: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,9 @@ type Config struct {
 	// MaxArrayValues is the maximum number of array items that the commands
 	// print, locals, args and vars should read (in verbose mode).
 	MaxArrayValues *int `yaml:"max-array-values,omitempty"`
+	// MaxVariableRecurse is output evaluation depth of of nested struct members, array and
+	// slice items and dereference pointers
+	MaxVariableRecurse *int `yaml:"max-variable-recurse,omitempty"`
 
 	// If ShowLocationExpr is true whatis will print the DWARF location
 	// expression for its argument.
@@ -215,6 +218,9 @@ substitute-path:
 
 # Maximum loaded string length.
 # max-string-len: 64
+
+# Output evaluation.
+# max-variable-recurse 1
 
 # Uncomment the following line to make the whatis command also print the DWARF location expression of its argument.
 # show-location-expr: true

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -691,6 +691,16 @@ func TestConfig(t *testing.T) {
 	if *term.conf.MaxStringLen != 10 {
 		t.Fatalf("expected MaxStringLen 10, got: %d", *term.conf.MaxStringLen)
 	}
+	err = configureCmd(&term, callContext{}, "max-variable-recurse 4")
+	if err != nil {
+		t.Fatalf("error executing configureCmd(max-variable-recurse): %v", err)
+	}
+	if term.conf.MaxVariableRecurse == nil {
+		t.Fatalf("expected MaxVariableRecurse 4, got nil")
+	}
+	if *term.conf.MaxVariableRecurse != 4 {
+		t.Fatalf("expected MaxVariableRecurse 4, got: %d", *term.conf.MaxVariableRecurse)
+	}
 
 	err = configureCmd(&term, callContext{}, "substitute-path a b")
 	if err != nil {

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -386,6 +386,9 @@ func (t *Term) loadConfig() api.LoadConfig {
 	if t.conf != nil && t.conf.MaxArrayValues != nil {
 		r.MaxArrayValues = *t.conf.MaxArrayValues
 	}
+	if t.conf != nil && t.conf.MaxVariableRecurse != nil {
+		r.MaxVariableRecurse = *t.conf.MaxVariableRecurse
+	}
 
 	return r
 }


### PR DESCRIPTION
Add max-variable-recurse parameter for print depth of pointers, nested structs and etc 
See feature request from issue https://github.com/go-delve/delve/issues/1625