### PR TITLE
proc: cache result of GetG

### DIFF
--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -47,6 +47,9 @@ func (t *Target) SupportsFunctionCalls() bool {
 // This should be called anytime the target process executes instructions.
 func (t *Target) ClearAllGCache() {
 	t.gcache.Clear()
+	for _, thread := range t.ThreadList() {
+		thread.Common().g = nil
+	}
 }
 
 // Restart will start the process over from the location specified by the "from" locspec.

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -70,6 +70,7 @@ func (tbe ErrThreadBlocked) Error() string {
 // implementations of the Thread interface.
 type CommonThread struct {
 	returnValues []*Variable
+	g            *G // cached g for this thread
 }
 
 // ReturnValues reads the return values from the function executing on
@@ -478,6 +479,9 @@ func newGVariable(thread Thread, gaddr uintptr, deref bool) (*Variable, error) {
 // In order to get around all this craziness, we read the address of the G structure for
 // the current thread from the thread local storage area.
 func GetG(thread Thread) (*G, error) {
+	if thread.Common().g != nil {
+		return thread.Common().g, nil
+	}
 	if loc, _ := thread.Location(); loc != nil && loc.Fn != nil && loc.Fn.Name == "runtime.clone" {
 		// When threads are executing runtime.clone the value of TLS is unreliable.
 		return nil, nil
@@ -520,6 +524,7 @@ func GetG(thread Thread) (*G, error) {
 	if loc, err := thread.Location(); err == nil {
 		g.CurrentLoc = *loc
 	}
+	thread.Common().g = g
 	return g, nil
 }
 


### PR DESCRIPTION
```
proc: cache result of GetG

Benchmark before:

BenchmarkConditionalBreakpoints-4   	       1	7031242832 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	5282482841 ns/op

Conditional breakpoint evaluation latency: 0.70ms -> 0.52ms

Updates #1549

```
