### PR TITLE
proc: only format registers value when it's necessary

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -21,6 +21,7 @@ type Arch interface {
 	RegSize(uint64) int
 	RegistersToDwarfRegisters(uint64, Registers) op.DwarfRegisters
 	AddrAndStackRegsToDwarfRegisters(uint64, uint64, uint64, uint64, uint64) op.DwarfRegisters
+	DwarfRegisterToString(string, *op.DwarfRegister) string
 }
 
 const (

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -244,8 +244,9 @@ func TestCore(t *testing.T) {
 		t.Fatalf("Couldn't get current thread registers: %v", err)
 	}
 	regslice := regs.Slice(true)
+	arch := p.BinInfo().Arch
 	for _, reg := range regslice {
-		t.Logf("%s = %s", reg.Name, reg.Value)
+		t.Logf("%s = %s", reg.Name, arch.DwarfRegisterToString(reg.Name, reg.Reg))
 	}
 }
 
@@ -312,8 +313,9 @@ func TestCoreFpRegisters(t *testing.T) {
 		{"XMM8", "0x4059999a404ccccd4059999a404ccccd"},
 	}
 
+	arch := p.BinInfo().Arch
 	for _, reg := range regs.Slice(true) {
-		t.Logf("%s = %s", reg.Name, reg.Value)
+		t.Logf("%s = %s", reg.Name, arch.DwarfRegisterToString(reg.Name, reg.Reg))
 	}
 
 	for _, regtest := range regtests {
@@ -321,8 +323,9 @@ func TestCoreFpRegisters(t *testing.T) {
 		for _, reg := range regs.Slice(true) {
 			if reg.Name == regtest.name {
 				found = true
-				if !strings.HasPrefix(reg.Value, regtest.value) {
-					t.Fatalf("register %s expected %q got %q", reg.Name, regtest.value, reg.Value)
+				regval := arch.DwarfRegisterToString(reg.Name, reg.Reg)
+				if !strings.HasPrefix(regval, regtest.value) {
+					t.Fatalf("register %s expected %q got %q", reg.Name, regtest.value, regval)
 				}
 			}
 		}

--- a/pkg/proc/fbsdutil/regs.go
+++ b/pkg/proc/fbsdutil/regs.go
@@ -101,17 +101,17 @@ func (r *AMD64Registers) Slice(floatingPoint bool) []proc.Register {
 		// FreeBSD defines the registers as signed, but Linux defines
 		// them as unsigned.  Of course, a register doesn't really have
 		// a concept of signedness.  Cast to what Delve expects.
-		out = proc.AppendQwordReg(out, reg.k, uint64(reg.v))
+		out = proc.AppendUint64Register(out, reg.k, uint64(reg.v))
 	}
 	for _, reg := range regs32 {
-		out = proc.AppendDwordReg(out, reg.k, reg.v)
+		out = proc.AppendUint64Register(out, reg.k, uint64(reg.v))
 	}
 	for _, reg := range regs16 {
-		out = proc.AppendWordReg(out, reg.k, reg.v)
+		out = proc.AppendUint64Register(out, reg.k, uint64(reg.v))
 	}
 	// x86 called this register "Eflags".  amd64 extended it and renamed it
 	// "Rflags", but Linux still uses the old name.
-	out = proc.AppendEflagReg(out, "Rflags", uint64(r.Regs.Rflags))
+	out = proc.AppendUint64Register(out, "Rflags", uint64(r.Regs.Rflags))
 	if floatingPoint {
 		out = append(out, r.Fpregs...)
 	}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1903,15 +1903,15 @@ func (regs *gdbRegisters) Slice(floatingPoint bool) []proc.Register {
 		}
 		switch {
 		case reginfo.Name == "eflags":
-			r = proc.AppendEflagReg(r, reginfo.Name, uint64(binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value)))
+			r = proc.AppendBytesRegister(r, "Rflags", regs.regs[reginfo.Name].value)
 		case reginfo.Name == "mxcsr":
-			r = proc.AppendMxcsrReg(r, reginfo.Name, uint64(binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value)))
+			r = proc.AppendBytesRegister(r, reginfo.Name, regs.regs[reginfo.Name].value)
 		case reginfo.Bitsize == 16:
-			r = proc.AppendWordReg(r, reginfo.Name, binary.LittleEndian.Uint16(regs.regs[reginfo.Name].value))
+			r = proc.AppendBytesRegister(r, reginfo.Name, regs.regs[reginfo.Name].value)
 		case reginfo.Bitsize == 32:
-			r = proc.AppendDwordReg(r, reginfo.Name, binary.LittleEndian.Uint32(regs.regs[reginfo.Name].value))
+			r = proc.AppendBytesRegister(r, reginfo.Name, regs.regs[reginfo.Name].value)
 		case reginfo.Bitsize == 64:
-			r = proc.AppendQwordReg(r, reginfo.Name, binary.LittleEndian.Uint64(regs.regs[reginfo.Name].value))
+			r = proc.AppendBytesRegister(r, reginfo.Name, regs.regs[reginfo.Name].value)
 		case reginfo.Bitsize == 80:
 			if !floatingPoint {
 				continue
@@ -1923,12 +1923,11 @@ func (regs *gdbRegisters) Slice(floatingPoint bool) []proc.Register {
 					break
 				}
 			}
-			value := regs.regs[reginfo.Name].value
-			r = proc.AppendX87Reg(r, idx, binary.LittleEndian.Uint16(value[8:]), binary.LittleEndian.Uint64(value[:8]))
+			r = proc.AppendBytesRegister(r, fmt.Sprintf("ST(%d)", idx), regs.regs[reginfo.Name].value)
 
 		case reginfo.Bitsize == 128:
 			if floatingPoint {
-				r = proc.AppendSSEReg(r, strings.ToUpper(reginfo.Name), regs.regs[reginfo.Name].value)
+				r = proc.AppendBytesRegister(r, strings.ToUpper(reginfo.Name), regs.regs[reginfo.Name].value)
 			}
 
 		case reginfo.Bitsize == 256:
@@ -1938,8 +1937,8 @@ func (regs *gdbRegisters) Slice(floatingPoint bool) []proc.Register {
 
 			value := regs.regs[reginfo.Name].value
 			xmmName := "x" + reginfo.Name[1:]
-			r = proc.AppendSSEReg(r, strings.ToUpper(xmmName), value[:16])
-			r = proc.AppendSSEReg(r, strings.ToUpper(reginfo.Name), value[16:])
+			r = proc.AppendBytesRegister(r, strings.ToUpper(xmmName), value[:16])
+			r = proc.AppendBytesRegister(r, strings.ToUpper(reginfo.Name), value[16:])
 		}
 	}
 	return r

--- a/pkg/proc/linutil/regs_arm64_arch.go
+++ b/pkg/proc/linutil/regs_arm64_arch.go
@@ -67,7 +67,7 @@ func (r *ARM64Registers) Slice(floatingPoint bool) []proc.Register {
 	}
 	out := make([]proc.Register, 0, len(regs64)+len(r.Fpregs))
 	for _, reg := range regs64 {
-		out = proc.AppendQwordReg(out, reg.k, reg.v)
+		out = proc.AppendUint64Register(out, reg.k, reg.v)
 	}
 	out = append(out, r.Fpregs...)
 	return out
@@ -128,7 +128,7 @@ func (r *ARM64Registers) Copy() proc.Registers {
 // Decode decodes an XSAVE area to a list of name/value pairs of registers.
 func Decode(fpregs []byte) (regs []proc.Register) {
 	for i := 0; i < len(fpregs); i += 16 {
-		regs = proc.AppendFPReg(regs, fmt.Sprintf("V%d", i/16), fpregs[i:i+16])
+		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("V%d", i/16), fpregs[i:i+16])
 	}
 	return
 }

--- a/pkg/proc/native/registers_darwin_amd64.go
+++ b/pkg/proc/native/registers_darwin_amd64.go
@@ -5,7 +5,6 @@ package native
 // #include "threads_darwin.h"
 import "C"
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"unsafe"
@@ -73,9 +72,9 @@ func (r *Regs) Slice(floatingPoint bool) []proc.Register {
 	out := make([]proc.Register, 0, len(regs)+len(r.fpregs))
 	for _, reg := range regs {
 		if reg.k == "Rflags" {
-			out = proc.AppendEflagReg(out, reg.k, reg.v)
+			out = proc.AppendUint64Register(out, reg.k, reg.v)
 		} else {
-			out = proc.AppendQwordReg(out, reg.k, reg.v)
+			out = proc.AppendUint64Register(out, reg.k, reg.v)
 		}
 	}
 	if floatingPoint {
@@ -342,25 +341,23 @@ func registers(thread *Thread, floatingPoint bool) (proc.Registers, error) {
 			return nil, fmt.Errorf("could not get floating point registers")
 		}
 
-		regs.fpregs = proc.AppendWordReg(regs.fpregs, "CW", *((*uint16)(unsafe.Pointer(&fpstate.__fpu_fcw))))
-		regs.fpregs = proc.AppendWordReg(regs.fpregs, "SW", *((*uint16)(unsafe.Pointer(&fpstate.__fpu_fsw))))
-		regs.fpregs = proc.AppendWordReg(regs.fpregs, "TW", uint16(fpstate.__fpu_ftw))
-		regs.fpregs = proc.AppendWordReg(regs.fpregs, "FOP", uint16(fpstate.__fpu_fop))
-		regs.fpregs = proc.AppendQwordReg(regs.fpregs, "FIP", uint64(fpstate.__fpu_cs)<<32|uint64(fpstate.__fpu_ip))
-		regs.fpregs = proc.AppendQwordReg(regs.fpregs, "FDP", uint64(fpstate.__fpu_ds)<<32|uint64(fpstate.__fpu_dp))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "CW", uint64(*((*uint16)(unsafe.Pointer(&fpstate.__fpu_fcw)))))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "SW", uint64(*((*uint16)(unsafe.Pointer(&fpstate.__fpu_fsw)))))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "TW", uint64(fpstate.__fpu_ftw))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "FOP", uint64(fpstate.__fpu_fop))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "FIP", uint64(fpstate.__fpu_cs)<<32|uint64(fpstate.__fpu_ip))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "FDP", uint64(fpstate.__fpu_ds)<<32|uint64(fpstate.__fpu_dp))
 
 		for i, st := range []*C.char{&fpstate.__fpu_stmm0.__mmst_reg[0], &fpstate.__fpu_stmm1.__mmst_reg[0], &fpstate.__fpu_stmm2.__mmst_reg[0], &fpstate.__fpu_stmm3.__mmst_reg[0], &fpstate.__fpu_stmm4.__mmst_reg[0], &fpstate.__fpu_stmm5.__mmst_reg[0], &fpstate.__fpu_stmm6.__mmst_reg[0], &fpstate.__fpu_stmm7.__mmst_reg[0]} {
 			stb := C.GoBytes(unsafe.Pointer(st), 10)
-			mantissa := binary.LittleEndian.Uint64(stb[:8])
-			exponent := binary.LittleEndian.Uint16(stb[8:])
-			regs.fpregs = proc.AppendX87Reg(regs.fpregs, i, exponent, mantissa)
+			regs.fpregs = proc.AppendBytesRegister(regs.fpregs, fmt.Sprintf("ST(%d)", i), stb)
 		}
 
-		regs.fpregs = proc.AppendMxcsrReg(regs.fpregs, "MXCSR", uint64(fpstate.__fpu_mxcsr))
-		regs.fpregs = proc.AppendDwordReg(regs.fpregs, "MXCSR_MASK", uint32(fpstate.__fpu_mxcsrmask))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "MXCSR", uint64(fpstate.__fpu_mxcsr))
+		regs.fpregs = proc.AppendUint64Register(regs.fpregs, "MXCSR_MASK", uint64(fpstate.__fpu_mxcsrmask))
 
 		for i, xmm := range []*C.char{&fpstate.__fpu_xmm0.__xmm_reg[0], &fpstate.__fpu_xmm1.__xmm_reg[0], &fpstate.__fpu_xmm2.__xmm_reg[0], &fpstate.__fpu_xmm3.__xmm_reg[0], &fpstate.__fpu_xmm4.__xmm_reg[0], &fpstate.__fpu_xmm5.__xmm_reg[0], &fpstate.__fpu_xmm6.__xmm_reg[0], &fpstate.__fpu_xmm7.__xmm_reg[0], &fpstate.__fpu_xmm8.__xmm_reg[0], &fpstate.__fpu_xmm9.__xmm_reg[0], &fpstate.__fpu_xmm10.__xmm_reg[0], &fpstate.__fpu_xmm11.__xmm_reg[0], &fpstate.__fpu_xmm12.__xmm_reg[0], &fpstate.__fpu_xmm13.__xmm_reg[0], &fpstate.__fpu_xmm14.__xmm_reg[0], &fpstate.__fpu_xmm15.__xmm_reg[0]} {
-			regs.fpregs = proc.AppendSSEReg(regs.fpregs, fmt.Sprintf("XMM%d", i), C.GoBytes(unsafe.Pointer(xmm), 16))
+			regs.fpregs = proc.AppendBytesRegister(regs.fpregs, fmt.Sprintf("XMM%d", i), C.GoBytes(unsafe.Pointer(xmm), 16))
 		}
 	}
 	return regs, nil

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -328,10 +328,10 @@ func LoadConfigFromProc(cfg *proc.LoadConfig) *LoadConfig {
 }
 
 // ConvertRegisters converts proc.Register to api.Register for a slice.
-func ConvertRegisters(in []proc.Register) (out []Register) {
+func ConvertRegisters(in []proc.Register, arch proc.Arch) (out []Register) {
 	out = make([]Register, len(in))
 	for i := range in {
-		out[i] = Register{in[i].Name, in[i].Value}
+		out[i] = Register{in[i].Name, arch.DwarfRegisterToString(in[i].Name, in[i].Reg)}
 	}
 	return
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -961,7 +961,7 @@ func (d *Debugger) Registers(threadID int, floatingPoint bool) (api.Registers, e
 	if err != nil {
 		return nil, err
 	}
-	return api.ConvertRegisters(regs.Slice(floatingPoint)), err
+	return api.ConvertRegisters(regs.Slice(floatingPoint), d.target.BinInfo().Arch), err
 }
 
 func convertVars(pv []*proc.Variable) []api.Variable {


### PR DESCRIPTION
```
proc: only format registers value when it's necessary

A significant amount of time is spent generating the string
representation for the proc.Registers object of each thread, since this
field is rarely used (only when the Registers API is called) it should
be generated on demand.

Also by changing the internal representation of proc.Register to be
closer to that of op.DwarfRegister it will help us implement #1838
(when Delve will need to be able to display the registers of an
internal frame, which we currently represent using op.DwarfRegister
objects).

Benchmark before:

BenchmarkConditionalBreakpoints-4   	       1	22292554301 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	17326345671 ns/op

Reduces conditional breakpoint latency from 2.2ms to 1.7ms.

Updates #1549, #1838

```
