### PR TITLE
cmd/dlv: Add support for piping data to cmd stdin

### DIFF
--- a/_fixtures/stdintest/main.go
+++ b/_fixtures/stdintest/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	line, _, err := bufio.NewReader(os.Stdin).ReadLine()
+
+	if err != nil {
+		os.Exit(1)
+	}
+
+	fmt.Println("echo:", string(line))
+}

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -65,12 +65,12 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string) (*
 	dbp.execPtraceFunc(func() {
 		process = exec.Command(cmd[0])
 		process.Args = cmd
+		process.Stdin = os.Stdin
 		process.Stdout = os.Stdout
 		process.Stderr = os.Stderr
 		process.SysProcAttr = &syscall.SysProcAttr{Ptrace: true, Setpgid: true, Foreground: foreground}
 		if foreground {
 			signal.Ignore(syscall.SIGTTOU, syscall.SIGTTIN)
-			process.Stdin = os.Stdin
 		}
 		if wd != "" {
 			process.Dir = wd


### PR DESCRIPTION
This change adds the support for piping data to the command stdin, as for example:

    $ cat <file> | dlv debug --headless ...

In any case it shouldn't be a problem to pass the existing stdin to the process that is being debugged.