### PR TITLE
debugger: fix nil pointer dereference in FunctionReturnLocations

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -237,6 +237,9 @@ const deferReturn = "runtime.deferreturn"
 // for the given function, a list of addresses corresponding
 // to 'ret' or 'call runtime.deferreturn'.
 func (d *Debugger) FunctionReturnLocations(fnName string) ([]uint64, error) {
+	d.processMutex.Lock()
+	defer d.processMutex.Unlock()
+
 	var (
 		p = d.target
 		g = p.SelectedGoroutine()
@@ -249,7 +252,7 @@ func (d *Debugger) FunctionReturnLocations(fnName string) ([]uint64, error) {
 
 	var regs proc.Registers
 	var mem proc.MemoryReadWriter = p.CurrentThread()
-	if g.Thread != nil {
+	if g != nil && g.Thread != nil {
 		mem = g.Thread
 		regs, _ = g.Thread.Registers(false)
 	}

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1810,3 +1810,13 @@ func TestRerecord(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue1787(t *testing.T) {
+	// Calling FunctionReturnLocations without a selected goroutine should
+	// work.
+	withTestClient2("testnextprog", t, func(c service.Client) {
+		if c, _ := c.(*rpc2.RPCClient); c != nil {
+			c.FunctionReturnLocations("main.main")
+		}
+	})
+}


### PR DESCRIPTION
```
debugger: fix nil pointer dereference in FunctionReturnLocations

Fixes #1787

```
