### PR TITLE
*: Add Go 1.14 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ arch:
 
 go:
   - tip
+  - 1.14.x
   - 1.13.x
   - 1.12.x
-  - 1.11.x
 
 matrix:
   allow_failures:


### PR DESCRIPTION
This also removes Go 1.11 from the test matrix.

Now that 1.14 has been released, as always it should be included in the
test matrix.