### PR TITLE
proc: better support for C pointers

### DIFF
--- a/Documentation/cli/expr.md
+++ b/Documentation/cli/expr.md
@@ -106,3 +106,7 @@ Packages with the same name can be disambiguated by using the full package path.
 (dlv) p "some/package".A
 (dlv) p "some/other/package".A
 ```
+
+# Pointers in Cgo
+
+Char pointers are always treated as NUL terminated strings, both indexing and the slice operator can be applied to them. Other C pointers can also be used similarly to Go slices, with indexing and the slice operator. In both of these cases it is up to the user to respect array bounds.

--- a/_fixtures/testvariablescgo/test.c
+++ b/_fixtures/testvariablescgo/test.c
@@ -1,0 +1,38 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef __amd64__
+#define BREAKPOINT asm("int3;")
+#elif __i386__
+#define BREAKPOINT asm("int3;")
+#elif __aarch64__
+#define BREAKPOINT asm("brk 0;")
+#endif
+
+#define N 100
+
+struct align_check {
+	int a;
+	char b;
+};
+
+void testfn(void) {
+	const char *s0 = "a string";
+	const char *longstring = "averylongstring0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g0123456789h0123456789";
+	int *v = malloc(sizeof(int) * N);
+	struct align_check *v_align_check = malloc(sizeof(struct align_check) * N);
+
+	for (int i = 0; i < N; i++) {
+		v[i] = i;
+		v_align_check[i].a = i;
+		v_align_check[i].b = i;
+	}
+
+	char *s = malloc(strlen(s0) + 1);
+	strcpy(s, s0);
+
+	BREAKPOINT;
+	
+	printf("%s %s %p %p\n", s, longstring, v, v_align_check);
+}

--- a/_fixtures/testvariablescgo/testvariablescgo.go
+++ b/_fixtures/testvariablescgo/testvariablescgo.go
@@ -1,0 +1,11 @@
+package main
+
+// #cgo CFLAGS: -g -Wall -O0 -std=gnu99
+/*
+extern void testfn(void);
+*/
+import "C"
+
+func main() {
+	C.testfn()
+}

--- a/pkg/proc/proc_general_test.go
+++ b/pkg/proc/proc_general_test.go
@@ -24,3 +24,73 @@ func TestIssue554(t *testing.T) {
 		t.Fatalf("should be false")
 	}
 }
+
+type dummyMem struct {
+	t     *testing.T
+	mem   []byte
+	base  uint64
+	reads []memRead
+}
+
+type memRead struct {
+	addr uint64
+	size int
+}
+
+func (dm *dummyMem) ReadMemory(buf []byte, addr uintptr) (int, error) {
+	dm.t.Logf("read addr=%#x size=%#x\n", addr, len(buf))
+	dm.reads = append(dm.reads, memRead{uint64(addr), len(buf)})
+	a := int64(addr) - int64(dm.base)
+	if a < 0 {
+		panic("reading below base")
+	}
+	if int(a)+len(buf) > len(dm.mem) {
+		panic("reading beyond end of mem")
+	}
+	copy(buf, dm.mem[a:])
+	return len(buf), nil
+}
+
+func (dm *dummyMem) WriteMemory(uintptr, []byte) (int, error) {
+	panic("not supported")
+}
+
+func TestReadCStringValue(t *testing.T) {
+	const tgt = "a test string"
+	const maxstrlen = 64
+
+	dm := &dummyMem{t: t}
+	dm.mem = make([]byte, maxstrlen)
+	copy(dm.mem, tgt)
+
+	for _, tc := range []struct {
+		base     uint64
+		numreads int
+	}{
+		{0x5000, 1},
+		{0x5001, 1},
+		{0x4fff, 2},
+		{uint64(0x5000 - len(tgt) - 1), 1},
+		{uint64(0x5000-len(tgt)-1) + 1, 2},
+	} {
+		t.Logf("base is %#x\n", tc.base)
+		dm.base = tc.base
+		dm.reads = dm.reads[:0]
+		out, done, err := readCStringValue(dm, uintptr(tc.base), LoadConfig{MaxStringLen: maxstrlen})
+		if err != nil {
+			t.Errorf("base=%#x readCStringValue: %v", tc.base, err)
+		}
+		if !done {
+			t.Errorf("base=%#x expected done but wasn't", tc.base)
+		}
+		if out != tgt {
+			t.Errorf("base=%#x got %q expected %q", tc.base, out, tgt)
+		}
+		if len(dm.reads) != tc.numreads {
+			t.Errorf("base=%#x wrong number of reads %d (expected %d)", tc.base, len(dm.reads), tc.numreads)
+		}
+		if tc.base == 0x4fff && dm.reads[0].size != 1 {
+			t.Errorf("base=%#x first read in not of one byte", tc.base)
+		}
+	}
+}


### PR DESCRIPTION
```
proc: better support for C pointers

- treat C pointers as arrays
- print 'char *' variables as strings

proc: fix findCompileUnitForOffset when plugins are used

Splits the compileUnits slice between images so that we can search for
an offset inside the debug info of a specific image file.

```
