### PR TITLE
Update CHANGELOG.md - fix v1.4.0's date being 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to Semantic Versioning.
 
 All changes mention the author, unless contributed by me (@derekparker).
 
-## [1.4.0] 2019-02-11
+## [1.4.0] 2020-02-11
 
 ### Added
 


### PR DESCRIPTION
I think that should've been 2020 ;)