### PR TITLE
service/debugger: support full path matching in location expressions.

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -29,7 +29,7 @@ create_breakpoint(Breakpoint) | Equivalent to API call [CreateBreakpoint](https:
 detach(Kill) | Equivalent to API call [Detach](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Detach)
 disassemble(Scope, StartPC, EndPC, Flavour) | Equivalent to API call [Disassemble](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Disassemble)
 eval(Scope, Expr, Cfg) | Equivalent to API call [Eval](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Eval)
-find_location(Scope, Loc, IncludeNonExecutableLines) | Equivalent to API call [FindLocation](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.FindLocation)
+find_location(Scope, Loc, IncludeNonExecutableLines, FullPathMatch) | Equivalent to API call [FindLocation](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.FindLocation)
 function_return_locations(FnName) | Equivalent to API call [FunctionReturnLocations](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.FunctionReturnLocations)
 get_breakpoint(Id, Name) | Equivalent to API call [GetBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.GetBreakpoint)
 get_thread(Id) | Equivalent to API call [GetThread](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.GetThread)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,6 +57,10 @@ type Config struct {
 	// DebugFileDirectories is the list of directories Delve will use
 	// in order to resolve external debug info files.
 	DebugInfoDirectories []string `yaml:"debug-info-directories"`
+
+	// If FullPathMatch is true Delve will try to resolve symbolic links when searching source files.
+	// Note: this option may cause performance degradation.
+	FullPathMatch bool `yaml:"full-path-match"`
 }
 
 // LoadConfig attempts to populate a Config object from the config.yml file.

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1183,7 +1183,7 @@ func clearAll(t *Term, ctx callContext, args string) error {
 
 	var locPCs map[uint64]struct{}
 	if args != "" {
-		locs, err := t.client.FindLocation(api.EvalScope{GoroutineID: -1, Frame: 0}, args, true)
+		locs, err := t.client.FindLocation(api.EvalScope{GoroutineID: -1, Frame: 0}, args, true, t.fullPathMatchConf())
 		if err != nil {
 			return err
 		}
@@ -1286,7 +1286,7 @@ func setBreakpoint(t *Term, ctx callContext, tracepoint bool, argstr string) err
 	}
 
 	requestedBp.Tracepoint = tracepoint
-	locs, err := t.client.FindLocation(ctx.Scope, locspec, true)
+	locs, err := t.client.FindLocation(ctx.Scope, locspec, true, t.fullPathMatchConf())
 	if err != nil {
 		if requestedBp.Name == "" {
 			return err
@@ -1294,7 +1294,7 @@ func setBreakpoint(t *Term, ctx callContext, tracepoint bool, argstr string) err
 		requestedBp.Name = ""
 		locspec = argstr
 		var err2 error
-		locs, err2 = t.client.FindLocation(ctx.Scope, locspec, true)
+		locs, err2 = t.client.FindLocation(ctx.Scope, locspec, true, t.fullPathMatchConf())
 		if err2 != nil {
 			return err
 		}
@@ -1670,7 +1670,7 @@ func getLocation(t *Term, ctx callContext, args string, showContext bool) (file 
 		return loc.File, loc.Line, true, nil
 
 	default:
-		locs, err := t.client.FindLocation(ctx.Scope, args, false)
+		locs, err := t.client.FindLocation(ctx.Scope, args, false, t.fullPathMatchConf())
 		if err != nil {
 			return "", 0, false, err
 		}
@@ -1729,7 +1729,7 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 
 	switch cmd {
 	case "":
-		locs, err := t.client.FindLocation(ctx.Scope, "+0", true)
+		locs, err := t.client.FindLocation(ctx.Scope, "+0", true, t.fullPathMatchConf())
 		if err != nil {
 			return err
 		}
@@ -1749,7 +1749,7 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 		}
 		disasm, disasmErr = t.client.DisassembleRange(ctx.Scope, uint64(startpc), uint64(endpc), api.IntelFlavour)
 	case "-l":
-		locs, err := t.client.FindLocation(ctx.Scope, rest, true)
+		locs, err := t.client.FindLocation(ctx.Scope, rest, true, t.fullPathMatchConf())
 		if err != nil {
 			return err
 		}

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -476,6 +476,12 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 3 && args[3] != starlark.None {
+			err := unmarshalStarlarkValue(args[3], &rpcArgs.FullPathMatch, "FullPathMatch")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
@@ -485,6 +491,8 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Loc, "Loc")
 			case "IncludeNonExecutableLines":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.IncludeNonExecutableLines, "IncludeNonExecutableLines")
+			case "FullPathMatch":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.FullPathMatch, "FullPathMatch")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -429,3 +429,10 @@ func isErrProcessExited(err error) bool {
 	rpcError, ok := err.(rpc.ServerError)
 	return ok && strings.Contains(rpcError.Error(), "has exited with status")
 }
+
+func (t *Term) fullPathMatchConf() bool {
+	if t.conf != nil {
+		return t.conf.FullPathMatch
+	}
+	return false
+}

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -125,6 +125,17 @@ type Thread struct {
 	ReturnValues []Variable
 }
 
+// FindLocCfg describes how to find location from target.
+type FindLocCfg struct {
+	// IncludeNonExecutableLines makes FindLocations return if the expression can be parsed,
+	// even if it doesn't end up matching any instruction in debug_line.
+	IncludeNonExecutableLines bool
+
+	// If FullPathMatch is true Delve will try to resolve symbolic links when searching source files.
+	// Note: this option may cause performance degradation.
+	FullPathMatch bool
+}
+
 // Location holds program location information.
 // In most cases a Location object will represent a physical location, with
 // a single PC address held in the PC field.

--- a/service/client.go
+++ b/service/client.go
@@ -120,7 +120,8 @@ type Client interface {
 	// * *<address> returns the location corresponding to the specified address
 	// NOTE: this function does not actually set breakpoints.
 	// If findInstruction is true FindLocation will only return locations that correspond to instructions.
-	FindLocation(scope api.EvalScope, loc string, findInstruction bool) ([]api.Location, error)
+	// If fullPathMatch is true Delve will try to resolve symbolic links when searching source files. Note: this option may cause performance degradation.
+	FindLocation(scope api.EvalScope, loc string, findInstruction bool, fullPathMatch bool) ([]api.Location, error)
 
 	// Disassemble code between startPC and endPC
 	DisassembleRange(scope api.EvalScope, startPC, endPC uint64, flavour api.AssemblyFlavour) (api.AsmInstructions, error)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1190,7 +1190,7 @@ func (d *Debugger) convertDefers(defers []*proc.Defer) []api.Defer {
 }
 
 // FindLocation will find the location specified by 'locStr'.
-func (d *Debugger) FindLocation(scope api.EvalScope, locStr string, includeNonExecutableLines bool) ([]api.Location, error) {
+func (d *Debugger) FindLocation(scope api.EvalScope, locStr string, cfg *api.FindLocCfg) ([]api.Location, error) {
 	d.processMutex.Lock()
 	defer d.processMutex.Unlock()
 
@@ -1204,8 +1204,10 @@ func (d *Debugger) FindLocation(scope api.EvalScope, locStr string, includeNonEx
 	}
 
 	s, _ := proc.ConvertEvalScope(d.target, scope.GoroutineID, scope.Frame, scope.DeferredCall)
-
-	locs, err := loc.Find(d, s, locStr, includeNonExecutableLines)
+	if cfg == nil {
+		cfg = &api.FindLocCfg{false, false}
+	}
+	locs, err := loc.Find(d, s, locStr, *cfg)
 	for i := range locs {
 		if locs[i].PC == 0 {
 			continue

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -305,7 +305,7 @@ type FindLocationArgs struct {
 
 func (c *RPCServer) FindLocation(args FindLocationArgs, answer *[]api.Location) error {
 	var err error
-	*answer, err = c.debugger.FindLocation(args.Scope, args.Loc, false)
+	*answer, err = c.debugger.FindLocation(args.Scope, args.Loc, &api.FindLocCfg{})
 	return err
 }
 

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -328,9 +328,9 @@ func (c *RPCClient) AttachedToExistingProcess() bool {
 	return out.Answer
 }
 
-func (c *RPCClient) FindLocation(scope api.EvalScope, loc string, findInstructions bool) ([]api.Location, error) {
+func (c *RPCClient) FindLocation(scope api.EvalScope, loc string, findInstructions bool, fullPathMatch bool) ([]api.Location, error) {
 	var out FindLocationOut
-	err := c.call("FindLocation", FindLocationIn{scope, loc, !findInstructions}, &out)
+	err := c.call("FindLocation", FindLocationIn{scope, loc, !findInstructions, fullPathMatch}, &out)
 	return out.Locations, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -574,6 +574,7 @@ type FindLocationIn struct {
 	Scope                     api.EvalScope
 	Loc                       string
 	IncludeNonExecutableLines bool
+	FullPathMatch             bool
 }
 
 type FindLocationOut struct {
@@ -595,7 +596,7 @@ type FindLocationOut struct {
 // NOTE: this function does not actually set breakpoints.
 func (c *RPCServer) FindLocation(arg FindLocationIn, out *FindLocationOut) error {
 	var err error
-	out.Locations, err = c.debugger.FindLocation(arg.Scope, arg.Loc, arg.IncludeNonExecutableLines)
+	out.Locations, err = c.debugger.FindLocation(arg.Scope, arg.Loc, &api.FindLocCfg{arg.IncludeNonExecutableLines, arg.FullPathMatch})
 	return err
 }
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -734,6 +734,19 @@ func TestClientServer_FindLocations(t *testing.T) {
 	}
 }
 
+func TestClientServer_FindLocationsSymLink(t *testing.T) {
+	// Issue #1808
+	originAbsPathFile, symbolLinkAbsDir := createSymLink(t, "locationsprog3.go", "symlink")
+	defer os.RemoveAll(symbolLinkAbsDir)
+	withTestClient2("symlink/", t, func(c service.Client) {
+		<-c.Continue()
+		_, err := c.FindLocation(api.EvalScope{-1, 0, 0}, originAbsPathFile+":11", false, true)
+		if err != nil {
+			t.Fatalf("Could not FindLocation when existing symlink: %s\n", err)
+		}
+	})
+}
+
 func TestClientServer_FindLocationsAddr(t *testing.T) {
 	withTestClient2("locationsprog2", t, func(c service.Client) {
 		<-c.Continue()
@@ -937,7 +950,7 @@ func TestIssue355(t *testing.T) {
 		assertError(err, t, "ListGoroutines()")
 		_, err = c.Stacktrace(gid, 10, 0, &normalLoadConfig)
 		assertError(err, t, "Stacktrace()")
-		_, err = c.FindLocation(api.EvalScope{gid, 0, 0}, "+1", false)
+		_, err = c.FindLocation(api.EvalScope{gid, 0, 0}, "+1", false, false)
 		assertError(err, t, "FindLocation()")
 		_, err = c.DisassemblePC(api.EvalScope{-1, 0, 0}, 0x40100, api.IntelFlavour)
 		assertError(err, t, "DisassemblePC()")
@@ -954,7 +967,7 @@ func TestDisasm(t *testing.T) {
 		state := <-ch
 		assertNoError(state.Err, t, "Continue()")
 
-		locs, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "main.main", false)
+		locs, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "main.main", false, false)
 		assertNoError(err, t, "FindLocation()")
 		if len(locs) != 1 {
 			t.Fatalf("wrong number of locations for main.main: %d", len(locs))
@@ -1205,7 +1218,7 @@ func TestTypesCommand(t *testing.T) {
 func TestIssue406(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestClient2("issue406", t, func(c service.Client) {
-		locs, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "issue406.go:146", false)
+		locs, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "issue406.go:146", false, false)
 		assertNoError(err, t, "FindLocation()")
 		_, err = c.CreateBreakpoint(&api.Breakpoint{Addr: locs[0].PC})
 		assertNoError(err, t, "CreateBreakpoint()")
@@ -1561,7 +1574,7 @@ func TestAcceptMulticlient(t *testing.T) {
 }
 
 func mustHaveDebugCalls(t *testing.T, c service.Client) {
-	locs, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "runtime.debugCallV1", false)
+	locs, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "runtime.debugCallV1", false, false)
 	if len(locs) == 0 || err != nil {
 		t.Skip("function calls not supported on this version of go")
 	}
@@ -1611,7 +1624,7 @@ func TestClientServerFunctionCallBadPos(t *testing.T) {
 	}
 	withTestClient2("fncall", t, func(c service.Client) {
 		mustHaveDebugCalls(t, c)
-		loc, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "fmt/print.go:649", false)
+		loc, err := c.FindLocation(api.EvalScope{-1, 0, 0}, "fmt/print.go:649", false, false)
 		assertNoError(err, t, "could not find location")
 
 		_, err = c.CreateBreakpoint(&api.Breakpoint{File: loc[0].File, Line: loc[0].Line})
@@ -1751,7 +1764,7 @@ func TestUnknownMethodCall(t *testing.T) {
 func TestIssue1703(t *testing.T) {
 	// Calling Disassemble when there is no current goroutine should work.
 	withTestClient2("testnextprog", t, func(c service.Client) {
-		locs, err := c.FindLocation(api.EvalScope{GoroutineID: -1}, "main.main", true)
+		locs, err := c.FindLocation(api.EvalScope{GoroutineID: -1}, "main.main", true, false)
 		assertNoError(err, t, "FindLocation")
 		t.Logf("FindLocation: %#v", locs)
 		text, err := c.DisassemblePC(api.EvalScope{GoroutineID: -1}, locs[0].PC, api.IntelFlavour)


### PR DESCRIPTION
Support both relative path and symbolic link in location expressions.

Fixes #1808