### PR TITLE
proc: do not load g0 until it's needed when stacktracing

### DIFF
--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -219,6 +219,7 @@ func (a *AMD64) SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 			return false
 		}
 
+		it.loadG0SchedSP()
 		if it.g0_sched_sp <= 0 {
 			return false
 		}

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -254,6 +254,7 @@ func (a *ARM64) SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters)
 			return false
 		}
 
+		it.loadG0SchedSP()
 		if it.g0_sched_sp <= 0 {
 			return false
 		}


### PR DESCRIPTION
```
proc: do not load g0 until it's needed when stacktracing

The stacktrace code occasionally needs the value of g.m.g0.sched.sp to
switch stacks. Since this is only needed rarely and calling parseG is
relatively expensive we should delay doing it until we know it will be
needed.

Benchmark before:

BenchmarkConditionalBreakpoints-4              1        17326345671 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	15649407130 ns/op

Reduces conditional breakpoint latency from 1.7ms to 1.56ms.

Updates #1549

```
