### PR TITLE
terminal: add `-l` prompt on goroutines help

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -301,7 +301,7 @@ Aliases: gr
 ## goroutines
 List program goroutines.
 
-	goroutines [-u (default: user location)|-r (runtime location)|-g (go statement location)|-s (start location)] [ -t (stack trace)]
+	goroutines [-u (default: user location)|-r (runtime location)|-g (go statement location)|-s (start location)] [-t (stack trace)] [-l (labels)]
 
 Print out info for every goroutine. The flag controls what information is shown along with each goroutine:
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -182,7 +182,7 @@ Current limitations:
 If called with the linespec argument it will delete all the breakpoints matching the linespec. If linespec is omitted all breakpoints are deleted.`},
 		{aliases: []string{"goroutines", "grs"}, group: goroutineCmds, cmdFn: goroutines, helpMsg: `List program goroutines.
 
-	goroutines [-u (default: user location)|-r (runtime location)|-g (go statement location)|-s (start location)] [ -t (stack trace)]
+	goroutines [-u (default: user location)|-r (runtime location)|-g (go statement location)|-s (start location)] [-t (stack trace)] [-l (labels)]
 
 Print out info for every goroutine. The flag controls what information is shown along with each goroutine:
 


### PR DESCRIPTION
Update: #1879


-----  

ps: 
In fact, I think the prompt of `goroutines` cmd maybe too long. 

How about this? 
```
goroutines [-u (default)| -r | -g | -s ](optional location) [-t (stack trace)] [-l (labels)]
``` 
the whole help info :
```
List program goroutines.

  goroutines [-u (default)| -r | -g | -s ](optional location) [-t (stack trace)] [-l (labels)]

Print out info for every goroutine. The flag controls what information is shown along with each goroutine:

  -u  displays location of topmost stackframe in user code
  -r  displays location of topmost stackframe (including frames inside private runtime functions)
  -g  displays location of go instruction that created the goroutine
  -s  displays location of the start function
  -t  displays goroutine's stacktrace
  -l  displays goroutine's labels

If no flag is specified the default is -u.
```