### PR TITLE
proc/core: enable PIE tests

### DIFF
--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -24,6 +24,7 @@ var buildMode string
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&buildMode, "test-buildmode", "", "selects build mode")
+	flag.Parse()
 	if buildMode != "" && buildMode != "pie" {
 		fmt.Fprintf(os.Stderr, "unknown build mode %q", buildMode)
 		os.Exit(1)

--- a/scripts/make.go
+++ b/scripts/make.go
@@ -187,7 +187,7 @@ func quotemaybe(args []string) []string {
 func getoutput(cmd string, args ...interface{}) string {
 	x := exec.Command(cmd, strflatten(args)...)
 	x.Env = os.Environ()
-	out, err := x.CombinedOutput()
+	out, err := x.Output()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
```
proc/core: enable PIE tests

PIE tests for core files were never enabled due to a missing flag.Parse
call.

Makefile: discard stderr of "go list"

In module mode "go" will print messages about downloading modules to
stderr, we shouldn't confuse them for the real command output.

```
