### PR TITLE
debugger: CreateBreakpoint should delete existing breakpoints

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -486,6 +486,9 @@ func createLogicalBreakpoint(p proc.Process, addrs []uint64, requestedBp *api.Br
 		}
 	}
 	if err != nil {
+		if isBreakpointExistsErr(err) {
+			return nil, err
+		}
 		for _, bp := range bps {
 			if bp == nil {
 				continue
@@ -499,6 +502,11 @@ func createLogicalBreakpoint(p proc.Process, addrs []uint64, requestedBp *api.Br
 	}
 	createdBp := api.ConvertBreakpoints(bps)
 	return createdBp[0], nil // we created a single logical breakpoint, the slice here will always have len == 1
+}
+
+func isBreakpointExistsErr(err error) bool {
+	_, r := err.(proc.BreakpointExistsError)
+	return r
 }
 
 // AmendBreakpoint will update the breakpoint with the matching ID.

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1819,3 +1819,35 @@ func TestIssue1787(t *testing.T) {
 		}
 	})
 }
+
+func TestDoubleCreateBreakpoint(t *testing.T) {
+	withTestClient2("testnextprog", t, func(c service.Client) {
+		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1, Name: "firstbreakpoint", Tracepoint: true})
+		assertNoError(err, t, "CreateBreakpoint 1")
+
+		bps, err := c.ListBreakpoints()
+		assertNoError(err, t, "ListBreakpoints 1")
+
+		t.Logf("breakpoints before second call:")
+		for _, bp := range bps {
+			t.Logf("\t%v", bp)
+		}
+
+		numBreakpoints := len(bps)
+
+		_, err = c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1, Name: "secondbreakpoint", Tracepoint: true})
+		assertError(err, t, "CreateBreakpoint 2") // breakpoint exists
+
+		bps, err = c.ListBreakpoints()
+		assertNoError(err, t, "ListBreakpoints 2")
+
+		t.Logf("breakpoints after second call:")
+		for _, bp := range bps {
+			t.Logf("\t%v", bp)
+		}
+
+		if len(bps) != numBreakpoints {
+			t.Errorf("wrong number of breakpoints, got %d expected %d", len(bps), numBreakpoints)
+		}
+	})
+}


### PR DESCRIPTION
```
debugger: CreateBreakpoint should delete existing breakpoints

Fixes a bug introduced by the logical breakpoint change, where creating
the same breakpoint twice deletes the breakpoint.

```
