### PR TITLE
proc,service: allow printing registers for arbitrary frames

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -45,7 +45,7 @@ goroutines(Start, Count) | Equivalent to API call [ListGoroutines](https://godoc
 local_vars(Scope, Cfg) | Equivalent to API call [ListLocalVars](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListLocalVars)
 package_vars(Filter, Cfg) | Equivalent to API call [ListPackageVars](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListPackageVars)
 packages_build_info(IncludeFiles) | Equivalent to API call [ListPackagesBuildInfo](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListPackagesBuildInfo)
-registers(ThreadID, IncludeFp) | Equivalent to API call [ListRegisters](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListRegisters)
+registers(ThreadID, IncludeFp, Scope) | Equivalent to API call [ListRegisters](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListRegisters)
 sources(Filter) | Equivalent to API call [ListSources](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListSources)
 threads() | Equivalent to API call [ListThreads](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListThreads)
 types(Filter) | Equivalent to API call [ListTypes](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListTypes)

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -21,7 +21,7 @@ type Arch interface {
 	RegSize(uint64) int
 	RegistersToDwarfRegisters(uint64, Registers) op.DwarfRegisters
 	AddrAndStackRegsToDwarfRegisters(uint64, uint64, uint64, uint64, uint64) op.DwarfRegisters
-	DwarfRegisterToString(string, *op.DwarfRegister) string
+	DwarfRegisterToString(int, *op.DwarfRegister) (string, bool, string)
 }
 
 const (

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -411,8 +411,22 @@ func (a *ARM64) AddrAndStackRegsToDwarfRegisters(staticBase, pc, sp, bp, lr uint
 	}
 }
 
-func (a *ARM64) DwarfRegisterToString(name string, reg *op.DwarfRegister) string {
-	if reg.Bytes != nil && (name[0] == 'v' || name[0] == 'V') {
+func (a *ARM64) DwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, floatingPoint bool, repr string) {
+	// see arm64DwarfToHardware table for explanation
+	switch {
+	case i <= 30:
+		name = fmt.Sprintf("X%d", i)
+	case i == 31:
+		name = "SP"
+	case i == 32:
+		name = "PC"
+	case i >= 64 && i <= 95:
+		name = fmt.Sprintf("V%d", i-64)
+	default:
+		name = fmt.Sprintf("unknown%d", i)
+	}
+
+	if reg.Bytes != nil && name[0] == 'V' {
 		buf := bytes.NewReader(reg.Bytes)
 
 		var out bytes.Buffer
@@ -445,9 +459,9 @@ func (a *ARM64) DwarfRegisterToString(name string, reg *op.DwarfRegister) string
 		}
 		fmt.Fprintf(&out, "\tv4_float={ %g %g %g %g }", v4[0], v4[1], v4[2], v4[3])
 
-		return out.String()
+		return name, true, out.String()
 	} else if reg.Bytes == nil || (reg.Bytes != nil && len(reg.Bytes) < 16) {
-		return fmt.Sprintf("%#016x", reg.Uint64Val)
+		return name, false, fmt.Sprintf("%#016x", reg.Uint64Val)
 	}
-	return fmt.Sprintf("%#x", reg.Bytes)
+	return name, false, fmt.Sprintf("%#x", reg.Bytes)
 }

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1595,7 +1595,13 @@ func regs(t *Term, ctx callContext, args string) error {
 	if args == "-a" {
 		includeFp = true
 	}
-	regs, err := t.client.ListRegisters(0, includeFp)
+	var regs api.Registers
+	var err error
+	if ctx.Scope.GoroutineID < 0 && ctx.Scope.Frame == 0 {
+		regs, err = t.client.ListThreadRegisters(0, includeFp)
+	} else {
+		regs, err = t.client.ListScopeRegisters(ctx.Scope, includeFp)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -967,7 +967,7 @@ func TestIssue1493(t *testing.T) {
 		ra := term.MustExec("regs -a")
 		nra := len(strings.Split(ra, "\n"))
 		t.Logf("regs -a: %s", ra)
-		if nr > nra/2 {
+		if nr > nra/2+1 {
 			t.Fatalf("'regs' returned too many registers (%d) compared to 'regs -a' (%d)", nr, nra)
 		}
 	})

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -934,6 +934,15 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 2 && args[2] != starlark.None {
+			err := unmarshalStarlarkValue(args[2], &rpcArgs.Scope, "Scope")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		} else {
+			scope := env.ctx.Scope()
+			rpcArgs.Scope = &scope
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
@@ -941,6 +950,8 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.ThreadID, "ThreadID")
 			case "IncludeFp":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.IncludeFp, "IncludeFp")
+			case "Scope":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Scope, "Scope")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -442,8 +442,9 @@ type SetAPIVersionOut struct {
 
 // Register holds information on a CPU register.
 type Register struct {
-	Name  string
-	Value string
+	Name        string
+	Value       string
+	DwarfNumber int
 }
 
 // Registers is a list of CPU registers.

--- a/service/client.go
+++ b/service/client.go
@@ -93,8 +93,10 @@ type Client interface {
 	ListLocalVariables(scope api.EvalScope, cfg api.LoadConfig) ([]api.Variable, error)
 	// ListFunctionArgs lists all arguments to the current function.
 	ListFunctionArgs(scope api.EvalScope, cfg api.LoadConfig) ([]api.Variable, error)
-	// ListRegisters lists registers and their values.
-	ListRegisters(threadID int, includeFp bool) (api.Registers, error)
+	// ListThreadRegisters lists registers and their values, for the given thread.
+	ListThreadRegisters(threadID int, includeFp bool) (api.Registers, error)
+	// ListScopeRegisters lists registers and their values, for the given scope.
+	ListScopeRegisters(scope api.EvalScope, includeFp bool) (api.Registers, error)
 
 	// ListGoroutines lists all goroutines.
 	ListGoroutines(start, count int) ([]*api.Goroutine, int, error)

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -204,7 +204,7 @@ func (s *RPCServer) ListRegisters(arg interface{}, registers *string) error {
 		return err
 	}
 
-	regs, err := s.debugger.Registers(state.CurrentThread.ID, false)
+	regs, err := s.debugger.Registers(state.CurrentThread.ID, nil, false)
 	if err != nil {
 		return err
 	}

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -292,9 +292,15 @@ func (c *RPCClient) ListLocalVariables(scope api.EvalScope, cfg api.LoadConfig) 
 	return out.Variables, err
 }
 
-func (c *RPCClient) ListRegisters(threadID int, includeFp bool) (api.Registers, error) {
+func (c *RPCClient) ListThreadRegisters(threadID int, includeFp bool) (api.Registers, error) {
 	out := new(ListRegistersOut)
-	err := c.call("ListRegisters", ListRegistersIn{ThreadID: threadID, IncludeFp: includeFp}, out)
+	err := c.call("ListRegisters", ListRegistersIn{ThreadID: threadID, IncludeFp: includeFp, Scope: nil}, out)
+	return out.Regs, err
+}
+
+func (c *RPCClient) ListScopeRegisters(scope api.EvalScope, includeFp bool) (api.Registers, error) {
+	out := new(ListRegistersOut)
+	err := c.call("ListRegisters", ListRegistersIn{ThreadID: 0, IncludeFp: includeFp, Scope: &scope}, out)
 	return out.Regs, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -368,6 +368,7 @@ func (s *RPCServer) ListPackageVars(arg ListPackageVarsIn, out *ListPackageVarsO
 type ListRegistersIn struct {
 	ThreadID  int
 	IncludeFp bool
+	Scope     *api.EvalScope
 }
 
 type ListRegistersOut struct {
@@ -376,8 +377,10 @@ type ListRegistersOut struct {
 }
 
 // ListRegisters lists registers and their values.
+// If ListRegistersIn.Scope is not nil the registers of that eval scope will
+// be returned, otherwise ListRegistersIn.ThreadID will be used.
 func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) error {
-	if arg.ThreadID == 0 {
+	if arg.ThreadID == 0 && arg.Scope == nil {
 		state, err := s.debugger.State(false)
 		if err != nil {
 			return err
@@ -385,7 +388,7 @@ func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) er
 		arg.ThreadID = state.CurrentThread.ID
 	}
 
-	regs, err := s.debugger.Registers(arg.ThreadID, arg.IncludeFp)
+	regs, err := s.debugger.Registers(arg.ThreadID, arg.Scope, arg.IncludeFp)
 	if err != nil {
 		return err
 	}

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -510,13 +510,28 @@ func TestClientServer_infoArgs(t *testing.T) {
 		if state.Err != nil {
 			t.Fatalf("Unexpected error: %v, state: %#v", state.Err, state)
 		}
-		regs, err := c.ListRegisters(0, false)
+		regs, err := c.ListThreadRegisters(0, false)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		if len(regs) == 0 {
 			t.Fatal("Expected string showing registers values, got empty string")
 		}
+
+		regs, err = c.ListScopeRegisters(api.EvalScope{GoroutineID: -1, Frame: 0}, false)
+		assertNoError(err, t, "ListScopeRegisters(-1, 0)")
+		if len(regs) == 0 {
+			t.Fatal("Expected string showing registers values, got empty string")
+		}
+		t.Logf("GoroutineID: -1, Frame: 0\n%s", regs.String())
+
+		regs, err = c.ListScopeRegisters(api.EvalScope{GoroutineID: -1, Frame: 1}, false)
+		assertNoError(err, t, "ListScopeRegisters(-1, 1)")
+		if len(regs) == 0 {
+			t.Fatal("Expected string showing registers values, got empty string")
+		}
+		t.Logf("GoroutineID: -1, Frame: 1\n%s", regs.String())
+
 		locals, err := c.ListFunctionArgs(api.EvalScope{-1, 0, 0}, normalLoadConfig)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
@@ -925,8 +940,10 @@ func TestIssue355(t *testing.T) {
 		assertError(err, t, "ListLocalVariables()")
 		_, err = c.ListFunctionArgs(api.EvalScope{gid, 0, 0}, normalLoadConfig)
 		assertError(err, t, "ListFunctionArgs()")
-		_, err = c.ListRegisters(0, false)
-		assertError(err, t, "ListRegisters()")
+		_, err = c.ListThreadRegisters(0, false)
+		assertError(err, t, "ListThreadRegisters()")
+		_, err = c.ListScopeRegisters(api.EvalScope{gid, 0, 0}, false)
+		assertError(err, t, "ListScopeRegisters()")
 		_, _, err = c.ListGoroutines(0, 0)
 		assertError(err, t, "ListGoroutines()")
 		_, err = c.Stacktrace(gid, 10, 0, &normalLoadConfig)
@@ -1279,8 +1296,8 @@ func TestClientServer_FpRegisters(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestClient2("fputest/", t, func(c service.Client) {
 		<-c.Continue()
-		regs, err := c.ListRegisters(0, true)
-		assertNoError(err, t, "ListRegisters()")
+		regs, err := c.ListThreadRegisters(0, true)
+		assertNoError(err, t, "ListThreadRegisters()")
 
 		t.Logf("%s", regs.String())
 


### PR DESCRIPTION
```
proc,service: allow printing registers for arbitrary frames

Adds an optional scope prefix to the `regs` command which allows
printing registers for any stack frame (as long as they were somehow
saved). Issue #1838 is not yet to be closed since we are still not
recovering the registers of a segfaulting frame.

Updates #1838

```
