### PR TITLE
pkg/config: add `disassemble-flavor` option for config 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,9 @@ type Config struct {
 	// MaxVariableRecurse is output evaluation depth of nested struct members, array and
 	// slice items and dereference pointers
 	MaxVariableRecurse *int `yaml:"max-variable-recurse,omitempty"`
+	// DisassembleFlavor allow user to specify output syntax flavor of assembly, one of
+	// this list "intel"(default), "gnu", "go"
+	DisassembleFlavor *string `yaml:"disassemble-flavor,omitempty"`
 
 	// If ShowLocationExpr is true whatis will print the DWARF location
 	// expression for its argument.
@@ -224,6 +227,9 @@ substitute-path:
 
 # Uncomment the following line to make the whatis command also print the DWARF location expression of its argument.
 # show-location-expr: true
+
+# Allow user to specify output syntax flavor of assembly, one of this list "intel"(default), "gnu", "go".
+# disassemble-flavor: intel
 
 # List of directories to use when searching for separate debug info files.
 debug-info-directories: ["/usr/lib/debug/.build-id"]

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1914,6 +1914,18 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 		rest = argv[1]
 	}
 
+	flavor := api.IntelFlavour
+	if t.conf != nil && t.conf.DisassembleFlavor != nil {
+		switch *t.conf.DisassembleFlavor {
+		case "go":
+			flavor = api.GoFlavour
+		case "gnu":
+			flavor = api.GNUFlavour
+		default:
+			flavor = api.IntelFlavour
+		}
+	}
+
 	var disasm api.AsmInstructions
 	var disasmErr error
 
@@ -1923,7 +1935,7 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 		if err != nil {
 			return err
 		}
-		disasm, disasmErr = t.client.DisassemblePC(ctx.Scope, locs[0].PC, api.IntelFlavour)
+		disasm, disasmErr = t.client.DisassemblePC(ctx.Scope, locs[0].PC, flavor)
 	case "-a":
 		v := split2PartsBySpace(rest)
 		if len(v) != 2 {
@@ -1937,7 +1949,7 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 		if err != nil {
 			return fmt.Errorf("wrong argument: %q is not a number", v[1])
 		}
-		disasm, disasmErr = t.client.DisassembleRange(ctx.Scope, uint64(startpc), uint64(endpc), api.IntelFlavour)
+		disasm, disasmErr = t.client.DisassembleRange(ctx.Scope, uint64(startpc), uint64(endpc), flavor)
 	case "-l":
 		locs, err := t.client.FindLocation(ctx.Scope, rest, true)
 		if err != nil {
@@ -1946,7 +1958,7 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 		if len(locs) != 1 {
 			return errors.New("expression specifies multiple locations")
 		}
-		disasm, disasmErr = t.client.DisassemblePC(ctx.Scope, locs[0].PC, api.IntelFlavour)
+		disasm, disasmErr = t.client.DisassemblePC(ctx.Scope, locs[0].PC, flavor)
 	default:
 		return disasmUsageError
 	}

--- a/pkg/terminal/config.go
+++ b/pkg/terminal/config.go
@@ -130,6 +130,8 @@ func configureSet(t *Term, args string) error {
 		case reflect.Bool:
 			v := rest == "true"
 			return reflect.ValueOf(&v), nil
+		case reflect.String:
+			return reflect.ValueOf(&rest), nil
 		default:
 			return reflect.ValueOf(nil), fmt.Errorf("unsupported type for configuration key %q", cfgname)
 		}

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -408,6 +408,8 @@ const (
 	GNUFlavour = AssemblyFlavour(proc.GNUFlavour)
 	// IntelFlavour will disassemble using Intel assembly syntax.
 	IntelFlavour = AssemblyFlavour(proc.IntelFlavour)
+	// GoFlavour will disassemble using Go assembly syntax.
+	GoFlavour = AssemblyFlavour(proc.GoFlavour)
 )
 
 // AsmInstruction represents one assembly instruction at some address


### PR DESCRIPTION
Allow user to specify output syntax flavor of assembly in the
disassemble command.

Close #415