### PR TITLE
terminal: preserve arguments and prefixes when repeating last command

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -78,10 +78,9 @@ func (c command) match(cmdstr string) bool {
 
 // Commands represents the commands for Delve terminal process.
 type Commands struct {
-	cmds    []command
-	lastCmd cmdfunc
-	client  service.Client
-	frame   int // Current frame as set by frame/up/down commands.
+	cmds   []command
+	client service.Client
+	frame  int // Current frame as set by frame/up/down commands.
 }
 
 var (
@@ -454,9 +453,6 @@ func (c *Commands) Register(cmdstr string, cf cmdfunc, helpMsg string) {
 func (c *Commands) Find(cmdstr string, prefix cmdPrefix) cmdfunc {
 	// If <enter> use last command, if there was one.
 	if cmdstr == "" {
-		if c.lastCmd != nil {
-			return c.lastCmd
-		}
 		return nullCommand
 	}
 
@@ -465,7 +461,6 @@ func (c *Commands) Find(cmdstr string, prefix cmdPrefix) cmdfunc {
 			if prefix != noPrefix && v.allowedPrefixes&prefix == 0 {
 				continue
 			}
-			c.lastCmd = v.cmdFn
 			return v.cmdFn
 		}
 	}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -187,23 +187,6 @@ func TestCommandDefault(t *testing.T) {
 	}
 }
 
-func TestCommandReplay(t *testing.T) {
-	cmds := DebugCommands(nil)
-	cmds.Register("foo", func(t *Term, ctx callContext, args string) error { return fmt.Errorf("registered command") }, "foo command")
-	cmd := cmds.Find("foo", noPrefix)
-
-	err := cmd(nil, callContext{}, "")
-	if err.Error() != "registered command" {
-		t.Fatal("wrong command output")
-	}
-
-	cmd = cmds.Find("", noPrefix)
-	err = cmd(nil, callContext{}, "")
-	if err.Error() != "registered command" {
-		t.Fatal("wrong command output")
-	}
-}
-
 func TestCommandReplayWithoutPreviousCommand(t *testing.T) {
 	var (
 		cmds = DebugCommands(nil)

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -213,6 +213,8 @@ func (t *Term) Run() (int, error) {
 		}
 	}
 
+	var lastCmd string
+
 	for {
 		cmdstr, err := t.promptForInput()
 		if err != nil {
@@ -222,6 +224,12 @@ func (t *Term) Run() (int, error) {
 			}
 			return 1, fmt.Errorf("Prompt for input failed.\n")
 		}
+
+		if strings.TrimSpace(cmdstr) == "" {
+			cmdstr = lastCmd
+		}
+
+		lastCmd = cmdstr
 
 		if err := t.cmds.Call(cmdstr, t); err != nil {
 			if _, ok := err.(ExitRequestError); ok {


### PR DESCRIPTION
```
terminal: preserve arguments and prefixes when repeating last command

```
