### PR TITLE
Better native.Process.stop performance for linux backend

### DIFF
--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -476,13 +476,10 @@ func (dbp *Process) stop(trapthread *Thread) (err error) {
 
 	// stop all threads that are still running
 	for _, th := range dbp.threads {
-		if !th.Stopped() {
+		if th.os.running {
 			if err := th.stop(); err != nil {
 				return dbp.exitGuard(err)
 			}
-		} else {
-			// Thread is already in a trace stop but we didn't get the notification yet.
-			th.os.running = false
 		}
 	}
 

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -16,6 +16,7 @@ type OSSpecificDetails struct {
 	delayedSignal int
 	registers     sys.PtraceRegs
 	running       bool
+	setbp         bool
 }
 
 func (t *Thread) stop() (err error) {


### PR DESCRIPTION
```
proc/native/linux: do not call (*Thread).Stopped inside (*Process).stop

(*Thread).Stopped is slow because it needs to open, read and parse a
file in /proc, we don't actually need to do that, we can just rely on
the value of Thread.os.running.

Benchmark before:

BenchmarkConditionalBreakpoints-4              1        12476166303 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	10403533675 ns/op

Conditional breakpoint evaluation: 1.24ms -> 1ms

Updates #1549

proc/native/linux: only set breakpoints on threads that receive SIGTRAP

```
