### PR TITLE
terminal/docgen: Specify all possible config locations

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -1,11 +1,8 @@
-# Configuration
+# Configuration and Command History
 
-Delve can be configured via the configuration file located in `$HOME/.config/dlv/config.yml`.
-You can open the file and discover all the configurable options and their default value.
+If `$XDG_CONFIG_HOME` is set, then configuration and command history files are located in `$XDG_CONFIG_HOME/dlv`. Otherwise, they are located in `$HOME/.config/dlv` on Linux and `$HOME/.dlv` on other systems.
 
-# History
-
-The command history of delve debugger is stored in `$HOME/.config/dlv/.dbg_history`.
+The configuration file `config.yml` contains all the configurable options and their default values. The command history is stored in `.dbg_history`.
 
 # Commands
 

--- a/pkg/terminal/docgen.go
+++ b/pkg/terminal/docgen.go
@@ -27,12 +27,11 @@ func replaceDocPath(s string) string {
 }
 
 func (commands *Commands) WriteMarkdown(w io.Writer) {
-	fmt.Fprint(w, "# Configuration\n\n")
-	fmt.Fprint(w, "Delve can be configured via the configuration file located in `$HOME/.config/dlv/config.yml`.\n")
-	fmt.Fprint(w, "You can open the file and discover all the configurable options and their default value.\n\n")
-
-	fmt.Fprint(w, "# History\n\n")
-	fmt.Fprint(w, "The command history of delve debugger is stored in `$HOME/.config/dlv/.dbg_history`.\n\n")
+	fmt.Fprint(w, "# Configuration and Command History\n\n")
+	fmt.Fprint(w, "If `$XDG_CONFIG_HOME` is set, then configuration and command history files are located in `$XDG_CONFIG_HOME/dlv`. ")
+	fmt.Fprint(w, "Otherwise, they are located in `$HOME/.config/dlv` on Linux and `$HOME/.dlv` on other systems.\n\n")
+	fmt.Fprint(w, "The configuration file `config.yml` contains all the configurable options and their default values. ")
+	fmt.Fprint(w, "The command history is stored in `.dbg_history`.\n\n")
 
 	fmt.Fprint(w, "# Commands\n\n")
 


### PR DESCRIPTION
Per the current `pkg/config/config.go`, the config and history files are not always at `$HOME/.config/dlv/`, so this just changes the docs to say so :pray: 