### PR TITLE
proc: do not set fileFound if there's a compileUnit without line section.

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -521,7 +521,7 @@ func (bi *BinaryInfo) LineToPC(filename string, lineno int) (pcs []uint64, err e
 	fileFound := false
 	var pc uint64
 	for _, cu := range bi.compileUnits {
-		if cu.lineInfo != nil && cu.lineInfo.Lookup[filename] == nil {
+		if cu.lineInfo == nil || cu.lineInfo.Lookup[filename] == nil {
 			continue
 		}
 		fileFound = true


### PR DESCRIPTION
In my opinion, we should not return error directly which set `fileFound` to be true
if `lineInfo` of one `compileUnits` is nil.