### PR TITLE
proc,proc/*: add StopReason field to Target

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -213,7 +213,12 @@ func OpenCore(corePath, exePath string, debugInfoDirs []string) (*proc.Target, e
 		return nil, err
 	}
 
-	return proc.NewTarget(p, exePath, debugInfoDirs, p.writeBreakpoint, false, proc.StopAttached)
+	return proc.NewTarget(p, proc.NewTargetConfig{
+		Path:                exePath,
+		DebugInfoDirs:       debugInfoDirs,
+		WriteBreakpoint:     p.writeBreakpoint,
+		DisableAsyncPreempt: false,
+		StopReason:          proc.StopAttached})
 }
 
 // BinInfo will return the binary info.

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -213,7 +213,7 @@ func OpenCore(corePath, exePath string, debugInfoDirs []string) (*proc.Target, e
 		return nil, err
 	}
 
-	return proc.NewTarget(p, exePath, debugInfoDirs, p.writeBreakpoint, false)
+	return proc.NewTarget(p, exePath, debugInfoDirs, p.writeBreakpoint, false, proc.StopAttached)
 }
 
 // BinInfo will return the binary info.
@@ -376,8 +376,8 @@ func (p *Process) ClearInternalBreakpoints() error {
 
 // ContinueOnce will always return an error because you
 // cannot control execution of a core file.
-func (p *Process) ContinueOnce() (proc.Thread, error) {
-	return nil, ErrContinueCore
+func (p *Process) ContinueOnce() (proc.Thread, proc.StopReason, error) {
+	return nil, proc.StopUnknown, ErrContinueCore
 }
 
 // StepInstruction will always return an error

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -155,11 +155,12 @@ type Process struct {
 
 	entryPoint uint64
 
-	bi                *proc.BinaryInfo
-	breakpoints       proc.BreakpointMap
-	currentThread     *Thread
-	selectedGoroutine *proc.G
+	bi            *proc.BinaryInfo
+	breakpoints   proc.BreakpointMap
+	currentThread *Thread
 }
+
+var _ proc.ProcessInternal = &Process{}
 
 // Thread represents a thread in the core file being debugged.
 type Thread struct {
@@ -212,29 +213,12 @@ func OpenCore(corePath, exePath string, debugInfoDirs []string) (*proc.Target, e
 		return nil, err
 	}
 
-	if err := p.initialize(exePath, debugInfoDirs); err != nil {
-		return nil, err
-	}
-
-	return proc.NewTarget(p, false), nil
-}
-
-// initialize for core files doesn't do much
-// aside from call the post initialization setup.
-func (p *Process) initialize(path string, debugInfoDirs []string) error {
-	return proc.PostInitializationSetup(p, path, debugInfoDirs, p.writeBreakpoint)
+	return proc.NewTarget(p, exePath, debugInfoDirs, p.writeBreakpoint, false)
 }
 
 // BinInfo will return the binary info.
 func (p *Process) BinInfo() *proc.BinaryInfo {
 	return p.bi
-}
-
-// SetSelectedGoroutine will set internally the goroutine that should be
-// the default for any command executed, the goroutine being actively
-// followed.
-func (p *Process) SetSelectedGoroutine(g *proc.G) {
-	p.selectedGoroutine = g
 }
 
 // EntryPoint will return the entry point address for this core file.
@@ -443,38 +427,9 @@ func (p *Process) Pid() int {
 func (p *Process) ResumeNotify(chan<- struct{}) {
 }
 
-// SelectedGoroutine returns the current active and selected
-// goroutine.
-func (p *Process) SelectedGoroutine() *proc.G {
-	return p.selectedGoroutine
-}
-
 // SetBreakpoint will always return an error for core files as you cannot write memory or control execution.
 func (p *Process) SetBreakpoint(addr uint64, kind proc.BreakpointKind, cond ast.Expr) (*proc.Breakpoint, error) {
 	return nil, ErrWriteCore
-}
-
-// SwitchGoroutine will change the selected and active goroutine.
-func (p *Process) SwitchGoroutine(g *proc.G) error {
-	if g == nil {
-		// user specified -1 and selectedGoroutine is nil
-		return nil
-	}
-	if g.Thread != nil {
-		return p.SwitchThread(g.Thread.ThreadID())
-	}
-	p.selectedGoroutine = g
-	return nil
-}
-
-// SwitchThread will change the selected and active thread.
-func (p *Process) SwitchThread(tid int) error {
-	if th, ok := p.Threads[tid]; ok {
-		p.currentThread = th
-		p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())
-		return nil
-	}
-	return fmt.Errorf("thread %d does not exist", tid)
 }
 
 // ThreadList will return a list of all threads currently in the process.
@@ -490,4 +445,9 @@ func (p *Process) ThreadList() []proc.Thread {
 func (p *Process) FindThread(threadID int) (proc.Thread, bool) {
 	t, ok := p.Threads[threadID]
 	return t, ok
+}
+
+// SetCurrentThread is used internally by proc.Target to change the current thread.
+func (p *Process) SetCurrentThread(th proc.Thread) {
+	p.currentThread = th.(*Thread)
 }

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -104,9 +104,8 @@ type Process struct {
 	bi   *proc.BinaryInfo
 	conn gdbConn
 
-	threads           map[int]*Thread
-	currentThread     *Thread
-	selectedGoroutine *proc.G
+	threads       map[int]*Thread
+	currentThread *Thread
 
 	exited, detached bool
 	ctrlC            bool // ctrl-c was sent to stop inferior
@@ -125,8 +124,9 @@ type Process struct {
 	waitChan chan *os.ProcessState
 
 	onDetach func() // called after a successful detach
-
 }
+
+var _ proc.ProcessInternal = &Process{}
 
 // Thread represents an operating system thread.
 type Thread struct {
@@ -198,7 +198,7 @@ func New(process *os.Process) *Process {
 }
 
 // Listen waits for a connection from the stub.
-func (p *Process) Listen(listener net.Listener, path string, pid int, debugInfoDirs []string) error {
+func (p *Process) Listen(listener net.Listener, path string, pid int, debugInfoDirs []string) (*proc.Target, error) {
 	acceptChan := make(chan net.Conn)
 
 	go func() {
@@ -210,17 +210,17 @@ func (p *Process) Listen(listener net.Listener, path string, pid int, debugInfoD
 	case conn := <-acceptChan:
 		listener.Close()
 		if conn == nil {
-			return errors.New("could not connect")
+			return nil, errors.New("could not connect")
 		}
 		return p.Connect(conn, path, pid, debugInfoDirs)
 	case status := <-p.waitChan:
 		listener.Close()
-		return fmt.Errorf("stub exited while waiting for connection: %v", status)
+		return nil, fmt.Errorf("stub exited while waiting for connection: %v", status)
 	}
 }
 
 // Dial attempts to connect to the stub.
-func (p *Process) Dial(addr string, path string, pid int, debugInfoDirs []string) error {
+func (p *Process) Dial(addr string, path string, pid int, debugInfoDirs []string) (*proc.Target, error) {
 	for {
 		conn, err := net.Dial("tcp", addr)
 		if err == nil {
@@ -228,7 +228,7 @@ func (p *Process) Dial(addr string, path string, pid int, debugInfoDirs []string
 		}
 		select {
 		case status := <-p.waitChan:
-			return fmt.Errorf("stub exited while attempting to connect: %v", status)
+			return nil, fmt.Errorf("stub exited while attempting to connect: %v", status)
 		default:
 		}
 		time.Sleep(time.Second)
@@ -241,13 +241,13 @@ func (p *Process) Dial(addr string, path string, pid int, debugInfoDirs []string
 // program and the PID of the target process, both are optional, however
 // some stubs do not provide ways to determine path and pid automatically
 // and Connect will be unable to function without knowing them.
-func (p *Process) Connect(conn net.Conn, path string, pid int, debugInfoDirs []string) error {
+func (p *Process) Connect(conn net.Conn, path string, pid int, debugInfoDirs []string) (*proc.Target, error) {
 	p.conn.conn = conn
 	p.conn.pid = pid
 	err := p.conn.handshake()
 	if err != nil {
 		conn.Close()
-		return err
+		return nil, err
 	}
 
 	if verbuf, err := p.conn.exec([]byte("$qGDBServerVersion"), "init"); err == nil {
@@ -262,8 +262,9 @@ func (p *Process) Connect(conn net.Conn, path string, pid int, debugInfoDirs []s
 		}
 	}
 
-	if err := p.initialize(path, debugInfoDirs); err != nil {
-		return err
+	tgt, err := p.initialize(path, debugInfoDirs)
+	if err != nil {
+		return nil, err
 	}
 
 	// None of the stubs we support returns the value of fs_base or gs_base
@@ -279,7 +280,8 @@ func (p *Process) Connect(conn net.Conn, path string, pid int, debugInfoDirs []s
 			p.loadGInstrAddr = addr
 		}
 	}
-	return nil
+
+	return tgt, nil
 }
 
 // unusedPort returns an unused tcp port
@@ -402,15 +404,13 @@ func LLDBLaunch(cmd []string, wd string, foreground bool, debugInfoDirs []string
 	p := New(process.Process)
 	p.conn.isDebugserver = isDebugserver
 
+	var tgt *proc.Target
 	if listener != nil {
-		err = p.Listen(listener, cmd[0], 0, debugInfoDirs)
+		tgt, err = p.Listen(listener, cmd[0], 0, debugInfoDirs)
 	} else {
-		err = p.Dial(port, cmd[0], 0, debugInfoDirs)
+		tgt, err = p.Dial(port, cmd[0], 0, debugInfoDirs)
 	}
-	if err != nil {
-		return nil, err
-	}
-	return proc.NewTarget(p, runtime.GOOS == "darwin"), nil
+	return tgt, err
 }
 
 // LLDBAttach starts an instance of lldb-server and connects to it, asking
@@ -454,15 +454,13 @@ func LLDBAttach(pid int, path string, debugInfoDirs []string) (*proc.Target, err
 	p := New(process.Process)
 	p.conn.isDebugserver = isDebugserver
 
+	var tgt *proc.Target
 	if listener != nil {
-		err = p.Listen(listener, path, pid, debugInfoDirs)
+		tgt, err = p.Listen(listener, path, pid, debugInfoDirs)
 	} else {
-		err = p.Dial(port, path, pid, debugInfoDirs)
+		tgt, err = p.Dial(port, path, pid, debugInfoDirs)
 	}
-	if err != nil {
-		return nil, err
-	}
-	return proc.NewTarget(p, false), nil
+	return tgt, err
 }
 
 // EntryPoint will return the process entry point address, useful for
@@ -481,7 +479,7 @@ func (p *Process) EntryPoint() (uint64, error) {
 // initialize uses qProcessInfo to load the inferior's PID and
 // executable path. This command is not supported by all stubs and not all
 // stubs will report both the PID and executable path.
-func (p *Process) initialize(path string, debugInfoDirs []string) error {
+func (p *Process) initialize(path string, debugInfoDirs []string) (*proc.Target, error) {
 	var err error
 	if path == "" {
 		// If we are attaching to a running process and the user didn't specify
@@ -495,11 +493,11 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 				_, path, err = queryProcessInfo(p, p.Pid())
 				if err != nil {
 					p.conn.conn.Close()
-					return err
+					return nil, err
 				}
 			} else {
 				p.conn.conn.Close()
-				return fmt.Errorf("could not determine executable path: %v", err)
+				return nil, fmt.Errorf("could not determine executable path: %v", err)
 			}
 		}
 	}
@@ -520,7 +518,7 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 	if err != nil {
 		p.conn.conn.Close()
 		p.bi.Close()
-		return err
+		return nil, err
 	}
 	p.clearThreadSignals()
 
@@ -529,14 +527,15 @@ func (p *Process) initialize(path string, debugInfoDirs []string) error {
 		if err != nil && !isProtocolErrorUnsupported(err) {
 			p.conn.conn.Close()
 			p.bi.Close()
-			return err
+			return nil, err
 		}
 	}
-	if err = proc.PostInitializationSetup(p, path, debugInfoDirs, p.writeBreakpoint); err != nil {
+	tgt, err := proc.NewTarget(p, path, debugInfoDirs, p.writeBreakpoint, runtime.GOOS == "darwin")
+	if err != nil {
 		p.conn.conn.Close()
-		return err
+		return nil, err
 	}
-	return nil
+	return tgt, nil
 }
 
 func queryProcessInfo(p *Process, pid int) (int, string, error) {
@@ -606,9 +605,9 @@ func (p *Process) CurrentThread() proc.Thread {
 	return p.currentThread
 }
 
-// SelectedGoroutine returns the current actuve selected goroutine.
-func (p *Process) SelectedGoroutine() *proc.G {
-	return p.selectedGoroutine
+// SetCurrentThread is used internally by proc.Target to change the current thread.
+func (p *Process) SetCurrentThread(th proc.Thread) {
+	p.currentThread = th.(*Thread)
 }
 
 const (
@@ -808,38 +807,6 @@ func (p *Process) handleThreadSignals(trapthread *Thread) (trapthreadOut *Thread
 	return trapthread, shouldStop
 }
 
-// SetSelectedGoroutine will set internally the goroutine that should be
-// the default for any command executed, the goroutine being actively
-// followed.
-func (p *Process) SetSelectedGoroutine(g *proc.G) {
-	p.selectedGoroutine = g
-}
-
-// SwitchThread will change the internal selected thread.
-func (p *Process) SwitchThread(tid int) error {
-	if p.exited {
-		return proc.ErrProcessExited{Pid: p.conn.pid}
-	}
-	if th, ok := p.threads[tid]; ok {
-		p.currentThread = th
-		p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())
-		return nil
-	}
-	return fmt.Errorf("thread %d does not exist", tid)
-}
-
-// SwitchGoroutine will change the internal selected goroutine.
-func (p *Process) SwitchGoroutine(g *proc.G) error {
-	if g == nil {
-		return nil
-	}
-	if g.Thread != nil {
-		return p.SwitchThread(g.Thread.ThreadID())
-	}
-	p.selectedGoroutine = g
-	return nil
-}
-
 // RequestManualStop will attempt to stop the process
 // without a breakpoint or signal having been recieved.
 func (p *Process) RequestManualStop() error {
@@ -944,7 +911,6 @@ func (p *Process) Restart(pos string) error {
 	}
 	p.clearThreadSignals()
 	p.clearThreadRegisters()
-	p.selectedGoroutine, _ = proc.GetG(p.CurrentThread())
 
 	for addr := range p.breakpoints.M {
 		p.conn.setBreakpoint(addr)

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -530,7 +530,12 @@ func (p *Process) initialize(path string, debugInfoDirs []string, stopReason pro
 			return nil, err
 		}
 	}
-	tgt, err := proc.NewTarget(p, path, debugInfoDirs, p.writeBreakpoint, runtime.GOOS == "darwin", stopReason)
+	tgt, err := proc.NewTarget(p, proc.NewTargetConfig{
+		Path:                path,
+		DebugInfoDirs:       debugInfoDirs,
+		WriteBreakpoint:     p.writeBreakpoint,
+		DisableAsyncPreempt: runtime.GOOS == "darwin",
+		StopReason:          stopReason})
 	if err != nil {
 		p.conn.conn.Close()
 		return nil, err

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -90,13 +90,13 @@ func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string)
 			safeRemoveAll(p.tracedir)
 		}
 	}
-	err = p.Dial(init.port, init.exe, 0, debugInfoDirs)
+	tgt, err := p.Dial(init.port, init.exe, 0, debugInfoDirs)
 	if err != nil {
 		rrcmd.Process.Kill()
 		return nil, err
 	}
 
-	return proc.NewTarget(p, false), nil
+	return tgt, nil
 }
 
 // ErrPerfEventParanoid is the error returned by Reply and Record if

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -90,7 +90,7 @@ func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string)
 			safeRemoveAll(p.tracedir)
 		}
 	}
-	tgt, err := p.Dial(init.port, init.exe, 0, debugInfoDirs)
+	tgt, err := p.Dial(init.port, init.exe, 0, debugInfoDirs, proc.StopLaunched)
 	if err != nil {
 		rrcmd.Process.Kill()
 		return nil, err

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -31,7 +31,7 @@ type ProcessInternal interface {
 	// number.
 	Restart(pos string) error
 	Detach(bool) error
-	ContinueOnce() (trapthread Thread, err error)
+	ContinueOnce() (trapthread Thread, stopReason StopReason, err error)
 }
 
 // RecordingManipulation is an interface for manipulating process recordings.

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -18,16 +18,27 @@ type Process interface {
 	RecordingManipulation
 }
 
-// RecordingManipulation is an interface for manipulating process recordings.
-type RecordingManipulation interface {
-	// Recorded returns true if the current process is a recording and the path
-	// to the trace directory.
-	Recorded() (recorded bool, tracedir string)
+// ProcessInternal holds a set of methods that are not meant to be called by
+// anyone except for an instance of `proc.Target`. These methods are not
+// safe to use by themselves and should never be called directly outside of
+// the `proc` package.
+// This is temporary and in support of an ongoing refactor.
+type ProcessInternal interface {
+	SetCurrentThread(Thread)
 	// Restart restarts the recording from the specified position, or from the
 	// last checkpoint if pos == "".
 	// If pos starts with 'c' it's a checkpoint ID, otherwise it's an event
 	// number.
 	Restart(pos string) error
+	Detach(bool) error
+	ContinueOnce() (trapthread Thread, err error)
+}
+
+// RecordingManipulation is an interface for manipulating process recordings.
+type RecordingManipulation interface {
+	// Recorded returns true if the current process is a recording and the path
+	// to the trace directory.
+	Recorded() (recorded bool, tracedir string)
 	// Direction changes execution direction.
 	Direction(Direction) error
 	// When returns current recording position.
@@ -71,7 +82,6 @@ type Info interface {
 	EntryPoint() (uint64, error)
 
 	ThreadInfo
-	GoroutineInfo
 }
 
 // ThreadInfo is an interface for getting information on active threads
@@ -82,22 +92,12 @@ type ThreadInfo interface {
 	CurrentThread() Thread
 }
 
-// GoroutineInfo is an interface for getting information on running goroutines.
-type GoroutineInfo interface {
-	SelectedGoroutine() *G
-	SetSelectedGoroutine(*G)
-}
-
 // ProcessManipulation is an interface for changing the execution state of a process.
 type ProcessManipulation interface {
-	ContinueOnce() (trapthread Thread, err error)
-	SwitchThread(int) error
-	SwitchGoroutine(*G) error
 	RequestManualStop() error
 	// CheckAndClearManualStopRequest returns true the first time it's called
 	// after a call to RequestManualStop.
 	CheckAndClearManualStopRequest() bool
-	Detach(bool) error
 }
 
 // BreakpointManipulation is an interface for managing breakpoints.

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -289,7 +289,12 @@ func (dbp *Process) initialize(path string, debugInfoDirs []string) (*proc.Targe
 	if !dbp.childProcess {
 		stopReason = proc.StopAttached
 	}
-	return proc.NewTarget(dbp, path, debugInfoDirs, dbp.writeBreakpoint, runtime.GOOS == "windows", stopReason)
+	return proc.NewTarget(dbp, proc.NewTargetConfig{
+		Path:                path,
+		DebugInfoDirs:       debugInfoDirs,
+		WriteBreakpoint:     dbp.writeBreakpoint,
+		DisableAsyncPreempt: runtime.GOOS == "windows",
+		StopReason:          stopReason})
 }
 
 // ClearInternalBreakpoints will clear all non-user set breakpoints. These

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -117,16 +117,14 @@ func Launch(cmd []string, wd string, foreground bool, _ []string) (*proc.Target,
 	}
 
 	dbp.os.initialized = true
-	err = dbp.initialize(argv0Go, []string{})
+	dbp.currentThread = trapthread
+
+	tgt, err := dbp.initialize(argv0Go, []string{})
 	if err != nil {
 		return nil, err
 	}
 
-	if err := dbp.SwitchThread(trapthread.ID); err != nil {
-		return nil, err
-	}
-
-	return proc.NewTarget(dbp, false), err
+	return tgt, err
 }
 
 // Attach to an existing process with the given PID.
@@ -153,12 +151,12 @@ func Attach(pid int, _ []string) (*proc.Target, error) {
 		return nil, err
 	}
 
-	err = dbp.initialize("", []string{})
+	tgt, err := dbp.initialize("", []string{})
 	if err != nil {
 		dbp.Detach(false)
 		return nil, err
 	}
-	return proc.NewTarget(dbp, false), nil
+	return tgt, nil
 }
 
 // Kill kills the process.
@@ -269,7 +267,7 @@ func (dbp *Process) addThread(port int, attach bool) (*Thread, error) {
 	dbp.threads[port] = thread
 	thread.os.threadAct = C.thread_act_t(port)
 	if dbp.currentThread == nil {
-		dbp.SwitchThread(thread.ID)
+		dbp.currentThread = thread
 	}
 	return thread, nil
 }

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -84,10 +84,11 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string) (*
 	if err != nil {
 		return nil, fmt.Errorf("waiting for target execve failed: %s", err)
 	}
-	if err = dbp.initialize(cmd[0], debugInfoDirs); err != nil {
+	tgt, err := dbp.initialize(cmd[0], debugInfoDirs)
+	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp, false), nil
+	return tgt, nil
 }
 
 // Attach to an existing process with the given PID. Once attached, if
@@ -106,12 +107,12 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 		return nil, err
 	}
 
-	err = dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
+	tgt, err := dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
 	if err != nil {
 		dbp.Detach(false)
 		return nil, err
 	}
-	return proc.NewTarget(dbp, false), nil
+	return tgt, nil
 }
 
 func initialize(dbp *Process) error {
@@ -165,7 +166,7 @@ func (dbp *Process) addThread(tid int, attach bool) (*Thread, error) {
 	}
 
 	if dbp.currentThread == nil {
-		dbp.SwitchThread(tid)
+		dbp.currentThread = dbp.threads[tid]
 	}
 
 	return dbp.threads[tid], nil

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -90,10 +90,11 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string) (*
 	if err != nil {
 		return nil, fmt.Errorf("waiting for target execve failed: %s", err)
 	}
-	if err = dbp.initialize(cmd[0], debugInfoDirs); err != nil {
+	tgt, err := dbp.initialize(cmd[0], debugInfoDirs)
+	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp, false), nil
+	return tgt, nil
 }
 
 // Attach to an existing process with the given PID. Once attached, if
@@ -112,7 +113,7 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 		return nil, err
 	}
 
-	err = dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
+	tgt, err := dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
 	if err != nil {
 		dbp.Detach(false)
 		return nil, err
@@ -124,7 +125,7 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(dbp, false), nil
+	return tgt, nil
 }
 
 func initialize(dbp *Process) error {
@@ -222,7 +223,7 @@ func (dbp *Process) addThread(tid int, attach bool) (*Thread, error) {
 		os:  new(OSSpecificDetails),
 	}
 	if dbp.currentThread == nil {
-		dbp.SwitchThread(tid)
+		dbp.currentThread = dbp.threads[tid]
 	}
 	return dbp.threads[tid], nil
 }

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -78,11 +78,12 @@ func Launch(cmd []string, wd string, foreground bool, _ []string) (*proc.Target,
 	dbp.pid = p.Pid
 	dbp.childProcess = true
 
-	if err = dbp.initialize(argv0Go, []string{}); err != nil {
+	tgt, err := dbp.initialize(argv0Go, []string{})
+	if err != nil {
 		dbp.Detach(true)
 		return nil, err
 	}
-	return proc.NewTarget(dbp, true), nil
+	return tgt, nil
 }
 
 func initialize(dbp *Process) error {
@@ -167,11 +168,12 @@ func Attach(pid int, _ []string) (*proc.Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = dbp.initialize(exepath, []string{}); err != nil {
+	tgt, err := dbp.initialize(exepath, []string{})
+	if err != nil {
 		dbp.Detach(true)
 		return nil, err
 	}
-	return proc.NewTarget(dbp, true), nil
+	return tgt, nil
 }
 
 // kill kills the process.
@@ -223,7 +225,7 @@ func (dbp *Process) addThread(hThread syscall.Handle, threadID int, attach, susp
 	thread.os.hThread = hThread
 	dbp.threads[threadID] = thread
 	if dbp.currentThread == nil {
-		dbp.SwitchThread(thread.ID)
+		dbp.currentThread = dbp.threads[threadID]
 	}
 	if suspendNewThreads {
 		_, err := _SuspendThread(thread.os.hThread)

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -1,8 +1,18 @@
 package proc
 
+import (
+	"fmt"
+)
+
 // Target represents the process being debugged.
 type Target struct {
 	Process
+
+	proc ProcessInternal
+
+	// Goroutine that will be used by default to set breakpoint, eval variables, etc...
+	// Normally selectedGoroutine is currentThread.GetG, it will not be only if SwitchGoroutine is called with a goroutine that isn't attached to a thread
+	selectedGoroutine *G
 
 	// fncallForG stores a mapping of current active function calls.
 	fncallForG map[int]*callInjection
@@ -17,18 +27,41 @@ type Target struct {
 }
 
 // NewTarget returns an initialized Target object.
-func NewTarget(p Process, disableAsyncPreempt bool) *Target {
+func NewTarget(p Process, path string, debugInfoDirs []string, writeBreakpoint WriteBreakpointFn, disableAsyncPreempt bool) (*Target, error) {
+	entryPoint, err := p.EntryPoint()
+	if err != nil {
+		return nil, err
+	}
+
+	err = p.BinInfo().LoadBinaryInfo(path, entryPoint, debugInfoDirs)
+	if err != nil {
+		return nil, err
+	}
+	for _, image := range p.BinInfo().Images {
+		if image.loadErr != nil {
+			return nil, image.loadErr
+		}
+	}
+
 	t := &Target{
 		Process:    p,
+		proc:       p.(ProcessInternal),
 		fncallForG: make(map[int]*callInjection),
 	}
+
+	g, _ := GetG(p.CurrentThread())
+	t.selectedGoroutine = g
+
+	createUnrecoveredPanicBreakpoint(p, writeBreakpoint)
+	createFatalThrowBreakpoint(p, writeBreakpoint)
+
 	t.gcache.init(p.BinInfo())
 
 	if disableAsyncPreempt {
 		setAsyncPreemptOff(t, 1)
 	}
 
-	return t
+	return t, nil
 }
 
 // SupportsFunctionCalls returns whether or not the backend supports
@@ -54,7 +87,45 @@ func (t *Target) ClearAllGCache() {
 // Restarting of a normal process happens at a higher level (debugger.Restart).
 func (t *Target) Restart(from string) error {
 	t.ClearAllGCache()
-	return t.Process.Restart(from)
+	err := t.proc.Restart(from)
+	if err != nil {
+		return err
+	}
+	t.selectedGoroutine, _ = GetG(t.CurrentThread())
+	return nil
+}
+
+// SelectedGoroutine returns the currently selected goroutine.
+func (t *Target) SelectedGoroutine() *G {
+	return t.selectedGoroutine
+}
+
+// SwitchGoroutine will change the selected and active goroutine.
+func (p *Target) SwitchGoroutine(g *G) error {
+	if ok, err := p.Valid(); !ok {
+		return err
+	}
+	if g == nil {
+		return nil
+	}
+	if g.Thread != nil {
+		return p.SwitchThread(g.Thread.ThreadID())
+	}
+	p.selectedGoroutine = g
+	return nil
+}
+
+// SwitchThread will change the selected and active thread.
+func (p *Target) SwitchThread(tid int) error {
+	if ok, err := p.Valid(); !ok {
+		return err
+	}
+	if th, ok := p.FindThread(tid); ok {
+		p.proc.SetCurrentThread(th)
+		p.selectedGoroutine, _ = GetG(p.CurrentThread())
+		return nil
+	}
+	return fmt.Errorf("thread %d does not exist", tid)
 }
 
 // Detach will detach the target from the underylying process.
@@ -65,5 +136,5 @@ func (t *Target) Detach(kill bool) error {
 	if !kill && t.asyncPreemptChanged {
 		setAsyncPreemptOff(t, t.asyncPreemptOff)
 	}
-	return t.Process.Detach(kill)
+	return t.proc.Detach(kill)
 }

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -142,7 +142,7 @@ func (err *ErrNoSourceForPC) Error() string {
 // for an inlined function call. Everything works the same as normal except
 // when removing instructions belonging to inlined calls we also remove all
 // instructions belonging to the current inlined call.
-func next(dbp Process, stepInto, inlinedStepOut bool) error {
+func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 	selg := dbp.SelectedGoroutine()
 	curthread := dbp.CurrentThread()
 	topframe, retframe, err := topframe(selg, curthread)


### PR DESCRIPTION
```
proc,proc/*: add StopReason field to Target

Adds a StopReason field to the Target object describing why the target
process is currently stopped. This will be useful for the DAP server
(which needs to report this reason in one of its requests) as well as
making pull request #1785 (reverse step) conformant to the new
architecture.

proc,proc/*: move SelectedGoroutine to proc.Target, remove PostInitializationSetup

moves SelectedGoroutine, SwitchThread and SwitchGoroutine to
proc.Target, merges PostInitializationSetup with NewTarget.

```
