### PR TITLE
proc/gdbserial: disable async preemption on macOS

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -390,6 +390,10 @@ func LLDBLaunch(cmd []string, wd string, foreground bool, debugInfoDirs []string
 
 	process.SysProcAttr = sysProcAttr(foreground)
 
+	if runtime.GOOS == "darwin" {
+		process.Env = proc.DisableAsyncPreemptEnv()
+	}
+
 	err := process.Start()
 	if err != nil {
 		return nil, err
@@ -406,7 +410,7 @@ func LLDBLaunch(cmd []string, wd string, foreground bool, debugInfoDirs []string
 	if err != nil {
 		return nil, err
 	}
-	return proc.NewTarget(p, false), nil
+	return proc.NewTarget(p, runtime.GOOS == "darwin"), nil
 }
 
 // LLDBAttach starts an instance of lldb-server and connects to it, asking
@@ -655,7 +659,6 @@ continueLoop:
 		var err error
 		var sig uint8
 		tu.Reset()
-		//TODO: pass thread list to resume, which should use it to pass the correct signals
 		threadID, sig, err = p.conn.resume(p.threads, &tu)
 		if err != nil {
 			if _, exited := err.(proc.ErrProcessExited); exited {

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"unsafe"
 
@@ -56,14 +55,7 @@ func Launch(cmd []string, wd string, foreground bool, _ []string) (*proc.Target,
 	}
 	closer.Close()
 
-	env := os.Environ()
-	for i := range env {
-		if strings.HasPrefix(env[i], "GODEBUG=") {
-			// Go 1.14 asynchronous preemption mechanism is incompatible with
-			// debuggers, see: https://github.com/golang/go/issues/36494
-			env[i] += ",asyncpreemptoff=1"
-		}
-	}
+	env := proc.DisableAsyncPreemptEnv()
 
 	var p *os.Process
 	dbp := New(0)


### PR DESCRIPTION
```
proc/gdbserial: disable async preemption on macOS

Disables async preemption on macOS

Fixes #1905

```
