### PR TITLE
pkg/terminal: Fix exit status

### DIFF
--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -281,6 +281,19 @@ func TestIssue411(t *testing.T) {
 	})
 }
 
+func TestExitStatus(t *testing.T) {
+	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
+		term.Exec("continue")
+		status, err := term.handleExit()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if status != 0 {
+			t.Fatalf("incorrect exit status, expected 0, got %d", status)
+		}
+	})
+}
+
 func TestScopePrefix(t *testing.T) {
 	if runtime.GOARCH == "arm64" {
 		t.Skip("arm64 does not support Stacktrace for now")

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -354,17 +354,20 @@ func (t *Term) handleExit() (int, error) {
 
 	s, err := t.client.GetState()
 	if err != nil {
-		if isErrProcessExited(err) && t.client.IsMulticlient() {
-			answer, err := yesno(t.line, "Remote process has exited. Would you like to kill the headless instance? [Y/n] ")
-			if err != nil {
-				return 2, io.EOF
-			}
-			if answer {
-				if err := t.client.Detach(true); err != nil {
-					return 1, err
+		if isErrProcessExited(err) {
+			if t.client.IsMulticlient() {
+				answer, err := yesno(t.line, "Remote process has exited. Would you like to kill the headless instance? [Y/n] ")
+				if err != nil {
+					return 2, io.EOF
 				}
+				if answer {
+					if err := t.client.Detach(true); err != nil {
+						return 1, err
+					}
+				}
+				return 0, err
 			}
-			return 0, err
+			return 0, nil
 		}
 		return 1, err
 	}


### PR DESCRIPTION
During a debug session if the process exited and then the user quit the
debug session, the process exit message would display again and Delve
would exit non-zero (specifically with exit code 1) despite nothing
going wrong.

This patch fixes this so that Delve exits with a clean 0 status and the
process exit message is not printed yet again.