### PR TITLE
Reduce latency of conditional breakpoints/stop-resume cycles {WIP]

### DIFF
--- a/_fixtures/issue1549.go
+++ b/_fixtures/issue1549.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	sum := int64(0)
+	start := time.Now()
+	for value := int64(0); value < 10000; value++ {
+		sum += value
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("Sum: %d\nTook %s\n", sum, elapsed)
+}

--- a/pkg/dwarf/reader/reader.go
+++ b/pkg/dwarf/reader/reader.go
@@ -426,6 +426,9 @@ childLoop:
 		default:
 			irdr.reader.SkipChildren()
 		}
+		if rentry == nil {
+			break
+		}
 	}
 
 	if rentry != nil && rentry.Tag == dwarf.TagInlinedSubroutine {

--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -361,6 +361,14 @@ var amd64DwarfToName = map[int]string{
 	66: "sw",
 }
 
+var amd64NameToDwarf = func() map[string]int {
+	r := make(map[string]int)
+	for regNum, regName := range amd64DwarfToName {
+		r[regName] = regNum
+	}
+	return r
+}()
+
 func maxAmd64DwarfRegister() int {
 	max := int(amd64DwarfIPRegNum)
 	for i := range amd64DwarfToHardware {
@@ -393,11 +401,8 @@ func (a *AMD64) RegistersToDwarfRegisters(staticBase uint64, regs Registers) op.
 	}
 
 	for _, reg := range regs.Slice(true) {
-		regName1 := strings.ToLower(reg.Name)
-		for dwarfReg, regName := range amd64DwarfToName {
-			if regName == regName1 {
-				dregs[dwarfReg] = reg.Reg
-			}
+		if dwarfReg, ok := amd64NameToDwarf[strings.ToLower(reg.Name)]; ok {
+			dregs[dwarfReg] = reg.Reg
 		}
 	}
 

--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -220,6 +220,7 @@ func (a *AMD64) SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 			return false
 		}
 
+		it.loadG0SchedSP()
 		if it.g0_sched_sp <= 0 {
 			return false
 		}

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -21,6 +21,7 @@ type Arch interface {
 	RegSize(uint64) int
 	RegistersToDwarfRegisters(uint64, Registers) op.DwarfRegisters
 	AddrAndStackRegsToDwarfRegisters(uint64, uint64, uint64, uint64, uint64) op.DwarfRegisters
+	DwarfRegisterToString(string, *op.DwarfRegister) string
 }
 
 const (

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -254,6 +254,7 @@ func (a *ARM64) SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters)
 			return false
 		}
 
+		it.loadG0SchedSP()
 		if it.g0_sched_sp <= 0 {
 			return false
 		}

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -1,7 +1,10 @@
 package proc
 
 import (
+	"bytes"
 	"encoding/binary"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/go-delve/delve/pkg/dwarf/frame"
@@ -404,5 +407,47 @@ func (a *ARM64) AddrAndStackRegsToDwarfRegisters(staticBase, pc, sp, bp, lr uint
 		SPRegNum:   arm64DwarfSPRegNum,
 		BPRegNum:   arm64DwarfBPRegNum,
 		LRRegNum:   arm64DwarfLRRegNum,
+	}
+}
+
+func (a *ARM64) DwarfRegisterToString(name string, reg *op.DwarfRegister) string {
+	if reg.Bytes != nil && (name[0] == 'v' || name[0] == 'V') {
+		buf := bytes.NewReader(reg.Bytes)
+
+		var out bytes.Buffer
+		var vi [16]uint8
+		for i := range vi {
+			binary.Read(buf, binary.LittleEndian, &vi[i])
+		}
+
+		fmt.Fprintf(&out, "0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8], vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
+
+		fmt.Fprintf(&out, "\tv2_int={ %02x%02x%02x%02x%02x%02x%02x%02x %02x%02x%02x%02x%02x%02x%02x%02x }", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0], vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
+
+		fmt.Fprintf(&out, "\tv4_int={ %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x }", vi[3], vi[2], vi[1], vi[0], vi[7], vi[6], vi[5], vi[4], vi[11], vi[10], vi[9], vi[8], vi[15], vi[14], vi[13], vi[12])
+
+		fmt.Fprintf(&out, "\tv8_int={ %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x }", vi[1], vi[0], vi[3], vi[2], vi[5], vi[4], vi[7], vi[6], vi[9], vi[8], vi[11], vi[10], vi[13], vi[12], vi[15], vi[14])
+
+		fmt.Fprintf(&out, "\tv16_int={ %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x }", vi[0], vi[1], vi[2], vi[3], vi[4], vi[5], vi[6], vi[7], vi[8], vi[9], vi[10], vi[11], vi[12], vi[13], vi[14], vi[15])
+
+		buf.Seek(0, os.SEEK_SET)
+		var v2 [2]float64
+		for i := range v2 {
+			binary.Read(buf, binary.LittleEndian, &v2[i])
+		}
+		fmt.Fprintf(&out, "\tv2_float={ %g %g }", v2[0], v2[1])
+
+		buf.Seek(0, os.SEEK_SET)
+		var v4 [4]float32
+		for i := range v4 {
+			binary.Read(buf, binary.LittleEndian, &v4[i])
+		}
+		fmt.Fprintf(&out, "\tv4_float={ %g %g %g %g }", v4[0], v4[1], v4[2], v4[3])
+
+		return out.String()
+	} else if reg.Bytes == nil || (reg.Bytes != nil && len(reg.Bytes) < 16) {
+		return fmt.Sprintf("%#016x", reg.Uint64Val)
+	} else {
+		return fmt.Sprintf("%#x", reg.Bytes)
 	}
 }

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -244,8 +244,9 @@ func TestCore(t *testing.T) {
 		t.Fatalf("Couldn't get current thread registers: %v", err)
 	}
 	regslice := regs.Slice(true)
+	arch := p.BinInfo().Arch
 	for _, reg := range regslice {
-		t.Logf("%s = %s", reg.Name, reg.Value)
+		t.Logf("%s = %s", reg.Name, arch.DwarfRegisterToString(reg.Name, reg.Reg))
 	}
 }
 
@@ -312,8 +313,9 @@ func TestCoreFpRegisters(t *testing.T) {
 		{"XMM8", "0x4059999a404ccccd4059999a404ccccd"},
 	}
 
+	arch := p.BinInfo().Arch
 	for _, reg := range regs.Slice(true) {
-		t.Logf("%s = %s", reg.Name, reg.Value)
+		t.Logf("%s = %s", reg.Name, arch.DwarfRegisterToString(reg.Name, reg.Reg))
 	}
 
 	for _, regtest := range regtests {
@@ -321,8 +323,9 @@ func TestCoreFpRegisters(t *testing.T) {
 		for _, reg := range regs.Slice(true) {
 			if reg.Name == regtest.name {
 				found = true
-				if !strings.HasPrefix(reg.Value, regtest.value) {
-					t.Fatalf("register %s expected %q got %q", reg.Name, regtest.value, reg.Value)
+				regval := arch.DwarfRegisterToString(reg.Name, reg.Reg)
+				if !strings.HasPrefix(regval, regtest.value) {
+					t.Fatalf("register %s expected %q got %q", reg.Name, regtest.value, regval)
 				}
 			}
 		}

--- a/pkg/proc/fbsdutil/regs.go
+++ b/pkg/proc/fbsdutil/regs.go
@@ -101,17 +101,17 @@ func (r *AMD64Registers) Slice(floatingPoint bool) []proc.Register {
 		// FreeBSD defines the registers as signed, but Linux defines
 		// them as unsigned.  Of course, a register doesn't really have
 		// a concept of signedness.  Cast to what Delve expects.
-		out = proc.AppendQwordReg(out, reg.k, uint64(reg.v))
+		out = proc.AppendUint64Register(out, reg.k, uint64(reg.v))
 	}
 	for _, reg := range regs32 {
-		out = proc.AppendDwordReg(out, reg.k, reg.v)
+		out = proc.AppendUint64Register(out, reg.k, uint64(reg.v))
 	}
 	for _, reg := range regs16 {
-		out = proc.AppendWordReg(out, reg.k, reg.v)
+		out = proc.AppendUint64Register(out, reg.k, uint64(reg.v))
 	}
 	// x86 called this register "Eflags".  amd64 extended it and renamed it
 	// "Rflags", but Linux still uses the old name.
-	out = proc.AppendEflagReg(out, "Rflags", uint64(r.Regs.Rflags))
+	out = proc.AppendUint64Register(out, "Rflags", uint64(r.Regs.Rflags))
 	if floatingPoint {
 		out = append(out, r.Fpregs...)
 	}

--- a/pkg/proc/fbsdutil/regs.go
+++ b/pkg/proc/fbsdutil/regs.go
@@ -132,11 +132,6 @@ func (r *AMD64Registers) BP() uint64 {
 	return uint64(r.Regs.Rbp)
 }
 
-// CX returns the value of RCX register.
-func (r *AMD64Registers) CX() uint64 {
-	return uint64(r.Regs.Rcx)
-}
-
 // TLS returns the address of the thread local storage memory segment.
 func (r *AMD64Registers) TLS() uint64 {
 	return r.Fsbase

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1800,15 +1800,15 @@ func (regs *gdbRegisters) Slice(floatingPoint bool) []proc.Register {
 		}
 		switch {
 		case reginfo.Name == "eflags":
-			r = proc.AppendEflagReg(r, reginfo.Name, uint64(binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value)))
+			r = proc.AppendBytesRegister(r, "Rflags", regs.regs[reginfo.Name].value)
 		case reginfo.Name == "mxcsr":
-			r = proc.AppendMxcsrReg(r, reginfo.Name, uint64(binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value)))
+			r = proc.AppendBytesRegister(r, reginfo.Name, regs.regs[reginfo.Name].value)
 		case reginfo.Bitsize == 16:
-			r = proc.AppendWordReg(r, reginfo.Name, binary.LittleEndian.Uint16(regs.regs[reginfo.Name].value))
+			r = proc.AppendBytesRegister(r, reginfo.Name, regs.regs[reginfo.Name].value)
 		case reginfo.Bitsize == 32:
-			r = proc.AppendDwordReg(r, reginfo.Name, binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value))
+			r = proc.AppendBytesRegister(r, reginfo.Name, regs.regs[reginfo.Name].value)
 		case reginfo.Bitsize == 64:
-			r = proc.AppendQwordReg(r, reginfo.Name, binary.LittleEndian.Uint64(regs.regs[reginfo.Name].value))
+			r = proc.AppendBytesRegister(r, reginfo.Name, regs.regs[reginfo.Name].value)
 		case reginfo.Bitsize == 80:
 			if !floatingPoint {
 				continue
@@ -1820,12 +1820,11 @@ func (regs *gdbRegisters) Slice(floatingPoint bool) []proc.Register {
 					break
 				}
 			}
-			value := regs.regs[reginfo.Name].value
-			r = proc.AppendX87Reg(r, idx, binary.LittleEndian.Uint16(value[8:]), binary.LittleEndian.Uint64(value[:8]))
+			r = proc.AppendBytesRegister(r, fmt.Sprintf("ST(%d)", idx), regs.regs[reginfo.Name].value)
 
 		case reginfo.Bitsize == 128:
 			if floatingPoint {
-				r = proc.AppendSSEReg(r, strings.ToUpper(reginfo.Name), regs.regs[reginfo.Name].value)
+				r = proc.AppendBytesRegister(r, strings.ToUpper(reginfo.Name), regs.regs[reginfo.Name].value)
 			}
 
 		case reginfo.Bitsize == 256:
@@ -1835,8 +1834,8 @@ func (regs *gdbRegisters) Slice(floatingPoint bool) []proc.Register {
 
 			value := regs.regs[reginfo.Name].value
 			xmmName := "x" + reginfo.Name[1:]
-			r = proc.AppendSSEReg(r, strings.ToUpper(xmmName), value[:16])
-			r = proc.AppendSSEReg(r, strings.ToUpper(reginfo.Name), value[16:])
+			r = proc.AppendBytesRegister(r, strings.ToUpper(xmmName), value[:16])
+			r = proc.AppendBytesRegister(r, strings.ToUpper(reginfo.Name), value[16:])
 		}
 	}
 	return r

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -104,9 +104,8 @@ type Process struct {
 	bi   *proc.BinaryInfo
 	conn gdbConn
 
-	threads           map[int]*Thread
-	currentThread     *Thread
-	selectedGoroutine *proc.G
+	threads       map[int]*Thread
+	currentThread *Thread
 
 	exited, detached bool
 	ctrlC            bool // ctrl-c was sent to stop inferior
@@ -197,7 +196,7 @@ func New(process *os.Process) *Process {
 }
 
 // Listen waits for a connection from the stub.
-func (p *Process) Listen(listener net.Listener, path string, pid int, debugInfoDirs []string) error {
+func (p *Process) Listen(listener net.Listener, path string, pid int, debugInfoDirs []string) (*proc.Target, error) {
 	acceptChan := make(chan net.Conn)
 
 	go func() {
@@ -209,17 +208,17 @@ func (p *Process) Listen(listener net.Listener, path string, pid int, debugInfoD
 	case conn := <-acceptChan:
 		listener.Close()
 		if conn == nil {
-			return errors.New("could not connect")
+			return nil, errors.New("could not connect")
 		}
 		return p.Connect(conn, path, pid, debugInfoDirs)
 	case status := <-p.waitChan:
 		listener.Close()
-		return fmt.Errorf("stub exited while waiting for connection: %v", status)
+		return nil, fmt.Errorf("stub exited while waiting for connection: %v", status)
 	}
 }
 
 // Dial attempts to connect to the stub.
-func (p *Process) Dial(addr string, path string, pid int, debugInfoDirs []string) error {
+func (p *Process) Dial(addr string, path string, pid int, debugInfoDirs []string) (*proc.Target, error) {
 	for {
 		conn, err := net.Dial("tcp", addr)
 		if err == nil {
@@ -227,7 +226,7 @@ func (p *Process) Dial(addr string, path string, pid int, debugInfoDirs []string
 		}
 		select {
 		case status := <-p.waitChan:
-			return fmt.Errorf("stub exited while attempting to connect: %v", status)
+			return nil, fmt.Errorf("stub exited while attempting to connect: %v", status)
 		default:
 		}
 		time.Sleep(time.Second)
@@ -240,13 +239,13 @@ func (p *Process) Dial(addr string, path string, pid int, debugInfoDirs []string
 // program and the PID of the target process, both are optional, however
 // some stubs do not provide ways to determine path and pid automatically
 // and Connect will be unable to function without knowing them.
-func (p *Process) Connect(conn net.Conn, path string, pid int, debugInfoDirs []string) error {
+func (p *Process) Connect(conn net.Conn, path string, pid int, debugInfoDirs []string) (*proc.Target, error) {
 	p.conn.conn = conn
 	p.conn.pid = pid
 	err := p.conn.handshake()
 	if err != nil {
 		conn.Close()
-		return err
+		return nil, err
 	}
 
 	if verbuf, err := p.conn.exec([]byte("$qGDBServerVersion"), "init"); err == nil {
@@ -261,8 +260,9 @@ func (p *Process) Connect(conn net.Conn, path string, pid int, debugInfoDirs []s
 		}
 	}
 
-	if err := p.initialize(path, debugInfoDirs); err != nil {
-		return err
+	tgt, err := p.initialize(path, debugInfoDirs)
+	if err != nil {
+		return nil, err
 	}
 
 	// None of the stubs we support returns the value of fs_base or gs_base
@@ -278,7 +278,8 @@ func (p *Process) Connect(conn net.Conn, path string, pid int, debugInfoDirs []s
 			p.loadGInstrAddr = addr
 		}
 	}
-	return nil
+
+	return tgt, nil
 }
 
 // unusedPort returns an unused tcp port
@@ -397,15 +398,13 @@ func LLDBLaunch(cmd []string, wd string, foreground bool, debugInfoDirs []string
 	p := New(process.Process)
 	p.conn.isDebugserver = isDebugserver
 
+	var tgt *proc.Target
 	if listener != nil {
-		err = p.Listen(listener, cmd[0], 0, debugInfoDirs)
+		tgt, err = p.Listen(listener, cmd[0], 0, debugInfoDirs)
 	} else {
-		err = p.Dial(port, cmd[0], 0, debugInfoDirs)
+		tgt, err = p.Dial(port, cmd[0], 0, debugInfoDirs)
 	}
-	if err != nil {
-		return nil, err
-	}
-	return proc.NewTarget(p), nil
+	return tgt, err
 }
 
 // LLDBAttach starts an instance of lldb-server and connects to it, asking
@@ -449,15 +448,13 @@ func LLDBAttach(pid int, path string, debugInfoDirs []string) (*proc.Target, err
 	p := New(process.Process)
 	p.conn.isDebugserver = isDebugserver
 
+	var tgt *proc.Target
 	if listener != nil {
-		err = p.Listen(listener, path, pid, debugInfoDirs)
+		tgt, err = p.Listen(listener, path, pid, debugInfoDirs)
 	} else {
-		err = p.Dial(port, path, pid, debugInfoDirs)
+		tgt, err = p.Dial(port, path, pid, debugInfoDirs)
 	}
-	if err != nil {
-		return nil, err
-	}
-	return proc.NewTarget(p), nil
+	return tgt, err
 }
 
 // EntryPoint will return the process entry point address, useful for
@@ -476,7 +473,7 @@ func (p *Process) EntryPoint() (uint64, error) {
 // initialize uses qProcessInfo to load the inferior's PID and
 // executable path. This command is not supported by all stubs and not all
 // stubs will report both the PID and executable path.
-func (p *Process) initialize(path string, debugInfoDirs []string) error {
+func (p *Process) initialize(path string, debugInfoDirs []string) (*proc.Target, error) {
 	var err error
 	if path == "" {
 		// If we are attaching to a running process and the user didn't specify
@@ -490,11 +487,11 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 				_, path, err = queryProcessInfo(p, p.Pid())
 				if err != nil {
 					p.conn.conn.Close()
-					return err
+					return nil, err
 				}
 			} else {
 				p.conn.conn.Close()
-				return fmt.Errorf("could not determine executable path: %v", err)
+				return nil, fmt.Errorf("could not determine executable path: %v", err)
 			}
 		}
 	}
@@ -515,7 +512,7 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 	if err != nil {
 		p.conn.conn.Close()
 		p.bi.Close()
-		return err
+		return nil, err
 	}
 
 	if p.conn.pid <= 0 {
@@ -523,14 +520,15 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 		if err != nil && !isProtocolErrorUnsupported(err) {
 			p.conn.conn.Close()
 			p.bi.Close()
-			return err
+			return nil, err
 		}
 	}
-	if err = proc.PostInitializationSetup(p, path, debugInfoDirs, p.writeBreakpoint); err != nil {
+	tgt, err := proc.NewTarget(p, path, debugInfoDirs, p.writeBreakpoint)
+	if err != nil {
 		p.conn.conn.Close()
-		return err
+		return nil, err
 	}
-	return nil
+	return tgt, nil
 }
 
 func queryProcessInfo(p *Process, pid int) (int, string, error) {
@@ -600,9 +598,9 @@ func (p *Process) CurrentThread() proc.Thread {
 	return p.currentThread
 }
 
-// SelectedGoroutine returns the current actuve selected goroutine.
-func (p *Process) SelectedGoroutine() *proc.G {
-	return p.selectedGoroutine
+// InternalSetCurrentThread is used internally by proc.Target to change the current thread.
+func (p *Process) InternalSetCurrentThread(th proc.Thread) {
+	p.currentThread = th.(*Thread)
 }
 
 const (
@@ -736,38 +734,6 @@ continueLoop:
 	return nil, fmt.Errorf("could not find thread %s", threadID)
 }
 
-// SetSelectedGoroutine will set internally the goroutine that should be
-// the default for any command executed, the goroutine being actively
-// followed.
-func (p *Process) SetSelectedGoroutine(g *proc.G) {
-	p.selectedGoroutine = g
-}
-
-// SwitchThread will change the internal selected thread.
-func (p *Process) SwitchThread(tid int) error {
-	if p.exited {
-		return proc.ErrProcessExited{Pid: p.conn.pid}
-	}
-	if th, ok := p.threads[tid]; ok {
-		p.currentThread = th
-		p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())
-		return nil
-	}
-	return fmt.Errorf("thread %d does not exist", tid)
-}
-
-// SwitchGoroutine will change the internal selected goroutine.
-func (p *Process) SwitchGoroutine(g *proc.G) error {
-	if g == nil {
-		return nil
-	}
-	if g.Thread != nil {
-		return p.SwitchThread(g.Thread.ThreadID())
-	}
-	p.selectedGoroutine = g
-	return nil
-}
-
 // RequestManualStop will attempt to stop the process
 // without a breakpoint or signal having been recieved.
 func (p *Process) RequestManualStop() error {
@@ -863,7 +829,6 @@ func (p *Process) Restart(pos string) error {
 	if err != nil {
 		return err
 	}
-	p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())
 
 	for addr := range p.breakpoints.M {
 		p.conn.setBreakpoint(addr)

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -90,13 +90,13 @@ func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string)
 			safeRemoveAll(p.tracedir)
 		}
 	}
-	err = p.Dial(init.port, init.exe, 0, debugInfoDirs)
+	tgt, err := p.Dial(init.port, init.exe, 0, debugInfoDirs)
 	if err != nil {
 		rrcmd.Process.Kill()
 		return nil, err
 	}
 
-	return proc.NewTarget(p), nil
+	return tgt, nil
 }
 
 // ErrPerfEventParanoid is the error returned by Reply and Record if

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -71,7 +71,6 @@ type Info interface {
 	EntryPoint() (uint64, error)
 
 	ThreadInfo
-	GoroutineInfo
 }
 
 // ThreadInfo is an interface for getting information on active threads
@@ -80,19 +79,12 @@ type ThreadInfo interface {
 	FindThread(threadID int) (Thread, bool)
 	ThreadList() []Thread
 	CurrentThread() Thread
-}
-
-// GoroutineInfo is an interface for getting information on running goroutines.
-type GoroutineInfo interface {
-	SelectedGoroutine() *G
-	SetSelectedGoroutine(*G)
+	InternalSetCurrentThread(Thread)
 }
 
 // ProcessManipulation is an interface for changing the execution state of a process.
 type ProcessManipulation interface {
 	ContinueOnce() (trapthread Thread, err error)
-	SwitchThread(int) error
-	SwitchGoroutine(*G) error
 	RequestManualStop() error
 	// CheckAndClearManualStopRequest returns true the first time it's called
 	// after a call to RequestManualStop.

--- a/pkg/proc/linutil/regs_amd64_arch.go
+++ b/pkg/proc/linutil/regs_amd64_arch.go
@@ -112,11 +112,6 @@ func (r *AMD64Registers) BP() uint64 {
 	return r.Regs.Rbp
 }
 
-// CX returns the value of RCX register.
-func (r *AMD64Registers) CX() uint64 {
-	return r.Regs.Rcx
-}
-
 // TLS returns the address of the thread local storage memory segment.
 func (r *AMD64Registers) TLS() uint64 {
 	return r.Regs.Fs_base

--- a/pkg/proc/linutil/regs_arm64_arch.go
+++ b/pkg/proc/linutil/regs_arm64_arch.go
@@ -67,7 +67,7 @@ func (r *ARM64Registers) Slice(floatingPoint bool) []proc.Register {
 	}
 	out := make([]proc.Register, 0, len(regs64)+len(r.Fpregs))
 	for _, reg := range regs64 {
-		out = proc.AppendQwordReg(out, reg.k, reg.v)
+		out = proc.AppendUint64Register(out, reg.k, reg.v)
 	}
 	out = append(out, r.Fpregs...)
 	return out
@@ -128,7 +128,7 @@ func (r *ARM64Registers) Copy() proc.Registers {
 // Decode decodes an XSAVE area to a list of name/value pairs of registers.
 func Decode(fpregs []byte) (regs []proc.Register) {
 	for i := 0; i < len(fpregs); i += 16 {
-		regs = proc.AppendFPReg(regs, fmt.Sprintf("V%d", i/16), fpregs[i:i+16])
+		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("V%d", i/16), fpregs[i:i+16])
 	}
 	return
 }

--- a/pkg/proc/linutil/regs_arm64_arch.go
+++ b/pkg/proc/linutil/regs_arm64_arch.go
@@ -87,11 +87,6 @@ func (r *ARM64Registers) BP() uint64 {
 	return r.Regs.Regs[29]
 }
 
-// CX returns the value of RCX register.
-func (r *ARM64Registers) CX() uint64 {
-	return 0
-}
-
 // TLS returns the address of the thread local storage memory segment.
 func (r *ARM64Registers) TLS() uint64 {
 	return 0

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -84,10 +84,11 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string) (*
 	if err != nil {
 		return nil, fmt.Errorf("waiting for target execve failed: %s", err)
 	}
-	if err = dbp.initialize(cmd[0], debugInfoDirs); err != nil {
+	tgt, err := dbp.initialize(cmd[0], debugInfoDirs)
+	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return tgt, nil
 }
 
 // Attach to an existing process with the given PID. Once attached, if
@@ -106,12 +107,12 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 		return nil, err
 	}
 
-	err = dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
+	tgt, err := dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
 	if err != nil {
 		dbp.Detach(false)
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return tgt, nil
 }
 
 func initialize(dbp *Process) error {
@@ -165,7 +166,7 @@ func (dbp *Process) addThread(tid int, attach bool) (*Thread, error) {
 	}
 
 	if dbp.currentThread == nil {
-		dbp.SwitchThread(tid)
+		dbp.currentThread = dbp.threads[tid]
 	}
 
 	return dbp.threads[tid], nil

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -90,10 +90,11 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string) (*
 	if err != nil {
 		return nil, fmt.Errorf("waiting for target execve failed: %s", err)
 	}
-	if err = dbp.initialize(cmd[0], debugInfoDirs); err != nil {
+	tgt, err := dbp.initialize(cmd[0], debugInfoDirs)
+	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return tgt, nil
 }
 
 // Attach to an existing process with the given PID. Once attached, if
@@ -112,7 +113,7 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 		return nil, err
 	}
 
-	err = dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
+	tgt, err := dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
 	if err != nil {
 		dbp.Detach(false)
 		return nil, err
@@ -124,7 +125,7 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return tgt, nil
 }
 
 func initialize(dbp *Process) error {
@@ -222,7 +223,7 @@ func (dbp *Process) addThread(tid int, attach bool) (*Thread, error) {
 		os:  new(OSSpecificDetails),
 	}
 	if dbp.currentThread == nil {
-		dbp.SwitchThread(tid)
+		dbp.currentThread = dbp.threads[tid]
 	}
 	return dbp.threads[tid], nil
 }

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -1,6 +1,7 @@
 package native
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -351,6 +352,7 @@ func status(pid int, comm string) rune {
 		return '\000'
 	}
 	defer f.Close()
+	rd := bufio.NewReader(f)
 
 	var (
 		p     int
@@ -361,7 +363,7 @@ func status(pid int, comm string) rune {
 	// The name of the task is the base name of the executable for this process limited to TASK_COMM_LEN characters
 	// Since both parenthesis and spaces can appear inside the name of the task and no escaping happens we need to read the name of the executable first
 	// See: include/linux/sched.c:315 and include/linux/sched.c:1510
-	fmt.Fscanf(f, "%d ("+comm+")  %c", &p, &state)
+	fmt.Fscanf(rd, "%d ("+comm+")  %c", &p, &state)
 	return state
 }
 

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -75,11 +75,12 @@ func Launch(cmd []string, wd string, foreground bool, _ []string) (*proc.Target,
 	dbp.pid = p.Pid
 	dbp.childProcess = true
 
-	if err = dbp.initialize(argv0Go, []string{}); err != nil {
+	tgt, err := dbp.initialize(argv0Go, []string{})
+	if err != nil {
 		dbp.Detach(true)
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return tgt, nil
 }
 
 func initialize(dbp *Process) error {
@@ -164,11 +165,12 @@ func Attach(pid int, _ []string) (*proc.Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = dbp.initialize(exepath, []string{}); err != nil {
+	tgt, err := dbp.initialize(exepath, []string{})
+	if err != nil {
 		dbp.Detach(true)
 		return nil, err
 	}
-	return proc.NewTarget(dbp), nil
+	return tgt, nil
 }
 
 // kill kills the process.
@@ -220,7 +222,7 @@ func (dbp *Process) addThread(hThread syscall.Handle, threadID int, attach, susp
 	thread.os.hThread = hThread
 	dbp.threads[threadID] = thread
 	if dbp.currentThread == nil {
-		dbp.SwitchThread(thread.ID)
+		dbp.currentThread = dbp.threads[threadID]
 	}
 	if suspendNewThreads {
 		_, err := _SuspendThread(thread.os.hThread)

--- a/pkg/proc/native/registers_darwin_amd64.go
+++ b/pkg/proc/native/registers_darwin_amd64.go
@@ -100,11 +100,6 @@ func (r *Regs) BP() uint64 {
 	return r.rbp
 }
 
-// CX returns the value of the RCX register.
-func (r *Regs) CX() uint64 {
-	return r.rcx
-}
-
 // TLS returns the value of the register
 // that contains the location of the thread
 // local storage segment.

--- a/pkg/proc/native/registers_darwin_amd64.go
+++ b/pkg/proc/native/registers_darwin_amd64.go
@@ -5,7 +5,6 @@ package native
 // #include "threads_darwin.h"
 import "C"
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"unsafe"
@@ -73,9 +72,9 @@ func (r *Regs) Slice(floatingPoint bool) []proc.Register {
 	out := make([]proc.Register, 0, len(regs)+len(r.fpregs))
 	for _, reg := range regs {
 		if reg.k == "Rflags" {
-			out = proc.AppendEflagReg(out, reg.k, reg.v)
+			out = proc.AppendUint64Register(out, reg.k, reg.v)
 		} else {
-			out = proc.AppendQwordReg(out, reg.k, reg.v)
+			out = proc.AppendUint64Register(out, reg.k, reg.v)
 		}
 	}
 	if floatingPoint {
@@ -342,25 +341,23 @@ func registers(thread *Thread, floatingPoint bool) (proc.Registers, error) {
 			return nil, fmt.Errorf("could not get floating point registers")
 		}
 
-		regs.fpregs = proc.AppendWordReg(regs.fpregs, "CW", *((*uint16)(unsafe.Pointer(&fpstate.__fpu_fcw))))
-		regs.fpregs = proc.AppendWordReg(regs.fpregs, "SW", *((*uint16)(unsafe.Pointer(&fpstate.__fpu_fsw))))
-		regs.fpregs = proc.AppendWordReg(regs.fpregs, "TW", uint16(fpstate.__fpu_ftw))
-		regs.fpregs = proc.AppendWordReg(regs.fpregs, "FOP", uint16(fpstate.__fpu_fop))
-		regs.fpregs = proc.AppendQwordReg(regs.fpregs, "FIP", uint64(fpstate.__fpu_cs)<<32|uint64(fpstate.__fpu_ip))
-		regs.fpregs = proc.AppendQwordReg(regs.fpregs, "FDP", uint64(fpstate.__fpu_ds)<<32|uint64(fpstate.__fpu_dp))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "CW", uint64(*((*uint16)(unsafe.Pointer(&fpstate.__fpu_fcw)))))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "SW", uint64(*((*uint16)(unsafe.Pointer(&fpstate.__fpu_fsw)))))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "TW", uint64(fpstate.__fpu_ftw))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "FOP", uint64(fpstate.__fpu_fop))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "FIP", uint64(fpstate.__fpu_cs)<<32|uint64(fpstate.__fpu_ip))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "FDP", uint64(fpstate.__fpu_ds)<<32|uint64(fpstate.__fpu_dp))
 
 		for i, st := range []*C.char{&fpstate.__fpu_stmm0.__mmst_reg[0], &fpstate.__fpu_stmm1.__mmst_reg[0], &fpstate.__fpu_stmm2.__mmst_reg[0], &fpstate.__fpu_stmm3.__mmst_reg[0], &fpstate.__fpu_stmm4.__mmst_reg[0], &fpstate.__fpu_stmm5.__mmst_reg[0], &fpstate.__fpu_stmm6.__mmst_reg[0], &fpstate.__fpu_stmm7.__mmst_reg[0]} {
 			stb := C.GoBytes(unsafe.Pointer(st), 10)
-			mantissa := binary.LittleEndian.Uint64(stb[:8])
-			exponent := binary.LittleEndian.Uint16(stb[8:])
-			regs.fpregs = proc.AppendX87Reg(regs.fpregs, i, exponent, mantissa)
+			regs.fpregs = proc.AppendBytesRegister(regs.fpregs, fmt.Sprintf("ST(%d)", i), stb)
 		}
 
-		regs.fpregs = proc.AppendMxcsrReg(regs.fpregs, "MXCSR", uint64(fpstate.__fpu_mxcsr))
-		regs.fpregs = proc.AppendDwordReg(regs.fpregs, "MXCSR_MASK", uint32(fpstate.__fpu_mxcsrmask))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "MXCSR", uint64(fpstate.__fpu_mxcsr))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "MXCSR_MASK", uint64(fpstate.__fpu_mxcsrmask))
 
 		for i, xmm := range []*C.char{&fpstate.__fpu_xmm0.__xmm_reg[0], &fpstate.__fpu_xmm1.__xmm_reg[0], &fpstate.__fpu_xmm2.__xmm_reg[0], &fpstate.__fpu_xmm3.__xmm_reg[0], &fpstate.__fpu_xmm4.__xmm_reg[0], &fpstate.__fpu_xmm5.__xmm_reg[0], &fpstate.__fpu_xmm6.__xmm_reg[0], &fpstate.__fpu_xmm7.__xmm_reg[0], &fpstate.__fpu_xmm8.__xmm_reg[0], &fpstate.__fpu_xmm9.__xmm_reg[0], &fpstate.__fpu_xmm10.__xmm_reg[0], &fpstate.__fpu_xmm11.__xmm_reg[0], &fpstate.__fpu_xmm12.__xmm_reg[0], &fpstate.__fpu_xmm13.__xmm_reg[0], &fpstate.__fpu_xmm14.__xmm_reg[0], &fpstate.__fpu_xmm15.__xmm_reg[0]} {
-			regs.fpregs = proc.AppendSSEReg(regs.fpregs, fmt.Sprintf("XMM%d", i), C.GoBytes(unsafe.Pointer(xmm), 16))
+			regs.fpregs = proc.AppendBytesRegister(regs.fpregs, fmt.Sprintf("XMM%d", i), C.GoBytes(unsafe.Pointer(xmm), 16))
 		}
 	}
 	return regs, nil

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -50,33 +50,6 @@ func (pe ProcessDetachedError) Error() string {
 	return "detached from the process"
 }
 
-// PostInitializationSetup handles all of the initialization procedures
-// that must happen after Delve creates or attaches to a process.
-func PostInitializationSetup(p Process, path string, debugInfoDirs []string, writeBreakpoint WriteBreakpointFn) error {
-	entryPoint, err := p.EntryPoint()
-	if err != nil {
-		return err
-	}
-
-	err = p.BinInfo().LoadBinaryInfo(path, entryPoint, debugInfoDirs)
-	if err != nil {
-		return err
-	}
-	for _, image := range p.BinInfo().Images {
-		if image.loadErr != nil {
-			return image.loadErr
-		}
-	}
-
-	g, _ := GetG(p.CurrentThread())
-	p.SetSelectedGoroutine(g)
-
-	createUnrecoveredPanicBreakpoint(p, writeBreakpoint)
-	createFatalThrowBreakpoint(p, writeBreakpoint)
-
-	return nil
-}
-
 // FindFileLocation returns the PC for a given file:line.
 // Assumes that `file` is normalized to lower case and '/' on Windows.
 func FindFileLocation(p Process, fileName string, lineno int) ([]uint64, error) {
@@ -313,7 +286,7 @@ func conditionErrors(threads []Thread) error {
 // 	- a thread with onTriggeredInternalBreakpoint() == true
 // 	- a thread with onTriggeredBreakpoint() == true (prioritizing trapthread)
 // 	- trapthread
-func pickCurrentThread(dbp Process, trapthread Thread, threads []Thread) error {
+func pickCurrentThread(dbp *Target, trapthread Thread, threads []Thread) error {
 	for _, th := range threads {
 		if bp := th.Breakpoint(); bp.Active && bp.Internal {
 			return dbp.SwitchThread(th.ThreadID())
@@ -334,7 +307,7 @@ func pickCurrentThread(dbp Process, trapthread Thread, threads []Thread) error {
 // function is neither fnname1 or fnname2.
 // This function is used to step out of runtime.Breakpoint as well as
 // runtime.debugCallV1.
-func stepInstructionOut(dbp Process, curthread Thread, fnname1, fnname2 string) error {
+func stepInstructionOut(dbp *Target, curthread Thread, fnname1, fnname2 string) error {
 	for {
 		if err := curthread.StepInstruction(); err != nil {
 			return err
@@ -533,7 +506,7 @@ func StepInstruction(dbp *Target) (err error) {
 		return err
 	}
 	if tg, _ := GetG(thread); tg != nil {
-		dbp.SetSelectedGoroutine(tg)
+		dbp.selectedGoroutine = tg
 	}
 	return nil
 }

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -18,7 +18,6 @@ type Registers interface {
 	PC() uint64
 	SP() uint64
 	BP() uint64
-	CX() uint64
 	TLS() uint64
 	// GAddr returns the address of the G variable if it is known, 0 and false otherwise
 	GAddr() (uint64, bool)

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -1,13 +1,12 @@
 package proc
 
 import (
-	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
-	"os"
 	"strings"
+
+	"github.com/go-delve/delve/pkg/dwarf/op"
 )
 
 // Registers is an interface for a generic register type. The
@@ -28,182 +27,18 @@ type Registers interface {
 	Copy() Registers
 }
 
-// Register represents a CPU register.
+// Register represents a CPU register
 type Register struct {
-	Name  string
-	Bytes []byte
-	Value string
+	Name string
+	Reg  *op.DwarfRegister
 }
 
-// AppendWordReg appends a word (16 bit) register to regs.
-func AppendWordReg(regs []Register, name string, value uint16) []Register {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.LittleEndian, value)
-	return append(regs, Register{name, buf.Bytes(), fmt.Sprintf("%#04x", value)})
+func AppendUint64Register(regs []Register, name string, value uint64) []Register {
+	return append(regs, Register{name, op.DwarfRegisterFromUint64(value)})
 }
 
-// AppendDwordReg appends a double word (32 bit) register to regs.
-func AppendDwordReg(regs []Register, name string, value uint32) []Register {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.LittleEndian, value)
-	return append(regs, Register{name, buf.Bytes(), fmt.Sprintf("%#08x", value)})
-}
-
-// AppendQwordReg appends a quad word (64 bit) register to regs.
-func AppendQwordReg(regs []Register, name string, value uint64) []Register {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.LittleEndian, value)
-	return append(regs, Register{name, buf.Bytes(), fmt.Sprintf("%#016x", value)})
-}
-
-func appendFlagReg(regs []Register, name string, value uint64, descr flagRegisterDescr, size int) []Register {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.LittleEndian, value)
-	return append(regs, Register{name, buf.Bytes()[:size], descr.Describe(value, size)})
-}
-
-// AppendEflagReg appends EFLAG register to regs.
-func AppendEflagReg(regs []Register, name string, value uint64) []Register {
-	return appendFlagReg(regs, name, value, eflagsDescription, 64)
-}
-
-// AppendMxcsrReg appends MXCSR register to regs.
-func AppendMxcsrReg(regs []Register, name string, value uint64) []Register {
-	return appendFlagReg(regs, name, value, mxcsrDescription, 32)
-}
-
-// AppendX87Reg appends a 80 bit float register to regs.
-func AppendX87Reg(regs []Register, index int, exponent uint16, mantissa uint64) []Register {
-	var f float64
-	fset := false
-
-	const (
-		_SIGNBIT    = 1 << 15
-		_EXP_BIAS   = (1 << 14) - 1 // 2^(n-1) - 1 = 16383
-		_SPECIALEXP = (1 << 15) - 1 // all bits set
-		_HIGHBIT    = 1 << 63
-		_QUIETBIT   = 1 << 62
-	)
-
-	sign := 1.0
-	if exponent&_SIGNBIT != 0 {
-		sign = -1.0
-	}
-	exponent &= ^uint16(_SIGNBIT)
-
-	NaN := math.NaN()
-	Inf := math.Inf(+1)
-
-	switch exponent {
-	case 0:
-		switch {
-		case mantissa == 0:
-			f = sign * 0.0
-			fset = true
-		case mantissa&_HIGHBIT != 0:
-			f = NaN
-			fset = true
-		}
-	case _SPECIALEXP:
-		switch {
-		case mantissa&_HIGHBIT == 0:
-			f = sign * Inf
-			fset = true
-		default:
-			f = NaN // signaling NaN
-			fset = true
-		}
-	default:
-		if mantissa&_HIGHBIT == 0 {
-			f = NaN
-			fset = true
-		}
-	}
-
-	if !fset {
-		significand := float64(mantissa) / (1 << 63)
-		f = sign * math.Ldexp(significand, int(exponent-_EXP_BIAS))
-	}
-
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.LittleEndian, exponent)
-	binary.Write(&buf, binary.LittleEndian, mantissa)
-
-	return append(regs, Register{fmt.Sprintf("ST(%d)", index), buf.Bytes(), fmt.Sprintf("%#04x%016x\t%g", exponent, mantissa, f)})
-}
-
-// AppendSSEReg appends a 256 bit SSE register to regs.
-func AppendSSEReg(regs []Register, name string, xmm []byte) []Register {
-	buf := bytes.NewReader(xmm)
-
-	var out bytes.Buffer
-	var vi [16]uint8
-	for i := range vi {
-		binary.Read(buf, binary.LittleEndian, &vi[i])
-	}
-
-	fmt.Fprintf(&out, "0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8], vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
-
-	fmt.Fprintf(&out, "\tv2_int={ %02x%02x%02x%02x%02x%02x%02x%02x %02x%02x%02x%02x%02x%02x%02x%02x }", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0], vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
-
-	fmt.Fprintf(&out, "\tv4_int={ %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x }", vi[3], vi[2], vi[1], vi[0], vi[7], vi[6], vi[5], vi[4], vi[11], vi[10], vi[9], vi[8], vi[15], vi[14], vi[13], vi[12])
-
-	fmt.Fprintf(&out, "\tv8_int={ %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x }", vi[1], vi[0], vi[3], vi[2], vi[5], vi[4], vi[7], vi[6], vi[9], vi[8], vi[11], vi[10], vi[13], vi[12], vi[15], vi[14])
-
-	fmt.Fprintf(&out, "\tv16_int={ %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x }", vi[0], vi[1], vi[2], vi[3], vi[4], vi[5], vi[6], vi[7], vi[8], vi[9], vi[10], vi[11], vi[12], vi[13], vi[14], vi[15])
-
-	buf.Seek(0, os.SEEK_SET)
-	var v2 [2]float64
-	for i := range v2 {
-		binary.Read(buf, binary.LittleEndian, &v2[i])
-	}
-	fmt.Fprintf(&out, "\tv2_float={ %g %g }", v2[0], v2[1])
-
-	buf.Seek(0, os.SEEK_SET)
-	var v4 [4]float32
-	for i := range v4 {
-		binary.Read(buf, binary.LittleEndian, &v4[i])
-	}
-	fmt.Fprintf(&out, "\tv4_float={ %g %g %g %g }", v4[0], v4[1], v4[2], v4[3])
-
-	return append(regs, Register{name, xmm, out.String()})
-}
-
-// AppendFPReg appends a 128 bit FP register to regs.
-func AppendFPReg(regs []Register, name string, reg_value []byte) []Register {
-	buf := bytes.NewReader(reg_value)
-
-	var out bytes.Buffer
-	var vi [16]uint8
-	for i := range vi {
-		binary.Read(buf, binary.LittleEndian, &vi[i])
-	}
-
-	fmt.Fprintf(&out, "0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8], vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
-
-	fmt.Fprintf(&out, "\tv2_int={ %02x%02x%02x%02x%02x%02x%02x%02x %02x%02x%02x%02x%02x%02x%02x%02x }", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0], vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
-
-	fmt.Fprintf(&out, "\tv4_int={ %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x }", vi[3], vi[2], vi[1], vi[0], vi[7], vi[6], vi[5], vi[4], vi[11], vi[10], vi[9], vi[8], vi[15], vi[14], vi[13], vi[12])
-
-	fmt.Fprintf(&out, "\tv8_int={ %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x }", vi[1], vi[0], vi[3], vi[2], vi[5], vi[4], vi[7], vi[6], vi[9], vi[8], vi[11], vi[10], vi[13], vi[12], vi[15], vi[14])
-
-	fmt.Fprintf(&out, "\tv16_int={ %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x }", vi[0], vi[1], vi[2], vi[3], vi[4], vi[5], vi[6], vi[7], vi[8], vi[9], vi[10], vi[11], vi[12], vi[13], vi[14], vi[15])
-
-	buf.Seek(0, os.SEEK_SET)
-	var v2 [2]float64
-	for i := range v2 {
-		binary.Read(buf, binary.LittleEndian, &v2[i])
-	}
-	fmt.Fprintf(&out, "\tv2_float={ %g %g }", v2[0], v2[1])
-
-	buf.Seek(0, os.SEEK_SET)
-	var v4 [4]float32
-	for i := range v4 {
-		binary.Read(buf, binary.LittleEndian, &v4[i])
-	}
-	fmt.Fprintf(&out, "\tv4_float={ %g %g %g %g }", v4[0], v4[1], v4[2], v4[3])
-
-	return append(regs, Register{name, reg_value, out.String()})
+func AppendBytesRegister(regs []Register, name string, value []byte) []Register {
+	return append(regs, Register{name, op.DwarfRegisterFromBytes(value)})
 }
 
 // ErrUnknownRegister is returned when the value of an unknown

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -534,11 +534,14 @@ func (it *stackIterator) loadG0SchedSP() {
 	}
 	it.g0_sched_sp_loaded = true
 	if it.g != nil {
-		g0var, _ := it.g.variable.fieldVariable("m").structMember("g0")
-		if g0var != nil {
-			g0, _ := g0var.parseG()
-			if g0 != nil {
-				it.g0_sched_sp = g0.SP
+		mvar, _ := it.g.variable.structMember("m")
+		if mvar != nil {
+			g0var, _ := mvar.structMember("g0")
+			if g0var != nil {
+				g0, _ := g0var.parseG()
+				if g0 != nil {
+					it.g0_sched_sp = g0.SP
+				}
 			}
 		}
 	}

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -1,8 +1,16 @@
 package proc
 
+import (
+	"fmt"
+)
+
 // Target represents the process being debugged.
 type Target struct {
 	Process
+
+	// Goroutine that will be used by default to set breakpoint, eval variables, etc...
+	// Normally selectedGoroutine is currentThread.GetG, it will not be only if SwitchGoroutine is called with a goroutine that isn't attached to a thread
+	selectedGoroutine *G
 
 	// fncallForG stores a mapping of current active function calls.
 	fncallForG map[int]*callInjection
@@ -14,13 +22,35 @@ type Target struct {
 }
 
 // NewTarget returns an initialized Target object.
-func NewTarget(p Process) *Target {
+func NewTarget(p Process, path string, debugInfoDirs []string, writeBreakpoint WriteBreakpointFn) (*Target, error) {
+	entryPoint, err := p.EntryPoint()
+	if err != nil {
+		return nil, err
+	}
+
+	err = p.BinInfo().LoadBinaryInfo(path, entryPoint, debugInfoDirs)
+	if err != nil {
+		return nil, err
+	}
+	for _, image := range p.BinInfo().Images {
+		if image.loadErr != nil {
+			return nil, image.loadErr
+		}
+	}
+
 	t := &Target{
 		Process:    p,
 		fncallForG: make(map[int]*callInjection),
 	}
+
+	g, _ := GetG(p.CurrentThread())
+	t.selectedGoroutine = g
+
+	createUnrecoveredPanicBreakpoint(p, writeBreakpoint)
+	createFatalThrowBreakpoint(p, writeBreakpoint)
+
 	t.gcache.init(p.BinInfo())
-	return t
+	return t, nil
 }
 
 // SupportsFunctionCalls returns whether or not the backend supports
@@ -43,5 +73,45 @@ func (t *Target) ClearAllGCache() {
 
 func (t *Target) Restart(from string) error {
 	t.ClearAllGCache()
-	return t.Process.Restart(from)
+	err := t.Process.Restart(from)
+	if err != nil {
+		return err
+	}
+	t.selectedGoroutine, _ = GetG(t.CurrentThread())
+	return nil
+}
+
+// SetSelectedGoroutine will set internally the goroutine that should be
+// the default for any command executed, the goroutine being actively
+// followed.
+func (t *Target) SelectedGoroutine() *G {
+	return t.selectedGoroutine
+}
+
+// SwitchGoroutine will change the selected and active goroutine.
+func (p *Target) SwitchGoroutine(g *G) error {
+	if ok, err := p.Valid(); !ok {
+		return err
+	}
+	if g == nil {
+		return nil
+	}
+	if g.Thread != nil {
+		return p.SwitchThread(g.Thread.ThreadID())
+	}
+	p.selectedGoroutine = g
+	return nil
+}
+
+// SwitchThread will change the selected and active thread.
+func (p *Target) SwitchThread(tid int) error {
+	if ok, err := p.Valid(); !ok {
+		return err
+	}
+	if th, ok := p.FindThread(tid); ok {
+		p.InternalSetCurrentThread(th)
+		p.selectedGoroutine, _ = GetG(p.CurrentThread())
+		return nil
+	}
+	return fmt.Errorf("thread %d does not exist", tid)
 }

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -69,6 +69,9 @@ func (t *Target) SupportsFunctionCalls() bool {
 // This should be called anytime the target process executes instructions.
 func (t *Target) ClearAllGCache() {
 	t.gcache.Clear()
+	for _, thread := range t.ThreadList() {
+		thread.Common().g = nil
+	}
 }
 
 func (t *Target) Restart(from string) error {

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -503,7 +503,11 @@ func GetG(thread Thread) (*G, error) {
 		// For our purposes it's better if we always return the real goroutine
 		// since the rest of the code assumes the goroutine ID is univocal.
 		// The real 'current goroutine' is stored in g0.m.curg
-		curgvar, err := g.variable.fieldVariable("m").structMember("curg")
+		mvar, err := g.variable.structMember("m")
+		if err != nil {
+			return nil, err
+		}
+		curgvar, err := mvar.structMember("curg")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -70,6 +70,7 @@ func (tbe ErrThreadBlocked) Error() string {
 // implementations of the Thread interface.
 type CommonThread struct {
 	returnValues []*Variable
+	g            *G // cached g for this thread
 }
 
 // ReturnValues reads the return values from the function executing on
@@ -478,6 +479,9 @@ func newGVariable(thread Thread, gaddr uintptr, deref bool) (*Variable, error) {
 // In order to get around all this craziness, we read the address of the G structure for
 // the current thread from the thread local storage area.
 func GetG(thread Thread) (*G, error) {
+	if thread.Common().g != nil {
+		return thread.Common().g, nil
+	}
 	if loc, _ := thread.Location(); loc != nil && loc.Fn != nil && loc.Fn.Name == "runtime.clone" {
 		// When threads are executing runtime.clone the value of TLS is unreliable.
 		return nil, nil
@@ -513,6 +517,7 @@ func GetG(thread Thread) (*G, error) {
 	if loc, err := thread.Location(); err == nil {
 		g.CurrentLoc = *loc
 	}
+	thread.Common().g = g
 	return g, nil
 }
 

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -142,7 +142,7 @@ func (err *ErrNoSourceForPC) Error() string {
 // for an inlined function call. Everything works the same as normal except
 // when removing instructions belonging to inlined calls we also remove all
 // instructions belonging to the current inlined call.
-func next(dbp Process, stepInto, inlinedStepOut bool) error {
+func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 	selg := dbp.SelectedGoroutine()
 	curthread := dbp.CurrentThread()
 	topframe, retframe, err := topframe(selg, curthread)

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -186,19 +186,18 @@ const (
 // G represents a runtime G (goroutine) structure (at least the
 // fields that Delve is interested in).
 type G struct {
-	ID         int    // Goroutine ID
-	PC         uint64 // PC of goroutine when it was parked.
-	SP         uint64 // SP of goroutine when it was parked.
-	BP         uint64 // BP of goroutine when it was parked (go >= 1.7).
-	LR         uint64 // LR of goroutine when it was parked.
-	GoPC       uint64 // PC of 'go' statement that created this goroutine.
-	StartPC    uint64 // PC of the first function run on this goroutine.
-	WaitReason string // Reason for goroutine being parked.
-	Status     uint64
-	stkbarVar  *Variable // stkbar field of g struct
-	stkbarPos  int       // stkbarPos field of g struct
-	stackhi    uint64    // value of stack.hi
-	stacklo    uint64    // value of stack.lo
+	ID        int    // Goroutine ID
+	PC        uint64 // PC of goroutine when it was parked.
+	SP        uint64 // SP of goroutine when it was parked.
+	BP        uint64 // BP of goroutine when it was parked (go >= 1.7).
+	LR        uint64 // LR of goroutine when it was parked.
+	GoPC      uint64 // PC of 'go' statement that created this goroutine.
+	StartPC   uint64 // PC of the first function run on this goroutine.
+	Status    uint64
+	stkbarVar *Variable // stkbar field of g struct
+	stkbarPos int       // stkbarPos field of g struct
+	stackhi   uint64    // value of stack.hi
+	stacklo   uint64    // value of stack.lo
 
 	SystemStack bool // SystemStack is true if this goroutine is currently executing on a system stack.
 
@@ -220,7 +219,11 @@ func (g *G) Defer() *Defer {
 	if g.variable.Unreadable != nil {
 		return nil
 	}
-	dvar := g.variable.fieldVariable("_defer").maybeDereference()
+	dvar, _ := g.variable.structMember("_defer")
+	if dvar == nil {
+		return nil
+	}
+	dvar = dvar.maybeDereference()
 	if dvar.Addr == 0 {
 		return nil
 	}
@@ -518,6 +521,8 @@ func (ng ErrNoGoroutine) Error() string {
 	return fmt.Sprintf("no G executing on thread %d", ng.tid)
 }
 
+var ErrUnreadableG = errors.New("could not read G struct")
+
 func (v *Variable) parseG() (*G, error) {
 	mem := v.mem
 	gaddr := uint64(v.Addr)
@@ -544,11 +549,13 @@ func (v *Variable) parseG() (*G, error) {
 		}
 		v = v.maybeDereference()
 	}
-	v.loadValue(LoadConfig{false, 2, 64, 0, -1, 0})
-	if v.Unreadable != nil {
-		return nil, v.Unreadable
+
+	v.mem = cacheMemory(v.mem, v.Addr, int(v.RealType.Size()))
+
+	schedVar := v.loadFieldNamed("sched")
+	if schedVar == nil {
+		return nil, ErrUnreadableG
 	}
-	schedVar := v.fieldVariable("sched")
 	pc, _ := constant.Int64Val(schedVar.fieldVariable("pc").Value)
 	sp, _ := constant.Int64Val(schedVar.fieldVariable("sp").Value)
 	var bp, lr int64
@@ -558,21 +565,24 @@ func (v *Variable) parseG() (*G, error) {
 	if bpvar := schedVar.fieldVariable("lr"); bpvar != nil && bpvar.Value != nil {
 		lr, _ = constant.Int64Val(bpvar.Value)
 	}
-	id, _ := constant.Int64Val(v.fieldVariable("goid").Value)
-	gopc, _ := constant.Int64Val(v.fieldVariable("gopc").Value)
-	startpc, _ := constant.Int64Val(v.fieldVariable("startpc").Value)
-	waitReason := ""
-	if wrvar := v.fieldVariable("waitreason"); wrvar.Value != nil {
-		switch wrvar.Kind {
-		case reflect.String:
-			waitReason = constant.StringVal(wrvar.Value)
-		case reflect.Uint:
-			waitReason = wrvar.ConstDescr()
-		}
 
+	unreadable := false
+
+	loadInt64Maybe := func(name string) int64 {
+		vv := v.loadFieldNamed(name)
+		if vv == nil {
+			unreadable = true
+			return 0
+		}
+		n, _ := constant.Int64Val(vv.Value)
+		return n
 	}
+
+	id := loadInt64Maybe("goid")
+	gopc := loadInt64Maybe("gopc")
+	startpc := loadInt64Maybe("startpc")
 	var stackhi, stacklo uint64
-	if stackVar := v.fieldVariable("stack"); stackVar != nil {
+	if stackVar := v.loadFieldNamed("stack"); stackVar != nil {
 		if stackhiVar := stackVar.fieldVariable("hi"); stackhiVar != nil {
 			stackhi, _ = constant.Uint64Val(stackhiVar.Value)
 		}
@@ -581,14 +591,19 @@ func (v *Variable) parseG() (*G, error) {
 		}
 	}
 
-	stkbarVar, _ := v.structMember("stkbar")
-	stkbarVarPosFld := v.fieldVariable("stkbarPos")
+	stkbarVar := v.loadFieldNamed("stkbar")
+	stkbarVarPosFld := v.loadFieldNamed("stkbarPos")
 	var stkbarPos int64
 	if stkbarVarPosFld != nil { // stack barriers were removed in Go 1.9
 		stkbarPos, _ = constant.Int64Val(stkbarVarPosFld.Value)
 	}
 
-	status, _ := constant.Int64Val(v.fieldVariable("atomicstatus").Value)
+	status := loadInt64Maybe("atomicstatus")
+
+	if unreadable {
+		return nil, ErrUnreadableG
+	}
+
 	f, l, fn := v.bi.PCToLine(uint64(pc))
 
 	g := &G{
@@ -599,7 +614,6 @@ func (v *Variable) parseG() (*G, error) {
 		SP:         uint64(sp),
 		BP:         uint64(bp),
 		LR:         uint64(lr),
-		WaitReason: waitReason,
 		Status:     uint64(status),
 		CurrentLoc: Location{PC: uint64(pc), File: f, Line: l, Fn: fn},
 		variable:   v,
@@ -624,6 +638,9 @@ func (v *Variable) loadFieldNamed(name string) *Variable {
 }
 
 func (v *Variable) fieldVariable(name string) *Variable {
+	if !v.loaded {
+		panic("fieldVariable called on a variable that wasn't loaded")
+	}
 	for i := range v.Children {
 		if child := &v.Children[i]; child.Name == name {
 			return child

--- a/pkg/proc/winutil/regs.go
+++ b/pkg/proc/winutil/regs.go
@@ -152,11 +152,6 @@ func (r *AMD64Registers) BP() uint64 {
 	return r.rbp
 }
 
-// CX returns the value of the RCX register.
-func (r *AMD64Registers) CX() uint64 {
-	return r.rcx
-}
-
 // TLS returns the value of the register
 // that contains the location of the thread
 // local storage segment.

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -328,10 +328,10 @@ func LoadConfigFromProc(cfg *proc.LoadConfig) *LoadConfig {
 }
 
 // ConvertRegisters converts proc.Register to api.Register for a slice.
-func ConvertRegisters(in []proc.Register) (out []Register) {
+func ConvertRegisters(in []proc.Register, arch proc.Arch) (out []Register) {
 	out = make([]Register, len(in))
 	for i := range in {
-		out[i] = Register{in[i].Name, in[i].Value}
+		out[i] = Register{in[i].Name, arch.DwarfRegisterToString(in[i].Name, in[i].Reg)}
 	}
 	return
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -961,7 +961,7 @@ func (d *Debugger) Registers(threadID int, floatingPoint bool) (api.Registers, e
 	if err != nil {
 		return nil, err
 	}
-	return api.ConvertRegisters(regs.Slice(floatingPoint)), err
+	return api.ConvertRegisters(regs.Slice(floatingPoint), d.target.BinInfo().Arch), err
 }
 
 func convertVars(pv []*proc.Variable) []api.Variable {


### PR DESCRIPTION
```
proc: optimize parseG

runtime.g is a large and growing struct, we only need a few fields.
Instead of using loadValue to load the full contents of g cache its
memory and then only load the fields we care about.

Benchmark before:

BenchmarkConditionalBreakpoints-4              1        10013510647 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	9330025748 ns/op

Conditional breakpoint evaluation: 1.0ms -> 0.93ms

Updates #1549

proc: optimize RegistersToDwarfRegisters

Benchmark before:

BenchmarkConditionalBreakpoints-4              1        11570508729 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	10013510647 ns/op

Conditional breakpoint evaluation 1.2ms -> 1.0ms

Updates #1549

proc: cache result of GetG

Benchmark before:

BenchmarkConditionalBreakpoints-4              1        15929810602 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	11570508729 ns/op

Conditional breakpoint evaluation 1.6ms -> 1.2ms

Updates #1549

proc,proc/*: move SelectedGoroutine to proc.Target

moves SelectedGoroutine, SwitchThread and SwitchGoroutine to
proc.Target, merges PostInitializationSetup with NewTarget.

proc/native: optimize native.status through buffering

Benchmark before:

BenchmarkConditionalBreakpoints-4              1        17294564246 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	15929810602 ns/op

Conditional breakpoint evaluation 1.7ms -> 1.6ms

Updates #1549

proc: do not load g0 until it's needed when stacktracing

The stacktrace code occasionally needs the value of g.m.g0.sched.sp to
switch stacks. Since this is only needed rarely and calling parseG is
relatively expensive we should delay doing it until we know it will be
needed.

Benchmark before:

BenchmarkConditionalBreakpoints-4              1        18397062447 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	17294564246 ns/op

i.e. this commit improves the time needed to evaluate a conditional
breakpoint from 1.8ms to 1.7ms.

Updates #1549

proc: only format registers value when it's necessary

Reduces the minimum amount of time needed to stop and resume a process
that hits a breakpoint.
A significant amount of time is spent generating the strings for the
proc.Registers object of each thread, since this field is rarely used
(only when the Registers API is called) it should be generated on
demand.

Benchmark before:

BenchmarkConditionalBreakpoints-4   	       1	22218288218 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	18397062447 ns/op

i.e. this commit reduces the time spent stopping and resuming a process
from 2.2ms to 1.8ms.

Updates #1549

dwarf/reader: precalcStack does not need to read past the first entry

It was reading all the way to the end of the debug_info section,
slowing down stacktraces substantially.

Benchmark before:

BenchmarkConditionalBreakpoints-4   	       1	80344642562 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	22218288218 ns/op

i.e. a reduction of the cost of a breakpoint hit from 8ms to 2.2ms

Updates #1549

tests: add benchmark for conditional breakpoints

proc: remove CX method from proc.Registers

It is not used anymore besides internally by the proc/gdbserial
backend.

```
