### PR TITLE
Revert "travis: exclude builds of Go other than most recent from ARM64 builds"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
   exclude:
     - os: osx
       arch: arm64
-    - os: linux
-      go: 1.11.x
-      arch: arm64
-    - os: linux
-      go: 1.12.x
-      arch: arm64
 
 before_install:
   - export GOFLAGS=-mod=vendor


### PR DESCRIPTION
```
Revert "travis: exclude builds of Go other than most recent from ARM64 builds"

This reverts commit 35d168ac16527dcb19f8e8761ad7c5de24b56eca.

See: https://github.com/go-delve/delve/pull/1786#issuecomment-562160264

```
