### PR TITLE
Set started to true in core.go

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -103,6 +103,9 @@ func (r *SplicedMemory) ReadMemory(buf []byte, addr uintptr) (n int, err error) 
 			return n, fmt.Errorf("hit unmapped area at %v after %v bytes", addr, n)
 		}
 
+		// The reading of the memory has been started after the first iteration
+		started = true
+
 		// Don't go past the region.
 		pb := buf
 		if addr+uintptr(len(buf)) > entry.offset+entry.length {


### PR DESCRIPTION
Sets started to true on line 107 of core.go in the function ReadMemory. This ensures that "if a read goes into an unmapped region, it will be silently continued at the next mapping instead of failing or zero-filling" (https://github.com/go-delve/delve/issues/1071#issuecomment-518838215).

Fixes issue #1071