### PR TITLE
proc: cache mapping between goroutine ID and runtime.allgs index

### DIFF
--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -114,10 +114,18 @@ type BreakpointManipulation interface {
 // CommonProcess contains fields used by this package, common to all
 // implementations of the Process interface.
 type CommonProcess struct {
-	allGCache     []*G
+	goroutineCache
+
 	fncallEnabled bool
 
 	fncallForG map[int]*callInjection
+}
+
+type goroutineCache struct {
+	partialGCache map[int]*G
+	allGCache     []*G
+
+	allgentryAddr, allglenAddr uint64
 }
 
 type callInjection struct {
@@ -132,9 +140,4 @@ type callInjection struct {
 // all process implementations.
 func NewCommonProcess(fncallEnabled bool) CommonProcess {
 	return CommonProcess{fncallEnabled: fncallEnabled, fncallForG: make(map[int]*callInjection)}
-}
-
-// ClearAllGCache clears the cached contents of the cache for runtime.allgs.
-func (p *CommonProcess) ClearAllGCache() {
-	p.allGCache = nil
 }


### PR DESCRIPTION
```
proc: cache mapping between goroutine ID and runtime.allgs index

Caches the mapping between a goroutine ID and its position inside the
runtime.allgs array, this allows speeding up FindGoroutine and makes
commands like 'goroutines -t' not be accidentally quadratic in the
number of goroutines.

```
