### PR TITLE
*: add option to re-record recorded targets

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -49,7 +49,7 @@ threads() | Equivalent to API call [ListThreads](https://godoc.org/github.com/go
 types(Filter) | Equivalent to API call [ListTypes](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListTypes)
 process_pid() | Equivalent to API call [ProcessPid](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ProcessPid)
 recorded() | Equivalent to API call [Recorded](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Recorded)
-restart(Position, ResetArgs, NewArgs) | Equivalent to API call [Restart](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Restart)
+restart(Position, ResetArgs, NewArgs, Rerecord) | Equivalent to API call [Restart](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Restart)
 set_expr(Scope, Symbol, Value) | Equivalent to API call [Set](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Set)
 stacktrace(Id, Depth, Full, Defers, Opts, Cfg) | Equivalent to API call [Stacktrace](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Stacktrace)
 state(NonBlocking) | Equivalent to API call [State](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.State)

--- a/_fixtures/testrerecord.go
+++ b/_fixtures/testrerecord.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	t := time.Now().Unix()
+	fmt.Println(t)
+}

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -560,13 +560,6 @@ func connect(addr string, clientConn net.Conn, conf *config.Config, kind execute
 			}
 		}
 	}
-	if client.Recorded() && (kind == executingGeneratedFile || kind == executingGeneratedTest) {
-		// When using the rr backend remove the trace directory if we built the
-		// executable
-		if tracedir, err := client.TraceDirectory(); err == nil {
-			defer SafeRemoveAll(tracedir)
-		}
-	}
 	term := terminal.New(client, conf)
 	term.InitFile = InitFile
 	status, err := term.Run()
@@ -740,29 +733,4 @@ func gocommand(command string, args ...string) error {
 	goBuild := exec.Command("go", allargs...)
 	goBuild.Stderr = os.Stderr
 	return goBuild.Run()
-}
-
-// SafeRemoveAll removes dir and its contents but only as long as dir does
-// not contain directories.
-func SafeRemoveAll(dir string) {
-	dh, err := os.Open(dir)
-	if err != nil {
-		return
-	}
-	defer dh.Close()
-	fis, err := dh.Readdir(-1)
-	if err != nil {
-		return
-	}
-	for _, fi := range fis {
-		if fi.IsDir() {
-			return
-		}
-	}
-	for _, fi := range fis {
-		if err := os.Remove(filepath.Join(dir, fi.Name())); err != nil {
-			return
-		}
-	}
-	os.Remove(dir)
 }

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-delve/delve/cmd/dlv/cmds"
 	protest "github.com/go-delve/delve/pkg/proc/test"
 	"github.com/go-delve/delve/pkg/terminal"
 	"github.com/go-delve/delve/service/rpc2"
@@ -284,7 +283,7 @@ func TestGeneratedDoc(t *testing.T) {
 	// Checks gen-usage-docs.go
 	tempDir, err := ioutil.TempDir(os.TempDir(), "test-gen-doc")
 	assertNoError(err, t, "TempDir")
-	defer cmds.SafeRemoveAll(tempDir)
+	defer protest.SafeRemoveAll(tempDir)
 	cmd := exec.Command("go", "run", "scripts/gen-usage-docs.go", tempDir)
 	cmd.Dir = projectRoot()
 	cmd.Run()

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -124,6 +124,8 @@ type Process struct {
 	process  *os.Process
 	waitChan chan *os.ProcessState
 
+	onDetach func() // called after a successful detach
+
 	common proc.CommonProcess
 }
 
@@ -866,6 +868,9 @@ func (p *Process) Detach(kill bool) error {
 		p.process = nil
 	}
 	p.detached = true
+	if p.onDetach != nil {
+		p.onDetach()
+	}
 	return p.bi.Close()
 }
 

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -38,9 +38,6 @@ func withTestRecording(name string, t testing.TB, fn func(p *gdbserial.Process, 
 
 	defer func() {
 		p.Detach(true)
-		if tracedir != "" {
-			protest.SafeRemoveAll(tracedir)
-		}
 	}()
 
 	fn(p, fixture)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -84,9 +84,6 @@ func withTestProcessArgs(name string, t testing.TB, wd string, args []string, bu
 
 	defer func() {
 		p.Detach(true)
-		if tracedir != "" {
-			protest.SafeRemoveAll(tracedir)
-		}
 	}()
 
 	fn(p, fixture)

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -161,11 +161,7 @@ func withTestTerminalBuildFlags(name string, t testing.TB, buildFlags test.Build
 	}
 	client := rpc2.NewClient(listener.Addr().String())
 	defer func() {
-		dir, _ := client.TraceDirectory()
 		client.Detach(true)
-		if dir != "" {
-			test.SafeRemoveAll(dir)
-		}
 	}()
 
 	ft := &FakeTerminal{

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -998,6 +998,12 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 3 && args[3] != starlark.None {
+			err := unmarshalStarlarkValue(args[3], &rpcArgs.Rerecord, "Rerecord")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
@@ -1007,6 +1013,8 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.ResetArgs, "ResetArgs")
 			case "NewArgs":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.NewArgs, "NewArgs")
+			case "Rerecord":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Rerecord, "Rerecord")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}

--- a/service/client.go
+++ b/service/client.go
@@ -21,7 +21,7 @@ type Client interface {
 	// Restarts program.
 	Restart() ([]api.DiscardedBreakpoint, error)
 	// Restarts program from the specified position.
-	RestartFrom(pos string, resetArgs bool, newArgs []string) ([]api.DiscardedBreakpoint, error)
+	RestartFrom(rerecord bool, pos string, resetArgs bool, newArgs []string) ([]api.DiscardedBreakpoint, error)
 
 	// GetState returns the current debugger state.
 	GetState() (*api.DebuggerState, error)

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -40,7 +40,7 @@ func (s *RPCServer) Restart(arg1 interface{}, arg2 *int) error {
 	if s.config.AttachPid != 0 {
 		return errors.New("cannot restart process Delve did not create")
 	}
-	_, err := s.debugger.Restart("", false, nil)
+	_, err := s.debugger.Restart(false, "", false, nil)
 	return err
 }
 

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -62,13 +62,13 @@ func (c *RPCClient) Detach(kill bool) error {
 
 func (c *RPCClient) Restart() ([]api.DiscardedBreakpoint, error) {
 	out := new(RestartOut)
-	err := c.call("Restart", RestartIn{"", false, nil}, out)
+	err := c.call("Restart", RestartIn{"", false, nil, false}, out)
 	return out.DiscardedBreakpoints, err
 }
 
-func (c *RPCClient) RestartFrom(pos string, resetArgs bool, newArgs []string) ([]api.DiscardedBreakpoint, error) {
+func (c *RPCClient) RestartFrom(rerecord bool, pos string, resetArgs bool, newArgs []string) ([]api.DiscardedBreakpoint, error) {
 	out := new(RestartOut)
-	err := c.call("Restart", RestartIn{pos, resetArgs, newArgs}, out)
+	err := c.call("Restart", RestartIn{pos, resetArgs, newArgs, rerecord}, out)
 	return out.DiscardedBreakpoints, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -73,6 +73,9 @@ type RestartIn struct {
 	// NewArgs are arguments to launch a new process.  They replace only the
 	// argv[1] and later. Argv[0] cannot be changed.
 	NewArgs []string
+
+	// When Rerecord is set the target will be rerecorded
+	Rerecord bool
 }
 
 type RestartOut struct {
@@ -85,7 +88,7 @@ func (s *RPCServer) Restart(arg RestartIn, out *RestartOut) error {
 		return errors.New("cannot restart process Delve did not create")
 	}
 	var err error
-	out.DiscardedBreakpoints, err = s.debugger.Restart(arg.Position, arg.ResetArgs, arg.NewArgs)
+	out.DiscardedBreakpoints, err = s.debugger.Restart(arg.Rerecord, arg.Position, arg.ResetArgs, arg.NewArgs)
 	return err
 }
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -138,9 +138,6 @@ func withTestProcessArgs(name string, t *testing.T, wd string, args []string, bu
 
 	defer func() {
 		p.Detach(true)
-		if tracedir != "" {
-			protest.SafeRemoveAll(tracedir)
-		}
 	}()
 
 	fn(p, fixture)


### PR DESCRIPTION
```
*: add option to re-record recorded targets

Adds a '-r' option to the 'restart' command (and to the Restart API)
that re-records the target when using rr.

Also moves the code to delete the trace directory inside the gdbserial
package.

```
