### PR TITLE
proc/native/linux: try to use process_vm_readv/writev

### DIFF
--- a/pkg/proc/native/ptrace_linux.go
+++ b/pkg/proc/native/ptrace_linux.go
@@ -49,3 +49,31 @@ func PtracePeekUser(tid int, off uintptr) (uintptr, error) {
 	}
 	return val, nil
 }
+
+// ProcessVmRead calls process_vm_readv
+func ProcessVmRead(tid int, addr uintptr, data []byte) (int, error) {
+	len_iov := uint64(len(data))
+	local_iov := sys.Iovec{Base: &data[0], Len: len_iov}
+	remote_iov := sys.Iovec{Base: (*byte)(unsafe.Pointer(addr)), Len: len_iov}
+	p_local := uintptr(unsafe.Pointer(&local_iov))
+	p_remote := uintptr(unsafe.Pointer(&remote_iov))
+	n, _, err := syscall.Syscall6(sys.SYS_PROCESS_VM_READV, uintptr(tid), p_local, 1, p_remote, 1, 0)
+	if err != syscall.Errno(0) {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// ProcessVmWrite calls process_vm_writev
+func ProcessVmWrite(tid int, addr uintptr, data []byte) (int, error) {
+	len_iov := uint64(len(data))
+	local_iov := sys.Iovec{Base: &data[0], Len: len_iov}
+	remote_iov := sys.Iovec{Base: (*byte)(unsafe.Pointer(addr)), Len: len_iov}
+	p_local := uintptr(unsafe.Pointer(&local_iov))
+	p_remote := uintptr(unsafe.Pointer(&remote_iov))
+	n, _, err := syscall.Syscall6(sys.SYS_PROCESS_VM_WRITEV, uintptr(tid), p_local, 1, p_remote, 1, 0)
+	if err != syscall.Errno(0) {
+		return 0, err
+	}
+	return int(n), nil
+}


### PR DESCRIPTION
This change adds `ProcessVmRead` and `ProcessVmWrite` wrappers around
the syscalls `process_vm_readv` and `process_vm_writev`, available since
Linux 3.2. These follow the same permission model as `ptrace`, but they
don't actually require being attached, which means they can be called
directly from any thread in the debugger. They also use `iovec` to write
entire blocks at once, rather than having to peek/poke each `uintptr`.

These wrappers are used in `Thread.ReadMemory` and `WriteMemory`, still
falling back to `ptrace` if that fails for any reason.  Notably,
`process_vm_writev` respects memory protection, so it can't modify
read-only memory like `ptrace`. This frequently occurs when writing
breakpoints in read-only `.text`, so to avoid a lot of wasted `EFAULT`
calls, we only try `process_vm_writev` for larger writes.