### PR TITLE
travis: bump continuous integration to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ os:
 
 go:
   - tip
+  - 1.13.x
   - 1.12.x
   - 1.11.x
-  - 1.10.x
 
 matrix:
   allow_failures:

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	minSupportedVersionOfGoMinor = 10
+	minSupportedVersionOfGoMinor = 11
 	maxSupportedVersionOfGoMinor = 13
 	goTooOldErr                  = fmt.Errorf("Version of Go is too old for this version of Delve (minimum supported version 1.%d, suppress this error with --check-go-version=false)", minSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Errorf("Version of Delve is too old for this version of Go (maximum supported version 1.%d, suppress this error with --check-go-version=false)", maxSupportedVersionOfGoMinor)


### PR DESCRIPTION
```
travis: bump continuous integration to 1.13

Bump continuous integration to include Go 1.13, drop 1.10 from
compatiblity file.

```
