### PR TITLE
tests: disable function call injection tests on macOS on Travis-CI

### DIFF
--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -311,6 +311,10 @@ func MustSupportFunctionCalls(t *testing.T, testBackend string) {
 	if testBackend == "rr" || (runtime.GOOS == "darwin" && testBackend == "native") {
 		t.Skip("this backend does not support function calls")
 	}
+
+	if runtime.GOOS == "darwin" && os.Getenv("TRAVIS") == "true" {
+		t.Skip("function call injection tests are failing on macOS on Travis-CI (see #1802)")
+	}
 }
 
 // DefaultTestBackend changes the value of testBackend to be the default


### PR DESCRIPTION
```
tests: disable function call injection tests on macOS on Travis-CI

Updates #1802

```
