### PR TITLE
test: fix probabilistic error when teststepconcurrent

### DIFF
--- a/_fixtures/teststepconcurrent.go
+++ b/_fixtures/teststepconcurrent.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"time"
 	"sync"
+	"time"
 )
 
 var v int = 99
@@ -34,9 +34,9 @@ func main() {
 	y := x * x
 	var z int
 	Threads(Foo)
+	wg.Wait()
 	for i := 0; i < 100; i++ {
 		z = Foo(x, y)
 	}
 	fmt.Printf("z=%d\n", z)
-	wg.Wait()
 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2310,7 +2310,7 @@ func TestStepConcurrentDirect(t *testing.T) {
 	}
 	protest.AllowRecording(t)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
-		bp := setFileBreakpoint(p, t, fixture.Source, 37)
+		bp := setFileBreakpoint(p, t, fixture.Source, 38)
 
 		assertNoError(proc.Continue(p), t, "Continue()")
 		_, err := p.ClearBreakpoint(bp.Addr)
@@ -2326,7 +2326,7 @@ func TestStepConcurrentDirect(t *testing.T) {
 
 		gid := p.SelectedGoroutine().ID
 
-		seq := []int{37, 38, 13, 15, 16, 38}
+		seq := []int{38, 39, 13, 15, 16, 39}
 
 		i := 0
 		count := 0
@@ -2338,7 +2338,7 @@ func TestStepConcurrentDirect(t *testing.T) {
 			}
 			f, ln := currentLineNumber(p, t)
 			if ln != seq[i] {
-				if i == 1 && ln == 40 {
+				if i == 1 && ln == 41 {
 					// loop exited
 					break
 				}


### PR DESCRIPTION
Ensure other goroutines has finished when we test `step loop` after
`concurrent`. Or it enter other goroutine probably that cause CI failed
sometime. 

---
fo example about ci test : 
[291401517](https://travis-ci.com/go-delve/delve/jobs/291401517)
[291203525](https://travis-ci.com/go-delve/delve/jobs/291203525)
and so on.

if my understanding is wrong, please point out and i will close.