### PR TITLE
scripts: Add 'make uninstall' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ build:
 install:
 	@go run scripts/make.go install
 
+uninstall:
+	@go run scripts/make.go uninstall
+
 test:
 	@go run scripts/make.go test
 

--- a/scripts/make.go
+++ b/scripts/make.go
@@ -54,6 +54,14 @@ func NewMakeCommands() *cobra.Command {
 		},
 	})
 
+	RootCommand.AddCommand(&cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstalls delve",
+		Run: func(cmd *cobra.Command, args []string) {
+			execute("go", "clean", "-i", DelveMainPackagePath)
+		},
+	})
+
 	test := &cobra.Command{
 		Use:   "test",
 		Short: "Tests delve",


### PR DESCRIPTION
This change adds the `make uninstall` command which will uninstall delve.