### PR TITLE
proc: correctly mark closure variables as shadowed

### DIFF
--- a/Documentation/KnownBugs.md
+++ b/Documentation/KnownBugs.md
@@ -1,6 +1,5 @@
 # Known Bugs
 
-- When a function defines two (or more) variables with the same name delve is unable to distinguish between them: `locals` will print both variables, `print` will randomly pick one. See [Issue #106](https://github.com/go-delve/delve/issues/106).
 - Delve does not currently support 32bit systems. This will usually manifest as a compiler error in `proc/disasm.go`. See [Issue #20](https://github.com/go-delve/delve/issues/20).
 - When Delve is compiled with versions of go prior to 1.7.0 it is not possible to set a breakpoint on a function in a remote package using the `Receiver.MethodName` syntax. See [Issue #528](https://github.com/go-delve/delve/issues/528).
-- When running Delve on binaries compiled with a version of go prior to 1.9.0 `locals` will print all local variables, including ones that are out of scope. If there are multiple variables defined with the same name in the current function `print` will not be able to select the correct one for the current line.
+- When running Delve on binaries compiled with a version of go prior to 1.9.0 `locals` will print all local variables, including ones that are out of scope, the shadowed flag will be applied arbitrarily. If there are multiple variables defined with the same name in the current function `print` will not be able to select the correct one for the current line.

--- a/_fixtures/scopetest.go
+++ b/_fixtures/scopetest.go
@@ -142,6 +142,18 @@ func TestClosureScope() {
 	f(3)
 	f1(b)
 }
+func TestClosureShadow() {
+	v := 1
+	closure := func() {
+		f1(v) // v int = 1
+		v := 2
+		f1(v) // v int = 1, v int = 2
+		for i := 0; i < 1; i++ {
+			f1(v) // v int = 1, v int = 2, i int = 0
+		}
+	}
+	closure()
+}
 func main() {
 	ch <- 12
 	TestNestedFor()
@@ -162,4 +174,5 @@ func main() {
 	TestDiscontiguousRanges()
 	TestDiscontiguousRanges()
 	TestClosureScope()
+	TestClosureShadow()
 }

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1946,16 +1946,21 @@ func (ctyp *constantType) describe(n int64) string {
 	return ""
 }
 
-type variablesByDepth struct {
+type variablesByDepthAndDeclLine struct {
 	vars   []*Variable
 	depths []int
 }
 
-func (v *variablesByDepth) Len() int { return len(v.vars) }
+func (v *variablesByDepthAndDeclLine) Len() int { return len(v.vars) }
 
-func (v *variablesByDepth) Less(i int, j int) bool { return v.depths[i] < v.depths[j] }
+func (v *variablesByDepthAndDeclLine) Less(i int, j int) bool {
+	if v.depths[i] == v.depths[j] {
+		return v.vars[i].DeclLine < v.vars[j].DeclLine
+	}
+	return v.depths[i] < v.depths[j]
+}
 
-func (v *variablesByDepth) Swap(i int, j int) {
+func (v *variablesByDepthAndDeclLine) Swap(i int, j int) {
 	v.depths[i], v.depths[j] = v.depths[j], v.depths[i]
 	v.vars[i], v.vars[j] = v.vars[j], v.vars[i]
 }


### PR DESCRIPTION
```
proc: correctly mark closure variables as shadowed

If a closure captures a variable but also defines a variable of the
same name in its root scope the shadowed flag would, sometimes, not be
appropriately applied to the captured variable.

This change:

1. sorts the variable list by depth *and* declaration line, so that
closure captured variables always appear before other root-scope
variables, regardless of the order used by the compiler

2. marks variable with the same name as shadowed even if there is only
one scope at play.

This fixes the problem but as a side effect:

1. programs compiled with Go prior to version 1.9 will have the
shadowed flag applied arbitrarily (previously the shadowed flag was not
applied at all)
2. programs compiled with Go prior to versoin 1.11 will still exhibit
the bug, as they do not have DeclLine information.

Fixes #1672

```
