### PR TITLE
proc/tests: disable TestIssue414 on linux/386/pie

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1803,12 +1803,18 @@ func TestIssue396(t *testing.T) {
 }
 
 func TestIssue414(t *testing.T) {
+	if runtime.GOOS == "linux" && runtime.GOARCH == "386" && buildMode == "pie" {
+		t.Skip("test occasionally hangs on linux/386/pie")
+	}
 	// Stepping until the program exits
 	protest.AllowRecording(t)
 	withTestProcess("math", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 9)
 		assertNoError(p.Continue(), t, "Continue()")
 		for {
+			pc := currentPC(p, t)
+			f, ln := currentLineNumber(p, t)
+			t.Logf("at %s:%d %#x\n", f, ln, pc)
 			err := p.Step()
 			if err != nil {
 				if _, exited := err.(proc.ErrProcessExited); exited {


### PR DESCRIPTION
```
scripts/make: do not test buildmode=pie on linux/386

The tests have a tendency to hang, see for example:

https://travis-ci.com/github/go-delve/delve/jobs/301890354

```
