### PR TITLE
proc/native: better error message when building on unsupported systems

### DIFF
--- a/pkg/proc/native/support_sentinel.go
+++ b/pkg/proc/native/support_sentinel.go
@@ -1,0 +1,5 @@
+// This file is used to detect build on unsupported GOOS/GOARCH combinations.
+
+//+build !linux,!darwin,!windows,!freebsd linux,!amd64,!arm64 darwin,!amd64 windows,!amd64 freebsd,!amd64
+
+package your_operating_system_and_architecture_combination_is_not_supported_by_delve


### PR DESCRIPTION
```
proc/native: better error message when building on unsupported systems

As we rearrange the code and the Go compiler changes the error message
returned by the compiler on unsupported architectures will change too,
making it un-googlable. Since the error message tends to be rather
obscure too this regularly confuses newbies.

This is an effort to make the error message for unsupported GOOS/GOARCH
combinations the same across all unsupported combinations and to make
it more user friendly.

Directories containing Go source code are supposed to contain a single
package. This property happens to be checked by cmd/go itself so it
will happen even before the syntax is fully checked and therefore has a
high probability of being the first (and only) error message being
print.

Here we take advantage of this by adding to the pkg/proc/native
directory a file with a bad package line that only gets compiled in on
unsupported GOOS/GOARCH combinations.

At present the error message for compiling Delve on unsupported systems
will be:

service/debugger/debugger.go:21:2: found packages native (proc.go) and your_operating_system_and_architecture_combination_is_not_supported_by_delve (support_sentinel.go) in $PATH_TO_DELVE/pkg/proc/native

```
