### PR TITLE
dwarf/line: make LineToPCIn behave like LineToPC for lines without stmt

### DIFF
--- a/_fixtures/issue1817.go
+++ b/_fixtures/issue1817.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+func main() {
+	l := int(51)
+	bs := make([]byte, l)
+	for i := 0; i < l; i++ {
+		bs[i] = byte(i + int(10))
+	}
+
+	p := uintptr(unsafe.Pointer(&bs))
+
+	fmt.Println(p)
+
+	bs[0] = 254
+
+	runtime.KeepAlive(bs)
+}

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -313,13 +313,19 @@ func (lineInfo *DebugLineInfo) LineToPCIn(filename string, lineno int, basePC, s
 
 	sm := lineInfo.stateMachineFor(basePC, startPC)
 
+	var fallbackPC uint64
+
 	for {
 		if sm.valid && sm.started {
 			if sm.address >= endPC {
-				return 0
+				break
 			}
-			if sm.line == lineno && sm.file == filename && sm.address >= startPC && sm.isStmt {
-				return sm.address
+			if sm.line == lineno && sm.file == filename && sm.address >= startPC {
+				if sm.isStmt {
+					return sm.address
+				} else {
+					fallbackPC = sm.address
+				}
 			}
 		}
 		if err := sm.next(); err != nil {
@@ -331,7 +337,7 @@ func (lineInfo *DebugLineInfo) LineToPCIn(filename string, lineno int, basePC, s
 
 	}
 
-	return 0
+	return fallbackPC
 }
 
 // PrologueEndPC returns the first PC address marked as prologue_end in the half open interval [start, end)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -199,7 +199,7 @@ func setFileBreakpoint(p proc.Process, t *testing.T, path string, lineno int) *p
 		t.Fatalf("%s:%d: FindFileLocation(%s, %d): %v", f, l, path, lineno, err)
 	}
 	if len(addrs) != 1 {
-		t.Fatalf("%s:%d: setFileLineBreakpoint(%s, %d): too many results %v", f, l, path, lineno, addrs)
+		t.Fatalf("%s:%d: setFileLineBreakpoint(%s, %d): too many (or not enough) results %v", f, l, path, lineno, addrs)
 	}
 	bp, err := p.SetBreakpoint(addrs[0], proc.UserBreakpoint, nil)
 	if err != nil {
@@ -4515,5 +4515,13 @@ func TestIssue1736(t *testing.T) {
 		if ch1BufVar2.Unreadable != nil {
 			t.Fatal(ch1BufVar2.Unreadable)
 		}
+	})
+}
+
+func TestIssue1817(t *testing.T) {
+	// Setting a breakpoint on a line that doesn't have any PC addresses marked
+	// is_stmt should work.
+	withTestProcess("issue1817", t, func(p proc.Process, fixture protest.Fixture) {
+		setFileBreakpoint(p, t, fixture.Source, 16)
 	})
 }


### PR DESCRIPTION
```
dwarf/line: make LineToPCIn behave like LineToPC for lines without stmt

When a line has instructions associated but none of them have is_stmt
set LineToPC and LineToPCIn should behave in the same way.

Fixes #1817

```
