### PR TITLE
README: rollback gitter chat link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,6 @@ Want to help contribute to Delve? Great! Any and all help is certainly appreciat
 
 If you are planning to contribute a significant change, please draft a design document (or start a conversation) and post it to the [developer mailing list](https://groups.google.com/forum/#!forum/delve-dev). This will allow other developers and users to discuss the proposed change.
 
-If you'd like to join the discussion, join the gitter chat (link in README).
-
 ## Filing issues
 
 When filing an issue, make sure to answer these six questions:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![GoDoc](https://godoc.org/github.com/go-delve/delve?status.svg)](https://godoc.org/github.com/go-delve/delve)
 [![Build Status](https://travis-ci.org/go-delve/delve.svg?branch=master)](https://travis-ci.org/go-delve/delve)
 [![Build status](https://ci.appveyor.com/api/projects/status/9e9edx1qlp3145j5/branch/master?svg=true)](https://ci.appveyor.com/project/go-delve/delve)
-[![Join the chat at https://gitter.im/go-delve/delve](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/go-delve/delve?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 The GitHub issue tracker is for **bugs** only. Please use the [developer mailing list](https://groups.google.com/forum/#!forum/delve-dev) for any feature proposals and discussions.
 


### PR DESCRIPTION
Keep gitter chat link valid.

Fix #1842