### PR TITLE
proc/core: implementing coredump functionality for ARM64 

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -190,7 +190,7 @@ var (
 
 type openFn func(string, string) (*Process, error)
 
-var openFns = []openFn{readLinuxAMD64Core, readAMD64Minidump}
+var openFns = []openFn{readLinuxCore, readAMD64Minidump}
 
 // ErrUnrecognizedFormat is returned when the core file is not recognized as
 // any of the supported formats.

--- a/pkg/proc/linutil/regs_arm64_arch.go
+++ b/pkg/proc/linutil/regs_arm64_arch.go
@@ -125,10 +125,22 @@ func (r *ARM64Registers) Copy() proc.Registers {
 	return &rr
 }
 
-// Decode decodes an XSAVE area to a list of name/value pairs of registers.
-func Decode(fpregs []byte) (regs []proc.Register) {
-	for i := 0; i < len(fpregs); i += 16 {
-		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("V%d", i/16), fpregs[i:i+16])
+type ARM64PtraceFpRegs struct {
+	Vregs []byte
+	Fpsr  uint32
+	Fpcr  uint32
+}
+
+const _ARM_FP_REGS_LENGTH = 512
+
+func (fpregs *ARM64PtraceFpRegs) Decode() (regs []proc.Register) {
+	for i := 0; i < len(fpregs.Vregs); i += 16 {
+		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("V%d", i/16), fpregs.Vregs[i:i+16])
 	}
 	return
+}
+
+func (fpregs *ARM64PtraceFpRegs) Byte() []byte {
+	fpregs.Vregs = make([]byte, _ARM_FP_REGS_LENGTH)
+	return fpregs.Vregs[:]
 }

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -1,6 +1,7 @@
 package native
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -351,6 +352,7 @@ func status(pid int, comm string) rune {
 		return '\000'
 	}
 	defer f.Close()
+	rd := bufio.NewReader(f)
 
 	var (
 		p     int
@@ -361,7 +363,7 @@ func status(pid int, comm string) rune {
 	// The name of the task is the base name of the executable for this process limited to TASK_COMM_LEN characters
 	// Since both parenthesis and spaces can appear inside the name of the task and no escaping happens we need to read the name of the executable first
 	// See: include/linux/sched.c:315 and include/linux/sched.c:1510
-	fmt.Fscanf(f, "%d ("+comm+")  %c", &p, &state)
+	fmt.Fscanf(rd, "%d ("+comm+")  %c", &p, &state)
 	return state
 }
 

--- a/pkg/proc/native/threads_linux_arm64.go
+++ b/pkg/proc/native/threads_linux_arm64.go
@@ -12,13 +12,15 @@ import (
 	"github.com/go-delve/delve/pkg/proc/linutil"
 )
 
-func (thread *Thread) fpRegisters() (fpregs []proc.Register, fpregset []byte, err error) {
-	thread.dbp.execPtraceFunc(func() { fpregset, err = PtraceGetFpRegset(thread.ID) })
-	fpregs = linutil.Decode(fpregset)
+func (thread *Thread) fpRegisters() ([]proc.Register, []byte, error) {
+	var err error
+	var arm_fpregs linutil.ARM64PtraceFpRegs
+	thread.dbp.execPtraceFunc(func() { arm_fpregs.Vregs, err = PtraceGetFpRegset(thread.ID) })
+	fpregs := arm_fpregs.Decode()
 	if err != nil {
 		err = fmt.Errorf("could not get floating point registers: %v", err.Error())
 	}
-	return
+	return fpregs, arm_fpregs.Vregs, err
 }
 
 func (t *Thread) restoreRegisters(savedRegs proc.Registers) error {


### PR DESCRIPTION
Implementing coredump functionality for ARM64 , now it can be checked by using "dlv core " command.
Floating point registers are not handled yet, working on it.