### PR TITLE
[WIP] pkg/proc: Move breakpoint logic up to Target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.11
 
 require (
 	github.com/cosiner/argv v0.0.0-20170225145430-13bacc38a0a5
+	github.com/cpuguy83/go-md2man v1.0.10 // indirect
 	github.com/google/go-dap v0.2.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.0.0-20170327083344-ded68f7a9561

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cosiner/argv v0.0.0-20170225145430-13bacc38a0a5 h1:rIXlvz2IWiupMFlC45cZCXZFvKX/ExBcSLrDy2G0Lp8=
 github.com/cosiner/argv v0.0.0-20170225145430-13bacc38a0a5/go.mod h1:p/NrK5tF6ICIly4qwEDsf6VDirFiWWz0FenfYBwJaKQ=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
+github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -32,6 +34,8 @@ github.com/pkg/profile v0.0.0-20170413231811-06b906832ed0 h1:wBza4Dlm/NCQF572oSG
 github.com/pkg/profile v0.0.0-20170413231811-06b906832ed0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
+github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v0.0.0-20180523074243-ea8897e79973 h1:3AJZYTzw3gm3TNTt30x0CCKD7GOn2sdd50Hn35fQkGY=
 github.com/sirupsen/logrus v0.0.0-20180523074243-ea8897e79973/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/spf13/cobra v0.0.0-20170417170307-b6cb39589372 h1:eRfW1vRS4th8IX2iQeyqQ8cOUNOySvAYJ0IUvTXGoYA=

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -225,7 +225,7 @@ func (bpmap *BreakpointMap) ResetBreakpointIDCounter() {
 // writting breakpoings into the target.
 type WriteBreakpointFn func(addr uint64) (file string, line int, fn *Function, originalData []byte, err error)
 
-type clearBreakpointFn func(*Breakpoint) error
+type clearBreakpointFn func(uint64, []byte) error
 
 // Set creates a breakpoint at addr calling writeBreakpoint. Do not call this
 // function, call proc.Process.SetBreakpoint instead, this function exists
@@ -306,7 +306,7 @@ func (bpmap *BreakpointMap) Clear(addr uint64, clearBreakpoint clearBreakpointFn
 		return bp, nil
 	}
 
-	if err := clearBreakpoint(bp); err != nil {
+	if err := clearBreakpoint(bp.Addr, bp.OriginalData); err != nil {
 		return nil, err
 	}
 
@@ -327,7 +327,7 @@ func (bpmap *BreakpointMap) ClearInternalBreakpoints(clearBreakpoint clearBreakp
 		if bp.Kind != 0 {
 			continue
 		}
-		if err := clearBreakpoint(bp); err != nil {
+		if err := clearBreakpoint(bp.Addr, bp.OriginalData); err != nil {
 			return err
 		}
 		delete(bpmap.M, addr)

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -115,8 +115,8 @@ type returnBreakpointInfo struct {
 }
 
 // CheckCondition evaluates bp's condition on thread.
-func (bp *Breakpoint) CheckCondition(thread Thread) BreakpointState {
-	bpstate := BreakpointState{Breakpoint: bp, Active: false, Internal: false, CondError: nil}
+func (bp *Breakpoint) CheckCondition(thread Thread) *BreakpointState {
+	bpstate := &BreakpointState{Breakpoint: bp, Active: false, Internal: false, CondError: nil}
 	if bp.Cond == nil && bp.internalCond == nil {
 		bpstate.Active = true
 		bpstate.Internal = bp.IsInternal()

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -390,6 +390,11 @@ func (p *Process) ContinueOnce() (proc.Thread, []proc.Thread, error) {
 	return nil, nil, ErrContinueCore
 }
 
+// CurrentDirection always returns forward for non-recorded processes.
+func (p *Process) CurrentDirection() proc.Direction {
+	return proc.Forward
+}
+
 // StepInstruction will always return an error
 // as you cannot control execution of a core file.
 func (p *Process) StepInstruction() error {

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -220,7 +220,7 @@ func OpenCore(corePath, exePath string, debugInfoDirs []string) (*proc.Target, e
 // initialize for core files doesn't do much
 // aside from call the post initialization setup.
 func (p *Process) initialize(path string, debugInfoDirs []string) error {
-	return proc.PostInitializationSetup(p, path, debugInfoDirs, p.WriteBreakpointFn)
+	return proc.PostInitializationSetup(p, path, debugInfoDirs)
 }
 
 // AdjustsPCAfterBreakpoint always returns false as the core backend does

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -392,8 +392,8 @@ func (p *Process) ClearInternalBreakpoints() error {
 
 // ContinueOnce will always return an error because you
 // cannot control execution of a core file.
-func (p *Process) ContinueOnce() (proc.Thread, error) {
-	return nil, ErrContinueCore
+func (p *Process) ContinueOnce() (proc.Thread, []proc.Thread, error) {
+	return nil, nil, ErrContinueCore
 }
 
 // StepInstruction will always return an error

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -223,9 +223,9 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 	return proc.PostInitializationSetup(p, path, debugInfoDirs)
 }
 
-// AdjustsPCAfterBreakpoint always returns false as the core backend does
+// AdjustPCAfterBreakpoint always returns false as the core backend does
 // not execute instructions or hit breakpoints.
-func (dbp *Process) AdjustsPCAfterBreakpoint() bool { return false }
+func (dbp *Process) AdjustPCAfterBreakpoint() bool { return false }
 
 // BinInfo will return the binary info.
 func (p *Process) BinInfo() *proc.BinaryInfo {

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -222,7 +222,7 @@ func OpenCore(corePath, exePath string, debugInfoDirs []string) (*proc.Target, e
 // initialize for core files doesn't do much
 // aside from call the post initialization setup.
 func (p *Process) initialize(path string, debugInfoDirs []string) error {
-	return proc.PostInitializationSetup(p, path, debugInfoDirs, p.writeBreakpoint)
+	return proc.PostInitializationSetup(p, path, debugInfoDirs, p.WriteBreakpointFn)
 }
 
 // BinInfo will return the binary info.
@@ -240,12 +240,6 @@ func (p *Process) SetSelectedGoroutine(g *proc.G) {
 // EntryPoint will return the entry point address for this core file.
 func (p *Process) EntryPoint() (uint64, error) {
 	return p.entryPoint, nil
-}
-
-// writeBreakpoint is a noop function since you
-// cannot write breakpoints into core files.
-func (p *Process) writeBreakpoint(addr uint64) (file string, line int, fn *proc.Function, originalData []byte, err error) {
-	return "", 0, nil, nil, errors.New("cannot write a breakpoint to a core file")
 }
 
 // Recorded returns whether this is a live or recorded process. Always returns true for core files.
@@ -452,6 +446,14 @@ func (p *Process) SelectedGoroutine() *proc.G {
 // SetBreakpoint will always return an error for core files as you cannot write memory or control execution.
 func (p *Process) SetBreakpoint(addr uint64, kind proc.BreakpointKind, cond ast.Expr) (*proc.Breakpoint, error) {
 	return nil, ErrWriteCore
+}
+
+func (p *Process) WriteBreakpointFn(addr uint64) (string, int, *proc.Function, []byte, error) {
+	return "", 0, nil, nil, ErrWriteCore
+}
+
+func (p *Process) ClearBreakpointFn(uint64, []byte) error {
+	return ErrWriteCore
 }
 
 // SwitchGoroutine will change the selected and active goroutine.

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -3,7 +3,6 @@ package core
 import (
 	"errors"
 	"fmt"
-	"go/ast"
 	"io"
 
 	"github.com/go-delve/delve/pkg/proc"
@@ -156,7 +155,6 @@ type Process struct {
 	entryPoint uint64
 
 	bi                *proc.BinaryInfo
-	breakpoints       proc.BreakpointMap
 	currentThread     *Thread
 	selectedGoroutine *proc.G
 }
@@ -228,10 +226,6 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 // AdjustsPCAfterBreakpoint always returns false as the core backend does
 // not execute instructions or hit breakpoints.
 func (dbp *Process) AdjustsPCAfterBreakpoint() bool { return false }
-
-func (dbp *Process) FindBreakpoint(pc uint64) (*proc.Breakpoint, bool) {
-	return nil, false
-}
 
 // BinInfo will return the binary info.
 func (p *Process) BinInfo() *proc.BinaryInfo {
@@ -375,23 +369,6 @@ func (t *Thread) SetDX(uint64) error {
 	return ErrChangeRegisterCore
 }
 
-// Breakpoints will return all breakpoints for the process.
-func (p *Process) Breakpoints() *proc.BreakpointMap {
-	return &p.breakpoints
-}
-
-// ClearBreakpoint will always return an error as you cannot set or clear
-// breakpoints on core files.
-func (p *Process) ClearBreakpoint(addr uint64) (*proc.Breakpoint, error) {
-	return nil, proc.NoBreakpointError{Addr: addr}
-}
-
-// ClearInternalBreakpointsInternal will always return nil and have no
-// effect since you cannot set breakpoints on core files.
-func (p *Process) ClearInternalBreakpointsInternal() error {
-	return nil
-}
-
 // ContinueOnce will always return an error because you
 // cannot control execution of a core file.
 func (p *Process) ContinueOnce() (proc.Thread, []proc.Thread, error) {
@@ -454,11 +431,6 @@ func (p *Process) ResumeNotify(chan<- struct{}) {
 // goroutine.
 func (p *Process) SelectedGoroutine() *proc.G {
 	return p.selectedGoroutine
-}
-
-// SetBreakpoint will always return an error for core files as you cannot write memory or control execution.
-func (p *Process) SetBreakpoint(addr uint64, kind proc.BreakpointKind, cond ast.Expr) (*proc.Breakpoint, error) {
-	return nil, ErrWriteCore
 }
 
 func (p *Process) WriteBreakpointFn(addr uint64) (string, int, *proc.Function, []byte, error) {

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -225,6 +225,14 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 	return proc.PostInitializationSetup(p, path, debugInfoDirs, p.WriteBreakpointFn)
 }
 
+// AdjustsPCAfterBreakpoint always returns false as the core backend does
+// not execute instructions or hit breakpoints.
+func (dbp *Process) AdjustsPCAfterBreakpoint() bool { return false }
+
+func (dbp *Process) FindBreakpoint(pc uint64) (*proc.Breakpoint, bool) {
+	return nil, false
+}
+
 // BinInfo will return the binary info.
 func (p *Process) BinInfo() *proc.BinaryInfo {
 	return p.bi
@@ -378,9 +386,9 @@ func (p *Process) ClearBreakpoint(addr uint64) (*proc.Breakpoint, error) {
 	return nil, proc.NoBreakpointError{Addr: addr}
 }
 
-// ClearInternalBreakpoints will always return nil and have no
+// ClearInternalBreakpointsInternal will always return nil and have no
 // effect since you cannot set breakpoints on core files.
-func (p *Process) ClearInternalBreakpoints() error {
+func (p *Process) ClearInternalBreakpointsInternal() error {
 	return nil
 }
 

--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -120,10 +120,9 @@ func readLinuxCore(corePath, exePath string) (*Process, error) {
 	memory := buildMemory(coreFile, exeELF, exe, notes)
 	entryPoint := findEntryPoint(notes)
 	p := &Process{
-		mem:         memory,
-		Threads:     map[int]*Thread{},
-		entryPoint:  entryPoint,
-		breakpoints: proc.NewBreakpointMap(),
+		mem:        memory,
+		Threads:    map[int]*Thread{},
+		entryPoint: entryPoint,
 	}
 
 	switch machineType {

--- a/pkg/proc/core/windows_amd64_minidump.go
+++ b/pkg/proc/core/windows_amd64_minidump.go
@@ -29,11 +29,10 @@ func readAMD64Minidump(minidumpPath, exePath string) (*Process, error) {
 	}
 
 	p := &Process{
-		mem:         memory,
-		Threads:     map[int]*Thread{},
-		bi:          proc.NewBinaryInfo("windows", "amd64"),
-		breakpoints: proc.NewBreakpointMap(),
-		pid:         int(mdmp.Pid),
+		mem:     memory,
+		Threads: map[int]*Thread{},
+		bi:      proc.NewBinaryInfo("windows", "amd64"),
+		pid:     int(mdmp.Pid),
 	}
 
 	for i := range mdmp.Threads {

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -56,7 +56,7 @@ type opcodeSeq []uint64
 // matching the instructions against known split-stack prologue patterns.
 // If sameline is set firstPCAfterPrologueDisassembly will always return an
 // address associated with the same line as fn.Entry
-func firstPCAfterPrologueDisassembly(p Process, fn *Function, sameline bool) (uint64, error) {
+func firstPCAfterPrologueDisassembly(p *Target, fn *Function, sameline bool) (uint64, error) {
 	var mem MemoryReadWriter = p.CurrentThread()
 	breakpoints := p.Breakpoints()
 	bi := p.BinInfo()

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -108,8 +108,6 @@ type Process struct {
 
 	manualStopRequested bool
 
-	breakpoints proc.BreakpointMap
-
 	gcmdok         bool   // true if the stub supports g and G commands
 	threadStopInfo bool   // true if the stub supports qThreadStopInfo
 	tracedir       string // if attached to rr the path to the trace directory
@@ -176,7 +174,6 @@ func New(process *os.Process) *Process {
 		},
 		threads:        make(map[int]*Thread),
 		bi:             proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH),
-		breakpoints:    proc.NewBreakpointMap(),
 		gcmdok:         true,
 		threadStopInfo: true,
 		process:        process,

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -537,7 +537,7 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 			return err
 		}
 	}
-	if err = proc.PostInitializationSetup(p, path, debugInfoDirs, p.WriteBreakpointFn); err != nil {
+	if err = proc.PostInitializationSetup(p, path, debugInfoDirs); err != nil {
 		p.conn.conn.Close()
 		return err
 	}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -707,14 +707,18 @@ continueLoop:
 		trapthread.sig = 0
 	}
 
-	r := make([]proc.Thread, 0, len(p.threads))
-	for _, t := range p.threads {
-		if t.strID != trapthread.ThreadID {
-			r = append(r, t)
+	tl := make([]proc.Thread, 0, len(p.threads))
+	for _, th := range p.threads {
+		if th.strID == threadID {
+			continue
+		}
+		if (p.threadStopInfo && th.setbp) || !p.threadStopInfo {
+			tl = append(tl, th)
 		}
 	}
+	return thread, tl, err
 
-	return trapthread, r, err
+	return trapthread, tl, err
 }
 
 func (p *Process) findThreadByStrID(threadID string) *Thread {

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -679,12 +679,12 @@ continueLoop:
 
 	if p.BinInfo().GOOS == "linux" {
 		if err := linutil.ElfUpdateSharedObjects(p); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	if trapthread == nil {
-		return nil, fmt.Errorf("could not find thread %s", threadID)
+		return nil, nil, fmt.Errorf("could not find thread %s", threadID)
 	}
 
 	var err error
@@ -716,8 +716,6 @@ continueLoop:
 			tl = append(tl, th)
 		}
 	}
-	return thread, tl, err
-
 	return trapthread, tl, err
 }
 

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -472,9 +472,9 @@ func (p *Process) EntryPoint() (uint64, error) {
 	return entryPoint, nil
 }
 
-// AdjustsPCAfterBreakpoint always returns true as the gdbserial backend
+// AdjustPCAfterBreakpoint always returns false as the gdbserial backend
 // automatically adjusts the PC register once a breakpoint is hit.
-func (dbp *Process) AdjustsPCAfterBreakpoint() bool { return true }
+func (dbp *Process) AdjustPCAfterBreakpoint() bool { return false }
 
 // CurrentDirection returns which direction the process will
 // execute in when continued. Only recorded processes will

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -628,9 +628,9 @@ const (
 
 // ContinueOnce will continue execution of the process until
 // a breakpoint is hit or signal is received.
-func (p *Process) ContinueOnce() (proc.Thread, error) {
+func (p *Process) ContinueOnce() (proc.Thread, []proc.Thread, error) {
 	if p.exited {
-		return nil, &proc.ErrProcessExited{Pid: p.conn.pid}
+		return nil, nil, &proc.ErrProcessExited{Pid: p.conn.pid}
 	}
 
 	if p.conn.direction == proc.Forward {
@@ -638,7 +638,7 @@ func (p *Process) ContinueOnce() (proc.Thread, error) {
 		for _, thread := range p.threads {
 			if thread.CurrentBreakpoint.Breakpoint != nil {
 				if err := thread.stepInstruction(&threadUpdater{p: p}); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 			}
 		}
@@ -664,7 +664,7 @@ continueLoop:
 			if _, exited := err.(proc.ErrProcessExited); exited {
 				p.exited = true
 			}
-			return nil, err
+			return nil, nil, err
 		}
 
 		// For stubs that support qThreadStopInfo updateThreadList will
@@ -693,10 +693,6 @@ continueLoop:
 		}
 	}
 
-	if err := p.setCurrentBreakpoints(); err != nil {
-		return nil, err
-	}
-
 	if trapthread == nil {
 		return nil, fmt.Errorf("could not find thread %s", threadID)
 	}
@@ -720,7 +716,15 @@ continueLoop:
 		// the signals that are reported here can not be propagated back to the target process.
 		trapthread.sig = 0
 	}
-	return trapthread, err
+
+	r := make([]proc.Thread, 0, len(p.threads))
+	for _, t := range p.threads {
+		if t.strID != trapthread.ThreadID {
+			r = append(r, t)
+		}
+	}
+
+	return trapthread, r, err
 }
 
 func (p *Process) findThreadByStrID(threadID string) *Thread {

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -49,7 +49,7 @@ func assertNoError(err error, t testing.TB, s string) {
 	}
 }
 
-func setFunctionBreakpoint(p proc.Process, t *testing.T, fname string) *proc.Breakpoint {
+func setFunctionBreakpoint(p *proc.Target, t *testing.T, fname string) *proc.Breakpoint {
 	_, f, l, _ := runtime.Caller(1)
 	f = filepath.Base(f)
 
@@ -117,7 +117,7 @@ func TestRestartDuringStop(t *testing.T) {
 	})
 }
 
-func setFileBreakpoint(p proc.Process, t *testing.T, fixture protest.Fixture, lineno int) *proc.Breakpoint {
+func setFileBreakpoint(p *proc.Target, t *testing.T, fixture protest.Fixture, lineno int) *proc.Breakpoint {
 	_, f, l, _ := runtime.Caller(1)
 	f = filepath.Base(f)
 

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -10,8 +10,19 @@ package proc
 type Process interface {
 	Info
 	ProcessManipulation
-	BreakpointManipulation
 	RecordingManipulation
+}
+
+// ProcessInternal holds a set of methods that are
+// not meant to be called by anyone except for an instance of
+// `proc.Target`. These methods are not safe to use by themselves
+// and should never be called directly outside of the `proc` package.
+// This is temporary and in support of an ongoing refactor.
+type ProcessInternal interface {
+	WriteBreakpointFn(addr uint64) (string, int, *Function, []byte, error)
+	ClearBreakpointFn(uint64, []byte) error
+	AdjustsPCAfterBreakpoint() bool
+	CurrentDirection() Direction
 }
 
 // RecordingManipulation is an interface for manipulating process recordings.
@@ -66,10 +77,6 @@ type Info interface {
 	BinInfo() *BinaryInfo
 	EntryPoint() (uint64, error)
 
-	AdjustsPCAfterBreakpoint() bool
-
-	CurrentDirection() Direction
-
 	ThreadInfo
 	GoroutineInfo
 }
@@ -98,10 +105,4 @@ type ProcessManipulation interface {
 	// after a call to RequestManualStop.
 	CheckAndClearManualStopRequest() bool
 	Detach(bool) error
-}
-
-// BreakpointManipulation is an interface for managing breakpoints.
-type BreakpointManipulation interface {
-	WriteBreakpointFn(addr uint64) (string, int, *Function, []byte, error)
-	ClearBreakpointFn(uint64, []byte) error
 }

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -1,9 +1,5 @@
 package proc
 
-import (
-	"go/ast"
-)
-
 // Process represents the target of the debugger. This
 // target could be a system process, core file, etc.
 //
@@ -71,7 +67,6 @@ type Info interface {
 	EntryPoint() (uint64, error)
 
 	AdjustsPCAfterBreakpoint() bool
-	FindBreakpoint(pc uint64) (*Breakpoint, bool)
 
 	CurrentDirection() Direction
 
@@ -107,11 +102,6 @@ type ProcessManipulation interface {
 
 // BreakpointManipulation is an interface for managing breakpoints.
 type BreakpointManipulation interface {
-	Breakpoints() *BreakpointMap
-	SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Expr) (*Breakpoint, error)
-	ClearBreakpoint(addr uint64) (*Breakpoint, error)
-	ClearInternalBreakpointsInternal() error
-
 	WriteBreakpointFn(addr uint64) (string, int, *Function, []byte, error)
 	ClearBreakpointFn(uint64, []byte) error
 }

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -70,6 +70,8 @@ type Info interface {
 	BinInfo() *BinaryInfo
 	EntryPoint() (uint64, error)
 
+	CurrentDirection() Direction
+
 	ThreadInfo
 	GoroutineInfo
 }

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -106,4 +106,7 @@ type BreakpointManipulation interface {
 	SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Expr) (*Breakpoint, error)
 	ClearBreakpoint(addr uint64) (*Breakpoint, error)
 	ClearInternalBreakpoints() error
+
+	WriteBreakpointFn(addr uint64) (string, int, *Function, []byte, error)
+	ClearBreakpointFn(uint64, []byte) error
 }

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -90,7 +90,7 @@ type GoroutineInfo interface {
 
 // ProcessManipulation is an interface for changing the execution state of a process.
 type ProcessManipulation interface {
-	ContinueOnce() (trapthread Thread, err error)
+	ContinueOnce() (trapthread Thread, additionalTrapThreads []Thread, err error)
 	SwitchThread(int) error
 	SwitchGoroutine(*G) error
 	RequestManualStop() error

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -70,6 +70,9 @@ type Info interface {
 	BinInfo() *BinaryInfo
 	EntryPoint() (uint64, error)
 
+	AdjustsPCAfterBreakpoint() bool
+	FindBreakpoint(pc uint64) (*Breakpoint, bool)
+
 	CurrentDirection() Direction
 
 	ThreadInfo
@@ -107,7 +110,7 @@ type BreakpointManipulation interface {
 	Breakpoints() *BreakpointMap
 	SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Expr) (*Breakpoint, error)
 	ClearBreakpoint(addr uint64) (*Breakpoint, error)
-	ClearInternalBreakpoints() error
+	ClearInternalBreakpointsInternal() error
 
 	WriteBreakpointFn(addr uint64) (string, int, *Function, []byte, error)
 	ClearBreakpointFn(uint64, []byte) error

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -59,7 +59,7 @@ func (dbp *Process) trapWait(pid int) (*Thread, error) {
 	panic(ErrNativeBackendDisabled)
 }
 
-func (dbp *Process) stop(trapthread *Thread) (err error) {
+func (dbp *Process) stop(trapthread *Thread) ([]proc.Thread, error) {
 	panic(ErrNativeBackendDisabled)
 }
 

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -128,6 +128,11 @@ func (dbp *Process) Detach(kill bool) (err error) {
 	return
 }
 
+// CurrentDirection always returns forward for non-recorded processes.
+func (p *Process) CurrentDirection() proc.Direction {
+	return proc.Forward
+}
+
 // Valid returns whether the process is still attached to and
 // has not exited.
 func (dbp *Process) Valid() (bool, error) {
@@ -342,6 +347,9 @@ func (dbp *Process) ClearInternalBreakpoints() error {
 			return err
 		}
 		for _, thread := range dbp.threads {
+			if thread.CurrentBreakpoint.Breakpoint == nil {
+				continue
+			}
 			if thread.CurrentBreakpoint.Breakpoint.Addr == addr {
 				thread.CurrentBreakpoint.Clear()
 			}

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -280,7 +280,7 @@ func (dbp *Process) initialize(path string, debugInfoDirs []string) error {
 	if err := dbp.updateThreadList(); err != nil {
 		return err
 	}
-	return proc.PostInitializationSetup(dbp, path, debugInfoDirs, dbp.WriteBreakpointFn)
+	return proc.PostInitializationSetup(dbp, path, debugInfoDirs)
 }
 
 // SetSelectedGoroutine will set internally the goroutine that should be

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -60,9 +60,9 @@ func (dbp *Process) BinInfo() *proc.BinaryInfo {
 	return dbp.bi
 }
 
-// AdjustsPCAfterBreakpoint always returns false as the native backend does
+// AdjustPCAfterBreakpoint always returns true as the native backend does
 // not automatically adjust the PC register once a breakpoint is hit.
-func (dbp *Process) AdjustsPCAfterBreakpoint() bool { return false }
+func (dbp *Process) AdjustPCAfterBreakpoint() bool { return true }
 
 // Recorded always returns false for the native proc backend.
 func (dbp *Process) Recorded() (bool, string) { return false, "" }

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -422,7 +422,7 @@ func (dbp *Process) stop(trapthread *Thread) ([]proc.Thread, error) {
 		}
 	}
 
-	ports, err := dbp.waitForStop()
+	_, err := dbp.waitForStop()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -104,10 +104,6 @@ func Launch(cmd []string, wd string, foreground bool, _ []string) (*proc.Target,
 		return nil, err
 	}
 
-	for _, th := range dbp.threads {
-		th.CurrentBreakpoint.Clear()
-	}
-
 	trapthread, err := dbp.trapWait(-1)
 	if err != nil {
 		return nil, err

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -404,15 +404,6 @@ func (dbp *Process) exitGuard(err error) error {
 }
 
 func (dbp *Process) resume() error {
-	// all threads stopped over a breakpoint are made to step over it
-	for _, thread := range dbp.threads {
-		if thread.CurrentBreakpoint.Breakpoint != nil {
-			if err := thread.StepInstruction(); err != nil {
-				return err
-			}
-			thread.CurrentBreakpoint.Clear()
-		}
-	}
 	// everything is resumed
 	for _, thread := range dbp.threads {
 		if err := thread.resume(); err != nil {
@@ -441,15 +432,6 @@ func (dbp *Process) stop(trapthread *Thread) ([]proc.Thread, error) {
 	}
 	if !dbp.os.initialized {
 		return nil, nil
-	}
-	trapthread.SetCurrentBreakpoint(true)
-	for _, port := range ports {
-		if th, ok := dbp.threads[port]; ok {
-			err := th.SetCurrentBreakpoint(true)
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 	return dbp.ThreadList(), nil
 }

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -331,19 +331,17 @@ func (dbp *Process) resume() error {
 
 // Used by ContinueOnce
 // stop stops all running threads and sets breakpoints
-func (dbp *Process) stop(trapthread *Thread) (err error) {
+func (dbp *Process) stop(trapthread *Thread) ([]proc.Thread, error) {
 	if dbp.exited {
-		return &proc.ErrProcessExited{Pid: dbp.Pid()}
+		return nil, &proc.ErrProcessExited{Pid: dbp.Pid()}
 	}
-	// set breakpoints on all threads
+	var r []proc.Thread
 	for _, th := range dbp.threads {
-		if th.CurrentBreakpoint.Breakpoint == nil {
-			if err := th.SetCurrentBreakpoint(true); err != nil {
-				return err
-			}
+		if th.ThreadID() != trapthread.ThreadID() {
+			r = append(r, th)
 		}
 	}
-	return nil
+	return r, nil
 }
 
 // Used by Detach

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -314,15 +314,6 @@ func (dbp *Process) exitGuard(err error) error {
 
 // Used by ContinueOnce
 func (dbp *Process) resume() error {
-	// all threads stopped over a breakpoint are made to step over it
-	for _, thread := range dbp.threads {
-		if thread.CurrentBreakpoint.Breakpoint != nil {
-			if err := thread.StepInstruction(); err != nil {
-				return err
-			}
-			thread.CurrentBreakpoint.Clear()
-		}
-	}
 	// all threads are resumed
 	var err error
 	dbp.execPtraceFunc(func() { err = PtraceCont(dbp.pid, 0) })

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -419,15 +419,6 @@ func (dbp *Process) exitGuard(err error) error {
 }
 
 func (dbp *Process) resume() error {
-	// all threads stopped over a breakpoint are made to step over it
-	for _, thread := range dbp.threads {
-		if thread.CurrentBreakpoint.Breakpoint != nil {
-			if err := thread.StepInstruction(); err != nil {
-				return err
-			}
-			thread.CurrentBreakpoint.Clear()
-		}
-	}
 	// everything is resumed
 	for _, thread := range dbp.threads {
 		if err := thread.resume(); err != nil && err != sys.ESRCH {

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -403,15 +403,6 @@ func (dbp *Process) exitGuard(err error) error {
 
 func (dbp *Process) resume() error {
 	for _, thread := range dbp.threads {
-		if thread.CurrentBreakpoint.Breakpoint != nil {
-			if err := thread.StepInstruction(); err != nil {
-				return err
-			}
-			thread.CurrentBreakpoint.Clear()
-		}
-	}
-
-	for _, thread := range dbp.threads {
 		_, err := _ResumeThread(thread.os.hThread)
 		if err != nil {
 			return err

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -61,7 +61,7 @@ func (t *Thread) StepInstruction() (err error) {
 	bp, ok := t.dbp.FindBreakpoint(pc, false)
 	if ok {
 		// Clear the breakpoint so that we can continue execution.
-		err = t.ClearBreakpoint(bp)
+		err = t.ClearBreakpoint(bp.Addr, bp.OriginalData)
 		if err != nil {
 			return err
 		}
@@ -155,8 +155,8 @@ func (t *Thread) ThreadID() int {
 }
 
 // ClearBreakpoint clears the specified breakpoint.
-func (t *Thread) ClearBreakpoint(bp *proc.Breakpoint) error {
-	if _, err := t.WriteMemory(uintptr(bp.Addr), bp.OriginalData); err != nil {
+func (t *Thread) ClearBreakpoint(addr uint64, originalData []byte) error {
+	if _, err := t.WriteMemory(uintptr(addr), originalData); err != nil {
 		return fmt.Errorf("could not clear breakpoint %s", err)
 	}
 	return nil

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -50,27 +50,7 @@ func (t *Thread) Continue() error {
 // Otherwise we simply execute the next instruction.
 func (t *Thread) StepInstruction() (err error) {
 	t.singleStepping = true
-	defer func() {
-		t.singleStepping = false
-	}()
-	pc, err := t.PC()
-	if err != nil {
-		return err
-	}
-
-	bp, ok := t.dbp.FindBreakpoint(pc, false)
-	if ok {
-		// Clear the breakpoint so that we can continue execution.
-		err = t.ClearBreakpoint(bp.Addr, bp.OriginalData)
-		if err != nil {
-			return err
-		}
-
-		// Restore breakpoint now that we have passed it.
-		defer func() {
-			err = t.dbp.writeSoftwareBreakpoint(t, bp.Addr)
-		}()
-	}
+	defer func() { t.singleStepping = false }()
 
 	err = t.singleStep()
 	if err != nil {

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -73,9 +73,6 @@ func PostInitializationSetup(p Process, path string, debugInfoDirs []string) err
 		}
 	}
 
-	g, _ := GetG(p.CurrentThread())
-	p.SetSelectedGoroutine(g)
-
 	return nil
 }
 
@@ -188,7 +185,7 @@ func Continue(dbp *Target) error {
 			}
 		}
 		dbp.threadToBreakpoint = make(map[int]*BreakpointState)
-		trapthread, additionalTrapThreads, err := dbp.ContinueOnce()
+		trapthread, additionalTrapThreads, err := dbp.proc.ContinueOnce()
 		if err != nil {
 			return err
 		}
@@ -545,7 +542,7 @@ func StepInstruction(dbp *Target) (err error) {
 	}
 
 	if tg, _ := GetG(thread); tg != nil {
-		dbp.SetSelectedGoroutine(tg)
+		dbp.proc.SetSelectedGoroutine(tg)
 	}
 	return nil
 }

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -57,7 +57,7 @@ func (pe ProcessDetachedError) Error() string {
 
 // PostInitializationSetup handles all of the initialization procedures
 // that must happen after Delve creates or attaches to a process.
-func PostInitializationSetup(p Process, path string, debugInfoDirs []string, writeBreakpoint WriteBreakpointFn) error {
+func PostInitializationSetup(p Process, path string, debugInfoDirs []string) error {
 	entryPoint, err := p.EntryPoint()
 	if err != nil {
 		return err

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -76,15 +76,12 @@ func PostInitializationSetup(p Process, path string, debugInfoDirs []string, wri
 	g, _ := GetG(p.CurrentThread())
 	p.SetSelectedGoroutine(g)
 
-	createUnrecoveredPanicBreakpoint(p, writeBreakpoint)
-	createFatalThrowBreakpoint(p, writeBreakpoint)
-
 	return nil
 }
 
 // FindFileLocation returns the PC for a given file:line.
 // Assumes that `file` is normalized to lower case and '/' on Windows.
-func FindFileLocation(p Process, fileName string, lineno int) ([]uint64, error) {
+func FindFileLocation(p *Target, fileName string, lineno int) ([]uint64, error) {
 	pcs, err := p.BinInfo().LineToPC(fileName, lineno)
 	if err != nil {
 		return nil, err
@@ -113,7 +110,7 @@ func (err *ErrFunctionNotFound) Error() string {
 
 // FindFunctionLocation finds address of a function's line
 // If lineOffset is passed FindFunctionLocation will return the address of that line
-func FindFunctionLocation(p Process, funcName string, lineOffset int) ([]uint64, error) {
+func FindFunctionLocation(p *Target, funcName string, lineOffset int) ([]uint64, error) {
 	bi := p.BinInfo()
 	origfn := bi.LookupFunc[funcName]
 	if origfn == nil {
@@ -185,10 +182,8 @@ func Continue(dbp *Target) error {
 		}
 		dbp.ClearAllGCache()
 		if dbp.Process.CurrentDirection() == Forward {
-			for _, th := range dbp.ThreadList() {
-				if dbp.ThreadToBreakpoint(th).Breakpoint == nil {
-					continue
-				}
+			for tid, _ := range dbp.threadToBreakpoint {
+				th, _ := dbp.FindThread(tid)
 				dbp.threadStepInstruction(th, false)
 			}
 		}
@@ -792,7 +787,7 @@ func FrameToScope(bi *BinaryInfo, thread MemoryReadWriter, g *G, frames ...Stack
 
 // createUnrecoveredPanicBreakpoint creates the unrecoverable-panic breakpoint.
 // This function is meant to be called by implementations of the Process interface.
-func createUnrecoveredPanicBreakpoint(p Process, writeBreakpoint WriteBreakpointFn) {
+func createUnrecoveredPanicBreakpoint(p *Target, writeBreakpoint WriteBreakpointFn) {
 	panicpcs, err := FindFunctionLocation(p, "runtime.startpanic", 0)
 	if _, isFnNotFound := err.(*ErrFunctionNotFound); isFnNotFound {
 		panicpcs, err = FindFunctionLocation(p, "runtime.fatalpanic", 0)
@@ -806,7 +801,7 @@ func createUnrecoveredPanicBreakpoint(p Process, writeBreakpoint WriteBreakpoint
 	}
 }
 
-func createFatalThrowBreakpoint(p Process, writeBreakpoint WriteBreakpointFn) {
+func createFatalThrowBreakpoint(p *Target, writeBreakpoint WriteBreakpointFn) {
 	fatalpcs, err := FindFunctionLocation(p, "runtime.fatalthrow", 0)
 	if err == nil {
 		bp, err := p.Breakpoints().SetWithID(fatalThrowID, fatalpcs[0], writeBreakpoint)
@@ -820,7 +815,7 @@ func createFatalThrowBreakpoint(p Process, writeBreakpoint WriteBreakpointFn) {
 // instruction after the prologue for function fn.
 // If sameline is set FirstPCAfterPrologue will always return an
 // address associated with the same line as fn.Entry.
-func FirstPCAfterPrologue(p Process, fn *Function, sameline bool) (uint64, error) {
+func FirstPCAfterPrologue(p *Target, fn *Function, sameline bool) (uint64, error) {
 	pc, _, line, ok := fn.cu.lineInfo.PrologueEndPC(fn.Entry, fn.End)
 	if ok {
 		if !sameline {

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -184,9 +184,16 @@ func Continue(dbp *Target) error {
 			return nil
 		}
 		dbp.ClearAllGCache()
-		trapthread, err := dbp.ContinueOnce()
+		trapthread, additionalTrapThreads, err := dbp.ContinueOnce()
 		if err != nil {
 			return err
+		}
+
+		trappedThreads := append([]Thread{trapthread}, additionalTrapThreads...)
+		for _, t := range trappedThreads {
+			if err := t.SetCurrentBreakpoint(true); err != nil {
+				return err
+			}
 		}
 
 		threads := dbp.ThreadList()

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -181,7 +181,7 @@ func Continue(dbp *Target) error {
 			return nil
 		}
 		dbp.ClearAllGCache()
-		if dbp.Process.CurrentDirection() == Forward {
+		if dbp.proc.CurrentDirection() == Forward {
 			for tid, _ := range dbp.threadToBreakpoint {
 				th, _ := dbp.FindThread(tid)
 				dbp.threadStepInstruction(th, false)
@@ -553,10 +553,10 @@ func StepInstruction(dbp *Target) (err error) {
 func (dbp *Target) threadStepInstruction(thread Thread, setbp bool) error {
 	bp := dbp.ThreadToBreakpoint(thread)
 	if bp.Breakpoint != nil {
-		if err := dbp.Process.ClearBreakpointFn(bp.Addr, bp.OriginalData); err != nil {
+		if err := dbp.proc.ClearBreakpointFn(bp.Addr, bp.OriginalData); err != nil {
 			return err
 		}
-		defer dbp.Process.WriteBreakpointFn(bp.Addr)
+		defer dbp.proc.WriteBreakpointFn(bp.Addr)
 	}
 	if err := thread.StepInstruction(); err != nil {
 		return err

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -609,7 +609,7 @@ func TestNextConcurrentVariant2(t *testing.T) {
 					proc.GetG(thread)
 				}
 				vval, _ = constant.Int64Val(v.Value)
-				if bpstate := p.CurrentThread().Breakpoint(); bpstate.Breakpoint == nil {
+				if bpstate := p.ThreadToBreakpoint(p.CurrentThread()); bpstate.Breakpoint == nil {
 					if vval != initVval {
 						t.Fatal("Did not end up on same goroutine")
 					}
@@ -1047,11 +1047,11 @@ func TestContinueMulti(t *testing.T) {
 			}
 			assertNoError(err, t, "Continue()")
 
-			if bp := p.CurrentThread().Breakpoint(); bp.LogicalID == bp1.LogicalID {
+			if bp := p.ThreadToBreakpoint(p.CurrentThread()); bp.LogicalID == bp1.LogicalID {
 				mainCount++
 			}
 
-			if bp := p.CurrentThread().Breakpoint(); bp.LogicalID == bp2.LogicalID {
+			if bp := p.ThreadToBreakpoint(p.CurrentThread()); bp.LogicalID == bp2.LogicalID {
 				sayhiCount++
 			}
 		}
@@ -1441,7 +1441,7 @@ func TestBreakpointCountsWithDetection(t *testing.T) {
 				assertNoError(err, t, "Continue()")
 			}
 			for _, th := range p.ThreadList() {
-				if bp := th.Breakpoint(); bp.Breakpoint == nil {
+				if bp := p.ThreadToBreakpoint(th); bp.Breakpoint == nil {
 					continue
 				}
 				scope, err := proc.GoroutineScope(th)
@@ -1836,7 +1836,7 @@ func TestPanicBreakpoint(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("panic", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(proc.Continue(p), t, "Continue()")
-		bp := p.CurrentThread().Breakpoint()
+		bp := p.ThreadToBreakpoint(p.CurrentThread())
 		if bp.Breakpoint == nil || bp.Name != proc.UnrecoveredPanic {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", bp)
 		}
@@ -1846,7 +1846,7 @@ func TestPanicBreakpoint(t *testing.T) {
 func TestCmdLineArgs(t *testing.T) {
 	expectSuccess := func(p *proc.Target, fixture protest.Fixture) {
 		err := proc.Continue(p)
-		bp := p.CurrentThread().Breakpoint()
+		bp := p.ThreadToBreakpoint(p.CurrentThread())
 		if bp.Breakpoint != nil && bp.Name == proc.UnrecoveredPanic {
 			t.Fatalf("testing args failed on unrecovered-panic breakpoint: %v", bp)
 		}
@@ -1862,7 +1862,7 @@ func TestCmdLineArgs(t *testing.T) {
 
 	expectPanic := func(p *proc.Target, fixture protest.Fixture) {
 		proc.Continue(p)
-		bp := p.CurrentThread().Breakpoint()
+		bp := p.ThreadToBreakpoint(p.CurrentThread())
 		if bp.Breakpoint == nil || bp.Name != proc.UnrecoveredPanic {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", bp)
 		}
@@ -2399,9 +2399,9 @@ func TestStepConcurrentPtr(t *testing.T) {
 			f, ln := currentLineNumber(p, t)
 			if ln != 24 {
 				for _, th := range p.ThreadList() {
-					t.Logf("thread %d stopped on breakpoint %v", th.ThreadID(), th.Breakpoint())
+					t.Logf("thread %d stopped on breakpoint %v", th.ThreadID(), p.ThreadToBreakpoint(th))
 				}
-				curbp := p.CurrentThread().Breakpoint()
+				curbp := p.ThreadToBreakpoint(p.CurrentThread())
 				t.Fatalf("Program did not continue at expected location (24): %s:%d %#x [%v] (gid %d count %d)", f, ln, currentPC(p, t), curbp, p.SelectedGoroutine().ID, count)
 			}
 
@@ -2713,7 +2713,7 @@ func TestStacktraceWithBarriers(t *testing.T) {
 			gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 			assertNoError(err, t, "GoroutinesInfo()")
 			for _, th := range p.ThreadList() {
-				if bp := th.Breakpoint(); bp.Breakpoint == nil {
+				if bp := p.ThreadToBreakpoint(th); bp.Breakpoint == nil {
 					continue
 				}
 
@@ -4224,7 +4224,7 @@ func TestDeadlockBreakpoint(t *testing.T) {
 	withTestProcess("testdeadlock", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(proc.Continue(p), t, "Continue()")
 
-		bp := p.CurrentThread().Breakpoint()
+		bp := p.ThreadToBreakpoint(p.CurrentThread())
 		if bp.Breakpoint == nil || bp.Name != deadlockBp {
 			t.Fatalf("did not stop at deadlock breakpoint %v", bp)
 		}
@@ -4354,7 +4354,7 @@ func TestCallConcurrent(t *testing.T) {
 		returned := testCallConcurrentCheckReturns(p, t, gid1, -1)
 
 		curthread := p.CurrentThread()
-		if curbp := curthread.Breakpoint(); curbp.Breakpoint == nil || curbp.LogicalID != bp.LogicalID || returned > 0 {
+		if curbp := p.ThreadToBreakpoint(curthread); curbp.Breakpoint == nil || curbp.LogicalID != bp.LogicalID || returned > 0 {
 			t.Logf("skipping test, the call injection terminated before we hit a breakpoint in a different thread")
 			return
 		}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -285,7 +285,7 @@ func TestStep(t *testing.T) {
 		regs := getRegisters(p, t)
 		rip := regs.PC()
 
-		err := p.CurrentThread().StepInstruction()
+		err := proc.StepInstruction(p)
 		assertNoError(err, t, "Step()")
 
 		regs = getRegisters(p, t)
@@ -466,8 +466,8 @@ func testseq2Args(wd string, args []string, buildFlags protest.BuildFlags, t *te
 			pc := regs.PC()
 
 			if traceTestseq2 {
-				t.Logf("at %#x %s:%d", pc, f, ln)
-				fmt.Printf("at %#x %s:%d", pc, f, ln)
+				t.Logf("at %#x %s:%d\n", pc, f, ln)
+				fmt.Printf("at %#x %s:%d\n", pc, f, ln)
 			}
 			switch pos := tc.pos.(type) {
 			case int:

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -86,7 +86,7 @@ func TestScope(t *testing.T) {
 				}
 				assertNoError(err, t, "Continue()")
 			}
-			bp := p.CurrentThread().Breakpoint()
+			bp := p.ThreadToBreakpoint(p.CurrentThread())
 
 			scopeCheck := findScopeCheck(scopeChecks, bp.Line)
 			if scopeCheck == nil {

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -86,7 +86,7 @@ func TestScope(t *testing.T) {
 				}
 				assertNoError(err, t, "Continue()")
 			}
-			bp := p.ThreadToBreakpoint(p.CurrentThread())
+			bp := p.CurrentThread().Common().GetCurrentBreakpoint()
 
 			scopeCheck := findScopeCheck(scopeChecks, bp.Line)
 			if scopeCheck == nil {

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -65,6 +65,9 @@ func (t *Target) Breakpoints() *BreakpointMap {
 // If 'kill' is true Delve will kill the process when detaching.
 func (t *Target) Detach(kill bool) error {
 	if !kill {
+		if t.asyncPreemptChanged {
+			setAsyncPreemptOff(t, t.asyncPreemptOff)
+		}
 		// Clean up any breakpoints we've set.
 		for _, bp := range t.Breakpoints().M {
 			if bp != nil {
@@ -216,11 +219,4 @@ func (t *Target) setThreadBreakpointState(th Thread, adjustPC bool) error {
 		t.threadToBreakpoint[th.ThreadID()] = bps
 	}
 	return nil
-}
-
-func (t *Target) Detach(kill bool) error {
-	if !kill && t.asyncPreemptChanged {
-		setAsyncPreemptOff(t, t.asyncPreemptOff)
-	}
-	return t.Process.Detach(kill)
 }

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -65,6 +65,23 @@ func (tbe ErrThreadBlocked) Error() string {
 // implementations of the Thread interface.
 type CommonThread struct {
 	returnValues []*Variable
+	// currentBreakpoint is the breakpoint this thread is currently stopped at.
+	currentBreakpoint *BreakpointState
+}
+
+func (t *CommonThread) SetCurrentBreakpoint(bps *BreakpointState) {
+	t.currentBreakpoint = bps
+}
+
+func (t *CommonThread) GetCurrentBreakpoint() *BreakpointState {
+	if t.currentBreakpoint != nil {
+		return t.currentBreakpoint
+	}
+	return new(BreakpointState)
+}
+
+func (t *CommonThread) ClearCurrentBreakpoint() {
+	t.currentBreakpoint = nil
 }
 
 // ReturnValues reads the return values from the function executing on
@@ -313,7 +330,7 @@ func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 		}
 	}
 
-	if bp := dbp.ThreadToBreakpoint(curthread); bp.Breakpoint == nil {
+	if bp := curthread.Common().GetCurrentBreakpoint(); bp.Breakpoint == nil {
 		dbp.setThreadBreakpointState(curthread, false)
 	}
 	success = true

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -368,7 +368,7 @@ func removePCsBetween(pcs []uint64, start, end, staticBase uint64) []uint64 {
 	return out
 }
 
-func setStepIntoBreakpoint(dbp Process, text []AsmInstruction, cond ast.Expr) error {
+func setStepIntoBreakpoint(dbp *Target, text []AsmInstruction, cond ast.Expr) error {
 	if len(text) <= 0 {
 		return nil
 	}

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -69,10 +69,16 @@ type CommonThread struct {
 	currentBreakpoint *BreakpointState
 }
 
+// SetCurrentBreakpoint is called when this thread is stopped at a breakpoint.
+// Calling this function will set the given breakpoint as the "current" breakpoint
+// for this thread.
 func (t *CommonThread) SetCurrentBreakpoint(bps *BreakpointState) {
 	t.currentBreakpoint = bps
 }
 
+// GetCurrentBreakpoint will return the breakpoint this thread is currently stopped at.
+// If this thread is not stopped at a breakpoint then a newly initialized BreakpointState
+// object will be returned with the Breakpoint field left nil.
 func (t *CommonThread) GetCurrentBreakpoint() *BreakpointState {
 	if t.currentBreakpoint != nil {
 		return t.currentBreakpoint
@@ -80,6 +86,7 @@ func (t *CommonThread) GetCurrentBreakpoint() *BreakpointState {
 	return new(BreakpointState)
 }
 
+// ClearCurrentBreakpoint clears the current breakpoint from this thread.
 func (t *CommonThread) ClearCurrentBreakpoint() {
 	t.currentBreakpoint = nil
 }

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -71,7 +71,7 @@ func ConvertBreakpoints(bps []*proc.Breakpoint) []*Breakpoint {
 
 // ConvertThread converts a proc.Thread into an
 // api thread.
-func ConvertThread(th proc.Thread, bps *proc.BreakpointState) *Thread {
+func ConvertThread(th proc.Thread) *Thread {
 	var (
 		function *Function
 		file     string
@@ -89,6 +89,7 @@ func ConvertThread(th proc.Thread, bps *proc.BreakpointState) *Thread {
 	}
 
 	var bp *Breakpoint
+	bps := th.Common().GetCurrentBreakpoint()
 	if bps.Active {
 		bp = ConvertBreakpoint(bps.Breakpoint)
 	}

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -71,7 +71,7 @@ func ConvertBreakpoints(bps []*proc.Breakpoint) []*Breakpoint {
 
 // ConvertThread converts a proc.Thread into an
 // api thread.
-func ConvertThread(th proc.Thread) *Thread {
+func ConvertThread(th proc.Thread, bps *proc.BreakpointState) *Thread {
 	var (
 		function *Function
 		file     string
@@ -89,9 +89,8 @@ func ConvertThread(th proc.Thread) *Thread {
 	}
 
 	var bp *Breakpoint
-
-	if b := th.Breakpoint(); b.Active {
-		bp = ConvertBreakpoint(b.Breakpoint)
+	if bps.Active {
+		bp = ConvertBreakpoint(bps.Breakpoint)
 	}
 
 	if g, _ := proc.GetG(th); g != nil {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -392,7 +392,8 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 	}
 
 	for _, thread := range d.target.ThreadList() {
-		th := api.ConvertThread(thread)
+		bps := d.target.ThreadToBreakpoint(thread)
+		th := api.ConvertThread(thread, bps)
 
 		if retLoadCfg != nil {
 			th.ReturnValues = convertVars(thread.Common().ReturnValues(*retLoadCfg))
@@ -639,7 +640,8 @@ func (d *Debugger) Threads() ([]*api.Thread, error) {
 
 	threads := []*api.Thread{}
 	for _, th := range d.target.ThreadList() {
-		threads = append(threads, api.ConvertThread(th))
+		bps := d.target.ThreadToBreakpoint(th)
+		threads = append(threads, api.ConvertThread(th, bps))
 	}
 	return threads, nil
 }
@@ -655,7 +657,8 @@ func (d *Debugger) FindThread(id int) (*api.Thread, error) {
 
 	for _, th := range d.target.ThreadList() {
 		if th.ThreadID() == id {
-			return api.ConvertThread(th), nil
+			bps := d.target.ThreadToBreakpoint(th)
+			return api.ConvertThread(th, bps), nil
 		}
 	}
 	return nil, nil

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -471,7 +471,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 
 // createLogicalBreakpoint creates one physical breakpoint for each address
 // in addrs and associates all of them with the same logical breakpoint.
-func createLogicalBreakpoint(p proc.Process, addrs []uint64, requestedBp *api.Breakpoint) (*api.Breakpoint, error) {
+func createLogicalBreakpoint(p *proc.Target, addrs []uint64, requestedBp *api.Breakpoint) (*api.Breakpoint, error) {
 	bps := make([]*proc.Breakpoint, len(addrs))
 	var err error
 	for i := range addrs {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -392,8 +392,7 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 	}
 
 	for _, thread := range d.target.ThreadList() {
-		bps := d.target.ThreadToBreakpoint(thread)
-		th := api.ConvertThread(thread, bps)
+		th := api.ConvertThread(thread)
 
 		if retLoadCfg != nil {
 			th.ReturnValues = convertVars(thread.Common().ReturnValues(*retLoadCfg))
@@ -640,8 +639,7 @@ func (d *Debugger) Threads() ([]*api.Thread, error) {
 
 	threads := []*api.Thread{}
 	for _, th := range d.target.ThreadList() {
-		bps := d.target.ThreadToBreakpoint(th)
-		threads = append(threads, api.ConvertThread(th, bps))
+		threads = append(threads, api.ConvertThread(th))
 	}
 	return threads, nil
 }
@@ -657,8 +655,7 @@ func (d *Debugger) FindThread(id int) (*api.Thread, error) {
 
 	for _, th := range d.target.ThreadList() {
 		if th.ThreadID() == id {
-			bps := d.target.ThreadToBreakpoint(th)
-			return api.ConvertThread(th, bps), nil
+			return api.ConvertThread(th), nil
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
This patch moves all breakpoint handling from the various backends
up to Target, removing a bunch of duplication.

When doing this I ran into an issue with Windows. For some reason I
don't fully understand, unlike the other backends, if you blindly
iterate over each thread and call SetCurrentBreakpoint it breaks Windows
in unexpected ways which manifests itself in the `StepConcurrent` tests.
This is resolved by returning not only the initial thread that we first
received the trap from, but all other threads that may have hit a
breakpoint as well. And then we only call SetCurrentBreakpoints on those
threads.

