### PR TITLE
pkg/proc/core: add error details when reading spliced memory

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -113,8 +113,11 @@ func (r *SplicedMemory) ReadMemory(buf []byte, addr uintptr) (n int, err error) 
 		}
 		pn, err := entry.reader.ReadMemory(pb, addr)
 		n += pn
-		if err != nil || pn != len(pb) {
-			return n, err
+		if err != nil {
+			return n, fmt.Errorf("error while reading spliced memory at %#x: %v", addr, err)
+		}
+		if pn != len(pb) {
+			return n, nil
 		}
 		buf = buf[pn:]
 		addr += uintptr(pn)


### PR DESCRIPTION
The origin error message is confusing, so add some details.

Fixes #1700   

-----   

I not sure whether the change is reasonable. So I will close this pr if disagree.   

-----   

This [ci](https://ci.appveyor.com/project/derekparker/delve-facy3/builds/27721539) failed, but it doesn't seem to have anything to do with my changes.