### PR TITLE
proc,service: construct import path to directory path map

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -43,6 +43,7 @@ functions(Filter) | Equivalent to API call [ListFunctions](https://godoc.org/git
 goroutines(Start, Count) | Equivalent to API call [ListGoroutines](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListGoroutines)
 local_vars(Scope, Cfg) | Equivalent to API call [ListLocalVars](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListLocalVars)
 package_vars(Filter, Cfg) | Equivalent to API call [ListPackageVars](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListPackageVars)
+packages_build_info(IncludeFiles) | Equivalent to API call [ListPackagesBuildInfo](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListPackagesBuildInfo)
 registers(ThreadID, IncludeFp) | Equivalent to API call [ListRegisters](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListRegisters)
 sources(Filter) | Equivalent to API call [ListSources](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListSources)
 threads() | Equivalent to API call [ListThreads](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListThreads)

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -385,9 +385,24 @@ func (lineInfo *DebugLineInfo) FirstStmtForLine(start, end uint64) (pc uint64, f
 		}
 		if err := sm.next(); err != nil {
 			if lineInfo.Logf != nil {
-				lineInfo.Logf("StmtAfter error: %v", err)
+				lineInfo.Logf("FirstStmtForLine error: %v", err)
 			}
 			return 0, "", 0, false
+		}
+	}
+}
+
+func (lineInfo *DebugLineInfo) FirstFile() string {
+	sm := newStateMachine(lineInfo, lineInfo.Instructions)
+	for {
+		if sm.valid {
+			return sm.file
+		}
+		if err := sm.next(); err != nil {
+			if lineInfo.Logf != nil {
+				lineInfo.Logf("FirstFile error: %v", err)
+			}
+			return ""
 		}
 	}
 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4525,3 +4525,24 @@ func TestIssue1817(t *testing.T) {
 		setFileBreakpoint(p, t, fixture.Source, 16)
 	})
 }
+
+func TestListPackagesBuildInfo(t *testing.T) {
+	withTestProcess("pkgrenames", t, func(p proc.Process, fixture protest.Fixture) {
+		pkgs := p.BinInfo().ListPackagesBuildInfo(true)
+		t.Logf("returned %d", len(pkgs))
+		if len(pkgs) < 10 {
+			t.Errorf("very few packages returned")
+		}
+		for _, pkg := range pkgs {
+			t.Logf("%q %q", pkg.ImportPath, pkg.DirectoryPath)
+			const _fixtures = "_fixtures"
+			fidx := strings.Index(pkg.ImportPath, _fixtures)
+			if fidx < 0 {
+				continue
+			}
+			if !strings.HasSuffix(strings.Replace(pkg.DirectoryPath, "\\", "/", -1), pkg.ImportPath[fidx:]) {
+				t.Errorf("unexpected suffix: %q %q", pkg.ImportPath, pkg.DirectoryPath)
+			}
+		}
+	})
+}

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -848,6 +848,36 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 		}
 		return env.interfaceToStarlarkValue(rpcRet), nil
 	})
+	r["packages_build_info"] = starlark.NewBuiltin("packages_build_info", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		if err := isCancelled(thread); err != nil {
+			return starlark.None, decorateError(thread, err)
+		}
+		var rpcArgs rpc2.ListPackagesBuildInfoIn
+		var rpcRet rpc2.ListPackagesBuildInfoOut
+		if len(args) > 0 && args[0] != starlark.None {
+			err := unmarshalStarlarkValue(args[0], &rpcArgs.IncludeFiles, "IncludeFiles")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
+		for _, kv := range kwargs {
+			var err error
+			switch kv[0].(starlark.String) {
+			case "IncludeFiles":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.IncludeFiles, "IncludeFiles")
+			default:
+				err = fmt.Errorf("unknown argument %q", kv[0])
+			}
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
+		err := env.ctx.Client().CallAPI("ListPackagesBuildInfo", &rpcArgs, &rpcRet)
+		if err != nil {
+			return starlark.None, err
+		}
+		return env.interfaceToStarlarkValue(rpcRet), nil
+	})
 	r["registers"] = starlark.NewBuiltin("registers", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		if err := isCancelled(thread); err != nil {
 			return starlark.None, decorateError(thread, err)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -509,3 +509,10 @@ const (
 	// values saved in the runtime.g structure.
 	StacktraceG
 )
+
+// ImportPathToDirectoryPath maps an import path to a directory path.
+type PackageBuildInfo struct {
+	ImportPath    string
+	DirectoryPath string
+	Files         []string
+}

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -731,3 +731,23 @@ func (s *RPCServer) ListDynamicLibraries(in ListDynamicLibrariesIn, out *ListDyn
 	out.List = s.debugger.ListDynamicLibraries()
 	return nil
 }
+
+// ListPackagesBuildInfoIn holds the arguments of ListPackages.
+type ListPackagesBuildInfoIn struct {
+	IncludeFiles bool
+}
+
+// ListPackagesBuildInfoOut holds the return values of ListPackages.
+type ListPackagesBuildInfoOut struct {
+	List []api.PackageBuildInfo
+}
+
+// ListPackagesBuildInfo returns the list of packages used by the program along with
+// the directory where each package was compiled and optionally the list of
+// files constituting the package.
+// Note that the directory path is a best guess and may be wrong is a tool
+// other than cmd/go is used to perform the build.
+func (s *RPCServer) ListPackagesBuildInfo(in ListPackagesBuildInfoIn, out *ListPackagesBuildInfoOut) error {
+	out.List = s.debugger.ListPackagesBuildInfo(in.IncludeFiles)
+	return nil
+}


### PR DESCRIPTION
```
proc,service: construct import path to directory path map

Adds an API call that returns a map from import paths to directory
paths that can be used by IDEs to map source file paths between
different development environments.

```
