### PR TITLE
terminal/command: add support for next [count]

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -296,6 +296,11 @@ If regex is specified only local variables with a name matching it will be retur
 ## next
 Step over to next source line.
 
+	 next [count]
+
+Optional [count] argument alloes you to skip multiple lines.
+
+
 Aliases: n
 
 ## on

--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -298,7 +298,7 @@ Step over to next source line.
 
 	 next [count]
 
-Optional [count] argument alloes you to skip multiple lines.
+Optional [count] argument allows you to skip multiple lines.
 
 
 Aliases: n

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -949,9 +949,11 @@ func (c *Commands) cont(t *Term, ctx callContext, args string) error {
 	return nil
 }
 
-func continueUntilCompleteNext(t *Term, state *api.DebuggerState, op string) error {
+func continueUntilCompleteNext(t *Term, state *api.DebuggerState, op string, shouldPrintFile bool) error {
 	if !state.NextInProgress {
-		printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
+		if shouldPrintFile {
+			printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
+		}
 		return nil
 	}
 	for {
@@ -1000,7 +1002,7 @@ func (c *Commands) step(t *Term, ctx callContext, args string) error {
 		return err
 	}
 	printcontext(t, state)
-	return continueUntilCompleteNext(t, state, "step")
+	return continueUntilCompleteNext(t, state, "step", true)
 }
 
 var notOnFrameZeroErr = errors.New("not on topmost frame")
@@ -1066,11 +1068,8 @@ func (c *Commands) next(t *Term, ctx callContext, args string) error {
 		if count == 1 {
 			printcontext(t, state)
 		}
-		// If we hit a breakpoint while executing this next, we need to keep going.
-		if state.NextInProgress {
-			if err := continueUntilCompleteNext(t, state, "next"); err != nil {
-				return err
-			}
+		if err := continueUntilCompleteNext(t, state, "next", count == 1); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -1089,7 +1088,7 @@ func (c *Commands) stepout(t *Term, ctx callContext, args string) error {
 		return err
 	}
 	printcontext(t, state)
-	return continueUntilCompleteNext(t, state, "stepout")
+	return continueUntilCompleteNext(t, state, "stepout", true)
 }
 
 func (c *Commands) call(t *Term, ctx callContext, args string) error {
@@ -1109,7 +1108,7 @@ func (c *Commands) call(t *Term, ctx callContext, args string) error {
 		return err
 	}
 	printcontext(t, state)
-	return continueUntilCompleteNext(t, state, "call")
+	return continueUntilCompleteNext(t, state, "call", true)
 }
 
 func clear(t *Term, ctx callContext, args string) error {

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -142,7 +142,7 @@ the arguments.  With -noargs, the process starts with an empty commandline.
 
 	 next [count]
 
-Optional [count] argument alloes you to skip multiple lines.
+Optional [count] argument allows you to skip multiple lines.
 `},
 		{aliases: []string{"stepout"}, cmdFn: c.stepout, helpMsg: "Step out of the current function."},
 		{aliases: []string{"call"}, cmdFn: c.call, helpMsg: `Resumes process, injecting a function call (EXPERIMENTAL!!!)
@@ -871,14 +871,11 @@ func parseArgs(args string) ([]string, error) {
 
 // parseOptionalCount parses an optional count argument.
 // If there are not arguments, a value of 1 is returned as the default.
-func parseOptionalCount(arg string) (val int64, err error) {
+func parseOptionalCount(arg string) (int64, error) {
 	if len(arg) == 0 {
 		return 1, nil
 	}
-	if val, err = strconv.ParseInt(arg, 0, 64); err != nil {
-		return 1, err
-	}
-	return val, err
+	return strconv.ParseInt(arg, 0, 64)
 }
 
 func restart(t *Term, ctx callContext, args string) error {
@@ -1065,10 +1062,11 @@ func (c *Commands) next(t *Term, ctx callContext, args string) error {
 			return err
 		}
 		// If we're about the exit the loop, print the context.
-		if count == 1 {
+		finishedNext := count == 1
+		if finishedNext {
 			printcontext(t, state)
 		}
-		if err := continueUntilCompleteNext(t, state, "next", count == 1); err != nil {
+		if err := continueUntilCompleteNext(t, state, "next", finishedNext); err != nil {
 			return err
 		}
 	}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1053,7 +1053,7 @@ func (c *Commands) next(t *Term, ctx callContext, args string) error {
 	if count, err = parseOptionalCount(args, 1); err != nil {
 		return err
 	}
-	if count != 0 {
+	if count > 0 {
 		var state *api.DebuggerState
 		for ; count != 0; count-- {
 			state, err = exitedToError(t.client.Next())

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -664,6 +664,15 @@ func TestCheckpoints(t *testing.T) {
 	})
 }
 
+func TestNextWithCount(t *testing.T) {
+	test.AllowRecording(t)
+	withTestTerminal("nextcond", t, func(term *FakeTerminal) {
+		term.MustExec("break main.main")
+		listIsAt(t, term, "continue", 8, -1, -1)
+		listIsAt(t, term, "next 2", 10, -1, -1)
+	})
+}
+
 func TestRestart(t *testing.T) {
 	withTestTerminal("restartargs", t, func(term *FakeTerminal) {
 		term.MustExec("break main.printArgs")


### PR DESCRIPTION
Add support for an optional [count] to the next command -- similar to gdb.

This fixes no outstanding issue, it just makes life a little easier for people familiar with gdb.