### PR TITLE
function backtraces of linux/arm64 core dumps are now printed correctly

### DIFF
--- a/pkg/proc/arm64_linux_stack.go
+++ b/pkg/proc/arm64_linux_stack.go
@@ -1,0 +1,70 @@
+package proc
+
+import (
+	"unsafe"
+)
+
+// The following code is specific to Linux and and the ARM64.  It sees if the
+// current return address points to the return-from-exception system call.
+// If so, it will locate the previous stack frame and it will set the CFA to
+// point to this previous stack frame.  It seems likely that code similar to
+// this will be useful for other architectures.  
+//
+// This code was adapted from "gdb".
+//
+// It might be possible to eliminate the offsets below by referring to
+// Dwarf symbols and/or exception routine name lookups.  For now, this will
+// have to wait until ARM64 Delve can more reliably look up local stack
+// variables.  Another (less satisfactory) way would be to duplicate Linux's
+// runtime exception structure's layouts, which is what gdb does.
+//
+// It might be good to put a "tag" into the stack structure indicating
+// when a frame is an "exception" frame, and hence "jumps".  Further,
+// exception frames contain the registers at the time of the exception.
+// When a GO program is compiled without debugging symbols, this register
+// structure should be used to fetch saved registers, thus allowing Delve
+// to print variables from previous frames that were still in registers
+// at the time of the procedure calls.
+
+func checkException_linux_arm64(it *stackIterator, ret *uint64) {
+	const sigreturn0 = 0xd2801168	// movz x8, 0x8b    (return from
+	const sigreturn4 = 0xd4000001	// svc  0x0          exception)
+
+	const sigreturnoffset = -0x18	// offset to signal return code fragment
+	const returnoffset    = 0x1a0	// offset to signal's return addresses
+
+	inst_size := int64(uintptr(unsafe.Sizeof(uint32(0))))
+
+	// See if the current return is to a return-from-execption system call.
+
+	val, err := readUintRaw(it.mem, uintptr(*ret), inst_size)
+	if err != nil || val != sigreturn0 {
+		return
+    }
+	val, err = readUintRaw(it.mem, uintptr(*ret+uint64(inst_size)), inst_size)
+	if (err != nil || val != sigreturn4) {
+		return
+    }
+
+	// Locate the address of the previous stack frame.
+
+	val, err = readUintRaw(it.mem, uintptr(uint64(it.regs.CFA+sigreturnoffset)), int64(it.bi.Arch.PtrSize()))
+	if err != nil {
+		return
+	}
+	val += returnoffset
+	val1, err := readUintRaw(it.mem, uintptr(val), int64(it.bi.Arch.PtrSize()))
+	if err != nil {
+		return
+	}
+	val += uint64(it.bi.Arch.PtrSize())
+
+	// Read the pointer to the previous stack frame and update the CFA.
+
+	val2, err := readUintRaw(it.mem, uintptr(val), int64(it.bi.Arch.PtrSize()))
+	if err != nil {
+        return
+    }
+	*ret = val2
+	it.regs.CFA = int64(val1+uint64(it.bi.Arch.PtrSize()))
+}


### PR DESCRIPTION
Backtracing was greatly improved on linux/arm64 core-file backtraces.
Previously, the backtrace of the goroutine that faulted and caused a core
dump was quite truncated.  Now, this goroutine's backtrace is correctly
printed out.

Faults cause exceptions.  Exceptions are taken on a different stack from
the goroutine which caused the exception.  Further, the exception's stack
frame is defined by the operating system (linux in this case) and not by
golang's runtime environment.  Thus, to correctly navigate a backtrace,
the stack unwinding code must have knowledge of how to process such exception
stack frames.  On the amd64 architecture, golang maintains explicit frame
pointers, easing this task.  On the arm64 architecture, frame pointers are
implicit, complicating this task.

Following gdb's lead in processing exception frames, code was added for the
linux/arm64 implementation to discover that a stack frame is an exception
frame.  If it discovers an exception stack frame, it navigates to the stack
frame that was interrupted.  This code is in the new source file
"arm64_linux_stack.go".

The procedure calls are now correctly printed out.  However, if the go code
was compiled with code optimization on, local variables are often not printed
out correctly.  This has not yet been investigated.  A tentative working
hypothesis is that the local-variable backtrace-following code also needs
to notice the exception record, and if one is detected, fetch the requested
register out of the exception record's register save area.

For now, the code has implicit knowledge of how to advance over an exception
stack frame by having explicit constant offsets.  A better way would be to
look up local stack symbols go's exception handler's code to fetch the
correct stack pointer and/or offset.  However, this will need to wait until
the fetching of local variables out of the stack frames is improved.

Finally, about 12% of the time the backtrace of a core-file was still
truncated.  This turned out to because of original:

  for i := range framectx.Regs {

loop in "stack.go".  As "framectx.Regs" is a map, go can return indices
in a pseudo-random order.  If the record for key "31" is returned before
the record for key "30", something in Delve/Dwarf's register-fix-up code
is done incorrectly.  The code was changed to copy the key/value pairs
into a slice.  The slice was then sorted, the for loop was changed to range
over the slice, and the bug went away.