### PR TITLE
proc/gdbserial,debugger: allow clients to stop a recording

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -13,7 +13,7 @@ Command | Description
 [call](#call) | Resumes process, injecting a function call (EXPERIMENTAL!!!)
 [continue](#continue) | Run until breakpoint or program termination.
 [next](#next) | Step over to next source line.
-[restart](#restart) | Restart process from a checkpoint or event.
+[restart](#restart) | Restart process.
 [rev](#rev) | Reverses the execution of the target program for the command specified.
 [rewind](#rewind) | Run backwards until breakpoint or program termination.
 [step](#step) | Single step through program.
@@ -396,9 +396,21 @@ Argument -a shows more registers.
 
 
 ## restart
-Restart process from a checkpoint or event.
+Restart process.
 
-  restart [event number or checkpoint id]
+For recorded targets the command takes the following forms:
+
+	restart				resets ot the start of the recording
+	restart [checkpoint]		resets the recording to the given checkpoint
+	restart -r [newargv...]		re-records the target process
+	
+For live targets the command takes the following forms:
+
+	restart [newargv...]		restarts the process
+
+If newargv is omitted the process is restarted (or re-recorded) with the same argument vector.
+If -noargs is specified instead, the argument vector is cleared.
+
 
 Aliases: r
 

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -11,21 +11,24 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"unicode"
 
 	"github.com/go-delve/delve/pkg/proc"
 )
 
-// Record uses rr to record the execution of the specified program and
-// returns the trace directory's path.
-func Record(cmd []string, wd string, quiet bool) (tracedir string, err error) {
+// RecordAsync configures rr to record the execution of the specified
+// program. Returns a run function which will actually record the program, a
+// stop function which will prematurely terminate the recording of the
+// program.
+func RecordAsync(cmd []string, wd string, quiet bool) (run func() (string, error), stop func() error, err error) {
 	if err := checkRRAvailabe(); err != nil {
-		return "", err
+		return nil, nil, err
 	}
 
 	rfd, wfd, err := os.Pipe()
 	if err != nil {
-		return "", err
+		return nil, nil, err
 	}
 
 	args := make([]string, 0, len(cmd)+2)
@@ -40,18 +43,36 @@ func Record(cmd []string, wd string, quiet bool) (tracedir string, err error) {
 	rrcmd.ExtraFiles = []*os.File{wfd}
 	rrcmd.Dir = wd
 
-	done := make(chan struct{})
+	tracedirChan := make(chan string)
 	go func() {
 		bs, _ := ioutil.ReadAll(rfd)
-		tracedir = strings.TrimSpace(string(bs))
-		close(done)
+		tracedirChan <- strings.TrimSpace(string(bs))
 	}()
 
-	err = rrcmd.Run()
+	run = func() (string, error) {
+		err := rrcmd.Run()
+		_ = wfd.Close()
+		tracedir := <-tracedirChan
+		return tracedir, err
+	}
+
+	stop = func() error {
+		return rrcmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	return run, stop, nil
+}
+
+// Record uses rr to record the execution of the specified program and
+// returns the trace directory's path.
+func Record(cmd []string, wd string, quiet bool) (tracedir string, err error) {
+	run, _, err := RecordAsync(cmd, wd, quiet)
+	if err != nil {
+		return "", err
+	}
+
 	// ignore run errors, it could be the program crashing
-	wfd.Close()
-	<-done
-	return
+	return run()
 }
 
 // Replay starts an instance of rr in replay mode, with the specified trace

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -395,7 +395,17 @@ The '-a' option adds an expression to the list of expression printed every time 
 If display is called without arguments it will print the value of all expression in the list.`},
 	}
 
-	if client == nil || client.Recorded() {
+	addrecorded := client == nil
+	if !addrecorded {
+		if state, err := client.GetStateNonBlocking(); err == nil {
+			addrecorded = state.Recording
+			if !addrecorded {
+				addrecorded = client.Recorded()
+			}
+		}
+	}
+
+	if addrecorded {
 		c.cmds = append(c.cmds,
 			command{
 				aliases: []string{"rewind", "rw"},
@@ -431,14 +441,6 @@ The "note" is arbitrary text that can be used to identify the checkpoint, if it 
 				helpMsg: `Reverses the execution of the target program for the command specified.
 Currently, only the rev step-instruction command is supported.`,
 			})
-		for i := range c.cmds {
-			v := &c.cmds[i]
-			if v.match("restart") {
-				v.helpMsg = `Restart process from a checkpoint or event.
-
-  restart [event number or checkpoint id]`
-			}
-		}
 	}
 
 	sort.Sort(ByFirstAlias(c.cmds))

--- a/scripts/gen-starlark-bindings.go
+++ b/scripts/gen-starlark-bindings.go
@@ -26,7 +26,7 @@ func getSuitableMethods(pkg *types.Package, typename string) []*types.Func {
 			continue
 		}
 
-		if fn.Name() == "Command" {
+		if fn.Name() == "Command" || fn.Name() == "Restart" || fn.Name() == "State" {
 			r = append(r, fn)
 			continue
 		}
@@ -120,8 +120,13 @@ func processServerMethods(serverMethods []*types.Func) []binding {
 		}
 
 		retType := sig.Params().At(1).Type().String()
-		if fn.Name() == "Command" {
+		switch fn.Name() {
+		case "Command":
 			retType = "rpc2.CommandOut"
+		case "Restart":
+			retType = "rpc2.RestartOut"
+		case "State":
+			retType = "rpc2.StateOut"
 		}
 
 		bindings[i] = binding{

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -19,6 +19,11 @@ var ErrNotExecutable = proc.ErrNotExecutable
 type DebuggerState struct {
 	// Running is true if the process is running and no other information can be collected.
 	Running bool
+	// Recording is true if the process is currently being recorded and no other
+	// information can be collected. While the debugger is in this state
+	// sending a StopRecording request will halt the recording, every other
+	// request will block until the process has been recorded.
+	Recording bool
 	// CurrentThread is the currently selected debugger thread.
 	CurrentThread *Thread `json:"currentThread,omitempty"`
 	// SelectedGoroutine is the currently selected goroutine

--- a/service/client.go
+++ b/service/client.go
@@ -162,6 +162,9 @@ type Client interface {
 	// This function will return an error if it reads less than `length` bytes.
 	ExamineMemory(address uintptr, length int) ([]byte, error)
 
+	// StopRecording stops a recording if one is in progress.
+	StopRecording() error
+
 	// Disconnect closes the connection to the server without sending a Detach request first.
 	// If cont is true a continue command will be sent instead.
 	Disconnect(cont bool) error

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -452,6 +452,10 @@ func (c *RPCClient) ExamineMemory(address uintptr, count int) ([]byte, error) {
 	return out.Mem, nil
 }
 
+func (c *RPCClient) StopRecording() error {
+	return c.call("StopRecording", StopRecordingIn{}, &StopRecordingOut{})
+}
+
 func (c *RPCClient) call(method string, args, reply interface{}) error {
 	return c.client.Call("RPCServer."+method, args, reply)
 }

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -3,7 +3,6 @@ package rpccommon
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -93,14 +92,6 @@ func (s *ServerImpl) Stop() error {
 	}
 	kill := s.config.AttachPid == 0
 	return s.debugger.Detach(kill)
-}
-
-// Restart restarts the debugger.
-func (s *ServerImpl) Restart() error {
-	if s.config.AttachPid != 0 {
-		return errors.New("cannot restart process Delve did not create")
-	}
-	return s.s2.Restart(rpc2.RestartIn{}, nil)
 }
 
 // Run starts a debugger and exposes it with an HTTP server. The debugger

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -154,19 +154,6 @@ func Test1Restart_duringStop(t *testing.T) {
 	})
 }
 
-func Test1Restart_attachPid(t *testing.T) {
-	// Assert it does not work and returns error.
-	// We cannot restart a process we did not spawn.
-	server := rpccommon.NewServer(&service.Config{
-		Listener:  nil,
-		AttachPid: 999,
-		Backend:   testBackend,
-	})
-	if err := server.Restart(); err == nil {
-		t.Fatal("expected error on restart after attaching to pid but got none")
-	}
-}
-
 func Test1ClientServer_exit(t *testing.T) {
 	withTestClient1("continuetestprog", t, func(c *rpc1.RPCClient) {
 		state, err := c.GetState()


### PR DESCRIPTION
```
proc/gdbserial,debugger: allow clients to stop a recording

Allows Delve clients to stop a recording midway by sending a Command('halt')
request.

This is implemented by changing debugger.New to start recording the process
on a separate goroutine while holding the processMutex locked. By locking
the processMutex we ensure that almost all RPC requests will block until the
recording is done, since we can not respond correctly to any of them.
API calls that do not require manipulating or examining the target process,
such as "IsMulticlient", "SetApiVersion" and "GetState(nowait=true)" will
work while we are recording the process.

Two other internal changes are made to the API: both GetState and Restart
become asynchronous requests, like Command. Restart because this way it can
be interrupted by a Command(halt) request if the rerecord option is passed.
GetState because clients need a call that will block until the recording is
compelted and can also be interrupted with a Command(halt)

Clients that are uninterested in allowing the user to stop a recording can
ignore this change, since eventually they will make a request to Delve that
will block until the recording is completed.

Clients that wish to support this feature must:

1. call GetState(nowait=false) after connecting to Delve, before any call
that would need to manipulate the target process
2. allow the user to send a Command(halt) request during the initial
GetState call
3. allow the user to send a Command(halt) request during any subsequent
Restart(rerecord=true) request (if supported).

Implements #1747

```
