### PR TITLE
proc: fix findCompileUnitForOffset when plugins are used

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -584,7 +584,7 @@ func newVariable(name string, addr uintptr, dwarfType godwarf.Type, bi *BinaryIn
 		// b. anonymous struct types (they contain the '{' character)
 		// c. Go internal struct types used to describe maps (they contain the '<'
 		// character).
-		cu := bi.findCompileUnitForOffset(dwarfType.Common().Offset)
+		cu := bi.Images[dwarfType.Common().Index].findCompileUnitForOffset(dwarfType.Common().Offset)
 		if cu != nil && cu.isgo {
 			dwarfType = &godwarf.TypedefType{
 				CommonType: *(dwarfType.Common()),


### PR DESCRIPTION
```
proc: fix findCompileUnitForOffset when plugins are used

Splits the compileUnits slice between images so that we can search for
an offset inside the debug info of a specific image file.

```
