### PR TITLE
proc: optimize parseG

### DIFF
--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -534,11 +534,14 @@ func (it *stackIterator) loadG0SchedSP() {
 	}
 	it.g0_sched_sp_loaded = true
 	if it.g != nil {
-		g0var, _ := it.g.variable.fieldVariable("m").structMember("g0")
-		if g0var != nil {
-			g0, _ := g0var.parseG()
-			if g0 != nil {
-				it.g0_sched_sp = g0.SP
+		mvar, _ := it.g.variable.structMember("m")
+		if mvar != nil {
+			g0var, _ := mvar.structMember("g0")
+			if g0var != nil {
+				g0, _ := g0var.parseG()
+				if g0 != nil {
+					it.g0_sched_sp = g0.SP
+				}
 			}
 		}
 	}

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -499,7 +499,11 @@ func GetG(thread Thread) (*G, error) {
 		// For our purposes it's better if we always return the real goroutine
 		// since the rest of the code assumes the goroutine ID is univocal.
 		// The real 'current goroutine' is stored in g0.m.curg
-		curgvar, err := g.variable.fieldVariable("m").structMember("curg")
+		mvar, err := g.variable.structMember("m")
+		if err != nil {
+			return nil, err
+		}
+		curgvar, err := mvar.structMember("curg")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
```
proc: optimize parseG

runtime.g is a large and growing struct, we only need a few fields.
Instead of using loadValue to load the full contents of g, cache its
memory and then only load the fields we care about.

Benchmark before:

BenchmarkConditionalBreakpoints-4              1        14586710018 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	12476166303 ns/op

Conditional breakpoint evaluation: 1.45ms -> 1.24ms

Updates #1549

```
