### PR TITLE
Go 1.14 support branch

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -63,7 +63,7 @@ func projectRoot() string {
 			return filepath.Join(curpath, "src", "github.com", "go-delve", "delve")
 		}
 	}
-	val, err := exec.Command("go", "list", "-m", "-f", "{{ .Dir }}").Output()
+	val, err := exec.Command("go", "list", "-mod=", "-m", "-f", "{{ .Dir }}").Output()
 	if err != nil {
 		panic(err) // the Go tool was tested to work earlier
 	}

--- a/pkg/dwarf/line/line_parser.go
+++ b/pkg/dwarf/line/line_parser.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-delve/delve/pkg/dwarf/util"
 )
@@ -34,9 +35,12 @@ type DebugLineInfo struct {
 
 	// lastMachineCache[pc] is a state machine stopped at an address after pc
 	lastMachineCache map[uint64]*StateMachine
-	
+
 	// staticBase is the address at which the executable is loaded, 0 for non-PIEs
 	staticBase uint64
+
+	// if normalizeBackslash is true all backslashes (\) will be converted into forward slashes (/)
+	normalizeBackslash bool
 }
 
 type FileEntry struct {
@@ -49,7 +53,7 @@ type FileEntry struct {
 type DebugLines []*DebugLineInfo
 
 // ParseAll parses all debug_line segments found in data
-func ParseAll(data []byte, logfn func(string, ...interface{}), staticBase uint64) DebugLines {
+func ParseAll(data []byte, logfn func(string, ...interface{}), staticBase uint64, normalizeBackslash bool) DebugLines {
 	var (
 		lines = make(DebugLines, 0)
 		buf   = bytes.NewBuffer(data)
@@ -57,7 +61,7 @@ func ParseAll(data []byte, logfn func(string, ...interface{}), staticBase uint64
 
 	// We have to parse multiple file name tables here.
 	for buf.Len() > 0 {
-		lines = append(lines, Parse("", buf, logfn, staticBase))
+		lines = append(lines, Parse("", buf, logfn, staticBase, normalizeBackslash))
 	}
 
 	return lines
@@ -65,7 +69,7 @@ func ParseAll(data []byte, logfn func(string, ...interface{}), staticBase uint64
 
 // Parse parses a single debug_line segment from buf. Compdir is the
 // DW_AT_comp_dir attribute of the associated compile unit.
-func Parse(compdir string, buf *bytes.Buffer, logfn func(string, ...interface{}), staticBase uint64) *DebugLineInfo {
+func Parse(compdir string, buf *bytes.Buffer, logfn func(string, ...interface{}), staticBase uint64, normalizeBackslash bool) *DebugLineInfo {
 	dbl := new(DebugLineInfo)
 	dbl.Logf = logfn
 	dbl.staticBase = staticBase
@@ -76,6 +80,7 @@ func Parse(compdir string, buf *bytes.Buffer, logfn func(string, ...interface{})
 
 	dbl.stateMachineCache = make(map[uint64]*StateMachine)
 	dbl.lastMachineCache = make(map[uint64]*StateMachine)
+	dbl.normalizeBackslash = normalizeBackslash
 
 	parseDebugLinePrologue(dbl, buf)
 	parseIncludeDirs(dbl, buf)
@@ -137,6 +142,10 @@ func readFileEntry(info *DebugLineInfo, buf *bytes.Buffer, exitOnEmptyPath bool)
 	entry.Path, _ = util.ParseString(buf)
 	if entry.Path == "" && exitOnEmptyPath {
 		return entry
+	}
+
+	if info.normalizeBackslash {
+		entry.Path = strings.Replace(entry.Path, "\\", "/", -1)
 	}
 
 	entry.DirIdx, _ = util.DecodeULEB128(buf)

--- a/pkg/dwarf/line/line_parser_test.go
+++ b/pkg/dwarf/line/line_parser_test.go
@@ -67,7 +67,7 @@ const (
 
 func testDebugLinePrologueParser(p string, t *testing.T) {
 	data := grabDebugLineSection(p, t)
-	debugLines := ParseAll(data, nil, 0)
+	debugLines := ParseAll(data, nil, 0, true)
 
 	mainFileFound := false
 
@@ -164,7 +164,7 @@ func BenchmarkLineParser(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = ParseAll(data, nil, 0)
+		_ = ParseAll(data, nil, 0, true)
 	}
 }
 
@@ -179,7 +179,7 @@ func loadBenchmarkData(tb testing.TB) DebugLines {
 		tb.Fatal("Could not read test data", err)
 	}
 
-	return ParseAll(data, nil, 0)
+	return ParseAll(data, nil, 0, true)
 }
 
 func BenchmarkStateMachine(b *testing.B) {

--- a/pkg/dwarf/line/state_machine_test.go
+++ b/pkg/dwarf/line/state_machine_test.go
@@ -80,7 +80,7 @@ func TestGrafana(t *testing.T) {
 		}
 		cuname, _ := e.Val(dwarf.AttrName).(string)
 
-		lineInfo := Parse(e.Val(dwarf.AttrCompDir).(string), debugLineBuffer, t.Logf, 0)
+		lineInfo := Parse(e.Val(dwarf.AttrCompDir).(string), debugLineBuffer, t.Logf, 0, false)
 		sm := newStateMachine(lineInfo, lineInfo.Instructions)
 
 		lnrdr, err := data.LineReader(e)

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -8,7 +8,7 @@ var (
 	MinSupportedVersionOfGoMajor = 1
 	MinSupportedVersionOfGoMinor = 11
 	MaxSupportedVersionOfGoMajor = 1
-	MaxSupportedVersionOfGoMinor = 13
+	MaxSupportedVersionOfGoMinor = 14
 	goTooOldErr                  = fmt.Errorf("Version of Go is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Errorf("Version of Delve is too old for this version of Go (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
 )

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1327,7 +1327,7 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugLineBytes []byte, wg 
 						logger.Printf(fmt, args)
 					}
 				}
-				cu.lineInfo = line.Parse(compdir, bytes.NewBuffer(debugLineBytes[lineInfoOffset:]), logfn, image.StaticBase)
+				cu.lineInfo = line.Parse(compdir, bytes.NewBuffer(debugLineBytes[lineInfoOffset:]), logfn, image.StaticBase, bi.GOOS == "windows")
 			}
 			cu.producer, _ = entry.Val(dwarf.AttrProducer).(string)
 			if cu.isgo && cu.producer != "" {

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -216,7 +216,7 @@ func OpenCore(corePath, exePath string, debugInfoDirs []string) (*proc.Target, e
 		return nil, err
 	}
 
-	return proc.NewTarget(p), nil
+	return proc.NewTarget(p, false), nil
 }
 
 // initialize for core files doesn't do much

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -135,7 +135,8 @@ type Thread struct {
 	regs              gdbRegisters
 	CurrentBreakpoint proc.BreakpointState
 	p                 *Process
-	setbp             bool // thread was stopped because of a breakpoint
+	sig               uint8 // signal received by thread after last stop
+	setbp             bool  // thread was stopped because of a breakpoint
 	common            proc.CommonThread
 }
 
@@ -646,13 +647,15 @@ func (p *Process) ContinueOnce() (proc.Thread, error) {
 
 	// resume all threads
 	var threadID string
-	var sig uint8
+	var trapthread *Thread
 	var tu = threadUpdater{p: p}
-	var err error
 continueLoop:
 	for {
+		var err error
+		var sig uint8
 		tu.Reset()
-		threadID, sig, err = p.conn.resume(sig, threadID, &tu)
+		//TODO: pass thread list to resume, which should use it to pass the correct signals
+		threadID, sig, err = p.conn.resume(p.threads, &tu)
 		if err != nil {
 			if _, exited := err.(proc.ErrProcessExited); exited {
 				p.exited = true
@@ -660,45 +663,25 @@ continueLoop:
 			return nil, err
 		}
 
-		// 0x5 is always a breakpoint, a manual stop either manifests as 0x13
-		// (lldb), 0x11 (debugserver) or 0x2 (gdbserver).
-		// Since 0x2 could also be produced by the user
-		// pressing ^C (in which case it should be passed to the inferior) we need
-		// the ctrlC flag to know that we are the originators.
-		switch sig {
-		case interruptSignal: // interrupt
-			if p.getCtrlC() {
-				break continueLoop
-			}
-		case breakpointSignal: // breakpoint
+		// For stubs that support qThreadStopInfo updateThreadListNoRegisters will
+		// find out the reason why each thread stopped.
+		p.updateThreadListNoRegisters(&tu)
+
+		trapthread = p.findThreadByStrID(threadID)
+		if trapthread != nil && !p.threadStopInfo {
+			// For stubs that do not support qThreadStopInfo we manually set the
+			// reason the thread returned by resume() stopped.
+			trapthread.sig = sig
+		}
+
+		var shouldStop bool
+		trapthread, shouldStop = p.handleThreadSignals(trapthread)
+		if shouldStop {
 			break continueLoop
-		case childSignal: // stop on debugserver but SIGCHLD on lldb-server/linux
-			if p.conn.isDebugserver {
-				break continueLoop
-			}
-		case stopSignal: // stop
-			break continueLoop
-
-		// The following are fake BSD-style signals sent by debugserver
-		// Unfortunately debugserver can not convert them into signals for the
-		// process so we must stop here.
-		case debugServerTargetExcBadAccess, debugServerTargetExcBadInstruction, debugServerTargetExcArithmetic, debugServerTargetExcEmulation, debugServerTargetExcSoftware, debugServerTargetExcBreakpoint:
-
-			break continueLoop
-
-		// Signal 0 is returned by rr when it reaches the start of the process
-		// in backward continue mode.
-		case 0:
-			if p.conn.direction == proc.Backward {
-				break continueLoop
-			}
-
-		default:
-			// any other signal is always propagated to inferior
 		}
 	}
 
-	if err := p.updateThreadList(&tu); err != nil {
+	if err := p.updateThreadRegisters(); err != nil {
 		return nil, err
 	}
 
@@ -712,28 +695,115 @@ continueLoop:
 		return nil, err
 	}
 
+	if trapthread == nil {
+		return nil, fmt.Errorf("could not find thread %s", threadID)
+	}
+
+	var err error
+	switch trapthread.sig {
+	case 0x91:
+		err = errors.New("bad access")
+	case 0x92:
+		err = errors.New("bad instruction")
+	case 0x93:
+		err = errors.New("arithmetic exception")
+	case 0x94:
+		err = errors.New("emulation exception")
+	case 0x95:
+		err = errors.New("software exception")
+	case 0x96:
+		err = errors.New("breakpoint exception")
+	}
+	if err != nil {
+		// the signals that are reported here can not be propagated back to the target process.
+		trapthread.sig = 0
+	}
+	return trapthread, err
+}
+
+func (p *Process) findThreadByStrID(threadID string) *Thread {
 	for _, thread := range p.threads {
 		if thread.strID == threadID {
-			var err error
-			switch sig {
-			case 0x91:
-				err = errors.New("bad access")
-			case 0x92:
-				err = errors.New("bad instruction")
-			case 0x93:
-				err = errors.New("arithmetic exception")
-			case 0x94:
-				err = errors.New("emulation exception")
-			case 0x95:
-				err = errors.New("software exception")
-			case 0x96:
-				err = errors.New("breakpoint exception")
+			return thread
+		}
+	}
+	return nil
+}
+
+// handleThreadSignals looks at the signals received by each thread and
+// decides which ones to mask and which ones to propagate back to the target
+// and returns true if we should stop execution in response to one of the
+// signals and return control to the user.
+// Adjusts trapthread to a thread that we actually want to stop at.
+func (p *Process) handleThreadSignals(trapthread *Thread) (trapthreadOut *Thread, shouldStop bool) {
+	var trapthreadCandidate *Thread
+
+	for _, th := range p.threads {
+		isStopSignal := false
+
+		// 0x5 is always a breakpoint, a manual stop either manifests as 0x13
+		// (lldb), 0x11 (debugserver) or 0x2 (gdbserver).
+		// Since 0x2 could also be produced by the user
+		// pressing ^C (in which case it should be passed to the inferior) we need
+		// the ctrlC flag to know that we are the originators.
+		switch th.sig {
+		case interruptSignal: // interrupt
+			if p.getCtrlC() {
+				isStopSignal = true
 			}
-			return thread, err
+		case breakpointSignal: // breakpoint
+			isStopSignal = true
+		case childSignal: // stop on debugserver but SIGCHLD on lldb-server/linux
+			if p.conn.isDebugserver {
+				isStopSignal = true
+			}
+		case stopSignal: // stop
+			isStopSignal = true
+
+		// The following are fake BSD-style signals sent by debugserver
+		// Unfortunately debugserver can not convert them into signals for the
+		// process so we must stop here.
+		case debugServerTargetExcBadAccess, debugServerTargetExcBadInstruction, debugServerTargetExcArithmetic, debugServerTargetExcEmulation, debugServerTargetExcSoftware, debugServerTargetExcBreakpoint:
+
+			trapthreadCandidate = th
+			shouldStop = true
+
+		// Signal 0 is returned by rr when it reaches the start of the process
+		// in backward continue mode.
+		case 0:
+			if p.conn.direction == proc.Backward {
+				isStopSignal = true
+			}
+
+		default:
+			// any other signal is always propagated to inferior
+		}
+
+		if isStopSignal {
+			if trapthreadCandidate == nil {
+				trapthreadCandidate = th
+			}
+			th.sig = 0
+			shouldStop = true
 		}
 	}
 
-	return nil, fmt.Errorf("could not find thread %s", threadID)
+	if (trapthread == nil || trapthread.sig != 0) && trapthreadCandidate != nil {
+		// proc.Continue wants us to return one of the threads that we should stop
+		// at, if the thread returned by vCont received a signal that we want to
+		// propagate back to the target thread but there were also other threads
+		// that we wish to stop at we should pick one of those.
+		trapthread = trapthreadCandidate
+	}
+
+	if p.getCtrlC() || p.getManualStopRequested() {
+		// If we request an interrupt and a target thread simultaneously receives
+		// an unrelated singal debugserver will discard our interrupt request and
+		// report the signal but we should stop anyway.
+		shouldStop = true
+	}
+
+	return trapthread, shouldStop
 }
 
 // SetSelectedGoroutine will set internally the goroutine that should be
@@ -788,6 +858,13 @@ func (p *Process) CheckAndClearManualStopRequest() bool {
 	p.conn.manualStopMutex.Lock()
 	msr := p.manualStopRequested
 	p.manualStopRequested = false
+	p.conn.manualStopMutex.Unlock()
+	return msr
+}
+
+func (p *Process) getManualStopRequested() bool {
+	p.conn.manualStopMutex.Lock()
+	msr := p.manualStopRequested
 	p.conn.manualStopMutex.Unlock()
 	return msr
 }
@@ -854,7 +931,7 @@ func (p *Process) Restart(pos string) error {
 
 	// for some reason we have to send a vCont;c after a vRun to make rr behave
 	// properly, because that's what gdb does.
-	_, _, err = p.conn.resume(0, "", nil)
+	_, _, err = p.conn.resume(nil, nil)
 	if err != nil {
 		return err
 	}
@@ -1081,7 +1158,7 @@ func (tu *threadUpdater) Finish() {
 			continue
 		}
 		delete(tu.p.threads, threadID)
-		if tu.p.currentThread.ID == threadID {
+		if tu.p.currentThread != nil && tu.p.currentThread.ID == threadID {
 			tu.p.currentThread = nil
 		}
 	}
@@ -1099,14 +1176,13 @@ func (tu *threadUpdater) Finish() {
 	}
 }
 
-// updateThreadsList retrieves the list of inferior threads from the stub
-// and passes it to the threadUpdater.
-// Then it reloads the register information for all running threads.
+// updateThreadListNoRegisters retrieves the list of inferior threads from
+// the stub and passes it to threadUpdater.
 // Some stubs will return the list of running threads in the stop packet, if
 // this happens the threadUpdater will know that we have already updated the
 // thread list and the first step of updateThreadList will be skipped.
 // Registers are always reloaded.
-func (p *Process) updateThreadList(tu *threadUpdater) error {
+func (p *Process) updateThreadListNoRegisters(tu *threadUpdater) error {
 	if !tu.done {
 		first := true
 		for {
@@ -1126,8 +1202,8 @@ func (p *Process) updateThreadList(tu *threadUpdater) error {
 		tu.Finish()
 	}
 
-	if p.threadStopInfo {
-		for _, th := range p.threads {
+	for _, th := range p.threads {
+		if p.threadStopInfo {
 			sig, reason, err := p.conn.threadStopInfo(th.strID)
 			if err != nil {
 				if isProtocolErrorUnsupported(err) {
@@ -1137,15 +1213,42 @@ func (p *Process) updateThreadList(tu *threadUpdater) error {
 				return err
 			}
 			th.setbp = (reason == "breakpoint" || (reason == "" && sig == breakpointSignal))
+			th.sig = sig
+		} else {
+			th.sig = 0
 		}
 	}
 
+	return nil
+}
+
+// updateThreadRegisters reloads register informations for all running
+// threads.
+func (p *Process) updateThreadRegisters() error {
 	for _, thread := range p.threads {
 		if err := thread.reloadRegisters(); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// updateThreadsList retrieves the list of inferior threads from the stub
+// and passes it to the threadUpdater.
+// Then it reloads the register information for all running threads.
+// Some stubs will return the list of running threads in the stop packet, if
+// this happens the threadUpdater will know that we have already updated the
+// thread list and the first step of updateThreadList will be skipped.
+// Registers are always reloaded.
+func (p *Process) updateThreadList(tu *threadUpdater) error {
+	err := p.updateThreadListNoRegisters(tu)
+	if err != nil {
+		return err
+	}
+	for _, th := range p.threads {
+		th.sig = 0
+	}
+	return p.updateThreadRegisters()
 }
 
 func (p *Process) setCurrentBreakpoints() error {

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -406,7 +406,7 @@ func LLDBLaunch(cmd []string, wd string, foreground bool, debugInfoDirs []string
 	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(p), nil
+	return proc.NewTarget(p, false), nil
 }
 
 // LLDBAttach starts an instance of lldb-server and connects to it, asking
@@ -458,7 +458,7 @@ func LLDBAttach(pid int, path string, debugInfoDirs []string) (*proc.Target, err
 	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(p), nil
+	return proc.NewTarget(p, false), nil
 }
 
 // EntryPoint will return the process entry point address, useful for

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -96,7 +96,7 @@ func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string)
 		return nil, err
 	}
 
-	return proc.NewTarget(p), nil
+	return proc.NewTarget(p, false), nil
 }
 
 // ErrPerfEventParanoid is the error returned by Reply and Record if

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -226,7 +226,8 @@ func TestCheckpoints(t *testing.T) {
 		// Move back to checkpoint, check that the output of 'when' is the same as
 		// what it was when we set the breakpoint
 		p.Restart(fmt.Sprintf("c%d", cpid))
-		p.SwitchGoroutine(1)
+		g, _ := proc.FindGoroutine(p, 1)
+		p.SwitchGoroutine(g)
 		when2, loc2 := getPosition(p, t)
 		t.Logf("when2: %q (%#x) %x", when2, loc2.PC, p.CurrentThread().ThreadID())
 		if loc2.PC != loc0.PC {
@@ -253,7 +254,8 @@ func TestCheckpoints(t *testing.T) {
 		_, err = p.ClearBreakpoint(bp.Addr)
 		assertNoError(err, t, "ClearBreakpoint")
 		p.Restart(fmt.Sprintf("c%d", cpid))
-		p.SwitchGoroutine(1)
+		g, _ = proc.FindGoroutine(p, 1)
+		p.SwitchGoroutine(g)
 		assertNoError(proc.Next(p), t, "First Next")
 		assertNoError(proc.Next(p), t, "Second Next")
 		when4, loc4 := getPosition(p, t)

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -197,7 +197,7 @@ func TestCheckpoints(t *testing.T) {
 		bp := setFunctionBreakpoint(p, t, "main.main")
 		assertNoError(proc.Continue(p), t, "Continue")
 		when0, loc0 := getPosition(p, t)
-		t.Logf("when0: %q (%#x)", when0, loc0.PC)
+		t.Logf("when0: %q (%#x) %x", when0, loc0.PC, p.CurrentThread().ThreadID())
 
 		// Create a checkpoint and check that the list of checkpoints reflects this
 		cpid, err := p.Checkpoint("checkpoint1")
@@ -215,7 +215,7 @@ func TestCheckpoints(t *testing.T) {
 		assertNoError(proc.Next(p), t, "First Next")
 		assertNoError(proc.Next(p), t, "Second Next")
 		when1, loc1 := getPosition(p, t)
-		t.Logf("when1: %q (%#x)", when1, loc1.PC)
+		t.Logf("when1: %q (%#x) %x", when1, loc1.PC, p.CurrentThread().ThreadID())
 		if loc0.PC == loc1.PC {
 			t.Fatalf("next did not move process %#x", loc0.PC)
 		}
@@ -226,8 +226,9 @@ func TestCheckpoints(t *testing.T) {
 		// Move back to checkpoint, check that the output of 'when' is the same as
 		// what it was when we set the breakpoint
 		p.Restart(fmt.Sprintf("c%d", cpid))
+		p.SwitchGoroutine(1)
 		when2, loc2 := getPosition(p, t)
-		t.Logf("when2: %q (%#x)", when2, loc2.PC)
+		t.Logf("when2: %q (%#x) %x", when2, loc2.PC, p.CurrentThread().ThreadID())
 		if loc2.PC != loc0.PC {
 			t.Fatalf("PC address mismatch %#x != %#x", loc0.PC, loc2.PC)
 		}
@@ -252,6 +253,7 @@ func TestCheckpoints(t *testing.T) {
 		_, err = p.ClearBreakpoint(bp.Addr)
 		assertNoError(err, t, "ClearBreakpoint")
 		p.Restart(fmt.Sprintf("c%d", cpid))
+		p.SwitchGoroutine(1)
 		assertNoError(proc.Next(p), t, "First Next")
 		assertNoError(proc.Next(p), t, "Second Next")
 		when4, loc4 := getPosition(p, t)

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -126,7 +126,7 @@ func Launch(cmd []string, wd string, foreground bool, _ []string) (*proc.Target,
 		return nil, err
 	}
 
-	return proc.NewTarget(dbp), err
+	return proc.NewTarget(dbp, false), err
 }
 
 // Attach to an existing process with the given PID.
@@ -158,7 +158,7 @@ func Attach(pid int, _ []string) (*proc.Target, error) {
 		dbp.Detach(false)
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return proc.NewTarget(dbp, false), nil
 }
 
 // Kill kills the process.

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -87,7 +87,7 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string) (*
 	if err = dbp.initialize(cmd[0], debugInfoDirs); err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return proc.NewTarget(dbp, false), nil
 }
 
 // Attach to an existing process with the given PID. Once attached, if
@@ -111,7 +111,7 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 		dbp.Detach(false)
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return proc.NewTarget(dbp, false), nil
 }
 
 func initialize(dbp *Process) error {

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -92,7 +92,7 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string) (*
 	if err = dbp.initialize(cmd[0], debugInfoDirs); err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return proc.NewTarget(dbp, false), nil
 }
 
 // Attach to an existing process with the given PID. Once attached, if
@@ -123,7 +123,7 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return proc.NewTarget(dbp, false), nil
 }
 
 func initialize(dbp *Process) error {

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1244,7 +1244,7 @@ func TestFrameEvaluation(t *testing.T) {
 				t.Logf("could not stacktrace goroutine %d: %v\n", g.ID, err)
 				continue
 			}
-			t.Logf("Goroutine %d", g.ID)
+			t.Logf("Goroutine %d %#v", g.ID, g.Thread)
 			logStacktrace(t, p.BinInfo(), frames)
 			for i := range frames {
 				if frames[i].Call.Fn != nil && frames[i].Call.Fn.Name == "main.agoroutine" {

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -271,8 +271,8 @@ func TestIssue411(t *testing.T) {
 	}
 	test.AllowRecording(t)
 	withTestTerminal("math", t, func(term *FakeTerminal) {
-		term.MustExec("break math.go:8")
-		term.MustExec("trace math.go:9")
+		term.MustExec("break _fixtures/math.go:8")
+		term.MustExec("trace _fixtures/math.go:9")
 		term.MustExec("continue")
 		out := term.MustExec("next")
 		if !strings.HasPrefix(out, "> main.main()") {
@@ -683,7 +683,9 @@ func TestCheckpoints(t *testing.T) {
 		term.MustExec("checkpoints")
 		listIsAt(t, term, "next", 17, -1, -1)
 		listIsAt(t, term, "next", 18, -1, -1)
-		listIsAt(t, term, "restart c1", 16, -1, -1)
+		term.MustExec("restart c1")
+		term.MustExec("goroutine 1")
+		listIsAt(t, term, "list", 16, -1, -1)
 	})
 }
 

--- a/scripts/make.go
+++ b/scripts/make.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/spf13/cobra"
 )
 
@@ -71,7 +72,7 @@ func NewMakeCommands() *cobra.Command {
 Use the flags -s, -r and -b to specify which tests to run. Specifying nothing is equivalent to:
 
 	go run scripts/make.go test -s all -b default
-	go run scripts/make.go test -s basic -b lldb    # if lldb-server is installed
+	go run scripts/make.go test -s basic -b lldb    # if lldb-server is installed and Go < 1.14
 	go run scripts/make.go test -s basic -b rr      # if rr is installed
 	
 	go run scripts/make.go test -s basic -m pie     # only on linux
@@ -295,7 +296,7 @@ func testCmd(cmd *cobra.Command, args []string) {
 
 		fmt.Println("Testing default backend")
 		testCmdIntl("all", "", "default", "normal")
-		if inpath("lldb-server") {
+		if inpath("lldb-server") && !goversion.VersionAfterOrEqual(runtime.Version(), 1, 14) {
 			fmt.Println("\nTesting LLDB backend")
 			testCmdIntl("basic", "", "lldb", "normal")
 		}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1205,7 +1205,6 @@ func TestCallFunction(t *testing.T) {
 		// support calling optimized functions
 		{`strings.Join(nil, "")`, []string{`:string:""`}, nil},
 		{`strings.Join(stringslice, comma)`, []string{`:string:"one,two,three"`}, nil},
-		{`strings.Join(s1, comma)`, nil, errors.New(`error evaluating "s1" as argument a in function strings.Join: could not find symbol value for s1`)},
 		{`strings.Join(intslice, comma)`, nil, errors.New("can not convert value of type []int to []string")},
 		{`strings.Join(stringslice, ",")`, []string{`:string:"one,two,three"`}, nil},
 		{`strings.LastIndexByte(stringslice[1], 'w')`, []string{":int:1"}, nil},
@@ -1230,6 +1229,14 @@ func TestCallFunction(t *testing.T) {
 		{`getVRcvrableFromAStructPtr(6).VRcvr(5)`, []string{`:string:"5 + 6 = 11"`}, nil}, // indirect call of method on interface / containing pointer with pointer method
 	}
 
+	var testcasesBefore114After112 = []testCaseCallFunction{
+		{`strings.Join(s1, comma)`, nil, errors.New(`error evaluating "s1" as argument a in function strings.Join: could not find symbol value for s1`)},
+	}
+
+	var testcases114 = []testCaseCallFunction{
+		{`strings.Join(s1, comma)`, nil, errors.New(`error evaluating "s1" as argument elems in function strings.Join: could not find symbol value for s1`)},
+	}
+
 	withTestProcess("fncall", t, func(p *proc.Target, fixture protest.Fixture) {
 		_, err := proc.FindFunctionLocation(p, "runtime.debugCallV1", 0)
 		if err != nil {
@@ -1244,10 +1251,21 @@ func TestCallFunction(t *testing.T) {
 			for _, tc := range testcases112 {
 				testCallFunction(t, p, tc)
 			}
+			if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 14) {
+				for _, tc := range testcasesBefore114After112 {
+					testCallFunction(t, p, tc)
+				}
+			}
 		}
 
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 13) {
 			for _, tc := range testcases113 {
+				testCallFunction(t, p, tc)
+			}
+		}
+
+		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 14) {
+			for _, tc := range testcases114 {
 				testCallFunction(t, p, tc)
 			}
 		}


### PR DESCRIPTION
```
goversion: update maximum supported version

tests: misc test fixes for go1.14

- math.go is now ambiguous due to changes to the go runtime so specify
that we mean our own math.go in _fixtures
- go list -m requires vendor-mode to be disabled so pass '-mod=' to it
in case user has GOFLAGS=-mod=vendor
- update version of go/packages, required to work with go 1.14 (and
executed go mod vendor)

```
