### PR TITLE
proc,service: expose goroutine pprof labels in api

### DIFF
--- a/_fixtures/goroutineLabels.go
+++ b/_fixtures/goroutineLabels.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"runtime"
+	"runtime/pprof"
+)
+
+func main() {
+	ctx := context.Background()
+	labels := pprof.Labels("k1", "v1", "k2", "v2")
+	runtime.Breakpoint()
+	pprof.Do(ctx, labels, f)
+}
+
+var dummy int
+
+func f(ctx context.Context) {
+	a := dummy
+	runtime.Breakpoint()
+	dummy++
+	dummy = a
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2310,17 +2310,18 @@ func TestGoroutineLables(t *testing.T) {
 		assertNoError(proc.Continue(p), t, "Continue()")
 		g, err := proc.GetG(p.CurrentThread())
 		assertNoError(err, t, "GetG()")
-		if len(g.Labels) != 0 {
+		if len(g.Labels()) != 0 {
 			t.Fatalf("No labels expected")
 		}
 
 		assertNoError(proc.Continue(p), t, "Continue()")
 		g, err = proc.GetG(p.CurrentThread())
 		assertNoError(err, t, "GetG()")
-		if v := g.Labels["k1"]; v != "v1" {
+		labels := g.Labels()
+		if v := labels["k1"]; v != "v1" {
 			t.Errorf("Unexpected label value k1=%v", v)
 		}
-		if v := g.Labels["k2"]; v != "v2" {
+		if v := labels["k2"]; v != "v2" {
 			t.Errorf("Unexpected label value k2=%v", v)
 		}
 	})

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2305,6 +2305,27 @@ func TestIssue561(t *testing.T) {
 	})
 }
 
+func TestGoroutineLables(t *testing.T) {
+	withTestProcess("goroutineLabels", t, func(p proc.Process, fixture protest.Fixture) {
+		assertNoError(proc.Continue(p), t, "Continue()")
+		g, err := proc.GetG(p.CurrentThread())
+		assertNoError(err, t, "GetG()")
+		if len(g.Labels) != 0 {
+			t.Fatalf("No labels expected")
+		}
+
+		assertNoError(proc.Continue(p), t, "Continue()")
+		g, err = proc.GetG(p.CurrentThread())
+		assertNoError(err, t, "GetG()")
+		if v := g.Labels["k1"]; v != "v1" {
+			t.Errorf("Unexpected label value k1=%v", v)
+		}
+		if v := g.Labels["k2"]; v != "v2" {
+			t.Errorf("Unexpected label value k2=%v", v)
+		}
+	})
+}
+
 func TestStepOut(t *testing.T) {
 	testseq2(t, "testnextprog", "main.helloworld", []seqTest{{contContinue, 13}, {contStepout, 35}})
 }

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -263,7 +263,7 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 		GoStatementLoc: ConvertLocation(g.Go()),
 		StartLoc:       ConvertLocation(g.StartLoc()),
 		ThreadID:       tid,
-		Labels:         g.Labels,
+		Labels:         g.Labels(),
 	}
 	if g.Unreadable != nil {
 		r.Unreadable = g.Unreadable.Error()

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -263,6 +263,7 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 		GoStatementLoc: ConvertLocation(g.Go()),
 		StartLoc:       ConvertLocation(g.StartLoc()),
 		ThreadID:       tid,
+		Labels:         g.Labels,
 	}
 	if g.Unreadable != nil {
 		r.Unreadable = g.Unreadable.Error()

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -308,6 +308,8 @@ type Goroutine struct {
 	// ID of the associated thread for running goroutines
 	ThreadID   int    `json:"threadID"`
 	Unreadable string `json:"unreadable"`
+	// Goroutine's pprof labels
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // DebuggerCommand is a command which changes the debugger's execution state.


### PR DESCRIPTION
Labels can help in identifying a particular goroutine during debugging.

Fixes #1763