### PR TITLE
dwarf/line: fix state machine behavior with multi-sequence units

### DIFF
--- a/pkg/dwarf/line/state_machine_test.go
+++ b/pkg/dwarf/line/state_machine_test.go
@@ -5,12 +5,15 @@ import (
 	"compress/gzip"
 	"debug/dwarf"
 	"debug/macho"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
+
+	"github.com/go-delve/delve/pkg/dwarf/util"
 )
 
 func slurpGzip(path string) ([]byte, error) {
@@ -124,5 +127,144 @@ func checkCompileUnit(t *testing.T, cuname string, lnrdr *dwarf.LineReader, sm *
 	err := lnrdr.Next(&lne)
 	if err != io.EOF {
 		t.Fatalf("state machine ended before the line reader for compile unit %s", cuname)
+	}
+}
+
+func TestMultipleSequences(t *testing.T) {
+	// Check that our state machine (specifically PCToLine and AllPCsBetween)
+	// are correct when dealing with units containing more than one sequence.
+
+	const thefile = "thefile.go"
+
+	instr := bytes.NewBuffer(nil)
+
+	write_DW_LNE_set_address := func(addr uint64) {
+		instr.WriteByte(0)
+		util.EncodeULEB128(instr, 9) // 1 + ptr_size
+		instr.WriteByte(DW_LINE_set_address)
+		binary.Write(instr, binary.LittleEndian, addr)
+
+	}
+
+	write_DW_LNS_copy := func() {
+		instr.WriteByte(DW_LNS_copy)
+	}
+
+	write_DW_LNS_advance_pc := func(off uint64) {
+		instr.WriteByte(DW_LNS_advance_pc)
+		util.EncodeULEB128(instr, off)
+	}
+
+	write_DW_LNS_advance_line := func(off int64) {
+		instr.WriteByte(DW_LNS_advance_line)
+		util.EncodeSLEB128(instr, off)
+	}
+
+	write_DW_LNE_end_sequence := func() {
+		instr.WriteByte(0)
+		util.EncodeULEB128(instr, 1)
+		instr.WriteByte(DW_LINE_end_sequence)
+	}
+
+	write_DW_LNE_set_address(0x400000)
+	write_DW_LNS_copy() // thefile.go:1 0x400000
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNS_advance_line(1)
+	write_DW_LNS_copy() // thefile.go:2 0x400002
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNS_advance_line(1)
+	write_DW_LNS_copy() // thefile.go:3 0x400004
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNE_end_sequence() // thefile.go:3 ends the byte before 0x400006
+
+	write_DW_LNE_set_address(0x600000)
+	write_DW_LNS_advance_line(10)
+	write_DW_LNS_copy() // thefile.go:11 0x600000
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNS_advance_line(1)
+	write_DW_LNS_copy() // thefile.go:12 0x600002
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNS_advance_line(1)
+	write_DW_LNS_copy() // thefile.go:13 0x600004
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNE_end_sequence() // thefile.go:13 ends the byte before 0x600006
+
+	write_DW_LNE_set_address(0x500000)
+	write_DW_LNS_advance_line(20)
+	write_DW_LNS_copy() // thefile.go:21 0x500000
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNS_advance_line(1)
+	write_DW_LNS_copy() // thefile.go:22 0x500002
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNS_advance_line(1)
+	write_DW_LNS_copy() // thefile.go:23 0x500004
+	write_DW_LNS_advance_pc(0x2)
+	write_DW_LNE_end_sequence() // thefile.go:23 ends the byte before 0x500006
+
+	lines := &DebugLineInfo{
+		Prologue: &DebugLinePrologue{
+			UnitLength:     1,
+			Version:        2,
+			MinInstrLength: 1,
+			InitialIsStmt:  1,
+			LineBase:       -3,
+			LineRange:      12,
+			OpcodeBase:     13,
+			StdOpLengths:   []uint8{0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1},
+		},
+		IncludeDirs:  []string{},
+		FileNames:    []*FileEntry{&FileEntry{Path: thefile}},
+		Instructions: instr.Bytes(),
+	}
+
+	// Test that PCToLine is correct for all three sequences
+
+	for _, testCase := range []struct {
+		pc   uint64
+		line int
+	}{
+		{0x400000, 1},
+		{0x400002, 2},
+		{0x400004, 3},
+
+		{0x500000, 21},
+		{0x500002, 22},
+		{0x500004, 23},
+
+		{0x600000, 11},
+		{0x600002, 12},
+		{0x600004, 13},
+	} {
+		sm := newStateMachine(lines, lines.Instructions)
+		file, curline, ok := sm.PCToLine(testCase.pc)
+		if !ok {
+			t.Fatalf("Could not find %#x", testCase.pc)
+		}
+		if file != thefile {
+			t.Fatalf("Wrong file returned for %#x %q", testCase.pc, file)
+		}
+		if curline != testCase.line {
+			t.Errorf("Wrong line returned for %#x: got %d expected %d", testCase.pc, curline, testCase.line)
+		}
+
+	}
+
+	// Test that AllPCsBetween is correct for all three sequences
+	for _, testCase := range []struct {
+		start, end uint64
+		tgt        []uint64
+	}{
+		{0x400000, 0x400005, []uint64{0x400000, 0x400002, 0x400004}},
+		{0x500000, 0x500005, []uint64{0x500000, 0x500002, 0x500004}},
+		{0x600000, 0x600005, []uint64{0x600000, 0x600002, 0x600004}},
+	} {
+		out, err := lines.AllPCsBetween(testCase.start, testCase.end, "", -1)
+		if err != nil {
+			t.Fatalf("AllPCsBetween(%#x, %#x): %v", testCase.start, testCase.end, err)
+		}
+
+		if len(out) != len(testCase.tgt) {
+			t.Errorf("AllPCsBetween(%#x, %#x): expected: %#x got: %#x", testCase.start, testCase.end, testCase.tgt, out)
+		}
 	}
 }


### PR DESCRIPTION
```
dwarf/line: fix state machine behavior with multi-sequence units

A compile unit can produce a debug_line program consisting of multiple
sequences according to the DWARF standard. The standard guarantees that
addresses monotonically increment within a single sequence but
different sequences may not follow this rule.

This commit changes dwarf/line (in particular PCToLine and
AllPCsBetween) to support debug_line sections containing units with
multiple sequences.

TestPCToLine needs to be changed so that it picks valid addresses (i.e.
addresses covered by a sequence) as values for basePC, instead of just
rounding.

```
