### PR TITLE
proc: support DW_AT_go_package_name

### DIFF
--- a/_fixtures/internal/dir.io/dir.go
+++ b/_fixtures/internal/dir.io/dir.go
@@ -3,3 +3,9 @@ package dirio
 type SomeType struct {
 	X int
 }
+
+var A string = "something"
+
+func SomeFunction() {
+	println("hello world")
+}

--- a/_fixtures/pkgrenames.go
+++ b/_fixtures/pkgrenames.go
@@ -8,6 +8,7 @@ import (
 	pkg1 "go/ast"
 	pkg2 "net/http"
 
+	"github.com/go-delve/delve/_fixtures/internal/dir.io"
 	"github.com/go-delve/delve/_fixtures/internal/dir0/pkg"
 	"github.com/go-delve/delve/_fixtures/internal/dir0/renamedpackage"
 	dir1pkg "github.com/go-delve/delve/_fixtures/internal/dir1/pkg"
@@ -51,5 +52,5 @@ func main() {
 	m := t.Method(0)
 	fmt.Println(m.Type.In(0))
 	fmt.Println(m.Type.String())
-	fmt.Println(badexpr, req, amap, amap2, dir0someType, dir1someType, amap3, anarray, achan, aslice, afunc, astruct, astruct2, iface2iface, iface3, pkg.SomeVar, pkg.A, dir1pkg.A)
+	fmt.Println(badexpr, req, amap, amap2, dir0someType, dir1someType, amap3, anarray, achan, aslice, afunc, astruct, astruct2, iface2iface, iface3, pkg.SomeVar, pkg.A, dir1pkg.A, dirio.A, dirio.SomeFunction)
 }

--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -26,6 +26,7 @@ const (
 	AttrGoElem          dwarf.Attr = 0x2902
 	AttrGoEmbeddedField dwarf.Attr = 0x2903
 	AttrGoRuntimeType   dwarf.Attr = 0x2904
+	AttrGoPackageName   dwarf.Attr = 0x2905
 )
 
 // Basic type encodings -- the value for AttrEncoding in a TagBaseType Entry.

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -15,7 +15,7 @@ type moduleData struct {
 func loadModuleData(bi *BinaryInfo, mem MemoryReadWriter) ([]moduleData, error) {
 	scope := globalScope(bi, bi.Images[0], mem)
 	var md *Variable
-	md, err := scope.findGlobal("runtime.firstmoduledata")
+	md, err := scope.findGlobal("runtime", "firstmoduledata")
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func resolveNameOff(bi *BinaryInfo, mds []moduleData, typeAddr uintptr, off uint
 
 func reflectOffsMapAccess(bi *BinaryInfo, off uintptr, mem MemoryReadWriter) (*Variable, error) {
 	scope := globalScope(bi, bi.Images[0], mem)
-	reflectOffs, err := scope.findGlobal("runtime.reflectOffs")
+	reflectOffs, err := scope.findGlobal("runtime", "reflectOffs")
 	if err != nil {
 		return nil, err
 	}

--- a/service/debugger/locations.go
+++ b/service/debugger/locations.go
@@ -216,7 +216,7 @@ func stripReceiverDecoration(in string) string {
 	return in[2 : len(in)-1]
 }
 
-func (spec *FuncLocationSpec) Match(sym proc.Function) bool {
+func (spec *FuncLocationSpec) Match(sym proc.Function, packageMap map[string][]string) bool {
 	if spec.BaseName != sym.BaseName() {
 		return false
 	}
@@ -231,15 +231,24 @@ func (spec *FuncLocationSpec) Match(sym proc.Function) bool {
 				return false
 			}
 		} else {
-			if !partialPathMatch(spec.PackageName, sym.PackageName()) {
+			if !packageMatch(spec.PackageName, sym.PackageName(), packageMap) {
 				return false
 			}
 		}
 	}
-	if spec.PackageOrReceiverName != "" && !partialPathMatch(spec.PackageOrReceiverName, sym.PackageName()) && spec.PackageOrReceiverName != recv {
+	if spec.PackageOrReceiverName != "" && !packageMatch(spec.PackageOrReceiverName, sym.PackageName(), packageMap) && spec.PackageOrReceiverName != recv {
 		return false
 	}
 	return true
+}
+
+func packageMatch(specPkg, symPkg string, packageMap map[string][]string) bool {
+	for _, pkg := range packageMap[specPkg] {
+		if partialPackageMatch(pkg, symPkg) {
+			return true
+		}
+	}
+	return partialPackageMatch(specPkg, symPkg)
 }
 
 func (loc *RegexLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr string, includeNonExecutableLines bool) ([]api.Location, error) {
@@ -304,6 +313,10 @@ func partialPathMatch(expr, path string) bool {
 		expr = strings.ToLower(filepath.ToSlash(expr))
 		path = strings.ToLower(filepath.ToSlash(path))
 	}
+	return partialPackageMatch(expr, path)
+}
+
+func partialPackageMatch(expr, path string) bool {
 	if len(expr) < len(path)-1 {
 		return strings.HasSuffix(path, expr) && (path[len(path)-len(expr)-1] == '/')
 	} else {
@@ -347,7 +360,7 @@ func (loc *NormalLocationSpec) Find(d *Debugger, scope *proc.EvalScope, locStr s
 	var candidateFuncs []string
 	if loc.FuncBase != nil {
 		for _, f := range d.target.BinInfo().Functions {
-			if !loc.FuncBase.Match(f) {
+			if !loc.FuncBase.Match(f, d.target.BinInfo().PackageMap) {
 				continue
 			}
 			if loc.Base == f.Name {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -725,6 +725,13 @@ func TestClientServer_FindLocations(t *testing.T) {
 		}
 		c.ClearBreakpoint(bp.ID)
 	})
+
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 13) {
+		withTestClient2("pkgrenames", t, func(c service.Client) {
+			someFuncLoc := findLocationHelper(t, c, "github.com/go-delve/delve/_fixtures/internal/dir%2eio.SomeFunction:0", false, 1, 0)[0]
+			findLocationHelper(t, c, "dirio.SomeFunction:0", false, 1, someFuncLoc)
+		})
+	}
 }
 
 func TestClientServer_FindLocationsAddr(t *testing.T) {


### PR DESCRIPTION
```
proc: support DW_AT_go_package_name

Use the name specified by compile unit attribute DW_AT_go_package_name,
introduced in Go 1.13, to map package names to package paths, instead of
trying to deduce it from names of types.
Also use this mapping for resolving global variables and function
expressions.

```
