### PR TITLE
service/dap: minor cosmetic changes

### DIFF
--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -1,3 +1,5 @@
+// Package daptest provides a sample client with utilities
+// for DAP mode testing.
 package daptest
 
 import (
@@ -11,9 +13,6 @@ import (
 
 	"github.com/google/go-dap"
 )
-
-// Package daptest provides a sample client with utilities
-// for DAP mode testing.
 
 // Client is a debugger service client that uses Debug Adaptor Protocol.
 // It does not (yet?) implement service.Client interface.
@@ -38,7 +37,7 @@ func NewClient(addr string) *Client {
 	return c
 }
 
-// Close closes the client connection
+// Close closes the client connection.
 func (c *Client) Close() {
 	c.conn.Close()
 }

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1,3 +1,11 @@
+// Package dap implements VSCode's Debug Adaptor Protocol (DAP).
+// This allows delve to communicate with frontends using DAP
+// without a separate adaptor. The frontend will run the debugger
+// (which now doubles as an adaptor) in server mode listening on
+// a port and communicating over TCP. This is work in progress,
+// so for now Delve in dap mode only supports synchronous
+// request-response communication, blocking while processing each request.
+// For DAP details see https://microsoft.github.io/debug-adapter-protocol.
 package dap
 
 import (
@@ -13,18 +21,10 @@ import (
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/api"
 	"github.com/go-delve/delve/service/debugger"
-	"github.com/google/go-dap"
+	"github.com/google/go-dap"  // dap
 	"github.com/sirupsen/logrus"
 )
 
-// Package dap implements VSCode's Debug Adaptor Protocol (DAP).
-// This allows delve to communicate with frontends using DAP
-// without a separate adaptor. The frontend will run the debugger
-// (which now doubles as an adaptor) in server mode listening on
-// a port and communicating over TCP. This is work in progress,
-// so for now Delve in dap mode only supports synchronous
-// request-response communication, blocking while processing each request.
-// For DAP details see https://microsoft.github.io/debug-adapter-protocol.
 
 // Server implements a DAP server that can accept a single client for
 // a single debug session. It does not support restarting.
@@ -300,7 +300,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 	if mode != "exec" {
 		s.sendErrorResponse(request.Request,
 			FailedToContinue, "Failed to launch",
-			fmt.Sprintf("Unsupported 'mode' value '%s' in debug configuration.", mode))
+			fmt.Sprintf("Unsupported 'mode' value %q in debug configuration.", mode))
 		return
 	}
 

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -41,6 +41,7 @@ func startDAPServer(t *testing.T) (server *Server, addr string) {
 }
 
 func expectMessage(t *testing.T, client *daptest.Client, want []byte) {
+	t.Helper()
 	got, err := client.ReadBaseMessage()
 	if err != nil {
 		t.Error(err)
@@ -56,9 +57,9 @@ func runTest(t *testing.T, name string, test func(c *daptest.Client, f protest.F
 	fixture := protest.BuildFixture(name, buildFlags)
 
 	server, addr := startDAPServer(t)
+	defer server.Stop()
 	client := daptest.NewClient(addr)
 	defer client.Close()
-	defer server.Stop()
 
 	test(client, fixture)
 }
@@ -123,6 +124,7 @@ func TestSetBreakpoint(t *testing.T) {
 }
 
 func expectErrorResponse(t *testing.T, client *daptest.Client, requestSeq int, command string, message string, id int) *dap.ErrorResponse {
+	t.Helper()
 	response, err := client.ReadErrorResponse()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
- Move package doc comments so they are recognized as package doc.
- Use t.Helper when appropriate.