### PR TITLE
Fix same-user check and add flag to disable it

### DIFF
--- a/Documentation/usage/dlv.md
+++ b/Documentation/usage/dlv.md
@@ -30,6 +30,7 @@ Pass flags to the program you are debugging using `--`, for example:
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -30,6 +30,7 @@ dlv attach pid [executable]
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_backend.md
+++ b/Documentation/usage/dlv_backend.md
@@ -29,6 +29,7 @@ are:
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_connect.md
+++ b/Documentation/usage/dlv_connect.md
@@ -25,6 +25,7 @@ dlv connect addr
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_core.md
+++ b/Documentation/usage/dlv_core.md
@@ -31,6 +31,7 @@ dlv core <executable> <core>
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -37,6 +37,7 @@ dlv debug [package]
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -37,6 +37,7 @@ dlv exec <path/to/binary>
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_log.md
+++ b/Documentation/usage/dlv_log.md
@@ -43,6 +43,7 @@ mode.
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_replay.md
+++ b/Documentation/usage/dlv_replay.md
@@ -29,6 +29,7 @@ dlv replay [trace directory]
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_run.md
+++ b/Documentation/usage/dlv_run.md
@@ -25,6 +25,7 @@ dlv run
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -36,6 +36,7 @@ dlv test [package]
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -40,6 +40,7 @@ dlv trace [package] regexp
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -25,6 +25,7 @@ dlv version
       --log                  Enable debugging server logging.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
       --wd string            Working directory for running the program. (default ".")
 ```
 

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -47,6 +47,9 @@ var (
 	BuildFlags string
 	// WorkingDir is the working directory for running the program.
 	WorkingDir string
+	// CheckLocalConnUser is true if the debugger should check that local
+	// connections come from the same user that started the headless server
+	CheckLocalConnUser bool
 
 	// Backend selection
 	Backend string
@@ -111,6 +114,7 @@ func New(docCall bool) *cobra.Command {
 	RootCommand.PersistentFlags().StringVar(&BuildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")
 	RootCommand.PersistentFlags().StringVar(&WorkingDir, "wd", ".", "Working directory for running the program.")
 	RootCommand.PersistentFlags().BoolVarP(&CheckGoVersion, "check-go-version", "", true, "Checks that the version of Go in use is compatible with Delve.")
+	RootCommand.PersistentFlags().BoolVarP(&CheckLocalConnUser, "only-same-user", "", true, "Only connections from the same user that started this instance of Delve are allowed to connect.")
 	RootCommand.PersistentFlags().StringVar(&Backend, "backend", "default", `Backend selection (see 'dlv help backend').`)
 
 	// 'attach' subcommand.
@@ -641,6 +645,7 @@ func execute(attachPid int, processArgs []string, conf *config.Config, coreFile 
 			Foreground:           Headless,
 			DebugInfoDirectories: conf.DebugInfoDirectories,
 			CheckGoVersion:       CheckGoVersion,
+			CheckLocalConnUser:   CheckLocalConnUser,
 
 			DisconnectChan: disconnectChan,
 		})

--- a/service/config.go
+++ b/service/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	// versions.
 	CheckGoVersion bool
 
+	// CheckLocalConnUser is true if the debugger should check that local
+	// connections come from the same user that started the headless server
+	CheckLocalConnUser bool
+
 	// DisconnectChan will be closed by the server when the client disconnects
 	DisconnectChan chan<- struct{}
 }

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -156,9 +156,11 @@ func (s *ServerImpl) Run() error {
 				}
 			}
 
-			if !canAccept(s.listener.Addr(), c.RemoteAddr()) {
-				c.Close()
-				continue
+			if s.config.CheckLocalConnUser {
+				if !canAccept(s.listener.Addr(), c.RemoteAddr()) {
+					c.Close()
+					continue
+				}
 			}
 
 			go s.serveJSONCodec(c)


### PR DESCRIPTION
```
cmd: add flag to disable same-user check

Fixes #1835

service: also search IPv6 connections when checking user

When checking if the user is allowed to connect to this Delve instance
also search IPv6 connections even though the local address is IPv4.

Fixes #1835

```
