### PR TITLE
pkg,service: Optimized the display of `examinemem` command.

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -216,10 +216,13 @@ Examine memory:
 
     examinemem [-fmt <format>] [-len <length>] <address>
 
-Format represents the data format and the value is one of this list (default hex): oct(octal), hex(hexadecimal), dec(decimal), bin(binary).
+Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal),.
 Length is the number of bytes (default 1) and must be less than or equal to 1000.
 Address is the memory location of the target to examine.
-For example:  x -fmt hex -len 20 0xc00008af38
+
+For example:
+
+    x -fmt hex -len 20 0xc00008af38
 
 Aliases: x
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -372,10 +372,13 @@ If locspec is omitted edit will open the current source file in the editor, othe
 
     examinemem [-fmt <format>] [-len <length>] <address>
 
-Format represents the data format and the value is one of this list (default hex): oct(octal), hex(hexadecimal), dec(decimal), bin(binary).
+Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal),.
 Length is the number of bytes (default 1) and must be less than or equal to 1000.
 Address is the memory location of the target to examine.
-For example:  x -fmt hex -len 20 0xc00008af38`},
+
+For example:
+
+    x -fmt hex -len 20 0xc00008af38`},
 	}
 
 	if client == nil || client.Recorded() {
@@ -1428,7 +1431,7 @@ func examineMemoryCmd(t *Term, ctx callContext, args string) error {
 		return err
 	}
 
-	fmt.Println(api.PrettyExamineMemory(uintptr(address), memArea, priFmt))
+	fmt.Printf(api.PrettyExamineMemory(uintptr(address), memArea, priFmt))
 	return nil
 }
 

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1009,13 +1009,13 @@ func TestExamineMemoryCmd(t *testing.T) {
 		res := term.MustExec("examinemem  -len 52 -fmt hex " + addressStr)
 		t.Logf("the result of examining memory \n%s", res)
 		// check first line
-		firstLine := fmt.Sprintf("%#x:    0xa     0xb     0xc     0xd     0xe     0xf     0x10    0x11", address)
+		firstLine := fmt.Sprintf("%#x:   0x0a   0x0b   0x0c   0x0d   0x0e   0x0f   0x10   0x11", address)
 		if !strings.Contains(res, firstLine) {
 			t.Fatalf("expected first line: %s", firstLine)
 		}
 
 		// check last line
-		lastLine := fmt.Sprintf("%#x:    0x3a    0x3b    0x3c    0x0", address+6*8)
+		lastLine := fmt.Sprintf("%#x:   0x3a   0x3b   0x3c   0x00", address+6*8)
 		if !strings.Contains(res, lastLine) {
 			t.Fatalf("expected last line: %s", lastLine)
 		}
@@ -1026,7 +1026,7 @@ func TestExamineMemoryCmd(t *testing.T) {
 		t.Logf("the second result of examining memory result \n%s", res)
 
 		// check first line
-		firstLine = fmt.Sprintf("%#x:    11111111    00001011    00001100    00001101", address)
+		firstLine = fmt.Sprintf("%#x:   11111111   00001011   00001100   00001101", address)
 		if !strings.Contains(res, firstLine) {
 			t.Fatalf("expected first line: %s", firstLine)
 		}

--- a/service/api/prettyprint_test.go
+++ b/service/api/prettyprint_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestPrettyExamineMemory(t *testing.T) {
+	// Test whether always use the last addr's len to format when the lens of two adjacent address are different
+	addr := uintptr(0xffff)
+	memArea := []byte("abcdefghijklmnopqrstuvwxyz")
+	format := byte('o')
+
+	display := []string{
+		"0x0ffff:   0141   0142   0143   0144   0145   0146   0147   0150",
+		"0x10007:   0151   0152   0153   0154   0155   0156   0157   0160",
+		"0x1000f:   0161   0162   0163   0164   0165   0166   0167   0170",
+		"0x10017:   0171   0172"}
+	res := strings.Split(strings.TrimSpace(PrettyExamineMemory(addr, memArea, format)), "\n")
+
+	if len(display) != len(res) {
+		t.Fatalf("wrong lines return, expected %d but got %d", len(display), len(res))
+	}
+
+	for i := 0; i < len(display); i++ {
+		if display[i] != res[i] {
+			errInfo := fmt.Sprintf("wrong display return at line %d\n", i+1)
+			errInfo += fmt.Sprintf("expected:\n   %q\n", display[i])
+			errInfo += fmt.Sprintf("but got:\n   %q\n", res[i])
+			t.Fatal(errInfo)
+		}
+	}
+}


### PR DESCRIPTION
1. Don't use intelligent '#' in fmt of go because it is not always satisfying
for diffrent version of golang. Always keep one leading zero for octal and
one leading '0x' for hex manually. Then keep alignment for every byte.

2. Always keep addr alignment when the lens of two adjacent address are
different.

Update #1814.  

---- 

Sorry for the diplay detail  about 'x'. #1814
When I use x command to try to implemnt 386 linux, I find something not friendly to user.  

1.
```
Before optimization:
(dlv) x -len 20 -fmt hex 0x4abd6d
0x4abd6d:    0xcc    0x8d    0x5     0xb1    0x96    0x3     0x0     0x48
0x4abd75:    0x89    0x4     0x24    0x48    0xc7    0x44    0x24    0x8 
0x4abd7d:    0xc     0x0     0x0     0x0 

After optimization:
(dlv) x -len 20 -fmt hex 0x4abd6d
0x4abd6d:   0xcc   0x8d   0x05   0xb1   0x96   0x03   0x00   0x48
0x4abd75:   0x89   0x04   0x24   0x48   0xc7   0x44   0x24   0x08
0x4abd7d:   0x0c   0x00   0x00   0x00
```
2. 
```
Before optimization:

0xffff:    0141    0142    0143    0144    0145    0146    0147    0150
0x10007:    0151    0152    0153    0154    0155    0156    0157    0160
0x1000f:    0161    0162    0163    0164    0165    0166    0167    0170

After optimization:

0x0ffff:   0141   0142   0143   0144   0145   0146   0147   0150
0x10007:   0151   0152   0153   0154   0155   0156   0157   0160
0x1000f:   0161   0162   0163   0164   0165   0166   0167   0170
```