### PR TITLE
pkg/proc: Judge the validity of addr ranges when disasm.

### DIFF
--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -1,5 +1,7 @@
 package proc
 
+import "fmt"
+
 // AsmInstruction represents one assembly instruction.
 type AsmInstruction struct {
 	Loc        Location
@@ -101,6 +103,9 @@ func checkPrologue(s []AsmInstruction, prologuePattern opcodeSeq) bool {
 // will evaluate the argument of the CALL instruction using the thread's registers.
 // Be aware that the Bytes field of each returned instruction is a slice of a larger array of size startAddr - endAddr.
 func Disassemble(mem MemoryReadWriter, regs Registers, breakpoints *BreakpointMap, bi *BinaryInfo, startAddr, endAddr uint64) ([]AsmInstruction, error) {
+	if startAddr > endAddr {
+		return nil, fmt.Errorf("start address(%x) should be less than end address(%x)", startAddr, endAddr)
+	}
 	return disassemble(mem, regs, breakpoints, bi, startAddr, endAddr, false)
 }
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -961,6 +961,11 @@ func TestDisasm(t *testing.T) {
 
 		pcstart := d1[0].Loc.PC
 		pcend := d1[len(d1)-1].Loc.PC + uint64(len(d1[len(d1)-1].Bytes))
+
+		// start address should be less than end address
+		_, err = c.DisassembleRange(api.EvalScope{-1, 0, 0}, pcend, pcstart, api.IntelFlavour)
+		assertError(err, t, "DisassembleRange()")
+
 		d2, err := c.DisassembleRange(api.EvalScope{-1, 0, 0}, pcstart, pcend, api.IntelFlavour)
 		assertNoError(err, t, "DisassembleRange()")
 


### PR DESCRIPTION
Avoid panic if start addr is greater than end addr when disasm.

[`mem := make([]byte, int(endAddr-startAddr))`](https://github.com/go-delve/delve/blob/6c1571e8ab071e42f9b653430c3400c4d44151de/pkg/proc/disasm.go#L105-L113) panic.
