### PR TITLE
proc: allow calls to optimized functions

### DIFF
--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -145,5 +145,6 @@ func main() {
 	runtime.Breakpoint()
 	call1(one, two)
 	fn2clos(2)
+	strings.LastIndexByte(stringslice[1], 'w')
 	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga, escapeArg, a2, square, intcallpanic, onetwothree, curriedAdd, getAStruct, getAStructPtr, getVRcvrableFromAStruct, getPRcvrableFromAStructPtr, getVRcvrableFromAStructPtr, pa2, noreturncall, str)
 }

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -102,6 +102,8 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 		return nil, errors.New("unable to find function context")
 	}
 
+	trustArgOrder := scope.BinInfo.Producer() != "" && goversion.ProducerAfterOrEqual(scope.BinInfo.Producer(), 1, 12)
+
 	var vars []*Variable
 	var depths []int
 	varReader := reader.Variables(scope.image().dwarf, scope.Fn.offset, reader.ToRelAddr(scope.PC, scope.image().StaticBase), scope.Line, true, false)
@@ -112,6 +114,14 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 		if err != nil {
 			// skip variables that we can't parse yet
 			continue
+		}
+		if trustArgOrder && val.Unreadable != nil && val.Addr == 0 && entry.Tag == dwarf.TagFormalParameter {
+			addr := afterLastArgAddr(vars)
+			if addr == 0 {
+				addr = uintptr(scope.Regs.CFA)
+			}
+			addr = uintptr(alignAddr(int64(addr), val.DwarfType.Align()))
+			val = newVariable(val.Name, addr, val.DwarfType, scope.BinInfo, scope.Mem)
 		}
 		vars = append(vars, val)
 		depth := varReader.Depth()
@@ -169,6 +179,16 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 	}
 
 	return vars, nil
+}
+
+func afterLastArgAddr(vars []*Variable) uintptr {
+	for i := len(vars) - 1; i >= 0; i-- {
+		v := vars[i]
+		if (v.Flags&VariableArgument != 0) || (v.Flags&VariableReturnArgument != 0) {
+			return v.Addr + uintptr(v.DwarfType.Size())
+		}
+	}
+	return 0
 }
 
 // setValue writes the value of srcv to dstv.
@@ -386,6 +406,9 @@ func (scope *EvalScope) findGlobal(name string) (*Variable, error) {
 			r.Value = constant.MakeString(fn.Name)
 			r.Base = uintptr(fn.Entry)
 			r.loaded = true
+			if fn.Entry == 0 {
+				r.Unreadable = fmt.Errorf("function %s is inlined", fn.Name)
+			}
 			return r, nil
 		}
 	}
@@ -785,27 +808,31 @@ func (scope *EvalScope) evalBuiltinCall(node *ast.CallExpr) (*Variable, error) {
 		return nil, nil
 	}
 
-	args := make([]*Variable, len(node.Args))
+	callBuiltinWithArgs := func(builtin func([]*Variable, []ast.Expr) (*Variable, error)) (*Variable, error) {
+		args := make([]*Variable, len(node.Args))
 
-	for i := range node.Args {
-		v, err := scope.evalAST(node.Args[i])
-		if err != nil {
-			return nil, err
+		for i := range node.Args {
+			v, err := scope.evalAST(node.Args[i])
+			if err != nil {
+				return nil, err
+			}
+			args[i] = v
 		}
-		args[i] = v
+
+		return builtin(args, node.Args)
 	}
 
 	switch fnnode.Name {
 	case "cap":
-		return capBuiltin(args, node.Args)
+		return callBuiltinWithArgs(capBuiltin)
 	case "len":
-		return lenBuiltin(args, node.Args)
+		return callBuiltinWithArgs(lenBuiltin)
 	case "complex":
-		return complexBuiltin(args, node.Args)
+		return callBuiltinWithArgs(complexBuiltin)
 	case "imag":
-		return imagBuiltin(args, node.Args)
+		return callBuiltinWithArgs(imagBuiltin)
 	case "real":
-		return realBuiltin(args, node.Args)
+		return callBuiltinWithArgs(realBuiltin)
 	}
 
 	return nil, nil

--- a/pkg/proc/proc_unexported_test.go
+++ b/pkg/proc/proc_unexported_test.go
@@ -1,0 +1,75 @@
+package proc
+
+import (
+	"testing"
+)
+
+func TestAlignAddr(t *testing.T) {
+	c := func(align, in, tgt int64) {
+		out := alignAddr(in, align)
+		if out != tgt {
+			t.Errorf("alignAddr(%x, %x) = %x, expected %x", in, align, out, tgt)
+		}
+	}
+
+	for i := int64(0); i <= 0xf; i++ {
+		c(1, i, i)
+		c(1, i+0x10000, i+0x10000)
+	}
+
+	for _, example := range []struct{ align, in, tgt int64 }{
+		{2, 0, 0},
+		{2, 1, 2},
+		{2, 2, 2},
+		{2, 3, 4},
+		{2, 4, 4},
+		{2, 5, 6},
+		{2, 6, 6},
+		{2, 7, 8},
+		{2, 8, 8},
+		{2, 9, 0xa},
+		{2, 0xa, 0xa},
+		{2, 0xb, 0xc},
+		{2, 0xc, 0xc},
+		{2, 0xd, 0xe},
+		{2, 0xe, 0xe},
+		{2, 0xf, 0x10},
+
+		{4, 0, 0},
+		{4, 1, 4},
+		{4, 2, 4},
+		{4, 3, 4},
+		{4, 4, 4},
+		{4, 5, 8},
+		{4, 6, 8},
+		{4, 7, 8},
+		{4, 8, 8},
+		{4, 9, 0xc},
+		{4, 0xa, 0xc},
+		{4, 0xb, 0xc},
+		{4, 0xc, 0xc},
+		{4, 0xd, 0x10},
+		{4, 0xe, 0x10},
+		{4, 0xf, 0x10},
+
+		{8, 0, 0},
+		{8, 1, 8},
+		{8, 2, 8},
+		{8, 3, 8},
+		{8, 4, 8},
+		{8, 5, 8},
+		{8, 6, 8},
+		{8, 7, 8},
+		{8, 8, 8},
+		{8, 9, 0x10},
+		{8, 0xa, 0x10},
+		{8, 0xb, 0x10},
+		{8, 0xc, 0x10},
+		{8, 0xd, 0x10},
+		{8, 0xe, 0x10},
+		{8, 0xf, 0x10},
+	} {
+		c(example.align, example.in, example.tgt)
+		c(example.align, example.in+0x10000, example.tgt+0x10000)
+	}
+}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1110,7 +1110,7 @@ func TestCallFunction(t *testing.T) {
 		{"callpanic()", []string{`~panic:interface {}:interface {}(string) "callpanic panicked"`}, nil},
 		{`stringsJoin(nil, "")`, []string{`:string:""`}, nil},
 		{`stringsJoin(stringslice, comma)`, []string{`:string:"one,two,three"`}, nil},
-		{`stringsJoin(s1, comma)`, nil, errors.New("could not find symbol value for s1")},
+		{`stringsJoin(s1, comma)`, nil, errors.New(`error evaluating "s1" as argument v in function main.stringsJoin: could not find symbol value for s1`)},
 		{`stringsJoin(intslice, comma)`, nil, errors.New("can not convert value of type []int to []string")},
 		{`noreturncall(2)`, nil, nil},
 
@@ -1172,6 +1172,15 @@ func TestCallFunction(t *testing.T) {
 		// string allocation requires trusted argument order, which we don't have in Go 1.11
 		{`stringsJoin(stringslice, ",")`, []string{`:string:"one,two,three"`}, nil},
 		{`str = "a new string"; str`, []string{`str:string:"a new string"`}, nil},
+
+		// support calling optimized functions
+		{`strings.Join(nil, "")`, []string{`:string:""`}, nil},
+		{`strings.Join(stringslice, comma)`, []string{`:string:"one,two,three"`}, nil},
+		{`strings.Join(s1, comma)`, nil, errors.New(`error evaluating "s1" as argument a in function strings.Join: could not find symbol value for s1`)},
+		{`strings.Join(intslice, comma)`, nil, errors.New("can not convert value of type []int to []string")},
+		{`strings.Join(stringslice, ",")`, []string{`:string:"one,two,three"`}, nil},
+		{`strings.LastIndexByte(stringslice[1], 'w')`, []string{":int:1"}, nil},
+		{`strings.LastIndexByte(stringslice[1], 'o')`, []string{":int:2"}, nil},
 	}
 
 	var testcases113 = []testCaseCallFunction{


### PR DESCRIPTION
```
proc: allow calls to optimized functions

Trust argument order to determine argument frame layout when calling
functions, this allows calling optimized functions and removes the
special cases for runtime.mallocgc.

Fixes #1589

```
