### PR TITLE
Documentation: add modules mode note to install documentation

### DIFF
--- a/Documentation/installation/freebsd/install.md
+++ b/Documentation/installation/freebsd/install.md
@@ -5,8 +5,10 @@ Please use the following steps to build and install Delve on FreeBSD.
 There are two ways to install on FreeBSD. First is the standard `go get` method:
 
 ```
-go get -u github.com/go-delve/delve/cmd/dlv
+go get github.com/go-delve/delve/cmd/dlv
 ```
+
+Note: if you are using Go in modules mode you must execute this command outside of a module directory or Delve will be added to your project as a dependency.
 
 Alternatively make sure $GOPATH is set (e.g. as `~/.go`) and:
 
@@ -16,4 +18,3 @@ $ cd $GOPATH/src/github.com/go-delve/delve
 $ gmake install
 ```
 
-Note: If you are using Go 1.5 you must set `GO15VENDOREXPERIMENT=1` before continuing. The `GO15VENDOREXPERIMENT` env var simply opts into the [Go 1.5 Vendor Experiment](https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/).

--- a/Documentation/installation/linux/install.md
+++ b/Documentation/installation/linux/install.md
@@ -5,8 +5,10 @@ Please use the following steps to build and install Delve on Linux.
 There are two ways to install on Linux. First is the standard `go get` method:
 
 ```
-go get -u github.com/go-delve/delve/cmd/dlv
+go get github.com/go-delve/delve/cmd/dlv
 ```
+
+Note: if you are using Go in modules mode you must execute this command outside of a module directory or Delve will be added to your project as a dependency.
 
 Alternatively make sure $GOPATH is set (e.g. as `~/.go`) and:
 
@@ -15,5 +17,3 @@ $ git clone https://github.com/go-delve/delve.git $GOPATH/src/github.com/go-delv
 $ cd $GOPATH/src/github.com/go-delve/delve
 $ make install
 ```
-
-Note: If you are using Go 1.5 you must set `GO15VENDOREXPERIMENT=1` before continuing. The `GO15VENDOREXPERIMENT` env var simply opts into the [Go 1.5 Vendor Experiment](https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/).

--- a/Documentation/installation/osx/install.md
+++ b/Documentation/installation/osx/install.md
@@ -9,8 +9,10 @@ This should be as simple as:
 Now you can install delve using `go get`:
 
 ```
-$ go get -u github.com/go-delve/delve/cmd/dlv
+$ go get github.com/go-delve/delve/cmd/dlv
 ```
+
+Note: if you are using Go in modules mode you must execute this command outside of a module directory or Delve will be added to your project as a dependency.
 
 With this method you will not be able to use delve's native backend, *but you don't need it anyway*: the native backend on macOS [has known problems](https://github.com/go-delve/delve/issues/1112) on recent issues of the OS and is not currently maintained.
 

--- a/Documentation/installation/windows/install.md
+++ b/Documentation/installation/windows/install.md
@@ -3,9 +3,9 @@
 Please use the standard `go get` command to build and install Delve on Windows.
 
 ```
-go get -u github.com/go-delve/delve/cmd/dlv
+go get github.com/go-delve/delve/cmd/dlv
 ```
 
-Also, if not already set, you have to add the %GOPATH%\bin directory to your PATH variable.
+Note: if you are using Go in modules mode you must execute this command outside of a module directory or Delve will be added to your project as a dependency.
 
-Note: If you are using Go 1.5 you must set `GO15VENDOREXPERIMENT=1` before continuing. The `GO15VENDOREXPERIMENT` env var simply opts into the [Go 1.5 Vendor Experiment](https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/).
+Also, if not already set, you have to add the %GOPATH%\bin directory to your PATH variable.


### PR DESCRIPTION
```
Documentation: add modules mode note to install documentation

1. Adds a note to the documentation describing how to use 'go get' in
modules mode
2. Removes the '-u' option which, when 'go get' is used incorrectly
will make 'go' try to compile Delve with unsupported dependencies
3. Removed obsolete note about Go 1.5 vendor experiment.

Fixes #1988

```
