### PR TITLE
proc: better handling of bad DW_TAG_inlined_subroutine without debug_line

### DIFF
--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -322,6 +322,10 @@ func (lineInfo *DebugLineInfo) LineToPC(filename string, lineno int) uint64 {
 
 // PrologueEndPC returns the first PC address marked as prologue_end in the half open interval [start, end)
 func (lineInfo *DebugLineInfo) PrologueEndPC(start, end uint64) (pc uint64, file string, line int, ok bool) {
+	if lineInfo == nil {
+		return 0, "", 0, false
+	}
+
 	sm := lineInfo.stateMachineForEntry(start)
 	for {
 		if sm.valid {

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1608,6 +1608,11 @@ func (bi *BinaryInfo) loadDebugInfoMapsInlinedCalls(ctxt *loadDebugInfoMapsConte
 				reader.SkipChildren()
 				continue
 			}
+			if cu.lineInfo == nil {
+				bi.logger.Errorf("Error reading debug_info: inlined call on a compilation unit without debug_line section at %#x", entry.Offset)
+				reader.SkipChildren()
+				continue
+			}
 			if int(callfileidx-1) >= len(cu.lineInfo.FileNames) {
 				bi.logger.Errorf("Error reading debug_info: CallFile (%d) of inlined call does not exist in compile unit file table at %#x", callfileidx, entry.Offset)
 				reader.SkipChildren()


### PR DESCRIPTION
```
proc: better handling of bad DW_TAG_inlined_subroutine without debug_line

Avoid crashing with nil pointer dereference, signal error instead.

Fixes #1720

```
