### PR TITLE
proc: fix breakpoint confusion on resume

### DIFF
--- a/_fixtures/nopbreakpoint/main.go
+++ b/_fixtures/nopbreakpoint/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+)
+
+var g int = 0
+
+func compromised()
+
+func skipped() {
+	g++
+}
+
+func main() {
+	compromised()
+	fmt.Printf("%d\n", g)
+}

--- a/_fixtures/nopbreakpoint/main.s
+++ b/_fixtures/nopbreakpoint/main.s
@@ -1,0 +1,6 @@
+#include "textflag.h"
+
+TEXT ·compromised(SB),NOSPLIT,$0-0
+	BYTE	 $0x90   // The assembler strips NOP, this is a hardcoded NOP instruction
+	CALL main·skipped(SB)
+	RET

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -58,7 +58,7 @@ func (t *Thread) StepInstruction() (err error) {
 		return err
 	}
 
-	bp, ok := t.dbp.FindBreakpoint(pc, true)
+	bp, ok := t.dbp.FindBreakpoint(pc, false)
 	if ok {
 		// Clear the breakpoint so that we can continue execution.
 		err = t.ClearBreakpoint(bp)


### PR DESCRIPTION
```
proc: fix breakpoint confusion on resume

Fixes a case of breakpoint confusion on resume caused by having two
breakpoints one byte apart. This bug can cause the target program to
resume execution a single byte inside an instruction and crash either
with SIGILL or a SIGSEGV, or misbehave (depending on how the truncated
instruction is decoded).

native.(*Thread).StepInstruction should call FindBreakpoint using
adjustPC==false because at that point the PC of the thread should
already have been adjusted (and it has been).

```
