### PR TITLE
proc,debugger: implement logical breakpoints

### DIFF
--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -73,16 +73,16 @@ func (v packageVarsByAddr) Less(i int, j int) bool { return v[i].addr < v[j].add
 func (v packageVarsByAddr) Swap(i int, j int)      { v[i], v[j] = v[j], v[i] }
 
 type loadDebugInfoMapsContext struct {
-	ardr                    *reader.Reader
-	abstractOriginNameTable map[dwarf.Offset]string
-	knownPackageVars        map[string]struct{}
+	ardr                *reader.Reader
+	abstractOriginTable map[dwarf.Offset]int
+	knownPackageVars    map[string]struct{}
 }
 
 func newLoadDebugInfoMapsContext(bi *BinaryInfo, image *Image) *loadDebugInfoMapsContext {
 	ctxt := &loadDebugInfoMapsContext{}
 
 	ctxt.ardr = image.DwarfReader()
-	ctxt.abstractOriginNameTable = make(map[dwarf.Offset]string)
+	ctxt.abstractOriginTable = make(map[dwarf.Offset]int)
 
 	ctxt.knownPackageVars = map[string]struct{}{}
 	for _, v := range bi.packageVars {

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -39,15 +39,17 @@ type DebuggerState struct {
 	Err error `json:"-"`
 }
 
-// Breakpoint addresses a location at which process execution may be
+// Breakpoint addresses a set of locations at which process execution may be
 // suspended.
 type Breakpoint struct {
 	// ID is a unique identifier for the breakpoint.
 	ID int `json:"id"`
-	// User defined name of the breakpoint
+	// User defined name of the breakpoint.
 	Name string `json:"name"`
-	// Addr is the address of the breakpoint.
+	// Addr is deprecated, use Addrs.
 	Addr uint64 `json:"addr"`
+	// Addrs is the list of addresses for this breakpoint.
+	Addrs []uint64 `json:"addrs"`
 	// File is the source file for the breakpoint.
 	File string `json:"file"`
 	// Line is a line in File for the breakpoint.

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1070,11 +1070,14 @@ func setFunctionBreakpoint(p proc.Process, t testing.TB, fname string) *proc.Bre
 	_, f, l, _ := runtime.Caller(1)
 	f = filepath.Base(f)
 
-	addr, err := proc.FindFunctionLocation(p, fname, 0)
+	addrs, err := proc.FindFunctionLocation(p, fname, 0)
 	if err != nil {
 		t.Fatalf("%s:%d: FindFunctionLocation(%s): %v", f, l, fname, err)
 	}
-	bp, err := p.SetBreakpoint(addr, proc.UserBreakpoint, nil)
+	if len(addrs) != 1 {
+		t.Fatalf("%s:%d: setFunctionBreakpoint(%s): too many results %v", f, l, fname, addrs)
+	}
+	bp, err := p.SetBreakpoint(addrs[0], proc.UserBreakpoint, nil)
 	if err != nil {
 		t.Fatalf("%s:%d: FindFunctionLocation(%s): %v", f, l, fname, err)
 	}
@@ -1352,11 +1355,14 @@ func setFileBreakpoint(p proc.Process, t *testing.T, fixture protest.Fixture, li
 	_, f, l, _ := runtime.Caller(1)
 	f = filepath.Base(f)
 
-	addr, err := proc.FindFileLocation(p, fixture.Source, lineno)
+	addrs, err := proc.FindFileLocation(p, fixture.Source, lineno)
 	if err != nil {
 		t.Fatalf("%s:%d: FindFileLocation(%s, %d): %v", f, l, fixture.Source, lineno, err)
 	}
-	bp, err := p.SetBreakpoint(addr, proc.UserBreakpoint, nil)
+	if len(addrs) != 1 {
+		t.Fatalf("%s:%d: setFileLineBreakpoint(%s, %d): too many results %v", f, l, fixture.Source, lineno, addrs)
+	}
+	bp, err := p.SetBreakpoint(addrs[0], proc.UserBreakpoint, nil)
 	if err != nil {
 		t.Fatalf("%s:%d: SetBreakpoint: %v", f, l, err)
 	}


### PR DESCRIPTION
```
proc,debugger: implement logical breakpoints

Modifies FindFileLocation, FindFunctionLocation and LineToPC as well as
service/debugger to support inlining and introduces the concept of
logical breakpoints.

For inlined functions FindFileLocation, FindFunctionLocation and
LineToPC will now return one PC address for each inlining and one PC
for the concrete implementation of the function (if present).

A proc.Breakpoint will continue to represent a physical breakpoint, at
a single memory location.

Breakpoints returned by service/debugger, however, will represent
logical breakpoints and may be associated with multiple memory
locations and, therefore, multiple proc.Breakpoints.

The necessary logic is introduced in service/debugger so that a change
to a logical breakpoint will be mirrored to all its physical
breakpoints and physical breakpoints are aggregated into a single
logical breakpoint when returned.

```
