### PR TITLE
pkg/proc: Fix ThreadId when ErrNoGoroutine on g0 stack in GetG

### DIFF
--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -509,6 +509,9 @@ func GetG(thread Thread) (*G, error) {
 		}
 		g, err = curgvar.parseG()
 		if err != nil {
+			if _, ok := err.(ErrNoGoroutine); ok {
+				err = ErrNoGoroutine{thread.ThreadID()}
+			}
 			return nil, err
 		}
 		g.SystemStack = true


### PR DESCRIPTION
Avoid always showing `no G executing on thread 0` when ErrNoGoroutine on
g0 stack in GetG.

------

If hit [`mem.(Thread)` ](https://github.com/go-delve/delve/blob/master/pkg/proc/variables.go#L540) on g0 stack, the thread's id about error always is 0.

No testcase, I don't konw how to structure cases in normal scenario. I meet it when i do something on 386 linux.
But I think the thread's id should be showed if ErrNoGoroutine.