### PR TITLE
Only load floating point registers when needed

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -170,7 +170,7 @@ type thread struct {
 }
 
 type osThread interface {
-	registers(floatingPoint bool) (proc.Registers, error)
+	registers() (proc.Registers, error)
 	pid() int
 }
 
@@ -281,7 +281,7 @@ func (t *thread) WriteMemory(addr uintptr, data []byte) (int, error) {
 // Location returns the location of this thread based on
 // the value of the instruction pointer register.
 func (t *thread) Location() (*proc.Location, error) {
-	regs, err := t.th.registers(false)
+	regs, err := t.th.registers()
 	if err != nil {
 		return nil, err
 	}
@@ -303,8 +303,8 @@ func (t *thread) ThreadID() int {
 }
 
 // Registers returns the current value of the registers for this thread.
-func (t *thread) Registers(floatingPoint bool) (proc.Registers, error) {
-	return t.th.registers(floatingPoint)
+func (t *thread) Registers() (proc.Registers, error) {
+	return t.th.registers()
 }
 
 // RestoreRegisters will only return an error for core files,

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -187,7 +187,9 @@ func withCoreFile(t *testing.T, name, args string) *proc.Target {
 
 func logRegisters(t *testing.T, regs proc.Registers, arch *proc.Arch) {
 	dregs := arch.RegistersToDwarfRegisters(0, regs)
-	for i, reg := range dregs.Regs {
+	dregs.Reg(^uint64(0))
+	for i := 0; i < dregs.CurrentSize(); i++ {
+		reg := dregs.Reg(uint64(i))
 		if reg == nil {
 			continue
 		}
@@ -250,7 +252,7 @@ func TestCore(t *testing.T) {
 		t.Errorf("main.msg = %q, want %q", msg.Value, "BOOM!")
 	}
 
-	regs, err := p.CurrentThread().Registers(true)
+	regs, err := p.CurrentThread().Registers()
 	if err != nil {
 		t.Fatalf("Couldn't get current thread registers: %v", err)
 	}
@@ -286,7 +288,7 @@ func TestCoreFpRegisters(t *testing.T) {
 				continue
 			}
 			if frames[i].Current.Fn.Name == "main.main" {
-				regs, err = thread.Registers(true)
+				regs, err = thread.Registers()
 				if err != nil {
 					t.Fatalf("Could not get registers for thread %x, %v", thread.ThreadID(), err)
 				}
@@ -326,7 +328,9 @@ func TestCoreFpRegisters(t *testing.T) {
 
 	for _, regtest := range regtests {
 		found := false
-		for i, reg := range dregs.Regs {
+		dregs.Reg(^uint64(0))
+		for i := 0; i < dregs.CurrentSize(); i++ {
+			reg := dregs.Reg(uint64(i))
 			regname, _, regval := arch.DwarfRegisterToString(i, reg)
 			if reg != nil && regname == regtest.name {
 				found = true

--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -154,21 +154,17 @@ type linuxARM64Thread struct {
 	t    *linuxPrStatusARM64
 }
 
-func (t *linuxAMD64Thread) registers(floatingPoint bool) (proc.Registers, error) {
+func (t *linuxAMD64Thread) registers() (proc.Registers, error) {
 	var r linutil.AMD64Registers
 	r.Regs = t.regs.Regs
-	if floatingPoint {
-		r.Fpregs = t.regs.Fpregs
-	}
+	r.Fpregs = t.regs.Fpregs
 	return &r, nil
 }
 
-func (t *linuxARM64Thread) registers(floatingPoint bool) (proc.Registers, error) {
+func (t *linuxARM64Thread) registers() (proc.Registers, error) {
 	var r linutil.ARM64Registers
 	r.Regs = t.regs.Regs
-	if floatingPoint {
-		r.Fpregs = t.regs.Fpregs
-	}
+	r.Fpregs = t.regs.Fpregs
 	return &r, nil
 }
 

--- a/pkg/proc/core/windows_amd64_minidump.go
+++ b/pkg/proc/core/windows_amd64_minidump.go
@@ -54,6 +54,6 @@ func (th *windowsAMD64Thread) pid() int {
 	return int(th.th.ID)
 }
 
-func (th *windowsAMD64Thread) registers(floatingPoint bool) (proc.Registers, error) {
-	return winutil.NewAMD64Registers(&th.th.Context, th.th.TEB, floatingPoint), nil
+func (th *windowsAMD64Thread) registers() (proc.Registers, error) {
+	return winutil.NewAMD64Registers(&th.th.Context, th.th.TEB), nil
 }

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -232,7 +232,7 @@ func TestDwarfExprLoclist(t *testing.T) {
 
 	uintExprCheck(t, scope, "a", before)
 	scope.PC = 0x40800
-	scope.Regs.Regs[scope.Regs.PCRegNum].Uint64Val = scope.PC
+	scope.Regs.Reg(scope.Regs.PCRegNum).Uint64Val = scope.PC
 	uintExprCheck(t, scope, "a", after)
 }
 

--- a/pkg/proc/mem.go
+++ b/pkg/proc/mem.go
@@ -104,6 +104,9 @@ func newCompositeMemory(mem MemoryReadWriter, regs op.DwarfRegisters, pieces []o
 				sz = len(reg)
 			}
 			if sz > len(reg) {
+				if regs.FloatLoadError != nil {
+					return nil, fmt.Errorf("could not read %d bytes from register %d (size: %d), also error loading floating point registers: %v", sz, piece.RegNum, len(reg), regs.FloatLoadError)
+				}
 				return nil, fmt.Errorf("could not read %d bytes from register %d (size: %d)", sz, piece.RegNum, len(reg))
 			}
 			cmem.data = append(cmem.data, reg[:sz]...)

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -39,7 +39,7 @@ func killProcess(pid int) error {
 	panic(ErrNativeBackendDisabled)
 }
 
-func registers(thread *nativeThread, floatingPoint bool) (proc.Registers, error) {
+func registers(thread *nativeThread) (proc.Registers, error) {
 	panic(ErrNativeBackendDisabled)
 }
 

--- a/pkg/proc/native/registers_freebsd_amd64.go
+++ b/pkg/proc/native/registers_freebsd_amd64.go
@@ -11,7 +11,7 @@ import (
 
 // SetPC sets RIP to the value specified by 'pc'.
 func (thread *nativeThread) SetPC(pc uint64) error {
-	ir, err := registers(thread, false)
+	ir, err := registers(thread)
 	if err != nil {
 		return err
 	}
@@ -24,7 +24,7 @@ func (thread *nativeThread) SetPC(pc uint64) error {
 // SetSP sets RSP to the value specified by 'sp'
 func (thread *nativeThread) SetSP(sp uint64) (err error) {
 	var ir proc.Registers
-	ir, err = registers(thread, false)
+	ir, err = registers(thread)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (thread *nativeThread) SetSP(sp uint64) (err error) {
 
 func (thread *nativeThread) SetDX(dx uint64) (err error) {
 	var ir proc.Registers
-	ir, err = registers(thread, false)
+	ir, err = registers(thread)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (thread *nativeThread) SetDX(dx uint64) (err error) {
 	return
 }
 
-func registers(thread *nativeThread, floatingPoint bool) (proc.Registers, error) {
+func registers(thread *nativeThread) (proc.Registers, error) {
 	var (
 		regs fbsdutil.AMD64PtraceRegs
 		err  error
@@ -60,15 +60,13 @@ func registers(thread *nativeThread, floatingPoint bool) (proc.Registers, error)
 	if err != nil {
 		return nil, err
 	}
-	r := &fbsdutil.AMD64Registers{&regs, nil, nil, uint64(fsbase)}
-	if floatingPoint {
+	r := fbsdutil.NewAMD64Registers(&regs, uint64(fsbase), func(r *fbsdutil.AMD64Registers) error {
 		var fpregset fbsdutil.AMD64Xstate
-		r.Fpregs, fpregset, err = thread.fpRegisters()
+		var floatLoadError error
+		r.Fpregs, fpregset, floatLoadError = thread.fpRegisters()
 		r.Fpregset = &fpregset
-		if err != nil {
-			return nil, err
-		}
-	}
+		return floatLoadError
+	})
 	return r, nil
 }
 

--- a/pkg/proc/native/registers_linux_amd64.go
+++ b/pkg/proc/native/registers_linux_amd64.go
@@ -11,7 +11,7 @@ import (
 
 // SetPC sets RIP to the value specified by 'pc'.
 func (thread *nativeThread) SetPC(pc uint64) error {
-	ir, err := registers(thread, false)
+	ir, err := registers(thread)
 	if err != nil {
 		return err
 	}
@@ -24,7 +24,7 @@ func (thread *nativeThread) SetPC(pc uint64) error {
 // SetSP sets RSP to the value specified by 'sp'
 func (thread *nativeThread) SetSP(sp uint64) (err error) {
 	var ir proc.Registers
-	ir, err = registers(thread, false)
+	ir, err = registers(thread)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (thread *nativeThread) SetSP(sp uint64) (err error) {
 
 func (thread *nativeThread) SetDX(dx uint64) (err error) {
 	var ir proc.Registers
-	ir, err = registers(thread, false)
+	ir, err = registers(thread)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (thread *nativeThread) SetDX(dx uint64) (err error) {
 	return
 }
 
-func registers(thread *nativeThread, floatingPoint bool) (proc.Registers, error) {
+func registers(thread *nativeThread) (proc.Registers, error) {
 	var (
 		regs linutil.AMD64PtraceRegs
 		err  error
@@ -55,15 +55,13 @@ func registers(thread *nativeThread, floatingPoint bool) (proc.Registers, error)
 	if err != nil {
 		return nil, err
 	}
-	r := &linutil.AMD64Registers{Regs: &regs}
-	if floatingPoint {
+	r := linutil.NewAMD64Registers(&regs, func(r *linutil.AMD64Registers) error {
 		var fpregset linutil.AMD64Xstate
-		r.Fpregs, fpregset, err = thread.fpRegisters()
+		var floatLoadError error
+		r.Fpregs, fpregset, floatLoadError = thread.fpRegisters()
 		r.Fpregset = &fpregset
-		if err != nil {
-			return nil, err
-		}
-	}
+		return floatLoadError
+	})
 	return r, nil
 }
 

--- a/pkg/proc/native/registers_windows_amd64.go
+++ b/pkg/proc/native/registers_windows_amd64.go
@@ -52,7 +52,7 @@ func (thread *nativeThread) SetDX(dx uint64) error {
 	return _SetThreadContext(thread.os.hThread, context)
 }
 
-func registers(thread *nativeThread, floatingPoint bool) (proc.Registers, error) {
+func registers(thread *nativeThread) (proc.Registers, error) {
 	context := winutil.NewCONTEXT()
 
 	context.ContextFlags = _CONTEXT_ALL
@@ -67,5 +67,5 @@ func registers(thread *nativeThread, floatingPoint bool) (proc.Registers, error)
 		return nil, fmt.Errorf("NtQueryInformationThread failed: it returns 0x%x", status)
 	}
 
-	return winutil.NewAMD64Registers(context, uint64(threadInfo.TebBaseAddress), floatingPoint), nil
+	return winutil.NewAMD64Registers(context, uint64(threadInfo.TebBaseAddress)), nil
 }

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -157,8 +157,8 @@ func (t *nativeThread) ClearBreakpoint(bp *proc.Breakpoint) error {
 }
 
 // Registers obtains register values from the debugged process.
-func (t *nativeThread) Registers(floatingPoint bool) (proc.Registers, error) {
-	return registers(t, floatingPoint)
+func (t *nativeThread) Registers() (proc.Registers, error) {
+	return registers(t)
 }
 
 // RestoreRegisters will set the value of the CPU registers to those
@@ -169,7 +169,7 @@ func (t *nativeThread) RestoreRegisters(savedRegs proc.Registers) error {
 
 // PC returns the current program counter value for this thread.
 func (t *nativeThread) PC() (uint64, error) {
-	regs, err := t.Registers(false)
+	regs, err := t.Registers()
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -87,7 +87,7 @@ func (t *nativeThread) resume() error {
 
 func (t *nativeThread) Blocked() bool {
 	// TODO(dp) cache the func pc to remove this lookup
-	regs, err := t.Registers(false)
+	regs, err := t.Registers()
 	if err != nil {
 		return false
 	}

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -72,7 +72,7 @@ func (t *nativeThread) singleStep() (err error) {
 }
 
 func (t *nativeThread) Blocked() bool {
-	regs, err := t.Registers(false)
+	regs, err := t.Registers()
 	if err != nil {
 		return false
 	}

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -114,7 +114,7 @@ func (t *nativeThread) resume() error {
 func (t *nativeThread) Blocked() bool {
 	// TODO: Probably incorrect - what are the runtime functions that
 	// indicate blocking on Windows?
-	regs, err := t.Registers(false)
+	regs, err := t.Registers()
 	if err != nil {
 		return false
 	}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -90,7 +90,7 @@ func withTestProcessArgs(name string, t testing.TB, wd string, args []string, bu
 }
 
 func getRegisters(p *proc.Target, t *testing.T) proc.Registers {
-	regs, err := p.CurrentThread().Registers(false)
+	regs, err := p.CurrentThread().Registers()
 	if err != nil {
 		t.Fatal("Registers():", err)
 	}
@@ -113,7 +113,7 @@ func assertNoError(err error, t testing.TB, s string) {
 }
 
 func currentPC(p *proc.Target, t *testing.T) uint64 {
-	regs, err := p.CurrentThread().Registers(false)
+	regs, err := p.CurrentThread().Registers()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestBreakpoint(t *testing.T) {
 		bp := setFunctionBreakpoint(p, t, "main.helloworld")
 		assertNoError(p.Continue(), t, "Continue()")
 
-		regs, err := p.CurrentThread().Registers(false)
+		regs, err := p.CurrentThread().Registers()
 		assertNoError(err, t, "Registers")
 		pc := regs.PC()
 
@@ -302,7 +302,7 @@ func TestBreakpointInSeparateGoRoutine(t *testing.T) {
 
 		assertNoError(p.Continue(), t, "Continue")
 
-		regs, err := p.CurrentThread().Registers(false)
+		regs, err := p.CurrentThread().Registers()
 		assertNoError(err, t, "Registers")
 		pc := regs.PC()
 
@@ -409,7 +409,7 @@ func testseq2Args(wd string, args []string, buildFlags protest.BuildFlags, t *te
 		if traceTestseq2 {
 			t.Logf("initial breakpoint %v", bp)
 		}
-		regs, err := p.CurrentThread().Registers(false)
+		regs, err := p.CurrentThread().Registers()
 		assertNoError(err, t, "Registers")
 
 		f, ln := currentLineNumber(p, t)
@@ -474,7 +474,7 @@ func testseq2Args(wd string, args []string, buildFlags protest.BuildFlags, t *te
 			}
 
 			f, ln = currentLineNumber(p, t)
-			regs, _ = p.CurrentThread().Registers(false)
+			regs, _ = p.CurrentThread().Registers()
 			pc := regs.PC()
 
 			if traceTestseq2 {
@@ -710,7 +710,7 @@ func TestRuntimeBreakpoint(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		regs, err := p.CurrentThread().Registers(false)
+		regs, err := p.CurrentThread().Registers()
 		assertNoError(err, t, "Registers")
 		pc := regs.PC()
 		f, l, _ := p.BinInfo().PCToLine(pc)
@@ -1770,7 +1770,7 @@ func TestIssue332_Part2(t *testing.T) {
 			}
 		}
 
-		regs, err := p.CurrentThread().Registers(false)
+		regs, err := p.CurrentThread().Registers()
 		assertNoError(err, t, "Registers()")
 		pc := regs.PC()
 		pcAfterPrologue := findFunctionLocation(p, t, "main.changeMe")
@@ -2502,7 +2502,7 @@ func TestStepOnCallPtrInstr(t *testing.T) {
 			if ln != 10 {
 				break
 			}
-			regs, err := p.CurrentThread().Registers(false)
+			regs, err := p.CurrentThread().Registers()
 			assertNoError(err, t, "Registers()")
 			pc := regs.PC()
 			text, err := proc.Disassemble(p.CurrentThread(), regs, p.Breakpoints(), p.BinInfo(), pc, pc+uint64(p.BinInfo().Arch.MaxInstructionLength()))
@@ -3611,7 +3611,7 @@ func TestDisassembleGlobalVars(t *testing.T) {
 	}
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
 		mainfn := p.BinInfo().LookupFunc["main.main"]
-		regs, _ := p.CurrentThread().Registers(false)
+		regs, _ := p.CurrentThread().Registers()
 		text, err := proc.Disassemble(p.CurrentThread(), regs, p.Breakpoints(), p.BinInfo(), mainfn.Entry, mainfn.End)
 		assertNoError(err, t, "Disassemble")
 		found := false
@@ -4168,7 +4168,7 @@ func TestIssue1374(t *testing.T) {
 		assertNoError(proc.EvalExpressionWithCalls(p, p.SelectedGoroutine(), "getNum()", normalLoadConfig, true), t, "Call")
 		err := p.Continue()
 		if _, isexited := err.(proc.ErrProcessExited); !isexited {
-			regs, _ := p.CurrentThread().Registers(false)
+			regs, _ := p.CurrentThread().Registers()
 			f, l, _ := p.BinInfo().PCToLine(regs.PC())
 			t.Fatalf("expected process exited error got %v at %s:%d", err, f, l)
 		}

--- a/pkg/proc/registers.go
+++ b/pkg/proc/registers.go
@@ -21,10 +21,10 @@ type Registers interface {
 	// GAddr returns the address of the G variable if it is known, 0 and false otherwise
 	GAddr() (uint64, bool)
 	Get(int) (uint64, error)
-	Slice(floatingPoint bool) []Register
+	Slice(floatingPoint bool) ([]Register, error)
 	// Copy returns a copy of the registers that is guaranteed not to change
 	// when the registers of the associated thread change.
-	Copy() Registers
+	Copy() (Registers, error)
 }
 
 // Register represents a CPU register.

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -95,7 +95,7 @@ func (frame *Stackframe) FramePointerOffset() int64 {
 func ThreadStacktrace(thread Thread, depth int) ([]Stackframe, error) {
 	g, _ := GetG(thread)
 	if g == nil {
-		regs, err := thread.Registers(true)
+		regs, err := thread.Registers()
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +114,7 @@ func (g *G) stackIterator(opts StacktraceOptions) (*stackIterator, error) {
 
 	bi := g.variable.bi
 	if g.Thread != nil {
-		regs, err := g.Thread.Registers(true)
+		regs, err := g.Thread.Registers()
 		if err != nil {
 			return nil, err
 		}
@@ -456,8 +456,8 @@ func (it *stackIterator) advanceRegs() (callFrameRegs op.DwarfRegisters, ret uin
 	}
 
 	if it.bi.Arch.Name == "arm64" {
-		if ret == 0 && it.regs.Regs[it.regs.LRRegNum] != nil {
-			ret = it.regs.Regs[it.regs.LRRegNum].Uint64Val
+		if ret == 0 && it.regs.Reg(it.regs.LRRegNum) != nil {
+			ret = it.regs.Reg(it.regs.LRRegNum).Uint64Val
 		}
 	}
 
@@ -666,7 +666,7 @@ func (d *Defer) EvalScope(thread Thread) (*EvalScope, error) {
 	// the space occupied by pushing the return address on the stack during the
 	// CALL.
 	scope.Regs.CFA = (int64(d.variable.Addr) + d.variable.RealType.Common().ByteSize)
-	scope.Regs.Regs[scope.Regs.SPRegNum].Uint64Val = uint64(scope.Regs.CFA - int64(bi.Arch.PtrSize()))
+	scope.Regs.Reg(scope.Regs.SPRegNum).Uint64Val = uint64(scope.Regs.CFA - int64(bi.Arch.PtrSize()))
 
 	rdr := scope.Fn.cu.image.dwarfReader
 	rdr.Seek(scope.Fn.offset)

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -230,7 +230,7 @@ func pickCurrentThread(dbp *Target, trapthread Thread, threads []Thread) error {
 }
 
 func disassembleCurrentInstruction(p Process, thread Thread) ([]AsmInstruction, error) {
-	regs, err := thread.Registers(false)
+	regs, err := thread.Registers()
 	if err != nil {
 		return nil, err
 	}
@@ -474,7 +474,7 @@ func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 	var regs Registers
 	if selg != nil && selg.Thread != nil {
 		thread = selg.Thread
-		regs, err = selg.Thread.Registers(false)
+		regs, err = selg.Thread.Registers()
 		if err != nil {
 			return err
 		}

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -19,7 +19,7 @@ type Thread interface {
 	// SetPC/SetSP/etc.
 	// To insure that the the returned variable won't change call the Copy
 	// method of Registers.
-	Registers(floatingPoint bool) (Registers, error)
+	Registers() (Registers, error)
 
 	// RestoreRegisters restores saved registers
 	RestoreRegisters(Registers) error

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -422,7 +422,7 @@ func FindGoroutine(dbp *Target, gid int) (*G, error) {
 }
 
 func getGVariable(thread Thread) (*Variable, error) {
-	regs, err := thread.Registers(false)
+	regs, err := thread.Registers()
 	if err != nil {
 		return nil, err
 	}

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -330,8 +330,11 @@ func LoadConfigFromProc(cfg *proc.LoadConfig) *LoadConfig {
 
 // ConvertRegisters converts proc.Register to api.Register for a slice.
 func ConvertRegisters(in op.DwarfRegisters, arch *proc.Arch, floatingPoint bool) (out []Register) {
-	out = make([]Register, 0, len(in.Regs))
-	for i := range in.Regs {
+	if floatingPoint {
+		in.Reg(^uint64(0)) // force loading all registers
+	}
+	out = make([]Register, 0, in.CurrentSize())
+	for i := 0; i < in.CurrentSize(); i++ {
 		reg := in.Reg(uint64(i))
 		if reg == nil {
 			continue

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1439,7 +1439,7 @@ func setFileBreakpoint(p *proc.Target, t *testing.T, fixture protest.Fixture, li
 }
 
 func currentLocation(p *proc.Target, t *testing.T) (pc uint64, f string, ln int, fn *proc.Function) {
-	regs, err := p.CurrentThread().Registers(false)
+	regs, err := p.CurrentThread().Registers()
 	if err != nil {
 		t.Fatalf("Registers error: %v", err)
 	}


### PR DESCRIPTION
```
proc/*: only load floating point registers when needed

Changes implementations of proc.Registers interface and the
op.DwarfRegisters struct so that floating point registers can be loaded
only when they are needed.
Removes the floatingPoint parameter from proc.Thread.Registers.
This accomplishes three things:

1. it simplifies the proc.Thread.Registers interface
2. it makes it impossible to accidentally create a broken set of saved
registers or of op.DwarfRegisters by accidentally calling
Registers(false)
3. it improves general performance of Delve by avoiding to load
floating point registers as much as possible

Floating point registers are loaded under two circumstances:

1. When the Slice method is called with floatingPoint == true
2. When the Copy method is called

Benchmark before:

BenchmarkConditionalBreakpoints-4   	       1	4327350142 ns/op

Benchmark after:

BenchmarkConditionalBreakpoints-4   	       1	3852642917 ns/op

Updates #1549

proc: do not convert floating point registers until needed

```
