### PR TITLE
pkg/terminal: tolerate spurious spaces between arguments of cli.

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -684,8 +684,16 @@ func selectedGID(state *api.DebuggerState) int {
 	return state.SelectedGoroutine.ID
 }
 
+func split2PartsBySpace(s string) []string {
+	v := strings.SplitN(s, " ", 2)
+	for i, _ := range v {
+		v[i] = strings.TrimSpace(v[i])
+	}
+	return v
+}
+
 func (c *Commands) goroutine(t *Term, ctx callContext, argstr string) error {
-	args := strings.SplitN(argstr, " ", 2)
+	args := split2PartsBySpace(argstr)
 
 	if ctx.Prefix == onPrefix {
 		if len(args) != 1 || args[0] != "" {
@@ -734,7 +742,7 @@ func (c *Commands) frameCommand(t *Term, ctx callContext, argstr string, directi
 			return errors.New("not enough arguments")
 		}
 	} else {
-		args := strings.SplitN(argstr, " ", 2)
+		args := split2PartsBySpace(argstr)
 		var err error
 		if frame, err = strconv.Atoi(args[0]); err != nil {
 			return err
@@ -872,7 +880,7 @@ func restart(t *Term, ctx callContext, args string) error {
 }
 
 func restartRecorded(t *Term, ctx callContext, args string) error {
-	v := strings.SplitN(args, " ", 2)
+	v := split2PartsBySpace(args)
 
 	rerecord := false
 	resetArgs := false
@@ -1267,7 +1275,7 @@ func breakpoints(t *Term, ctx callContext, args string) error {
 }
 
 func setBreakpoint(t *Term, ctx callContext, tracepoint bool, argstr string) error {
-	args := strings.SplitN(argstr, " ", 2)
+	args := split2PartsBySpace(argstr)
 
 	requestedBp := &api.Breakpoint{}
 	locspec := ""
@@ -1448,7 +1456,7 @@ func types(t *Term, ctx callContext, args string) error {
 }
 
 func parseVarArguments(args string, t *Term) (filter string, cfg api.LoadConfig) {
-	if v := strings.SplitN(args, " ", 2); len(v) >= 1 && v[0] == "-v" {
+	if v := split2PartsBySpace(args); len(v) >= 1 && v[0] == "-v" {
 		if len(v) == 2 {
 			return v[1], t.loadConfig()
 		} else {
@@ -1716,7 +1724,7 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 	var cmd, rest string
 
 	if args != "" {
-		argv := strings.SplitN(args, " ", 2)
+		argv := split2PartsBySpace(args)
 		if len(argv) != 2 {
 			return disasmUsageError
 		}
@@ -1735,17 +1743,17 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 		}
 		disasm, disasmErr = t.client.DisassemblePC(ctx.Scope, locs[0].PC, api.IntelFlavour)
 	case "-a":
-		v := strings.SplitN(rest, " ", 2)
+		v := split2PartsBySpace(rest)
 		if len(v) != 2 {
 			return disasmUsageError
 		}
 		startpc, err := strconv.ParseInt(v[0], 0, 64)
 		if err != nil {
-			return fmt.Errorf("wrong argument: %s is not a number", v[0])
+			return fmt.Errorf("wrong argument: %q is not a number", v[0])
 		}
 		endpc, err := strconv.ParseInt(v[1], 0, 64)
 		if err != nil {
-			return fmt.Errorf("wrong argument: %s is not a number", v[1])
+			return fmt.Errorf("wrong argument: %q is not a number", v[1])
 		}
 		disasm, disasmErr = t.client.DisassembleRange(ctx.Scope, uint64(startpc), uint64(endpc), api.IntelFlavour)
 	case "-l":
@@ -2076,7 +2084,7 @@ func getBreakpointByIDOrName(t *Term, arg string) (*api.Breakpoint, error) {
 }
 
 func (c *Commands) onCmd(t *Term, ctx callContext, argstr string) error {
-	args := strings.SplitN(argstr, " ", 2)
+	args := split2PartsBySpace(argstr)
 
 	if len(args) < 2 {
 		return errors.New("not enough arguments")
@@ -2097,7 +2105,7 @@ func (c *Commands) onCmd(t *Term, ctx callContext, argstr string) error {
 }
 
 func conditionCmd(t *Term, ctx callContext, argstr string) error {
-	args := strings.SplitN(argstr, " ", 2)
+	args := split2PartsBySpace(argstr)
 
 	if len(args) < 2 {
 		return fmt.Errorf("not enough arguments")

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -774,6 +774,13 @@ func TestConfig(t *testing.T) {
 	if *term.conf.MaxStringLen != 10 {
 		t.Fatalf("expected MaxStringLen 10, got: %d", *term.conf.MaxStringLen)
 	}
+	err = configureCmd(&term, callContext{}, "show-location-expr   true")
+	if err != nil {
+		t.Fatalf("error executing configureCmd(show-location-expr   true)")
+	}
+	if term.conf.ShowLocationExpr != true {
+		t.Fatalf("expected ShowLocationExpr true, got false")
+	}
 	err = configureCmd(&term, callContext{}, "max-variable-recurse 4")
 	if err != nil {
 		t.Fatalf("error executing configureCmd(max-variable-recurse): %v", err)

--- a/pkg/terminal/config.go
+++ b/pkg/terminal/config.go
@@ -95,7 +95,7 @@ func configureList(t *Term) error {
 }
 
 func configureSet(t *Term, args string) error {
-	v := strings.SplitN(args, " ", 2)
+	v := split2PartsBySpace(args)
 
 	cfgname := v[0]
 	var rest string


### PR DESCRIPTION
Expression such as:  
```
   config show-location-expr  true
   disassemble -a  0x4a23a0 0x4a23f2
   disassemble -a 0x4a23a0  0x4a23f2 
```
should all execute correctly.

Extend #795. 

---- 

1. I take this pr beacause I meet one problem when working on #1810. 

Ex:
```
(dlv) config show-location-expr true
(dlv) config show-location-expr  true
```
The second type show nothing(no error), but set `show-location-expr` false actually which is not expected.


2. Then I test some similar cmd.

```
(dlv) disassemble -a  0x4a23a0 0x4a23f2
Command failed: wrong argument:  is not a number
```

or 

```
disassemble -a 0x4a23a0  0x4a2424
Command failed: wrong argument:  0x4a2424 is not a number
```

or

```
(dlv) locals  -v   a  
(get `  a` but expected `a`)
```

3. #795 maybe not solve that spurious spaces between arguments.  