### PR TITLE
pkg/proc: Remove disasm based prologue detection

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -11,7 +11,6 @@ type Arch interface {
 	PtrSize() int
 	MaxInstructionLength() int
 	AsmDecode(asmInst *AsmInstruction, mem []byte, regs Registers, memrw MemoryReadWriter, bi *BinaryInfo) error
-	Prologues() []opcodeSeq
 	BreakpointInstruction() []byte
 	BreakInstrMovesPC() bool
 	BreakpointSize() int

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -49,52 +49,6 @@ const (
 
 type opcodeSeq []uint64
 
-// firstPCAfterPrologueDisassembly returns the address of the first
-// instruction after the prologue for function fn by disassembling fn and
-// matching the instructions against known split-stack prologue patterns.
-// If sameline is set firstPCAfterPrologueDisassembly will always return an
-// address associated with the same line as fn.Entry
-func firstPCAfterPrologueDisassembly(p Process, fn *Function, sameline bool) (uint64, error) {
-	var mem MemoryReadWriter = p.CurrentThread()
-	breakpoints := p.Breakpoints()
-	bi := p.BinInfo()
-	text, err := disassemble(mem, nil, breakpoints, bi, fn.Entry, fn.End, false)
-	if err != nil {
-		return fn.Entry, err
-	}
-
-	if len(text) <= 0 {
-		return fn.Entry, nil
-	}
-
-	for _, prologue := range p.BinInfo().Arch.Prologues() {
-		if len(prologue) >= len(text) {
-			continue
-		}
-		if checkPrologue(text, prologue) {
-			r := &text[len(prologue)]
-			if sameline {
-				if r.Loc.Line != text[0].Loc.Line {
-					return fn.Entry, nil
-				}
-			}
-			return r.Loc.PC, nil
-		}
-	}
-
-	return fn.Entry, nil
-}
-
-func checkPrologue(s []AsmInstruction, prologuePattern opcodeSeq) bool {
-	line := s[0].Loc.Line
-	for i, op := range prologuePattern {
-		if !s[i].Inst.OpcodeEquals(op) || s[i].Loc.Line != line {
-			return false
-		}
-	}
-	return true
-}
-
 // Disassemble disassembles target memory between startAddr and endAddr, marking
 // the current instruction being executed in goroutine g.
 // If currentGoroutine is set and thread is stopped at a CALL instruction Disassemble

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -801,20 +801,15 @@ func FirstPCAfterPrologue(p Process, fn *Function, sameline bool) (uint64, error
 		if entryLine == line {
 			return pc, nil
 		}
+	} else {
+		pc = fn.Entry
 	}
 
-	pc, err := firstPCAfterPrologueDisassembly(p, fn, sameline)
-	if err != nil {
-		return fn.Entry, err
-	}
-
-	if pc == fn.Entry {
-		// Look for the first instruction with the stmt flag set, so that setting a
-		// breakpoint with file:line and with the function name always result on
-		// the same instruction being selected.
-		if pc2, _, _, ok := fn.cu.lineInfo.FirstStmtForLine(fn.Entry, fn.End); ok {
-			return pc2, nil
-		}
+	// Look for the first instruction with the stmt flag set, so that setting a
+	// breakpoint with file:line and with the function name always result on
+	// the same instruction being selected.
+	if pc2, _, _, ok := fn.cu.lineInfo.FirstStmtForLine(fn.Entry, fn.End); ok {
+		return pc2, nil
 	}
 
 	return pc, nil


### PR DESCRIPTION
Go started using the prologue_end DWARF attr in v1.11. Since that is now
the minimum supported Go version (Travis only tests 1.11 and above)
let's remove the legacy code which tries to disassemble the function to
find the end of the prologue.