### PR TITLE
pkg: fix abbreviation of Flag Register on amd64

### DIFF
--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -342,7 +342,7 @@ var amd64DwarfToName = map[int]string{
 	38: "ST(5)",
 	39: "ST(6)",
 	40: "ST(7)",
-	49: "Eflags",
+	49: "Rflags",
 	50: "Es",
 	51: "Cs",
 	52: "Ss",


### PR DESCRIPTION
Left is i386, and rigth is x86_64.  
![image](https://user-images.githubusercontent.com/7046329/72914481-b843a700-3d79-11ea-9755-05b9703b2115.png)



Should be `Rflags` here on amd64 if I understand right.