### PR TITLE
cmd/dlv: actually disable C compiler optimizations when building

### DIFF
--- a/_fixtures/cgosigsegvstack.go
+++ b/_fixtures/cgosigsegvstack.go
@@ -1,0 +1,18 @@
+package main
+
+// #cgo CFLAGS: -g -Wall -O0
+
+/*
+void sigsegv(int x) {
+	int *p = NULL;
+	*p = x;
+}
+void testfn(int x) {
+	sigsegv(x);
+}
+*/
+import "C"
+
+func main() {
+	C.testfn(C.int(10))
+}

--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -17,7 +17,7 @@ func main() {
 	}
 	const cgoCflagsEnv = "CGO_CFLAGS"
 	if os.Getenv(cgoCflagsEnv) == "" {
-		os.Setenv(cgoCflagsEnv, "-O -g")
+		os.Setenv(cgoCflagsEnv, "-O0 -g")
 	} else {
 		logrus.WithFields(logrus.Fields{"layer": "dlv"}).Warnln("CGO_CFLAGS already set, Cgo code could be optimized.")
 	}


### PR DESCRIPTION
```
cmd/dlv: actually disable C compiler optimizations when building

proc: fix stacktraces when a SIGSEGV happens during a cgo call

When a SIGSEGV happens in a cgo call (for example as a result of
dereferencing a NULL pointer) the stack layout will look like this:

(system stack) runtime.fatalthrow
(system stack) runtime.throw
(system stack) runtime.sigpanic
(system stack) offending C function
... other C functions...
(system stack) runtime.asmcgocall
(goroutine stack) call inside cgo

The code in switchStack would switch directly from the
runtime.fatalthrow frame to the first frame in the goroutine stack,
hiding important information.

Disable this switch for runtime.fatalthrow and reintroduce the check
for runtime.mstart that existed before this version of the code was
implemented in commit 7bec20.

This problem was reported in comment:
https://github.com/go-delve/delve/issues/935#issuecomment-512182533

```
