### PR TITLE
service/dap: Change event reason to "entry" when stopping on entry

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -438,7 +438,7 @@ func (s *Server) onConfigurationDoneRequest(request *dap.ConfigurationDoneReques
 	if s.stopOnEntry {
 		e := &dap.StoppedEvent{
 			Event: *newEvent("stopped"),
-			Body:  dap.StoppedEventBody{Reason: "breakpoint", ThreadId: 1, AllThreadsStopped: true},
+			Body:  dap.StoppedEventBody{Reason: "entry", ThreadId: 1, AllThreadsStopped: true},
 		}
 		s.send(e)
 	}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -135,10 +135,10 @@ func TestStopOnEntry(t *testing.T) {
 		client.ConfigurationDoneRequest()
 		stopEvent := client.ExpectStoppedEvent(t)
 		if stopEvent.Seq != 0 ||
-			stopEvent.Body.Reason != "breakpoint" ||
+			stopEvent.Body.Reason != "entry" ||
 			stopEvent.Body.ThreadId != 1 ||
 			!stopEvent.Body.AllThreadsStopped {
-			t.Errorf("\ngot %#v\nwant Seq=0, Body={Reason=\"breakpoint\", ThreadId=1, AllThreadsStopped=true}", stopEvent)
+			t.Errorf("\ngot %#v\nwant Seq=0, Body={Reason=\"entry\", ThreadId=1, AllThreadsStopped=true}", stopEvent)
 		}
 		cdResp := client.ExpectConfigurationDoneResponse(t)
 		if cdResp.Seq != 0 || cdResp.RequestSeq != 5 {


### PR DESCRIPTION
Existing code matched [vscode-go](https://github.com/microsoft/vscode-go/blob/master/src/debugAdapter/goDebug.ts#L824), setting reason to 'breakpoint', but that's misleading and according to the [spec](https://microsoft.github.io/debug-adapter-protocol/specification#Events_Stopped), there is a special option for entry. Use that option. This impacts what is displayed in the UI ('paused on breakpoint' vs 'paused on entry').
<img width="500" alt="pause-on-entry" src="https://user-images.githubusercontent.com/51177946/78054766-6732cf00-7337-11ea-8e05-832b08afd364.png">

