### PR TITLE
cmds/commands: Add --continue flag to attach

### DIFF
--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -16,6 +16,12 @@ option to let the process continue or kill it.
 dlv attach pid [executable]
 ```
 
+### Options
+
+```
+      --continue   Continue the debugged process on start.
+```
+
 ### Options inherited from parent commands
 
 ```

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -137,6 +137,7 @@ option to let the process continue or kill it.
 		},
 		Run: attachCmd,
 	}
+	attachCommand.Flags().BoolVar(&continueOnStart, "continue", false, "Continue the debugged process on start.")
 	rootCommand.AddCommand(attachCommand)
 
 	// 'connect' subcommand.


### PR DESCRIPTION
The `--continue` flag is being used downstream by the `attach` command however it's improperly blocked by the flag validation code. I decorated the `attachCommand` variable with the `--continue` reference, so this combination will be recognized as valid.

Fixes #1995