### PR TITLE
service/debugger: make Disassemble work without a selected goroutine

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1175,13 +1175,13 @@ func (d *Debugger) Disassemble(goroutineID int, addr1, addr2 uint64, flavour api
 		return nil, err
 	}
 
-	var regs proc.Registers
-	var mem proc.MemoryReadWriter = d.target.CurrentThread()
-	if g.Thread != nil {
-		mem = g.Thread
-		regs, _ = g.Thread.Registers(false)
+	curthread := d.target.CurrentThread()
+	if g != nil && g.Thread != nil {
+		curthread = g.Thread
 	}
-	insts, err := proc.Disassemble(mem, regs, d.target.Breakpoints(), d.target.BinInfo(), addr1, addr2)
+	regs, _ := curthread.Registers(false)
+
+	insts, err := proc.Disassemble(curthread, regs, d.target.Breakpoints(), d.target.BinInfo(), addr1, addr2)
 	if err != nil {
 		return nil, err
 	}

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1718,3 +1718,15 @@ func TestUnknownMethodCall(t *testing.T) {
 		t.Errorf("wrong error message: %v", err)
 	}
 }
+
+func TestIssue1703(t *testing.T) {
+	// Calling Disassemble when there is no current goroutine should work.
+	withTestClient2("testnextprog", t, func(c service.Client) {
+		locs, err := c.FindLocation(api.EvalScope{GoroutineID: -1}, "main.main")
+		assertNoError(err, t, "FindLocation")
+		t.Logf("FindLocation: %#v", locs)
+		text, err := c.DisassemblePC(api.EvalScope{GoroutineID: -1}, locs[0].PC, api.IntelFlavour)
+		assertNoError(err, t, "DisassemblePC")
+		t.Logf("text: %#v\n", text)
+	})
+}


### PR DESCRIPTION
```
service/debugger: make Disassemble work without a selected goroutine

The Disassemble API call should work when there is no selected
goroutine (for example because the program was just started).

Fixes #1703

```
