### PR TITLE
logflags: reduce default loglevel to Error

### DIFF
--- a/pkg/logflags/logflags.go
+++ b/pkg/logflags/logflags.go
@@ -34,7 +34,7 @@ func makeLogger(flag bool, fields logrus.Fields) *logrus.Entry {
 	}
 	logger.Logger.Level = logrus.DebugLevel
 	if !flag {
-		logger.Logger.Level = logrus.PanicLevel
+		logger.Logger.Level = logrus.ErrorLevel
 	}
 	return logger
 }


### PR DESCRIPTION
```
logflags: reduce default loglevel to Error

Logged errors should be visible even if the corresponding flag was not
selected.

```
