### PR TITLE
Misc plugin-related bugfixes

### DIFF
--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -118,6 +118,13 @@ func Attach(pid int, debugInfoDirs []string) (*Process, error) {
 		dbp.Detach(false)
 		return nil, err
 	}
+
+	// ElfUpdateSharedObjects can only be done after we initialize because it
+	// needs an initialized BinaryInfo object to work.
+	err = linutil.ElfUpdateSharedObjects(dbp)
+	if err != nil {
+		return nil, err
+	}
 	return dbp, nil
 }
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1302,7 +1302,7 @@ func (d *Debugger) ListDynamicLibraries() []api.Image {
 	r := make([]api.Image, 0, len(bi.Images)-1)
 	// skips the first image because it's the executable file
 	for i := range bi.Images[1:] {
-		r = append(r, api.ConvertImage(bi.Images[i]))
+		r = append(r, api.ConvertImage(bi.Images[i+1]))
 	}
 	return r
 }


### PR DESCRIPTION
```
proc/native: call ElfUpdateSharedObjects after Attach

When attaching to a process in linux ElfUpdateSharedObjects will be
called for the first time during the call to updateThreadList,
unfortunately it won't do anything because the dynamic section of the
base elf executable needs to have been read first and that's done when
we initialize the BinaryInfo object (which happens later during the
call to initialize).

debugger: fix off-by-one error in ListDynamicLibraries

```
