### PR TITLE
*: Add DeepSource CI config

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,13 @@
+version = 1
+
+test_patterns = ["**/*_test.go"]
+
+exclude_patterns = ["vendor"]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_path = "github.com/go-delve/delve"
+  dependencies_vendored = true


### PR DESCRIPTION
Adds a config for https://deepsource.io to enable some static analysis CI on this repo.