### PR TITLE
tests: fix TestGeneratedDoc

### DIFF
--- a/Documentation/usage/dlv_backend.md
+++ b/Documentation/usage/dlv_backend.md
@@ -25,7 +25,7 @@ are:
       --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "localhost:0")
+  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')

--- a/Documentation/usage/dlv_log.md
+++ b/Documentation/usage/dlv_log.md
@@ -39,7 +39,7 @@ mode.
       --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
       --headless             Run debug server only, in headless mode.
       --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "localhost:0")
+  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -285,7 +285,9 @@ func TestGeneratedDoc(t *testing.T) {
 	tempDir, err := ioutil.TempDir(os.TempDir(), "test-gen-doc")
 	assertNoError(err, t, "TempDir")
 	defer cmds.SafeRemoveAll(tempDir)
-	exec.Command("go", "run", "scripts/gen-usage-docs.go", tempDir).Run()
+	cmd := exec.Command("go", "run", "scripts/gen-usage-docs.go", tempDir)
+	cmd.Dir = projectRoot()
+	cmd.Run()
 	entries, err := ioutil.ReadDir(tempDir)
 	assertNoError(err, t, "ReadDir")
 	for _, doc := range entries {


### PR DESCRIPTION
```
tests: fix TestGeneratedDoc

It was failing silently.

```
