### PR TITLE
proc: add *Function.PrologueEndPC to support optargorder tool

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -191,6 +191,15 @@ func (fn *Function) Optimized() bool {
 	return fn.cu.optimized
 }
 
+// PrologueEndPC returns the PC just after the function prologue
+func (fn *Function) PrologueEndPC() uint64 {
+	pc, _, _, ok := fn.cu.lineInfo.PrologueEndPC(fn.Entry, fn.End)
+	if !ok {
+		return fn.Entry
+	}
+	return pc
+}
+
 type constantsMap map[dwarfRef]*constantType
 
 type constantType struct {


### PR DESCRIPTION
Intent here is to bring optargorder up to date with delve
and keep it in sync (and to use optargorder to help monitor
compiler output for debugging quality regressions).