### PR TITLE
proc: GetG should check that loc isn't nil before accessing its members

### DIFF
--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -478,7 +478,7 @@ func newGVariable(thread Thread, gaddr uintptr, deref bool) (*Variable, error) {
 // In order to get around all this craziness, we read the address of the G structure for
 // the current thread from the thread local storage area.
 func GetG(thread Thread) (*G, error) {
-	if loc, _ := thread.Location(); loc.Fn != nil && loc.Fn.Name == "runtime.clone" {
+	if loc, _ := thread.Location(); loc != nil && loc.Fn != nil && loc.Fn.Name == "runtime.clone" {
 		// When threads are executing runtime.clone the value of TLS is unreliable.
 		return nil, nil
 	}


### PR DESCRIPTION
```
proc: GetG should check that loc isn't nil before accessing its members

Updates #1711

```
