### PR TITLE
proc/linux: do not route signals to threads while stopping

### DIFF
--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -16,8 +16,9 @@ type WaitStatus sys.WaitStatus
 // OSSpecificDetails hold Linux specific
 // process details.
 type OSSpecificDetails struct {
-	registers sys.PtraceRegs
-	running   bool
+	delayedSignal int
+	registers     sys.PtraceRegs
+	running       bool
 }
 
 func (t *Thread) stop() (err error) {
@@ -37,7 +38,9 @@ func (t *Thread) Stopped() bool {
 }
 
 func (t *Thread) resume() error {
-	return t.resumeWithSig(0)
+	sig := t.os.delayedSignal
+	t.os.delayedSignal = 0
+	return t.resumeWithSig(sig)
 }
 
 func (t *Thread) resumeWithSig(sig int) (err error) {

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -953,7 +953,7 @@ func TestStacktraceGoroutine(t *testing.T) {
 					if locations[i].Call.Fn != nil {
 						name = locations[i].Call.Fn.Name
 					}
-					t.Logf("\t%s:%d %s (%#x)\n", locations[i].Call.File, locations[i].Call.Line, name, locations[i].Current.PC)
+					t.Logf("\t%s:%d %s (%#x) %x %v\n", locations[i].Call.File, locations[i].Call.Line, name, locations[i].Current.PC, locations[i].FrameOffset(), locations[i].SystemStack)
 				}
 			}
 		}

--- a/scripts/make.go
+++ b/scripts/make.go
@@ -187,7 +187,7 @@ func quotemaybe(args []string) []string {
 func getoutput(cmd string, args ...interface{}) string {
 	x := exec.Command(cmd, strflatten(args)...)
 	x.Env = os.Environ()
-	out, err := x.CombinedOutput()
+	out, err := x.Output()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
```
proc/linux: do not route signals to threads while stopping

While we are trying to stop the process we should not route signals
sent to threads because that will result in threads being resumed.
Also keep better track of which threads are stopped.

This fixes an incompatibility with Go 1.14, which sends a lot of
signals to its threads to implement non-cooperative preemption,
resulting in Delve hanging waiting for an already-stopped thread to
stop.

In principle however this bug has nothing to do with Go 1.14 and could
manifest in any instance of high signal pressure.

```
