### PR TITLE
*: Consolidate service/debugger config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ script: >-
       docker run \
       -v $(pwd):/delve \
       --env TRAVIS=true \
+      --env CI=true \
       --privileged i386/centos:7 \
       /bin/bash -c "set -x && \
            cd delve && \

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-delve/delve/pkg/proc/test"
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/api"
+	"github.com/go-delve/delve/service/debugger"
 	"github.com/go-delve/delve/service/rpc2"
 	"github.com/go-delve/delve/service/rpccommon"
 )
@@ -154,7 +155,9 @@ func withTestTerminalBuildFlags(name string, t testing.TB, buildFlags test.Build
 	server := rpccommon.NewServer(&service.Config{
 		Listener:    listener,
 		ProcessArgs: []string{test.BuildFixture(name, buildFlags).Path},
-		Backend:     testBackend,
+		Debugger: debugger.Config{
+			Backend: testBackend,
+		},
 	})
 	if err := server.Run(); err != nil {
 		t.Fatal(err)

--- a/service/config.go
+++ b/service/config.go
@@ -1,6 +1,10 @@
 package service
 
-import "net"
+import (
+	"net"
+
+	"github.com/go-delve/delve/service/debugger"
+)
 
 // Config provides the configuration to start a Debugger and expose it with a
 // service.
@@ -9,40 +13,22 @@ import "net"
 // provided, a new process will be launched. Otherwise, the debugger will try
 // to attach to an existing process with AttachPid.
 type Config struct {
+	// Debugger configuration object, used to configure the underlying
+	// debugger used by the server.
+	Debugger debugger.Config
+
 	// Listener is used to serve requests.
 	Listener net.Listener
+
 	// ProcessArgs are the arguments to launch a new process.
 	ProcessArgs []string
-	// WorkingDir is working directory of the new process. This field is used
-	// only when launching a new process.
-	WorkingDir string
 
-	// AttachPid is the PID of an existing process to which the debugger should
-	// attach.
-	AttachPid int
 	// AcceptMulti configures the server to accept multiple connection.
 	// Note that the server API is not reentrant and clients will have to coordinate.
 	AcceptMulti bool
+
 	// APIVersion selects which version of the API to serve (default: 1).
 	APIVersion int
-
-	// CoreFile specifies the path to the core dump to open.
-	CoreFile string
-
-	// DebugInfoDirectories is the list of directories to look for
-	// when resolving external debug info files.
-	DebugInfoDirectories []string
-
-	// Selects server backend.
-	Backend string
-
-	// Foreground lets target process access stdin.
-	Foreground bool
-
-	// CheckGoVersion is true if the debugger should check the version of Go
-	// used to compile the executable and refuse to work on incompatible
-	// versions.
-	CheckGoVersion bool
 
 	// CheckLocalConnUser is true if the debugger should check that local
 	// connections come from the same user that started the headless server

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -16,6 +16,7 @@ import (
 	protest "github.com/go-delve/delve/pkg/proc/test"
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/dap/daptest"
+	"github.com/go-delve/delve/service/debugger"
 	"github.com/google/go-dap"
 )
 
@@ -42,8 +43,10 @@ func runTest(t *testing.T, name string, test func(c *daptest.Client, f protest.F
 	disconnectChan := make(chan struct{})
 	server := NewServer(&service.Config{
 		Listener:       listener,
-		Backend:        "default",
 		DisconnectChan: disconnectChan,
+		Debugger: debugger.Config{
+			Backend: "default",
+		},
 	})
 	server.Run()
 	// Give server time to start listening for clients

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -77,6 +77,7 @@ type Config struct {
 
 	// CoreFile specifies the path to the core dump to open.
 	CoreFile string
+
 	// Backend specifies the debugger backend.
 	Backend string
 

--- a/service/debugger/debugger_unix_test.go
+++ b/service/debugger/debugger_unix_test.go
@@ -54,7 +54,7 @@ func TestDebugger_LaunchNoExecutablePerm(t *testing.T) {
 }
 
 func TestDebugger_LaunchWithTTY(t *testing.T) {
-	if os.Getenv("TRAVIS") == "true" {
+	if os.Getenv("CI") == "true" {
 		if _, err := exec.LookPath("lsof"); err != nil {
 			t.Skip("skipping test in CI, system does not contain lsof")
 		}

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -43,7 +43,7 @@ func (s *RPCServer) Detach(kill bool, ret *int) error {
 }
 
 func (s *RPCServer) Restart(arg1 interface{}, arg2 *int) error {
-	if s.config.AttachPid != 0 {
+	if s.config.Debugger.AttachPid != 0 {
 		return errors.New("cannot restart process Delve did not create")
 	}
 	_, err := s.debugger.Restart(false, "", false, nil)
@@ -298,7 +298,7 @@ func (s *RPCServer) ListGoroutines(arg interface{}, goroutines *[]*api.Goroutine
 }
 
 func (c *RPCServer) AttachedToExistingProcess(arg interface{}, answer *bool) error {
-	if c.config.AttachPid != 0 {
+	if c.config.Debugger.AttachPid != 0 {
 		*answer = true
 	}
 	return nil

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -84,7 +84,7 @@ type RestartOut struct {
 
 // Restart restarts program.
 func (s *RPCServer) Restart(arg RestartIn, cb service.RPCCallback) {
-	if s.config.AttachPid != 0 {
+	if s.config.Debugger.AttachPid != 0 {
 		cb.Return(nil, errors.New("cannot restart process Delve did not create"))
 		return
 	}
@@ -571,7 +571,7 @@ type AttachedToExistingProcessOut struct {
 
 // AttachedToExistingProcess returns whether we attached to a running process or not
 func (c *RPCServer) AttachedToExistingProcess(arg AttachedToExistingProcessIn, out *AttachedToExistingProcessOut) error {
-	if c.config.AttachPid != 0 {
+	if c.config.Debugger.AttachPid != 0 {
 		out.Answer = true
 	}
 	return nil

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -71,7 +71,7 @@ func NewServer(config *service.Config) *ServerImpl {
 	if config.APIVersion < 2 {
 		logger.Info("Using API v1")
 	}
-	if config.Foreground {
+	if config.Debugger.Foreground {
 		// Print listener address
 		logflags.WriteAPIListeningMessage(config.Listener.Addr().String())
 		logger.Debug("API server pid = ", os.Getpid())
@@ -90,7 +90,7 @@ func (s *ServerImpl) Stop() error {
 		close(s.stopChan)
 		s.listener.Close()
 	}
-	kill := s.config.AttachPid == 0
+	kill := s.config.Debugger.AttachPid == 0
 	return s.debugger.Detach(kill)
 }
 
@@ -108,17 +108,8 @@ func (s *ServerImpl) Run() error {
 	}
 
 	// Create and start the debugger
-	if s.debugger, err = debugger.New(&debugger.Config{
-		AttachPid:            s.config.AttachPid,
-		WorkingDir:           s.config.WorkingDir,
-		CoreFile:             s.config.CoreFile,
-		Backend:              s.config.Backend,
-		Foreground:           s.config.Foreground,
-		DebugInfoDirectories: s.config.DebugInfoDirectories,
-		CheckGoVersion:       s.config.CheckGoVersion,
-		TTY:                  s.config.TTY,
-	},
-		s.config.ProcessArgs); err != nil {
+	config := s.config.Debugger
+	if s.debugger, err = debugger.New(&config, s.config.ProcessArgs); err != nil {
 		return err
 	}
 

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	protest "github.com/go-delve/delve/pkg/proc/test"
+	"github.com/go-delve/delve/service/debugger"
 
 	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/go-delve/delve/service"
@@ -43,7 +44,9 @@ func withTestClient1Extended(name string, t *testing.T, fn func(c *rpc1.RPCClien
 	server := rpccommon.NewServer(&service.Config{
 		Listener:    listener,
 		ProcessArgs: []string{fixture.Path},
-		Backend:     testBackend,
+		Debugger: debugger.Config{
+			Backend: testBackend,
+		},
 	})
 	if err := server.Run(); err != nil {
 		t.Fatal(err)
@@ -71,7 +74,9 @@ func Test1RunWithInvalidPath(t *testing.T) {
 	server := rpccommon.NewServer(&service.Config{
 		Listener:    listener,
 		ProcessArgs: []string{"invalid_path"},
-		Backend:     testBackend,
+		Debugger: debugger.Config{
+			Backend: testBackend,
+		},
 	})
 	if err := server.Run(); err == nil {
 		t.Fatal("Expected Run to return error for invalid program path")

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	protest "github.com/go-delve/delve/pkg/proc/test"
+	"github.com/go-delve/delve/service/debugger"
 
 	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/go-delve/delve/pkg/logflags"
@@ -68,10 +69,12 @@ func startServer(name string, buildFlags protest.BuildFlags, t *testing.T) (clie
 	}
 	fixture = protest.BuildFixture(name, buildFlags)
 	server := rpccommon.NewServer(&service.Config{
-		Listener:       listener,
-		ProcessArgs:    []string{fixture.Path},
-		Backend:        testBackend,
-		CheckGoVersion: true,
+		Listener:    listener,
+		ProcessArgs: []string{fixture.Path},
+		Debugger: debugger.Config{
+			Backend:        testBackend,
+			CheckGoVersion: true,
+		},
 	})
 	if err := server.Run(); err != nil {
 		t.Fatal(err)
@@ -105,7 +108,9 @@ func TestRunWithInvalidPath(t *testing.T) {
 		Listener:    listener,
 		ProcessArgs: []string{"invalid_path"},
 		APIVersion:  2,
-		Backend:     testBackend,
+		Debugger: debugger.Config{
+			Backend: testBackend,
+		},
 	})
 	if err := server.Run(); err == nil {
 		t.Fatal("Expected Run to return error for invalid program path")
@@ -1566,9 +1571,11 @@ func TestAcceptMulticlient(t *testing.T) {
 		server := rpccommon.NewServer(&service.Config{
 			Listener:       listener,
 			ProcessArgs:    []string{protest.BuildFixture("testvariables2", 0).Path},
-			Backend:        testBackend,
 			AcceptMulti:    true,
 			DisconnectChan: disconnectChan,
+			Debugger: debugger.Config{
+				Backend: testBackend,
+			},
 		})
 		if err := server.Run(); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Embed the debugger config object in the service config object to avoid needless duplication of fields.