### PR TITLE
pkg/proc: Allow function calls on non-struct types

### DIFF
--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -121,7 +121,7 @@ func noreturncall(n int) {
 	return
 }
 
-type Base struct{
+type Base struct {
 	y int
 }
 
@@ -132,6 +132,18 @@ type Derived struct {
 
 func (b *Base) Method() int {
 	return b.y
+}
+
+type X int
+
+func (_ X) CallMe() {
+	println("foo")
+}
+
+type X2 int
+
+func (_ X2) CallMe(i int) int {
+	return i * i
 }
 
 func main() {
@@ -148,6 +160,8 @@ func main() {
 	var vable_a VRcvrable = a
 	var vable_pa VRcvrable = pa
 	var pable_pa PRcvrable = pa
+	var x X = 2
+	var x2 X2 = 2
 
 	fn2clos := makeclos(pa)
 	fn2glob := call1
@@ -163,5 +177,6 @@ func main() {
 	strings.LastIndexByte(stringslice[1], 'w')
 	d.Method()
 	d.Base.Method()
-	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga, escapeArg, a2, square, intcallpanic, onetwothree, curriedAdd, getAStruct, getAStructPtr, getVRcvrableFromAStruct, getPRcvrableFromAStructPtr, getVRcvrableFromAStructPtr, pa2, noreturncall, str, d)
+	x.CallMe()
+	fmt.Println(one, two, zero, callpanic, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga, escapeArg, a2, square, intcallpanic, onetwothree, curriedAdd, getAStruct, getAStructPtr, getVRcvrableFromAStruct, getPRcvrableFromAStructPtr, getVRcvrableFromAStructPtr, pa2, noreturncall, str, d, x, x2.CallMe(5))
 }

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -437,7 +437,12 @@ func funcCallEvalFuncExpr(scope *EvalScope, fncall *functionCallState, allowCall
 
 	argnum := len(fncall.expr.Args)
 
-	if len(fnvar.Children) > 0 {
+	// If the function variable has a child then that child is the method
+	// receiver. However, if the method receiver is not being used (e.g.
+	// func (_ X) Foo()) then it will not actually be listed as a formal
+	// argument. Ensure that we are really off by 1 to add the receiver to
+	// the function call.
+	if len(fnvar.Children) > 0 && argnum == (len(fncall.formalArgs)-1) {
 		argnum++
 		fncall.receiver = &fnvar.Children[0]
 		fncall.receiver.Name = exprToString(fncall.expr.Fun)

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1178,6 +1178,9 @@ func TestCallFunction(t *testing.T) {
 
 		{"ga.PRcvr(2)", []string{`:string:"2 - 0 = 2"`}, nil},
 
+		{"x.CallMe()", nil, nil},
+		{"x2.CallMe(5)", []string{":int:25"}, nil},
+
 		// Nested function calls tests
 
 		{`onetwothree(intcallpanic(2))`, []string{`:[]int:[]int len: 3, cap: 3, [3,4,5]`}, nil},


### PR DESCRIPTION
Removes the restriction that the DWARF type for the receiver of a method
must be a TypeDef. This seems reasonable in theory, but in practice it turns out
Go DWARF does not consider

```
type X int
```

to be a typedef. This patch also allows for calling a method where the
receiver is not used or passed in, such as:

```
func (_ X) Method() { println("why") }
```