### PR TITLE
pkg/proc: Refactor pkg/proc/arch.go

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -23,12 +23,8 @@ type Arch interface {
 
 // AMD64 represents the AMD64 CPU architecture.
 type AMD64 struct {
-	ptrSize                 int
-	breakInstruction        []byte
-	breakInstructionLen     int
-	gStructOffset           uint64
-	hardwareBreakpointUsage []bool
-	goos                    string
+	gStructOffset uint64
+	goos          string
 
 	// crosscall2fn is the DIE of crosscall2, a function used by the go runtime
 	// to call C functions. This function in go 1.9 (and previous versions) had
@@ -48,36 +44,32 @@ const (
 	amd64DwarfBPRegNum uint64 = 6
 )
 
+var amd64BreakInstruction = []byte{0xCC}
+
 // AMD64Arch returns an initialized AMD64
 // struct.
 func AMD64Arch(goos string) *AMD64 {
-	var breakInstr = []byte{0xCC}
-
 	return &AMD64{
-		ptrSize:                 8,
-		breakInstruction:        breakInstr,
-		breakInstructionLen:     len(breakInstr),
-		hardwareBreakpointUsage: make([]bool, 4),
-		goos:                    goos,
+		goos: goos,
 	}
 }
 
 // PtrSize returns the size of a pointer
 // on this architecture.
 func (a *AMD64) PtrSize() int {
-	return a.ptrSize
+	return 8
 }
 
 // BreakpointInstruction returns the Breakpoint
 // instruction for this architecture.
 func (a *AMD64) BreakpointInstruction() []byte {
-	return a.breakInstruction
+	return amd64BreakInstruction
 }
 
 // BreakpointSize returns the size of the
 // breakpoint instruction on this architecture.
 func (a *AMD64) BreakpointSize() int {
-	return a.breakInstructionLen
+	return len(amd64BreakInstruction)
 }
 
 // DerefTLS returns true if the value of regs.TLS()+GStructOffset() is a
@@ -100,7 +92,6 @@ func (a *AMD64) FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *
 	}
 
 	if fctxt == nil || (a.sigreturnfn != nil && pc >= a.sigreturnfn.Entry && pc < a.sigreturnfn.End) {
-		//if true {
 		// When there's no frame descriptor entry use BP (the frame pointer) instead
 		// - return register is [bp + a.PtrSize()] (i.e. [cfa-a.PtrSize()])
 		// - cfa is bp + a.PtrSize()*2

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -435,8 +435,8 @@ func (bi *BinaryInfo) PCToFunc(pc uint64) *Function {
 	return nil
 }
 
-// pcToImage returns the image containing the given PC address.
-func (bi *BinaryInfo) pcToImage(pc uint64) *Image {
+// PCToImage returns the image containing the given PC address.
+func (bi *BinaryInfo) PCToImage(pc uint64) *Image {
 	fn := bi.PCToFunc(pc)
 	return bi.funcToImage(fn)
 }

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -90,7 +90,8 @@ func dwarfExprCheck(t *testing.T, mem proc.MemoryReadWriter, regs op.DwarfRegist
 
 func dwarfRegisters(bi *proc.BinaryInfo, regs *linutil.AMD64Registers) op.DwarfRegisters {
 	a := proc.AMD64Arch("linux")
-	dwarfRegs := a.RegistersToDwarfRegisters(bi, regs)
+	so := bi.PCToImage(regs.PC())
+	dwarfRegs := a.RegistersToDwarfRegisters(so.StaticBase, regs)
 	dwarfRegs.CFA = defaultCFA
 	dwarfRegs.FrameBase = defaultCFA
 	return dwarfRegs

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -100,7 +100,8 @@ func ThreadStacktrace(thread Thread, depth int) ([]Stackframe, error) {
 		if err != nil {
 			return nil, err
 		}
-		it := newStackIterator(thread.BinInfo(), thread, thread.BinInfo().Arch.RegistersToDwarfRegisters(thread.BinInfo(), regs), 0, nil, -1, nil)
+		so := thread.BinInfo().PCToImage(regs.PC())
+		it := newStackIterator(thread.BinInfo(), thread, thread.BinInfo().Arch.RegistersToDwarfRegisters(so.StaticBase, regs), 0, nil, -1, nil)
 		return it.stacktrace(depth)
 	}
 	return g.Stacktrace(depth, false)
@@ -117,7 +118,8 @@ func (g *G) stackIterator() (*stackIterator, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newStackIterator(g.variable.bi, g.Thread, g.variable.bi.Arch.RegistersToDwarfRegisters(g.variable.bi, regs), g.stackhi, stkbar, g.stkbarPos, g), nil
+		so := g.variable.bi.PCToImage(regs.PC())
+		return newStackIterator(g.variable.bi, g.Thread, g.variable.bi.Arch.RegistersToDwarfRegisters(so.StaticBase, regs), g.stackhi, stkbar, g.stkbarPos, g), nil
 	}
 	return newStackIterator(g.variable.bi, g.variable.mem, g.variable.bi.Arch.GoroutineToDwarfRegisters(g), g.stackhi, stkbar, g.stkbarPos, g), nil
 }
@@ -517,7 +519,7 @@ func (it *stackIterator) advanceRegs() (callFrameRegs op.DwarfRegisters, ret uin
 	}
 	it.regs.CFA = int64(cfareg.Uint64Val)
 
-	callimage := it.bi.pcToImage(it.pc)
+	callimage := it.bi.PCToImage(it.pc)
 
 	callFrameRegs = op.DwarfRegisters{StaticBase: callimage.StaticBase, ByteOrder: it.regs.ByteOrder, PCRegNum: it.regs.PCRegNum, SPRegNum: it.regs.SPRegNum, BPRegNum: it.regs.BPRegNum}
 

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -119,9 +119,16 @@ func (g *G) stackIterator() (*stackIterator, error) {
 			return nil, err
 		}
 		so := g.variable.bi.PCToImage(regs.PC())
-		return newStackIterator(g.variable.bi, g.Thread, g.variable.bi.Arch.RegistersToDwarfRegisters(so.StaticBase, regs), g.stackhi, stkbar, g.stkbarPos, g), nil
+		return newStackIterator(
+			g.variable.bi, g.Thread,
+			g.variable.bi.Arch.RegistersToDwarfRegisters(so.StaticBase, regs),
+			g.stackhi, stkbar, g.stkbarPos, g), nil
 	}
-	return newStackIterator(g.variable.bi, g.variable.mem, g.variable.bi.Arch.GoroutineToDwarfRegisters(g), g.stackhi, stkbar, g.stkbarPos, g), nil
+	so := g.variable.bi.PCToImage(g.PC)
+	return newStackIterator(
+		g.variable.bi, g.variable.mem,
+		g.variable.bi.Arch.AddrAndStackRegsToDwarfRegisters(so.StaticBase, g.PC, g.SP, g.BP),
+		g.stackhi, stkbar, g.stkbarPos, g), nil
 }
 
 // Stacktrace returns the stack trace for a goroutine.


### PR DESCRIPTION
This is part 1 in a series of upcoming small untangling refactors. I've been trying, unsuccessfully, to refactor to code base as it's in need of a lot of cleanup. The main goal I am trying to get to is that `proc` should more or less be stateless, and just provide low-level functionality for manipulating a process. The debugger layer should actually be taking on a lot more of the actual "business logic".

The problem that I ran into when trying to clean things up over the past few days is that *everything* within `pkg/proc` knows about *everything else* within `pkg/proc`. We pass around `BinaryInfo` and copy it everywhere, we pass in full structs (such as `BinaryInfo`, `G`, etc) when the function maybe only needs one member, which we can just pass explicitly.

Anyways, all that to say: I'm going to start untangling the code in `pkg/proc` in an effort to simplify the codebase and improve readability.

After all refactoring is done I will continue my work on adding more arches. 