### PR TITLE
*: Transfer 32-bit test into travis from cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,28 +1,9 @@
-freebsd_task:
-  env:
-    GOFLAGS: -mod=vendor
-  
-  freebsd_instance:
-    image: freebsd-11-2-release-amd64
+env:
+  GOFLAGS: -mod=vendor
 
+freebsd_instance:
+  image: freebsd-11-2-release-amd64
+
+test_task:
   install_script: pkg install -y go gcc git
   test_script: make test
-
-linux386_task:
-  container:
-    image: i386/ubuntu:18.04
-  env:
-    matrix:
-      - GOVERSION: 1.12
-      - GOVERSION: 1.13
-      - GOVERSION: 1.14
-  test_script:
-    -  apt-get -y update
-    -  apt-get -y install software-properties-common
-    -  apt-get -y install git
-    -  add-apt-repository ppa:longsleep/golang-backports
-    -  apt-get -y install golang-${GOVERSION}-go
-    -  export PATH=$PATH:/usr/lib/go-${GOVERSION}/bin
-    -  go version
-    -  uname -a
-    -  make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ arch:
   - arm64
 
 go:
-  - tip
   - 1.14.x
   - 1.13.x
   - 1.12.x
+  - tip
 
 matrix:
   allow_failures:
@@ -41,6 +41,31 @@ before_install:
   - export GOFLAGS=-mod=vendor
   - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo apt-get -qq update; sudo apt-get install -y dwz; echo "dwz version $(dwz --version)"; fi
   - if [ $TRAVIS_OS_NAME = "windows" ]; then choco install procdump make; fi
+
+
+# 386 linux
+jobs:
+  include:
+    -  os: linux
+       services: docker
+       env: go_32_version=1.14
+
+script: >-
+    if [ $TRAVIS_OS_NAME = "linux" ] && [ $go_32_version ]; then
+      docker pull i386/centos:7;
+      docker run -v $(pwd):/delve --privileged i386/centos:7 /bin/bash -c "set -x && \
+           cd delve && \
+           yum -y update && yum -y upgrade && \
+           yum -y install wget make git gcc && \
+           wget -q https://dl.google.com/go/go${go_32_version}.linux-386.tar.gz && \
+           tar -C /usr/local -xzf go${go_32_version}.linux-386.tar.gz && \
+           export PATH=$PATH:/usr/local/go/bin && \
+           go version && \
+           uname -a && \
+           make test";
+    else
+      make test;
+    fi
   
 cache:
   directories:


### PR DESCRIPTION
1. 32bit docker on cicurs CI
https://github.com/go-delve/delve/runs/501900175
https://github.com/go-delve/delve/runs/501900189
https://github.com/go-delve/delve/runs/498813610
https://github.com/go-delve/delve/runs/498813609
https://github.com/go-delve/delve/runs/498813615
...
This 32bit docker on cirrus CI  failed frequency. The erros all have similar memory problems.  
Then I do 
```for ((i=1; i<=300; i++)); do go test -v -test.run TestStepConcurrentDirect ; done```
 on cirrus CI, see the error every CI period. 
(150 loops is enough in fact)

2. Never reproduct on my local env.
   A. 386/centos  go1.12.8/go1.13.6/go1.14
   B. 386 docker on 64-bit ubunut (kernel 5.3) go1.12.8/go1.13.6/go1.14

3. amd64 on cicurs CI
Then I try test amd64 on cicurs CI and find same problem as 386. 
Also use 
```for ((i=1; i<=300; i++)); do go test -v -test.run TestStepConcurrentDirect ; done```
 on cirrus CI, see the same error every CI period. 
https://github.com/go-delve/delve/runs/507318116
https://github.com/go-delve/delve/runs/507318112
https://cirrus-ci.com/task/4921825478049792
https://github.com/go-delve/delve/runs/507957824
...


4. 64bit on travis CI
All are ok.
https://travis-ci.com/github/go-delve/delve/jobs/298173516
https://travis-ci.com/github/go-delve/delve/jobs/298173518
https://travis-ci.com/github/go-delve/delve/jobs/298174477
https://travis-ci.com/github/go-delve/delve/jobs/298174479
...
Also 
```for ((i=1; i<=600; i++)); do go test -v -test.run TestStepConcurrentDirect ; done```
 on cirrus CI, 
I use 600 loops here but all are ok.  

5. 32bit on travis CI 
https://travis-ci.com/github/go-delve/delve/jobs/298209841
https://travis-ci.com/github/go-delve/delve/jobs/298209842
https://travis-ci.com/github/go-delve/delve/jobs/298209843
...
All are ok, also 600 loops for teststepconcurrent



I think there maybe a problem about 386 docker with specify linux kernel for golang.
(May be similar to https://github.com/golang/go/issues/35777 ?)  

Sorry for this crude solution, I can't find a better way about ci failed of cicurs on 386 linux. Platform change is the only thing I can think of. Meanwhile I'm worried about complicating the .travis.yml file







**Ps**: 
1. I will close #1924 once this pr merged or a better way.
2. travis report display  

![image](https://user-images.githubusercontent.com/7046329/76690903-dc3bae80-667f-11ea-853b-bc7d91b766d3.png)   

3. other problem   
There's  other question of probability the ci test hang over 10 minutes, need time to find  reason .





