### PR TITLE
Use proper spelling of Xcode

### DIFF
--- a/Documentation/installation/osx/install.md
+++ b/Documentation/installation/osx/install.md
@@ -14,7 +14,7 @@ $ go get -u github.com/go-delve/delve/cmd/dlv
 
 With this method you will not be able to use delve's native backend, *but you don't need it anyway*: the native backend on macOS [has known problems](https://github.com/go-delve/delve/issues/1112) on recent issues of the OS and is not currently maintained.
 
-If you didn't enable Developer Mode using XCode you will be asked to authorize the debugger every time you use it. To enable Developer Mode and only have to authorize once per session use:
+If you didn't enable Developer Mode using Xcode you will be asked to authorize the debugger every time you use it. To enable Developer Mode and only have to authorize once per session use:
 
 ```
 sudo /usr/sbin/DevToolsSecurity -enable

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -291,7 +291,7 @@ func (d *Debugger) Attach(pid int, path string) (*proc.Target, error) {
 	}
 }
 
-var errMacOSBackendUnavailable = errors.New("debugserver or lldb-server not found: install XCode's command line tools or lldb-server")
+var errMacOSBackendUnavailable = errors.New("debugserver or lldb-server not found: install Xcode's command line tools or lldb-server")
 
 func betterGdbserialLaunchError(p *proc.Target, err error) (*proc.Target, error) {
 	if runtime.GOOS != "darwin" {


### PR DESCRIPTION
Two minor spelling fixes to use the correct casing for "Xcode"