### PR TITLE
proc: fix bad cached goroutines after a call injection

### DIFF
--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -330,6 +330,7 @@ func disassembleCurrentInstruction(p Process, thread Thread) ([]AsmInstruction, 
 // This function is used to step out of runtime.Breakpoint as well as
 // runtime.debugCallV1.
 func stepInstructionOut(dbp *Target, curthread Thread, fnname1, fnname2 string) error {
+	defer dbp.ClearAllGCache()
 	for {
 		if err := curthread.StepInstruction(); err != nil {
 			return err

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -315,6 +315,9 @@ func MustSupportFunctionCalls(t *testing.T, testBackend string) {
 	if runtime.GOOS == "darwin" && os.Getenv("TRAVIS") == "true" {
 		t.Skip("function call injection tests are failing on macOS on Travis-CI (see #1802)")
 	}
+	if runtime.GOARCH == "arm64" || runtime.GOARCH == "386" {
+		t.Skip(fmt.Errorf("%s does not support FunctionCall for now", runtime.GOARCH))
+	}
 }
 
 // DefaultTestBackend changes the value of testBackend to be the default


### PR DESCRIPTION
```
proc: fix bad cached goroutines after a call injection

Inserts a call to ClearAllGCache into stepInstructionOut so that cached
goroutine state is not inconsistent after an injected function call.\

Fixes #1925

```
