### PR TITLE
*: Update go.mod version to 1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-delve/delve
 
-go 1.10
+go 1.11
 
 require (
 	github.com/cosiner/argv v0.0.0-20170225145430-13bacc38a0a5


### PR DESCRIPTION
We've dropped support for 1.11 in our CI runs, we should also update the
minimum require Go version in the mod file as well.

Resolves #1813