### PR TITLE
pkg,service: add cmd `examinemem`(`x`) for examining memory.

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -27,6 +27,7 @@ Command | Description
 [disassemble](#disassemble) | Disassembler.
 [down](#down) | Move the current frame down.
 [edit](#edit) | Open where you are in $DELVE_EDITOR or $EDITOR
+[examinemem](#examinemem) | Examine memory:
 [exit](#exit) | Exit the debugger.
 [frame](#frame) | Set the current frame, or execute command on a different frame.
 [funcs](#funcs) | Print list of functions.
@@ -212,6 +213,18 @@ Open where you are in $DELVE_EDITOR or $EDITOR
 If locspec is omitted edit will open the current source file in the editor, otherwise it will open the specified location.
 
 Aliases: ed
+
+## examinemem
+Examine memory:
+
+    examinemem [-fmt <format>] [-len <length>] <address>
+
+Format represents the data format and the value is one of this list (default hex): oct(octal), hex(hexadecimal), dec(decimal), bin(binary).
+Length is the number of bytes (default 1) and must be less than or equal to 1000.
+Address is the memory location of the target to examine.
+For example:  x -fmt hex -len 20 0xc00008af38
+
+Aliases: x
 
 ## exit
 Exit the debugger.

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -29,6 +29,7 @@ create_breakpoint(Breakpoint) | Equivalent to API call [CreateBreakpoint](https:
 detach(Kill) | Equivalent to API call [Detach](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Detach)
 disassemble(Scope, StartPC, EndPC, Flavour) | Equivalent to API call [Disassemble](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Disassemble)
 eval(Scope, Expr, Cfg) | Equivalent to API call [Eval](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Eval)
+examine_memory(Address, Length) | Equivalent to API call [ExamineMemory](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ExamineMemory)
 find_location(Scope, Loc, IncludeNonExecutableLines) | Equivalent to API call [FindLocation](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.FindLocation)
 function_return_locations(FnName) | Equivalent to API call [FunctionReturnLocations](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.FunctionReturnLocations)
 get_breakpoint(Id, Name) | Equivalent to API call [GetBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.GetBreakpoint)

--- a/_fixtures/examinememory.go
+++ b/_fixtures/examinememory.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+func main() {
+	l := int(51)
+	bs := make([]byte, l)
+	for i := 0; i < l; i++ {
+		bs[i] = byte(i + int(10))
+	}
+
+	bsp := (*byte)(unsafe.Pointer(&bs[0]))
+
+	bspUintptr := uintptr(unsafe.Pointer(bsp))
+
+	fmt.Printf("%#x\n", bspUintptr)
+	_ = *bsp
+
+	bs[0] = 255
+
+	_ = *bsp
+}

--- a/service/client.go
+++ b/service/client.go
@@ -147,6 +147,11 @@ type Client interface {
 	// ListDynamicLibraries returns a list of loaded dynamic libraries.
 	ListDynamicLibraries() ([]api.Image, error)
 
+	// ExamineMemory returns the raw memory stored at the given address.
+	// The amount of data to be read is specified by length which must be less than or equal to 1000.
+	// This function will return an error if it reads less than `length` bytes.
+	ExamineMemory(address uintptr, length int) ([]byte, error)
+
 	// Disconnect closes the connection to the server without sending a Detach request first.
 	// If cont is true a continue command will be sent instead.
 	Disconnect(cont bool) error

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1310,6 +1310,25 @@ func (d *Debugger) ListDynamicLibraries() []api.Image {
 	return r
 }
 
+// ExamineMemory returns the raw memory stored at the given address.
+// The amount of data to be read is specified by length.
+// This function will return an error if it reads less than `length` bytes.
+func (d *Debugger) ExamineMemory(address uintptr, length int) ([]byte, error) {
+	d.processMutex.Lock()
+	defer d.processMutex.Unlock()
+
+	thread := d.target.CurrentThread()
+	data := make([]byte, length)
+	n, err := thread.ReadMemory(data, address)
+	if err != nil {
+		return nil, err
+	}
+	if length != n {
+		return nil, errors.New("the specific range has exceeded readable area")
+	}
+	return data, nil
+}
+
 func (d *Debugger) GetVersion(out *api.GetVersionOut) error {
 	if d.config.CoreFile != "" {
 		if d.config.Backend == "rr" {

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -413,6 +413,17 @@ func (c *RPCClient) ListDynamicLibraries() ([]api.Image, error) {
 	return out.List, nil
 }
 
+func (c *RPCClient) ExamineMemory(address uintptr, count int) ([]byte, error) {
+	out := &ExaminedMemoryOut{}
+
+	err := c.call("ExamineMemory", ExamineMemoryIn{Length: count, Address: address}, out)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.Mem, nil
+}
+
 func (c *RPCClient) call(method string, args, reply interface{}) error {
 	return c.client.Call("RPCServer."+method, args, reply)
 }

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -751,3 +751,27 @@ func (s *RPCServer) ListPackagesBuildInfo(in ListPackagesBuildInfoIn, out *ListP
 	out.List = s.debugger.ListPackagesBuildInfo(in.IncludeFiles)
 	return nil
 }
+
+// ExamineMemoryIn holds the arguments of ExamineMemory
+type ExamineMemoryIn struct {
+	Address uintptr
+	Length  int
+}
+
+// ExaminedMemoryOut holds the return values of ExamineMemory
+type ExaminedMemoryOut struct {
+	Mem []byte
+}
+
+func (s *RPCServer) ExamineMemory(arg ExamineMemoryIn, out *ExaminedMemoryOut) error {
+	if arg.Length > 1000 {
+		return fmt.Errorf("len must be less than or equal to 1000")
+	}
+	Mem, err := s.debugger.ExamineMemory(arg.Address, arg.Length)
+	if err != nil {
+		return err
+	}
+
+	out.Mem = Mem
+	return nil
+}


### PR DESCRIPTION
According to #1800 #1584 #1038, `dlv` should enable the user to dive into
memory. User can print binary data in specific memory address range.
But not support for sepecific variable name or structures temporarily.(Because
I have no idea that modify `print` command.)  

Close #1584.


Next some questions: 
1. support the format for `print`cmd, include `address` , `variable name` and `structures`(no idea).  
2. support the form about `t(binary), f(float), a(address), i(instruction), c(char), s(string)` .  
3. support the negative position from address. (This is why also use `x /<FMT> [address]` like gdb, but not `x -<FMT> [address]`).  

----
I can close this pr if you against. 