### PR TITLE
Fix serious performance degradation when building stack traces

### DIFF
--- a/_fixtures/issue1549.go
+++ b/_fixtures/issue1549.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	sum := int64(0)
+	start := time.Now()
+	for value := int64(0); value < 10000; value++ {
+		sum += value
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("Sum: %d\nTook %s\n", sum, elapsed)
+}

--- a/pkg/dwarf/reader/reader.go
+++ b/pkg/dwarf/reader/reader.go
@@ -426,6 +426,9 @@ childLoop:
 		default:
 			irdr.reader.SkipChildren()
 		}
+		if rentry == nil {
+			break
+		}
 	}
 
 	if rentry != nil && rentry.Tag == dwarf.TagInlinedSubroutine {

--- a/pkg/proc/fbsdutil/regs.go
+++ b/pkg/proc/fbsdutil/regs.go
@@ -132,11 +132,6 @@ func (r *AMD64Registers) BP() uint64 {
 	return uint64(r.Regs.Rbp)
 }
 
-// CX returns the value of RCX register.
-func (r *AMD64Registers) CX() uint64 {
-	return uint64(r.Regs.Rcx)
-}
-
 // TLS returns the address of the thread local storage memory segment.
 func (r *AMD64Registers) TLS() uint64 {
 	return r.Fsbase

--- a/pkg/proc/linutil/regs_amd64_arch.go
+++ b/pkg/proc/linutil/regs_amd64_arch.go
@@ -112,11 +112,6 @@ func (r *AMD64Registers) BP() uint64 {
 	return r.Regs.Rbp
 }
 
-// CX returns the value of RCX register.
-func (r *AMD64Registers) CX() uint64 {
-	return r.Regs.Rcx
-}
-
 // TLS returns the address of the thread local storage memory segment.
 func (r *AMD64Registers) TLS() uint64 {
 	return r.Regs.Fs_base

--- a/pkg/proc/linutil/regs_arm64_arch.go
+++ b/pkg/proc/linutil/regs_arm64_arch.go
@@ -87,11 +87,6 @@ func (r *ARM64Registers) BP() uint64 {
 	return r.Regs.Regs[29]
 }
 
-// CX returns the value of RCX register.
-func (r *ARM64Registers) CX() uint64 {
-	return 0
-}
-
 // TLS returns the address of the thread local storage memory segment.
 func (r *ARM64Registers) TLS() uint64 {
 	return 0

--- a/pkg/proc/native/registers_darwin_amd64.go
+++ b/pkg/proc/native/registers_darwin_amd64.go
@@ -100,11 +100,6 @@ func (r *Regs) BP() uint64 {
 	return r.rbp
 }
 
-// CX returns the value of the RCX register.
-func (r *Regs) CX() uint64 {
-	return r.rcx
-}
-
 // TLS returns the value of the register
 // that contains the location of the thread
 // local storage segment.

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -18,7 +18,6 @@ type Registers interface {
 	PC() uint64
 	SP() uint64
 	BP() uint64
-	CX() uint64
 	TLS() uint64
 	// GAddr returns the address of the G variable if it is known, 0 and false otherwise
 	GAddr() (uint64, bool)

--- a/pkg/proc/winutil/regs.go
+++ b/pkg/proc/winutil/regs.go
@@ -152,11 +152,6 @@ func (r *AMD64Registers) BP() uint64 {
 	return r.rbp
 }
 
-// CX returns the value of the RCX register.
-func (r *AMD64Registers) CX() uint64 {
-	return r.rcx
-}
-
 // TLS returns the value of the register
 // that contains the location of the thread
 // local storage segment.


### PR DESCRIPTION
```
dwarf/reader: precalcStack does not need to read past the first entry

It was reading all the way to the end of the debug_info section,
slowing down stacktraces substantially.

Benchmark before:

BenchmarkConditionalBreakpoints-4   	       1	80344642562 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	22218288218 ns/op

i.e. a reduction of the cost of a breakpoint hit from 8ms to 2.2ms

Updates #1549

tests: add benchmark for conditional breakpoints

proc: remove CX method from proc.Registers

It is not used anymore besides internally by the proc/gdbserial
backend.

```
