### PR TITLE
service/api: Refactor examine memory pretty printer

### DIFF
--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 )
 
 const (
@@ -383,6 +384,7 @@ func PrettyExamineMemory(address uintptr, memArea []byte, format byte) string {
 	default:
 		return fmt.Sprintf("not supprted format %q\n", string(format))
 	}
+	colFormat += "\t"
 
 	l := len(memArea)
 	rows := l / cols
@@ -394,17 +396,18 @@ func PrettyExamineMemory(address uintptr, memArea []byte, format byte) string {
 	if l != 0 {
 		addrLen = len(fmt.Sprintf("%x", uint64(address)+uint64(l)))
 	}
-	addrFmt = "0x%0" + strconv.Itoa(addrLen) + "x:"
+	addrFmt = "0x%0" + strconv.Itoa(addrLen) + "x:\t"
 
-	lines := ""
+	var b strings.Builder
+	w := tabwriter.NewWriter(&b, 0, 0, 3, ' ', 0)
 	for i := 0; i < rows; i++ {
-		lines += fmt.Sprintf(addrFmt, address)
+		fmt.Fprintf(w, addrFmt, address)
 		for j := 0; j < cols && i*cols+j < l; j++ {
-			curOutput := "   " + fmt.Sprintf(colFormat, memArea[i*cols+j])
-			lines += curOutput
+			fmt.Fprintf(w, colFormat, memArea[i*cols+j])
 		}
-		lines += "\n"
+		fmt.Fprintln(w, "")
 		address += uintptr(cols)
 	}
-	return lines
+	w.Flush()
+	return b.String()
 }

--- a/service/api/prettyprint_test.go
+++ b/service/api/prettyprint_test.go
@@ -13,9 +13,9 @@ func TestPrettyExamineMemory(t *testing.T) {
 	format := byte('o')
 
 	display := []string{
-		"0x0ffff:   0141   0142   0143   0144   0145   0146   0147   0150",
-		"0x10007:   0151   0152   0153   0154   0155   0156   0157   0160",
-		"0x1000f:   0161   0162   0163   0164   0165   0166   0167   0170",
+		"0x0ffff:   0141   0142   0143   0144   0145   0146   0147   0150   ",
+		"0x10007:   0151   0152   0153   0154   0155   0156   0157   0160   ",
+		"0x1000f:   0161   0162   0163   0164   0165   0166   0167   0170   ",
 		"0x10017:   0171   0172"}
 	res := strings.Split(strings.TrimSpace(PrettyExamineMemory(addr, memArea, format)), "\n")
 


### PR DESCRIPTION
Use strings.Builder and tabwriter to format the output of the examine
memory command instead of doing direct string manipulation and
allocating.