### PR TITLE
pkg/prog: Make sure Attach is executed on a single thread

### DIFF
--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -152,8 +152,12 @@ func findExePath(pid int) (string, error) {
 
 // Attach to an existing process with the given PID.
 func Attach(pid int, _ []string) (*Process, error) {
-	// TODO: Probably should have SeDebugPrivilege before starting here.
-	err := _DebugActiveProcess(uint32(pid))
+	dbp := New(pid)
+	var err error
+	dbp.execPtraceFunc(func() {
+		// TODO: Probably should have SeDebugPrivilege before starting here.
+		err = _DebugActiveProcess(uint32(pid))
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +165,6 @@ func Attach(pid int, _ []string) (*Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	dbp := New(pid)
 	if err = dbp.initialize(exepath, []string{}); err != nil {
 		dbp.Detach(true)
 		return nil, err


### PR DESCRIPTION
Specifically, make sure that both DebugActiveProcess and
WaitForDebugEvent Windows APIs are executed on the same thread.

Otherwise WaitForDebugEvent fails with ERROR_INVALID_HANDLE as per its
documentation

https://docs.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-waitfordebugevent

'... Only the thread that created the process being debugged can call
WaitForDebugEvent. ...'

Fixes #1825