### PR TITLE
proc/gdbserial: reset thread updater in step loop

### DIFF
--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -599,6 +599,9 @@ func (conn *gdbConn) step(threadID string, tu *threadUpdater, ignoreFaultSignal 
 		if err := conn.send(conn.outbuf.Bytes()); err != nil {
 			return err
 		}
+		if tu != nil {
+			tu.Reset()
+		}
 		var err error
 		_, sig, err = conn.waitForvContStop("singlestep", threadID, tu)
 		if err != nil {


### PR DESCRIPTION
```
proc/gdbserial: reset thread updater in step loop

threadUpdater needs to be reset before every possible use.

Fixes #1659

```
