### PR TITLE
gdbserial: propagate unhandled signals back to a specific thread

### DIFF
--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -539,14 +539,15 @@ func (conn *gdbConn) writeRegister(threadID string, regnum int, data []byte) err
 }
 
 // resume executes a 'vCont' command on all threads with action 'c' if sig
-// is 0 or 'C' if it isn't.
-func (conn *gdbConn) resume(sig uint8, tu *threadUpdater) (string, uint8, error) {
+// is 0 or 'C' if it isn't. If sig isn't 0 a threadID should be specified as
+// the target of the signal.
+func (conn *gdbConn) resume(sig uint8, threadID string, tu *threadUpdater) (string, uint8, error) {
 	if conn.direction == proc.Forward {
 		conn.outbuf.Reset()
 		if sig == 0 {
 			fmt.Fprint(&conn.outbuf, "$vCont;c")
 		} else {
-			fmt.Fprintf(&conn.outbuf, "$vCont;C%02x", sig)
+			fmt.Fprintf(&conn.outbuf, "$vCont;C%02x:%s;c", sig, threadID)
 		}
 	} else {
 		if err := conn.selectThread('c', "p-1.-1", "resume"); err != nil {

--- a/pkg/proc/proc_unix_test.go
+++ b/pkg/proc/proc_unix_test.go
@@ -4,7 +4,6 @@ package proc_test
 
 import (
 	"fmt"
-	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -23,10 +22,6 @@ func (npe errIssue419) Error() string {
 }
 
 func TestIssue419(t *testing.T) {
-	if testBackend == "lldb" && runtime.GOOS == "darwin" {
-		// debugserver bug?
-		return
-	}
 	if testBackend == "rr" {
 		return
 	}


### PR DESCRIPTION
```
gdbserial: propagate unhandled signals back to a specific thread

Instead of just sending unhandled signals back to the process send them
to the specific thread that received them.
This is important because:

1. debugserver does not appear to support the vCont;CXX packet without
specifying a target thread
2. the non-cooperative preemption change in an upcoming version of Go
(1.15?) will require sending signals to a specific thread.

Fixes #1744

```
