### PR TITLE
service/test: Fix a wrong judgment about err.

### DIFF
--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -364,8 +364,8 @@ func TestClientServer_breakpointInMainThread(t *testing.T) {
 		}
 
 		state := <-c.Continue()
-		if err != nil {
-			t.Fatalf("Unexpected error: %v, state: %#v", err, state)
+		if state.Err != nil {
+			t.Fatalf("Unexpected error: %v, state: %#v", state.Err, state)
 		}
 
 		pc := state.CurrentThread.PC


### PR DESCRIPTION
Should judge `state.Err` instead of `err`.