### PR TITLE
proc: fix switch to goroutine stack

### DIFF
--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -267,7 +267,7 @@ func (it *stackIterator) switchToGoroutineStack() {
 	it.top = false
 	it.pc = it.g.PC
 	it.regs.Reg(it.regs.SPRegNum).Uint64Val = it.g.SP
-	it.regs.Reg(it.regs.BPRegNum).Uint64Val = it.g.BP
+	it.regs.AddReg(it.regs.BPRegNum, op.DwarfRegisterFromUint64(it.g.BP))
 	if _, ok := it.bi.Arch.(*ARM64); ok {
 		it.regs.Reg(it.regs.LRRegNum).Uint64Val = it.g.LR
 	}


### PR DESCRIPTION
```
proc: fix switch to goroutine stack

When switching to the goroutine stack the stack iterator registers
might not have any entry for the BP register, make sure to add it
instead of just trying to change it.

```
