### PR TITLE
proc: fix inlined stack reading for midstack inlined calls

### DIFF
--- a/_fixtures/issue1795.go
+++ b/_fixtures/issue1795.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"runtime"
+)
+
+func main() {
+	r := regexp.MustCompile("ab")
+	runtime.Breakpoint()
+	out := r.MatchString("blah")
+	fmt.Printf("%v\n", out)
+}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -440,7 +440,7 @@ func (bi *BinaryInfo) PCToInlineFunc(pc uint64) *Function {
 	fn := bi.PCToFunc(pc)
 	irdr := reader.InlineStack(fn.cu.image.dwarf, fn.offset, reader.ToRelAddr(pc, fn.cu.image.StaticBase))
 	var inlineFnEntry *dwarf.Entry
-	for irdr.Next() {
+	if irdr.Next() {
 		inlineFnEntry = irdr.Entry()
 	}
 


### PR DESCRIPTION
```
proc: fix inlined stack reading for midstack inlined calls

Due to a bug in the Go compiler midstack inlined calls do not report
their ranges correctly. We can't check if an address is in the range of
a DIE by simply looking at that DIE's range, we should also recursively
check the DIE's children's ranges.

Also fixes the way stacktraces of midstack inlined calls are reported
(they used to be inverted, with the deepest inlined stack frame
reported last).

Fixes #1795

```
