### PR TITLE
terminal: add display command

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -39,6 +39,7 @@ Command | Description
 Command | Description
 --------|------------
 [args](#args) | Print function arguments.
+[display](#display) | Print value of an expression every time the program stops.
 [examinemem](#examinemem) | Examine memory:
 [locals](#locals) | Print local variables.
 [print](#print) | Evaluate an expression.
@@ -225,6 +226,17 @@ If no argument is specified the function being executed in the selected stack fr
 
 Aliases: disass
 
+## display
+Print value of an expression every time the program stops.
+
+	display -a <expression>
+	display -d <number>
+
+The '-a' option adds an expression to the list of expression printed every time the program stops. The '-d' option removes the specified expression from the list.
+
+If display is called without arguments it will print the value of all expression in the list.
+
+
 ## down
 Move the current frame down.
 
@@ -246,7 +258,7 @@ Aliases: ed
 ## examinemem
 Examine memory:
 
-    examinemem [-fmt <format>] [-len <length>] <address>
+	examinemem [-fmt <format>] [-len <length>] <address>
 
 Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal),.
 Length is the number of bytes (default 1) and must be less than or equal to 1000.

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -374,7 +374,7 @@ If locspec is omitted edit will open the current source file in the editor, othe
 
 		{aliases: []string{"examinemem", "x"}, group: dataCmds, cmdFn: examineMemoryCmd, helpMsg: `Examine memory:
 
-    examinemem [-fmt <format>] [-len <length>] <address>
+	examinemem [-fmt <format>] [-len <length>] <address>
 
 Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal),.
 Length is the number of bytes (default 1) and must be less than or equal to 1000.
@@ -383,6 +383,15 @@ Address is the memory location of the target to examine.
 For example:
 
     x -fmt hex -len 20 0xc00008af38`},
+
+		{aliases: []string{"display"}, group: dataCmds, cmdFn: display, helpMsg: `Print value of an expression every time the program stops.
+
+	display -a <expression>
+	display -d <number>
+
+The '-a' option adds an expression to the list of expression printed every time the program stops. The '-d' option removes the specified expression from the list.
+
+If display is called without arguments it will print the value of all expression in the list.`},
 	}
 
 	if client == nil || client.Recorded() {
@@ -979,6 +988,7 @@ func restartRecorded(t *Term, ctx callContext, args string) error {
 	}
 	printcontext(t, state)
 	printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
+	t.onStop()
 	return nil
 }
 
@@ -1055,6 +1065,7 @@ func (c *Commands) cont(t *Term, ctx callContext, args string) error {
 	if ctx.Prefix == revPrefix {
 		return c.rewind(t, ctx, args)
 	}
+	defer t.onStop()
 	c.frame = 0
 	stateChan := t.client.Continue()
 	var state *api.DebuggerState
@@ -1070,6 +1081,7 @@ func (c *Commands) cont(t *Term, ctx callContext, args string) error {
 }
 
 func continueUntilCompleteNext(t *Term, state *api.DebuggerState, op string, shouldPrintFile bool) error {
+	defer t.onStop()
 	if !state.NextInProgress {
 		if shouldPrintFile {
 			printfile(t, state.CurrentThread.File, state.CurrentThread.Line, true)
@@ -1138,6 +1150,8 @@ func (c *Commands) stepInstruction(t *Term, ctx callContext, args string) error 
 	if c.frame != 0 {
 		return notOnFrameZeroErr
 	}
+
+	defer t.onStop()
 
 	var fn func() (*api.DebuggerState, error)
 	if ctx.Prefix == revPrefix {
@@ -2382,6 +2396,37 @@ func clearCheckpoint(t *Term, ctx callContext, args string) error {
 		return errors.New("clear-checkpoint argument must be a checkpoint ID")
 	}
 	return t.client.ClearCheckpoint(id)
+}
+
+func display(t *Term, ctx callContext, args string) error {
+	const (
+		addOption = "-a "
+		delOption = "-d "
+	)
+	switch {
+	case args == "":
+		t.printDisplays()
+
+	case strings.HasPrefix(args, addOption):
+		args = strings.TrimSpace(args[len(addOption):])
+		if args == "" {
+			return fmt.Errorf("not enough arguments")
+		}
+		t.addDisplay(args)
+		t.printDisplay(len(t.displays) - 1)
+
+	case strings.HasPrefix(args, delOption):
+		args = strings.TrimSpace(args[len(delOption):])
+		n, err := strconv.Atoi(args)
+		if err != nil {
+			return fmt.Errorf("%q is not a number", args)
+		}
+		return t.removeDisplay(n)
+
+	default:
+		return fmt.Errorf("wrong arguments")
+	}
+	return nil
 }
 
 func formatBreakpointName(bp *api.Breakpoint, upcase bool) string {


### PR DESCRIPTION
```
terminal: add display command

Implements #1256

terminal: divide commands into categories

There are too many commands, for clarity they should be divided into
categories when printing and generating documentation.

```
