### PR TITLE
cmd,pkg,service: support mtls and tls with token.

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -20,6 +20,7 @@ Function | API Call
 amend_breakpoint(Breakpoint) | Equivalent to API call [AmendBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.AmendBreakpoint)
 ancestors(GoroutineID, NumAncestors, Depth) | Equivalent to API call [Ancestors](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Ancestors)
 attached_to_existing_process() | Equivalent to API call [AttachedToExistingProcess](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.AttachedToExistingProcess)
+auth(Token) | Equivalent to API call [Auth](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Auth)
 cancel_next() | Equivalent to API call [CancelNext](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.CancelNext)
 checkpoint(Where) | Equivalent to API call [Checkpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Checkpoint)
 clear_breakpoint(Id, Name) | Equivalent to API call [ClearBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ClearBreakpoint)

--- a/Documentation/usage/dlv.md
+++ b/Documentation/usage/dlv.md
@@ -30,6 +30,12 @@ Pass flags to the program you are debugging using `--`, for example:
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -30,6 +30,12 @@ dlv attach pid [executable]
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_backend.md
+++ b/Documentation/usage/dlv_backend.md
@@ -29,6 +29,12 @@ are:
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_connect.md
+++ b/Documentation/usage/dlv_connect.md
@@ -25,6 +25,12 @@ dlv connect addr
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_core.md
+++ b/Documentation/usage/dlv_core.md
@@ -31,6 +31,12 @@ dlv core <executable> <core>
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -37,6 +37,12 @@ dlv debug [package]
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -37,6 +37,12 @@ dlv exec <path/to/binary>
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_log.md
+++ b/Documentation/usage/dlv_log.md
@@ -43,6 +43,12 @@ mode.
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_replay.md
+++ b/Documentation/usage/dlv_replay.md
@@ -29,6 +29,12 @@ dlv replay [trace directory]
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_run.md
+++ b/Documentation/usage/dlv_run.md
@@ -25,6 +25,12 @@ dlv run
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -36,6 +36,12 @@ dlv test [package]
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -40,6 +40,12 @@ dlv trace [package] regexp
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -25,6 +25,12 @@ dlv version
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --mtls-ca-crt string   Specify ca crt file path of mtls to establish tcp connection.
+      --mtls-crt string      Specify crt file path of mtls to establish tcp connection.
+      --mtls-key string      Specify key file path of mtls to establish tcp connection.
+      --tls-crt string       Specify crt file path of tls, need to be generated manually by server and set by server/client.
+      --tls-key string       Specify key file path of tls, need to be generated manually by server and only set by server.
+      --tls-token string     Specify token string for authentication, set same value by server/client.
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/_fixtures/testtls.go
+++ b/_fixtures/testtls.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello dlv")
+}

--- a/pkg/tls/mtls.go
+++ b/pkg/tls/mtls.go
@@ -1,0 +1,59 @@
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+)
+
+func LoadCertPool(caCrtPath string) (*x509.CertPool, error) {
+	pem, err := ioutil.ReadFile(caCrtPath)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("pool append certs from pem failed")
+	}
+	return pool, nil
+}
+
+// loadMtlsConfig return *tls.Config by parsing caFile, certFile and KeyFile
+func loadMtlsConfig(caCrtPath, crtPath, keyPath string) (*tls.Config, error) {
+	pool, err := LoadCertPool(caCrtPath)
+	if err != nil {
+		return nil, fmt.Errorf("load cert pool from (%s): %v", caCrtPath, err)
+	}
+	cert, err := tls.LoadX509KeyPair(crtPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("load x509 key pair from (%s, %s): %v", crtPath, keyPath, err)
+	}
+	cfg := &tls.Config{
+		RootCAs:      pool,
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{cert},
+	}
+	return cfg, nil
+}
+
+// WrapListenerWithMtls return a listener with mtls validation.
+func WrapListenerWithMtls(l net.Listener, caCrtPath, crtPath, keyPath string) (net.Listener, error) {
+	config, err := loadMtlsConfig(caCrtPath, crtPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	return tls.NewListener(l, config), nil
+}
+
+// DialWithMtls return a connection with mtls validation.
+func DialWithMtls(network, addr string, caCrtPath string, crtPath string, keyPath string) (net.Conn, error) {
+	config, err := loadMtlsConfig(caCrtPath, crtPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	return tls.Dial(network, addr, config)
+}

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -1,0 +1,32 @@
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+)
+
+// WrapListenerWithTls return a listener with tls validation.
+func WrapListenerWithTls(l net.Listener, crtPath, keyPath string) (net.Listener, error) {
+	cert, err := tls.LoadX509KeyPair(crtPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	config := &tls.Config{Certificates: []tls.Certificate{cert}}
+	return tls.NewListener(l, config), nil
+}
+
+// DialWithTls return a connection with tls validation.
+func DialWithTls(network, addr, svcCrtPath string) (net.Conn, error) {
+	pem, err := ioutil.ReadFile(svcCrtPath)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("pool append certs from pem failed")
+	}
+	return tls.Dial(network, addr, &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12})
+}

--- a/scripts/openssl_generate_mtls_cert.go
+++ b/scripts/openssl_generate_mtls_cert.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Some parts are borrow from https://golang.org/src/crypto/tls/generate_cert.go.
+// Note: generate_cert.go don't support thant signed by ca.
+
+var (
+	host   = flag.String("host", "", "Comma-separated hostnames and IPs to generate a certificate for")
+	output = flag.String("output", "./", "")
+)
+
+func CreateCrtKey(pathPrefix string, host string, isCa bool, caPathPrefix string) {
+	x509Crt := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject:      pkix.Name{},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	x509CaCrt := x509Crt
+	var caPrivKey interface{}
+	if isCa {
+		x509Crt.IsCA = true
+		x509Crt.BasicConstraintsValid = true
+		x509Crt.KeyUsage = x509Crt.KeyUsage | x509.KeyUsageCertSign
+	} else {
+		if host != "" {
+			hosts := strings.Split(host, ",")
+			for _, h := range hosts {
+				if ip := net.ParseIP(h); ip != nil {
+					x509Crt.IPAddresses = append(x509Crt.IPAddresses, ip)
+				} else {
+					x509Crt.DNSNames = append(x509Crt.DNSNames, h)
+				}
+			}
+		}
+		if caPathPrefix != "" {
+			ca, err := tls.LoadX509KeyPair(fmt.Sprintf("%s.crt", caPathPrefix), fmt.Sprintf("%s.key", caPathPrefix))
+			if err != nil {
+				log.Fatalf("Error LoadX509KeyPair failed, %s", err)
+			}
+			x509CaCrt, err = x509.ParseCertificate(ca.Certificate[0])
+			if err != nil {
+				log.Fatalf("Error ParseX509KeyPair failed, %s", err)
+			}
+			caPrivKey = ca.PrivateKey
+		}
+	}
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		log.Fatalf("rsa generate key failed, %s", err)
+	}
+	if caPrivKey == nil {
+		caPrivKey = privKey
+	}
+	crtBytes, err := x509.CreateCertificate(rand.Reader, x509Crt, x509CaCrt, &privKey.PublicKey, caPrivKey)
+	if err != nil {
+		log.Fatalf("create crt failed %s", err)
+	}
+
+	// pem encode
+	crtPEM, err := os.Create(pathPrefix + ".crt")
+	if err != nil {
+		log.Fatalf("Failed to open %s for writing: %s", pathPrefix+".crt", err)
+	}
+	defer crtPEM.Close()
+	err = pem.Encode(crtPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: crtBytes,
+	})
+	if err != nil {
+		log.Fatalf("Failed to encode crt pem %s", err)
+	}
+
+	certPrivKeyPEM, err := os.Create(pathPrefix + ".key")
+	if err != nil {
+		log.Fatalf("Failed to open %s for writing: %s", pathPrefix+".key", err)
+	}
+	defer certPrivKeyPEM.Close()
+	err = pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+	})
+	if err != nil {
+		log.Fatalf("Failed to encode private pem %s", err)
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	if len(*host) == 0 {
+		log.Fatalf("Missing required --host parameter")
+	}
+
+	if err := os.MkdirAll(*output, 0755); err != nil && !os.IsExist(err) {
+		log.Fatal(err)
+	}
+
+	CreateCrtKey(filepath.Join(*output, "ca"), "", true, "")
+	CreateCrtKey(filepath.Join(*output, "server"), "127.0.0.1", false, filepath.Join(*output, "ca"))
+	CreateCrtKey(filepath.Join(*output, "client"), "", false, filepath.Join(*output, "ca"))
+}

--- a/scripts/openssl_generate_mtls_cert.sh
+++ b/scripts/openssl_generate_mtls_cert.sh
@@ -1,0 +1,18 @@
+mkdir mtls
+
+# specity the ip that the server will listen or client will connect
+echo subjectAltName = IP:127.0.0.1 > ./mtls/extfile.cnf
+
+# generate ca.key/ca.crt
+openssl genrsa -out ./mtls/ca.key 2048
+openssl req -x509 -new -nodes -key ./mtls/ca.key -days 5000 -subj "/CN=go-delve" -out ./mtls/ca.crt
+
+# generate sever.key/server.scr/server.crt
+openssl genrsa -out ./mtls/server.key 2048
+openssl req -new -key ./mtls/server.key -subj "/CN=go-delve" -out ./mtls/server.csr
+openssl x509 -req -in ./mtls/server.csr -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -CAcreateserial -extfile ./mtls/extfile.cnf -out ./mtls/server.crt -days 5000
+
+# generate client.key/client.scr/client.crt
+openssl genrsa -out ./mtls/client.key 2048
+openssl req -new -key ./mtls/client.key -subj "/CN=go-delve" -out ./mtls/client.csr
+openssl x509 -req -in ./mtls/client.csr -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -CAcreateserial -out ./mtls/client.crt -days 5000

--- a/service/client.go
+++ b/service/client.go
@@ -151,6 +151,9 @@ type Client interface {
 	// If cont is true a continue command will be sent instead.
 	Disconnect(cont bool) error
 
+	// Auth will verify the validity of token and error only occur when rpc failed.
+	Auth(token string) (bool, error)
+
 	// CallAPI allows calling an arbitrary rpc method (used by starlark bindings)
 	CallAPI(method string, args, reply interface{}) error
 }

--- a/service/config.go
+++ b/service/config.go
@@ -46,4 +46,8 @@ type Config struct {
 
 	// DisconnectChan will be closed by the server when the client disconnects
 	DisconnectChan chan<- struct{}
+
+	// Token are used for authentication of connection between server and client. Skip
+	// authentication if the value is nil.
+	Token string
 }

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -751,3 +751,22 @@ func (s *RPCServer) ListPackagesBuildInfo(in ListPackagesBuildInfoIn, out *ListP
 	out.List = s.debugger.ListPackagesBuildInfo(in.IncludeFiles)
 	return nil
 }
+
+type AuthIn struct {
+	Token string
+}
+
+type AuthOut struct {
+	IsValid bool
+}
+
+// Auth will verify the validity of token from client by s.config.Token.
+// Always return pass if s.config.Token is nil.
+func (s *RPCServer) Auth(in AuthIn, out *AuthOut) error {
+	if s.config.Token == "" || s.config.Token == in.Token {
+		out.IsValid = true
+		return nil
+	}
+	out.IsValid = false
+	return nil
+}

--- a/service/test/tls_test.go
+++ b/service/test/tls_test.go
@@ -1,0 +1,306 @@
+package service_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	protest "github.com/go-delve/delve/pkg/proc/test"
+	nativetls "github.com/go-delve/delve/pkg/tls"
+	"github.com/go-delve/delve/service"
+	"github.com/go-delve/delve/service/api"
+	"github.com/go-delve/delve/service/rpc2"
+	"github.com/go-delve/delve/service/rpccommon"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+/*
+
+# Using openssl to generate is also ok.
+
+mtls.sh
+	mkdir mtls
+
+	# specity the ip that the server will listen or client will connect
+	echo subjectAltName = IP:127.0.0.1 > ./mtls/extfile.cnf
+
+	# generate ca.key/ca.crt
+	openssl genrsa -out ./mtls/ca.key 2048
+	openssl req -x509 -new -nodes -key ./mtls/ca.key -days 5000 -subj "/CN=go-delve" -out ./mtls/ca.crt
+
+	# generate sever.key/server.scr/server.crt with ca signed
+	openssl genrsa -out ./mtls/server.key 2048
+	openssl req -new -key ./mtls/server.key -subj "/CN=go-delve" -out ./mtls/server.csr
+	openssl x509 -req -in ./mtls/server.csr -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -CAcreateserial -extfile ./mtls/extfile.cnf -out ./mtls/server.crt -days 5000
+
+	# generate client.key/client.scr/client.crt with ca signed
+	openssl genrsa -out ./mtls/client.key 2048
+	openssl req -new -key ./mtls/client.key -subj "/CN=go-delve" -out ./mtls/client.csr
+	openssl x509 -req -in ./mtls/client.csr -CA ./mtls/ca.crt -CAkey ./mtls/ca.key -CAcreateserial -out ./mtls/client.crt -days 5000
+
+
+tlstoken.sh
+    # some parts are borrowed by https://stackoverflow.com/questions/21488845/how-can-i-generate-a-self-signed-certificate-with-subjectaltname-using-openssl
+    mkdir tlstoken
+
+	# specity the ip that the server will listen or client will connect
+	echo -e "[req]\nx509_extensions = v3_ca\ndistinguished_name = req_distinguished_name\n[req_distinguished_name]\n\n[v3_ca]\n\nsubjectAltName = @alt_names\nbasicConstraints = CA:FALSE\nkeyUsage = nonRepudiation, digitalSignature, keyEncipherment\n\n\n[alt_names]\nIP = 127.0.0.1" > ./tlstoken/config.cnf
+
+    openssl genrsa -out ./tlstoken/server.key 2048
+    openssl req -new -x509 -key ./tlstoken/server.key -days 3650 -subj "/CN=go-delve"  -config ./tlstoken/config.cnf -out ./tlstoken/server.crt
+
+    (or use `go run $GOROOT/src/crypto/tls/generate_cert.go --host 127.0.0.1`, be careful to the name and path of files maybe diffrent with above)
+*/
+
+// CreateCaFile will create a pair about crt/key (signed with itself / signed with ca) and return paths of those.
+// Some parts are borrowed from https://golang.org/src/crypto/tls/generate_cert.go.
+func CreateCrtKey(pathPrefix string, host string, isCa bool, caPathPrefix string) {
+	x509Crt := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject:      pkix.Name{},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	x509CaCrt := x509Crt
+	var caPrivKey interface{}
+	if isCa {
+		x509Crt.IsCA = true
+		x509Crt.BasicConstraintsValid = true
+		x509Crt.KeyUsage = x509Crt.KeyUsage | x509.KeyUsageCertSign
+	} else {
+		if host != "" {
+			hosts := strings.Split(host, ",")
+			for _, h := range hosts {
+				if ip := net.ParseIP(h); ip != nil {
+					x509Crt.IPAddresses = append(x509Crt.IPAddresses, ip)
+				} else {
+					x509Crt.DNSNames = append(x509Crt.DNSNames, h)
+				}
+			}
+		}
+		if caPathPrefix != "" {
+			ca, err := tls.LoadX509KeyPair(fmt.Sprintf("%s.crt", caPathPrefix), fmt.Sprintf("%s.key", caPathPrefix))
+			if err != nil {
+				log.Fatalf("Error LoadX509KeyPair failed, %s", err)
+			}
+			x509CaCrt, err = x509.ParseCertificate(ca.Certificate[0])
+			if err != nil {
+				log.Fatalf("Error ParseX509KeyPair failed, %s", err)
+			}
+			caPrivKey = ca.PrivateKey
+		}
+	}
+	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		log.Fatalf("rsa generate key failed, %s", err)
+	}
+	if caPrivKey == nil {
+		caPrivKey = privKey
+	}
+	crtBytes, err := x509.CreateCertificate(rand.Reader, x509Crt, x509CaCrt, &privKey.PublicKey, caPrivKey)
+	if err != nil {
+		log.Fatalf("create crt failed %s", err)
+	}
+
+	// pem encode
+	crtPEM, err := os.Create(pathPrefix + ".crt")
+	if err != nil {
+		log.Fatalf("Failed to open %s for writing: %s", pathPrefix+".crt", err)
+	}
+	defer crtPEM.Close()
+	err = pem.Encode(crtPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: crtBytes,
+	})
+	if err != nil {
+		log.Fatalf("Failed to encode crt pem %s", err)
+	}
+
+	certPrivKeyPEM, err := os.Create(pathPrefix + ".key")
+	if err != nil {
+		log.Fatalf("Failed to open %s for writing: %s", pathPrefix+".key", err)
+	}
+	defer certPrivKeyPEM.Close()
+	err = pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+	})
+	if err != nil {
+		log.Fatalf("Failed to encode private pem %s", err)
+	}
+}
+
+func createNSetsFileOfCrtsAndKeys(N int, outputPath string, t *testing.T) {
+	err := os.MkdirAll(outputPath, 0755)
+	if err != nil && os.IsExist(err) {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < N; i++ {
+		CreateCrtKey(filepath.Join(outputPath, fmt.Sprintf("ca%d", i)), "", true, "")
+		CreateCrtKey(filepath.Join(outputPath, fmt.Sprintf("server%d", i)), "127.0.0.1", false, filepath.Join(outputPath, fmt.Sprintf("ca%d", i)))
+		CreateCrtKey(filepath.Join(outputPath, fmt.Sprintf("client%d", i)), "", false, filepath.Join(outputPath, fmt.Sprintf("ca%d", i)))
+	}
+}
+
+func getTlsPathArugments(path, name string, idx int) (string, string, string) {
+	caCrt := filepath.Join(path, fmt.Sprintf("ca%d.crt", idx))
+	crt := filepath.Join(path, fmt.Sprintf("%s%d.crt", name, idx))
+	key := filepath.Join(path, fmt.Sprintf("%s%d.key", name, idx))
+	return caCrt, crt, key
+}
+
+func withTestClient2OnMtls(name, genPath string, cKeyPairIdx, sKeyPairIdx int, t *testing.T, fn func(c service.Client, err error)) {
+	if testBackend == "rr" {
+		protest.MustHaveRecordingAllowed(t)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("couldn't start listener: %s\n", err)
+	}
+	defer listener.Close()
+	var buildFlags protest.BuildFlags
+	if buildMode == "pie" {
+		buildFlags = protest.BuildModePIE
+	}
+	sCaCrt, sCrt, sKey := getTlsPathArugments(genPath, "server", sKeyPairIdx)
+	listener, err = nativetls.WrapListenerWithMtls(listener, sCaCrt, sCrt, sKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixture := protest.BuildFixture(name, buildFlags)
+	server := rpccommon.NewServer(&service.Config{
+		Listener:       listener,
+		ProcessArgs:    []string{fixture.Path},
+		Backend:        testBackend,
+		CheckGoVersion: true,
+	})
+	if err := server.Run(); err != nil {
+		t.Fatal(err)
+	}
+	cCaCrt, cCrt, cKey := getTlsPathArugments(genPath, "client", cKeyPairIdx)
+	var client *rpc2.RPCClient
+	client, err = rpc2.NewMtlsClientWithCrtKeyPath(listener.Addr().String(), cCaCrt, cCrt, cKey)
+	if err == nil {
+		defer func() {
+			client.Detach(true)
+		}()
+	}
+
+	fn(client, err)
+}
+
+func TestRunOnMtls(t *testing.T) {
+	genPath := "./test_mtls_path"
+
+	// Generate 2 sets of caCrt, crt and key
+	createNSetsFileOfCrtsAndKeys(2, genPath, t)
+	defer os.RemoveAll(genPath)
+
+	// If the crts of server and client are signed with different cas, it will expect a error
+	withTestClient2OnMtls("testtls", genPath, 0, 1, t, func(c service.Client, err error) {
+		assertError(err, t, "get client2 on mtls")
+	})
+
+	// If the crts of server and client are signed with the same ca, will run ok
+	withTestClient2OnMtls("testtls", genPath, 0, 0, t, func(c service.Client, err error) {
+		assertNoError(err, t, "get client2 on mtls")
+
+		_, err = c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		stateCh := <-c.Continue()
+		if stateCh.Err != nil {
+			t.Fatalf("Unexpected error: %v, state: %#v", stateCh.Err, stateCh)
+		}
+		<-c.Continue()
+	})
+}
+
+func withTestClient2OnTlsToken(name, pathPrefix, cToken, sToken string, t *testing.T, fn func(c service.Client, err error)) {
+	if testBackend == "rr" {
+		protest.MustHaveRecordingAllowed(t)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("couldn't start listener: %s\n", err)
+	}
+	defer listener.Close()
+	var buildFlags protest.BuildFlags
+	if buildMode == "pie" {
+		buildFlags = protest.BuildModePIE
+	}
+	sCrtPath := pathPrefix + ".crt"
+	sKeyPath := pathPrefix + ".key"
+	listener, err = nativetls.WrapListenerWithTls(listener, sCrtPath, sKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := protest.BuildFixture(name, buildFlags)
+	server := rpccommon.NewServer(&service.Config{
+		Listener:       listener,
+		ProcessArgs:    []string{fixture.Path},
+		Backend:        testBackend,
+		CheckGoVersion: true,
+		Token:          sToken,
+	})
+	if err := server.Run(); err != nil {
+		t.Fatal(err)
+	}
+	var client *rpc2.RPCClient
+	client, err = rpc2.NewTlsClientWithToken(listener.Addr().String(), sCrtPath, cToken)
+	if err == nil {
+		defer func() {
+			client.Detach(true)
+		}()
+	}
+	fn(client, err)
+}
+
+func TestRunOnTlsToken(t *testing.T) {
+	genPath := "./test_tls_path"
+	err := os.MkdirAll(genPath, 0755)
+	if err != nil && os.IsExist(err) {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(genPath)
+	// Generate the key pair of server
+	CreateCrtKey(filepath.Join(genPath, "server"), "127.0.0.1", false, "")
+
+	// If the crts of server/client are signed with the ca and tokens are different, it will expect a error.
+	withTestClient2OnTlsToken("testtls", genPath+"/server", "chainhelen-client", "dlv-server", t, func(c service.Client, err error) {
+		assertError(err, t, "get client2 on TlsToken")
+	})
+
+	// If the crts of server/client are signed with the ca and tokens are same, it will run ok.
+	withTestClient2OnTlsToken("testtls", genPath+"/server", "dlv-server", "dlv-server", t, func(c service.Client, err error) {
+		assertNoError(err, t, "get client2 on TlsToken")
+
+		_, err = c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		state := <-c.Continue()
+		if state.Err != nil {
+			t.Fatalf("Unexpected error: %v, state: %#v", state.Err, state)
+		}
+		if state.CurrentThread.Line != 6 {
+			t.Fatalf("Program not stopped at correct spot expected %d was %d", 6, state.CurrentThread.Line)
+		}
+		<-c.Continue()
+	})
+}


### PR DESCRIPTION
Ensure the safety of data transmission during remote debugging by mtls or tls
with token.

Fix #861 #1332  

---- 
I implement two ways about tls  (Tls should be L4, and token seem like L7).    

**1. mtls**  
Generate 3 key pairs(6 files) for ca/client/server. (no need to have token. Maybe not friendly for goland? and very complicated to me), can use the following steps to test. 
 
　　1.1.  Generate (Note: the ip for server default 127.0.0.1) 
       ```use openssl by ./scripts/openssl_generate_mtls_cert.sh (or go run ./scripts/openssl_generate_mtls_cert.go --host 127.0.0.1 --output ./mtls)```  

　　1.2. Server side 
       ```dlv debug main.go --mtls-ca-crt ./mtls/ca.crt --mtls-crt ./mtls/server.crt --mtls-key ./mtls/server.key  --headless --listen 127.0.0.1:3333```    

　　1.3. Client side
       ```dlv connect 127.0.0.1:3333 --mtls-ca-crt ./mtls/ca.crt --mtls-crt ./mtls/client.crt --mtls-key ./mtls/client.key```   

**2. tls(One-Way SSL) and token**
    2.1. Just only need the machine of server side to generate one key pairs(2 files, crt is signed with itself without ca)    
  ```   
# use openssl
# some parts are borrowed by https://stackoverflow.com/questions/21488845/how-can-i-generate-a-self-signed-certificate-with-subjectaltname-using-openssl   

# tlstoken.sh
mkdir tlstoken 

# specity the ip that the server will listen or client will connect
echo -e "[req]\nx509_extensions = v3_ca\ndistinguished_name = req_distinguished_name\n[req_distinguished_name]\n\n[v3_ca]\n\nsubjectAltName = @alt_names\nbasicConstraints = CA:FALSE\nkeyUsage = nonRepudiation, digitalSignature, keyEncipherment\n\n\n[alt_names]\nIP = 127.0.0.1" > ./tlstoken/config.cnf  

openssl genrsa -out ./tlstoken/server.key 2048  

openssl req -new -x509 -key ./tlstoken/server.key -days 3650 -subj "/CN=go-delve"  -config ./tlstoken/config.cnf -out ./tlstoken/server.crt
```
or 
```
use "go run $GOROOT/src/crypto/tls/generate_cert.go --host 127.0.0.1"  to generate (Be careful to the name and path of files maybe different with below) 
```

　　2.2 Server side 
　　　```dlv debug main.go --tls-crt ./tlstoken/server.crt --tls-key ./tlstoken/server.key --tls-token godelve  --headless --listen 127.0.0.1:3333```    

　　2.3 Client side (need to copy server.crt from server side)  
　　　```dlv connect 127.0.0.1:3333 --tls-crt ./tlstoken/server.crt --tls-token godelve```    

----   


I think it's possible that mtls can be removed because it is unfriendly to operate, just save tls with token.  
Need discussion,  @dlsniper @justinclift (#861) @antong (#1332) , thx.


