### PR TITLE
Makefile: discard stderr of "go list"

### DIFF
--- a/scripts/make.go
+++ b/scripts/make.go
@@ -187,7 +187,7 @@ func quotemaybe(args []string) []string {
 func getoutput(cmd string, args ...interface{}) string {
 	x := exec.Command(cmd, strflatten(args)...)
 	x.Env = os.Environ()
-	out, err := x.CombinedOutput()
+	out, err := x.Output()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
```
Makefile: discard stderr of "go list"

In module mode "go" will print messages about downloading modules to
stderr, we shouldn't confuse them for the real command output.

```
