### PR TITLE
pkg/proc: Prevent program crash when called meanless expression

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1041,10 +1041,16 @@ func (scope *EvalScope) evalStructSelector(node *ast.SelectorExpr) (*Variable, e
 	if err != nil {
 		return nil, err
 	}
+
 	// Prevent abuse, attempting to call "nil.member" directly.
 	if xv.Addr == 0 && xv.Name == "nil" {
 		return nil, fmt.Errorf("%s (type %s) is not a struct", xv.Name, xv.TypeString())
 	}
+	// Prevent abuse, attempting to call "\"fake\".member" directly.
+	if xv.Addr == 0 && xv.Name == "" && xv.DwarfType == nil && xv.RealType == nil {
+		return nil, fmt.Errorf("%s (type %s) is not a struct", xv.Value, xv.TypeString())
+	}
+
 	rv, err := xv.findMethod(node.Sel.Name)
 	if err != nil {
 		return nil, err

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1195,6 +1195,8 @@ func TestCallFunction(t *testing.T) {
 		{"x.CallMe()", nil, nil},
 		{"x2.CallMe(5)", []string{":int:25"}, nil},
 
+		{"\"delve\".CallMe()", nil, errors.New("\"delve\" (type string) is not a struct")},
+
 		// Nested function calls tests
 
 		{`onetwothree(intcallpanic(2))`, []string{`:[]int:[]int len: 3, cap: 3, [3,4,5]`}, nil},


### PR DESCRIPTION
If we call one expression which is the fake method of meanless
string, `delve` will panic. Strengthen the inspection of boundary
conditions when supporting function calls on non-struct types.

Update: #1871  

-----   

Eg: 
```
package main

import (
	"fmt"
)

func main() {
	fmt.Printf("hello world\n")  // set breakpoint
}
```
```
(dlv) call "delve".callme()
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x6f614f]

goroutine 51 [running]:
github.com/go-delve/delve/pkg/proc.(*Variable).findMethod(0xc0001945a0, 0xc000362548, 0x6, 0xc0001945a0, 0x0, 0x0)
	/media/chainhelen/LENOVO/xlworkspace/code/go/src/github.com/go-delve/delve/pkg/proc/eval.go:1829 +0x16f
github.com/go-delve/delve/pkg/proc.(*EvalScope).evalStructSelector(0xc0000ab2b0, 0xc0000c1240, 0x5, 0xc000362548, 0x6)
	/media/chainhelen/LENOVO/xlworkspace/code/go/src/github.com/go-delve/delve/pkg/proc/eval.go:1048 +0xbe
github.com/go-delve/delve/pkg/proc.(*EvalScope).evalAST(0xc0000ab2b0, 0xcb9440, 0xc0000c1240, 0xc000498000, 0x300, 0x0)
	/media/chainhelen/LENOVO/xlworkspace/code/go/src/github.com/go-delve/delve/pkg/proc/eval.go:639 +0x718
github.com/go-delve/delve/pkg/proc.funcCallEvalFuncExpr(0xc0000ab2b0, 0xc0003c3d30, 0x4abf00, 0x0, 0x0)
	/media/chainhelen/LENOVO/xlworkspace/code/go/src/github.com/go-delve/delve/pkg/proc/fncall.go:404 +0x87
github.com/go-delve/delve/pkg/proc.evalFunctionCall(0xc0000ab2b0, 0xc0000d5bc0, 0x0, 0x0, 0xc000068e50)
	/media/chainhelen/LENOVO/xlworkspace/code/go/src/github.com/go-delve/delve/pkg/proc/fncall.go:273 +0x25d
github.com/go-delve/delve/pkg/proc.(*EvalScope).evalAST(0xc0000ab2b0, 0xcb8d00, 0xc0000d5bc0, 0x1, 0x1, 0x40)
	/media/chainhelen/LENOVO/xlworkspace/code/go/src/github.com/go-delve/delve/pkg/proc/eval.go:606 +0x2c2
github.com/go-delve/delve/pkg/proc.(*EvalScope).EvalExpression(0xc0000ab2b0, 0xc00016c0a0, 0x10, 0x1, 0x1, 0x40, 0x40, 0xffffffffffffffff, 0x0, 0x0, ...)
	/media/chainhelen/LENOVO/xlworkspace/code/go/src/github.com/go-delve/delve/pkg/proc/eval.go:77 +0x56c
created by github.com/go-delve/delve/pkg/proc.EvalExpressionWithCalls
	/media/chainhelen/LENOVO/xlworkspace/code/go/src/github.com/go-delve/delve/pkg/proc/fncall.go:185 +0x35a

```
