### PR TITLE
service,terminal: support logical breakpoints

### DIFF
--- a/service/api/types.go
+++ b/service/api/types.go
@@ -126,11 +126,16 @@ type Thread struct {
 }
 
 // Location holds program location information.
+// In most cases a Location object will represent a physical location, with
+// a single PC address held in the PC field.
+// FindLocations however returns logical locations that can either have
+// multiple PC addresses each (due to inlining) or no PC address at all.
 type Location struct {
 	PC       uint64    `json:"pc"`
 	File     string    `json:"file"`
 	Line     int       `json:"line"`
 	Function *Function `json:"function,omitempty"`
+	PCs      []uint64  `json:"pcs,omitempty"`
 }
 
 // Stackframe describes one frame in a stack trace.

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -446,6 +446,8 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 		addrs, err = proc.FindFileLocation(d.target, fileName, requestedBp.Line)
 	case len(requestedBp.FunctionName) > 0:
 		addrs, err = proc.FindFunctionLocation(d.target, requestedBp.FunctionName, requestedBp.Line)
+	case len(requestedBp.Addrs) > 0:
+		addrs = requestedBp.Addrs
 	default:
 		addrs = []uint64{requestedBp.Addr}
 	}

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -231,6 +231,9 @@ type CreateBreakpointOut struct {
 // the breakpoint will be created on the specified function:line
 // location.
 //
+// - If arg.Breakpoint.Addrs is filled it will create a logical breakpoint
+// corresponding to all specified addresses.
+//
 // - Otherwise the value specified by arg.Breakpoint.Addr will be used.
 func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpointOut) error {
 	createdbp, err := s.debugger.CreateBreakpoint(&arg.Breakpoint)
@@ -577,7 +580,7 @@ type FindLocationOut struct {
 	Locations []api.Location
 }
 
-// FindLocation returns concrete location information described by a location expression
+// FindLocation returns concrete location information described by a location expression.
 //
 //  loc ::= <filename>:<line> | <function>[:<line>] | /<regex>/ | (+|-)<offset> | <line> | *<address>
 //  * <filename> can be the full path of a file or just a suffix


### PR DESCRIPTION
```
service,terminal: support logical breakpoints

Changes CreateBreakpoint to create a logical breakpoint when multiple
addresses are specified, FindLocation and the api.Location type to
return logical locations and the cli to support logical breakpoints.

```
