### PR TITLE
proc/gdbserial: add logging when Thread.Location will fail

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1268,6 +1268,11 @@ func (t *Thread) Location() (*proc.Location, error) {
 	if err != nil {
 		return nil, err
 	}
+	if pcreg, ok := regs.(*gdbRegisters).regs[regnamePC]; !ok {
+		t.p.conn.log.Errorf("thread %d could not find RIP register", t.ID)
+	} else if len(pcreg.value) < t.p.bi.Arch.PtrSize() {
+		t.p.conn.log.Errorf("thread %d bad length for RIP register: %d", t.ID, len(pcreg.value))
+	}
 	pc := regs.PC()
 	f, l, fn := t.p.bi.PCToLine(pc)
 	return &proc.Location{PC: pc, File: f, Line: l, Fn: fn}, nil


### PR DESCRIPTION
```
proc/gdbserial: add logging when Thread.Location will fail

Add logging for Issue #1927. The bug happens during the call to
api.ConvertThread, returning an error will not suffice since
ConvertThread will not surface it.

Updates #1927

```
