### PR TITLE
proc: avoid constructing unnecessary strings when evaluating variables

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -266,7 +266,8 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 			}
 			v.Name = name[1:]
 			v.Flags |= VariableEscaped
-			v.LocationExpr = locationExpr + " (escaped)"
+			locationExpr.isEscaped = true
+			v.LocationExpr = locationExpr
 			v.DeclLine = declLine
 			vars[i] = v
 		}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -118,8 +118,8 @@ type Variable struct {
 	loaded     bool
 	Unreadable error
 
-	LocationExpr string // location expression
-	DeclLine     int64  // line number of this variable's declaration
+	LocationExpr *locationExpr // location expression
+	DeclLine     int64         // line number of this variable's declaration
 }
 
 // LoadConfig controls how variables are loaded from the targets memory.
@@ -441,8 +441,6 @@ func newGVariable(thread Thread, gaddr uintptr, deref bool) (*Variable, error) {
 		return nil, err
 	}
 
-	name := ""
-
 	if deref {
 		typ = &godwarf.PtrType{
 			CommonType: godwarf.CommonType{
@@ -453,11 +451,9 @@ func newGVariable(thread Thread, gaddr uintptr, deref bool) (*Variable, error) {
 			},
 			Type: typ,
 		}
-	} else {
-		name = "runtime.curg"
 	}
 
-	return newVariableFromThread(thread, name, gaddr, typ), nil
+	return newVariableFromThread(thread, "", gaddr, typ), nil
 }
 
 // Defer returns the top-most defer of the goroutine.
@@ -850,6 +846,8 @@ func (v *Variable) parseG() (*G, error) {
 	}
 
 	f, l, fn := v.bi.PCToLine(uint64(pc))
+
+	v.Name = "runtime.curg"
 
 	g := &G{
 		ID:         int(id),

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -148,7 +148,7 @@ func ConvertVar(v *proc.Variable) *Variable {
 		Flags:    VariableFlags(v.Flags),
 		Base:     v.Base,
 
-		LocationExpr: v.LocationExpr,
+		LocationExpr: v.LocationExpr.String(),
 		DeclLine:     v.DeclLine,
 	}
 


### PR DESCRIPTION
```
proc: avoid constructing unnecessary strings when evaluating variables

Avoids constructing:

1. name of runtime.curg fields while executing parseG
2. the location expression while evaluating any variable.

Benchmark before:

BenchmarkConditionalBreakpoints-4   	       1	4953889884 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	4419775128 ns/op

Updates #1549

```
