### PR TITLE
travis.yml: Add go_import_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 sudo: required
+go_import_path: github.com/go-delve/delve
 
 os:
   - linux

--- a/scripts/gen-travis.go
+++ b/scripts/gen-travis.go
@@ -58,6 +58,7 @@ func main() {
 	out := bufio.NewWriter(os.Stdout)
 	err := template.Must(template.New("travis.yml").Parse(`language: go
 sudo: required
+go_import_path: github.com/go-delve/delve
 
 os:
   - linux


### PR DESCRIPTION
This makes it so that CI will still work on forks, if necessary.