### PR TITLE
proc: discard variables with address 0 in disassembly sym lookup

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1576,7 +1576,7 @@ func (bi *BinaryInfo) symLookup(addr uint64) (string, uint64) {
 		// report previous variable + offset if i-th variable starts after addr
 		i--
 	}
-	if i > 0 {
+	if i >= 0 && bi.packageVars[i].addr != 0 {
 		return bi.packageVars[i].name, bi.packageVars[i].addr
 	}
 	return "", 0


### PR DESCRIPTION
```
proc: discard variables with address 0 in disassembly sym lookup

They are irrelevant and confusing.

```
