### PR TITLE
cmd: support `LookPath` when debugging on windows.

### DIFF
--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -19,7 +19,7 @@ dlv test [package]
 ### Options
 
 ```
-      --output string   Output path for the binary. (default "debug.test")
+      --output string   Output path for the binary. (default "./__debug_test")
 ```
 
 ### Options inherited from parent commands

--- a/_fixtures/issue505.go
+++ b/_fixtures/issue505.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	file, err := exec.LookPath(os.Args[0])
+	fmt.Printf("%s - %s", file, err)
+}

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -211,7 +211,7 @@ Alternatively you can specify a package name, and Delve will debug the tests in
 that package instead.`,
 		Run: testCmd,
 	}
-	testCommand.Flags().String("output", "debug.test", "Output path for the binary.")
+	testCommand.Flags().String("output", "./__debug_test", "Output path for the binary.")
 	RootCommand.AddCommand(testCommand)
 
 	// 'trace' subcommand.
@@ -347,6 +347,9 @@ func debugCmd(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			return 1
 		}
+		if runtime.GOOS == "windows" {
+			debugname += ".exe"
+		}
 
 		dlvArgs, targetArgs := splitArgs(cmd, args)
 		err = gobuild(debugname, dlvArgs)
@@ -403,6 +406,9 @@ func traceCmd(cmd *cobra.Command, args []string) {
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "%v\n", err)
 					return 1
+				}
+				if runtime.GOOS == "windows" {
+					debugname += ".exe"
 				}
 				if traceTestBinary {
 					if err := gotestbuild(debugname, dlvArgs); err != nil {
@@ -494,6 +500,9 @@ func testCmd(cmd *cobra.Command, args []string) {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			return 1
+		}
+		if runtime.GOOS == "windows" {
+			debugname += ".exe"
 		}
 
 		dlvArgs, targetArgs := splitArgs(cmd, args)

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -82,6 +82,9 @@ func TestBuild(t *testing.T) {
 	}
 
 	dlvbin := filepath.Join(cmd.Dir, "dlv")
+	if runtime.GOOS == "windows" {
+		dlvbin += ".exe"
+	}
 	defer os.Remove(dlvbin)
 
 	fixtures := protest.FindFixturesDir()
@@ -129,6 +132,9 @@ func testOutput(t *testing.T, dlvbin, output string, delveCmds []string) (stdout
 		} else {
 			debugbin = filepath.Join(buildtestdir, output)
 		}
+	}
+	if runtime.GOOS == "windows" {
+		debugbin += ".exe"
 	}
 	cmd := exec.Command(c[0], c[1:]...)
 	cmd.Dir = buildtestdir

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1820,3 +1820,22 @@ func TestIssue1787(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue505(t *testing.T) {
+	withTestClient2("issue505", t, func(c service.Client) {
+		fp := testProgPath(t, "issue505")
+		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 11})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		state := <-c.Continue()
+		if state.Err != nil {
+			t.Fatalf("Unexpected error: %v, state: %#v", state.Err, state)
+		}
+		var1, err := c.EvalVariable(api.EvalScope{-1, 0, 0}, "err", normalLoadConfig)
+		assertNoError(err, t, "EvalVariable")
+		if var1.Value != "" {
+			t.Fatalf("Wrong variable value: %s", var1.Value)
+		}
+	})
+}


### PR DESCRIPTION
Add suffix `.exe` when building executable on windows.

Fix go-delve#505