### PR TITLE
Documentation/cli: add info for element limit config keys

### DIFF
--- a/Documentation/cli/expr.md
+++ b/Documentation/cli/expr.md
@@ -56,6 +56,8 @@ To see more values use the slice operator:
 
 For this purpose delve allows use of the slice operator on maps, `m[64:]` will return the key/value pairs of map `m` that follow the first 64 key/value pairs (note that delve iterates over maps using a fixed ordering).
 
+These limits can be configured with `max-string-len` and `max-array-values`. See [config](https://github.com/go-delve/delve/tree/master/Documentation/cli#config) for usage.
+
 # Interfaces
 
 Interfaces will be printed using the following syntax:


### PR DESCRIPTION
I updated the docs to add more information about element limit configuration options in the CLI. I came to the *expr* page reading about the element limit, but it was not apparent that I could change these limits.