### PR TITLE
Go 1.15 support branch

### DIFF
--- a/_fixtures/decllinetest.go
+++ b/_fixtures/decllinetest.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"runtime"
 )
 
 func main() {
 	a := 0
-	runtime.Breakpoint()
 	a++
 	b := 0
-	runtime.Breakpoint()
-	fmt.Println(a, b)
+	f1(a, b)
+}
+
+func f1(a, b int) {
+	fmt.Printf("%d %d\n", a, b)
 }

--- a/_fixtures/testvariables.go
+++ b/_fixtures/testvariables.go
@@ -20,8 +20,8 @@ type Nest struct {
 }
 
 func barfoo() {
-	runtime.Breakpoint()
 	a1 := "bur"
+	runtime.Breakpoint()
 	fmt.Println(a1)
 }
 

--- a/pkg/dwarf/reader/variables.go
+++ b/pkg/dwarf/reader/variables.go
@@ -11,29 +11,45 @@ type Variable struct {
 	Depth int
 }
 
+// VariablesFlags specifies some configuration flags for the Variables function.
+type VariablesFlags uint8
+
+const (
+	VariablesOnlyVisible VariablesFlags = 1 << iota
+	VariablesSkipInlinedSubroutines
+	VariablesTrustDeclLine
+)
+
 // Variables returns a list of variables contained inside 'root'.
 // If onlyVisible is true only variables visible at pc will be returned.
 // If skipInlinedSubroutines is true inlined subroutines will be skipped
-func Variables(root *godwarf.Tree, pc uint64, line int, onlyVisible, skipInlinedSubroutines bool) []Variable {
-	return variablesInternal(nil, root, 0, pc, line, onlyVisible, skipInlinedSubroutines)
+func Variables(root *godwarf.Tree, pc uint64, line int, flags VariablesFlags) []Variable {
+	return variablesInternal(nil, root, 0, pc, line, flags)
 }
 
-func variablesInternal(v []Variable, root *godwarf.Tree, depth int, pc uint64, line int, onlyVisible, skipInlinedSubroutines bool) []Variable {
+func variablesInternal(v []Variable, root *godwarf.Tree, depth int, pc uint64, line int, flags VariablesFlags) []Variable {
 	switch root.Tag {
 	case dwarf.TagInlinedSubroutine:
-		if skipInlinedSubroutines {
+		if flags&VariablesSkipInlinedSubroutines != 0 {
 			return v
 		}
 		fallthrough
 	case dwarf.TagLexDwarfBlock, dwarf.TagSubprogram:
-		if !onlyVisible || root.ContainsPC(pc) {
+		if (flags&VariablesOnlyVisible == 0) || root.ContainsPC(pc) {
 			for _, child := range root.Children {
-				v = variablesInternal(v, child, depth+1, pc, line, onlyVisible, skipInlinedSubroutines)
+				v = variablesInternal(v, child, depth+1, pc, line, flags)
 			}
 		}
 		return v
 	default:
-		if declLine, ok := root.Val(dwarf.AttrDeclLine).(int64); !ok || line >= int(declLine) {
+		o := 0
+		if root.Tag != dwarf.TagFormalParameter && (flags&VariablesTrustDeclLine != 0) {
+			// visibility for variables starts the line after declaration line,
+			// except for formal parameters, which are visible on the same line they
+			// are defined.
+			o = 1
+		}
+		if declLine, ok := root.Val(dwarf.AttrDeclLine).(int64); !ok || line >= int(declLine)+o {
 			return append(v, Variable{root, depth})
 		}
 		return v

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -8,7 +8,7 @@ var (
 	MinSupportedVersionOfGoMajor = 1
 	MinSupportedVersionOfGoMinor = 12
 	MaxSupportedVersionOfGoMajor = 1
-	MaxSupportedVersionOfGoMinor = 14
+	MaxSupportedVersionOfGoMinor = 15
 	goTooOldErr                  = fmt.Errorf("Version of Go is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Errorf("Version of Delve is too old for this version of Go (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
 )

--- a/pkg/proc/arm64_disasm.go
+++ b/pkg/proc/arm64_disasm.go
@@ -28,6 +28,8 @@ func arm64AsmDecode(asmInst *AsmInstruction, mem []byte, regs Registers, memrw M
 		asmInst.Kind = RetInstruction
 	case arm64asm.B, arm64asm.BR:
 		asmInst.Kind = JmpInstruction
+	case arm64asm.BRK:
+		asmInst.Kind = HardBreakInstruction
 	}
 
 	asmInst.DestLoc = resolveCallArgARM64(&inst, asmInst.Loc.PC, asmInst.AtPC, regs, memrw, bi)

--- a/pkg/proc/core/windows_amd64_minidump.go
+++ b/pkg/proc/core/windows_amd64_minidump.go
@@ -28,10 +28,16 @@ func readAMD64Minidump(minidumpPath, exePath string) (*process, error) {
 		memory.Add(m, uintptr(m.Addr), uintptr(len(m.Data)))
 	}
 
+	entryPoint := uint64(0)
+	if len(mdmp.Modules) > 0 {
+		entryPoint = mdmp.Modules[0].BaseOfImage
+	}
+
 	p := &process{
 		mem:         memory,
 		Threads:     map[int]*thread{},
 		bi:          proc.NewBinaryInfo("windows", "amd64"),
+		entryPoint:  entryPoint,
 		breakpoints: proc.NewBreakpointMap(),
 		pid:         int(mdmp.Pid),
 	}

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -23,6 +23,7 @@ const (
 	CallInstruction
 	RetInstruction
 	JmpInstruction
+	HardBreakInstruction
 )
 
 // IsCall is true if instr is a call instruction.
@@ -38,6 +39,11 @@ func (instr *AsmInstruction) IsRet() bool {
 // IsJmp is true if instr is an unconditional jump instruction.
 func (instr *AsmInstruction) IsJmp() bool {
 	return instr.Kind == JmpInstruction
+}
+
+// IsHardBreak is true if instr is a hardcoded breakpoint instruction.
+func (instr *AsmInstruction) IsHardBreak() bool {
+	return instr.Kind == HardBreakInstruction
 }
 
 type archInst interface {

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -215,7 +215,12 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 		return nil, err
 	}
 
-	varEntries := reader.Variables(dwarfTree, scope.PC, scope.Line, true, false)
+	variablesFlags := reader.VariablesOnlyVisible
+	if scope.BinInfo.Producer() != "" && goversion.ProducerAfterOrEqual(scope.BinInfo.Producer(), 1, 15) {
+		variablesFlags |= reader.VariablesTrustDeclLine
+	}
+
+	varEntries := reader.Variables(dwarfTree, scope.PC, scope.Line, variablesFlags)
 	vars := make([]*Variable, 0, len(varEntries))
 	depths := make([]int, 0, len(varEntries))
 	for _, entry := range varEntries {

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -229,7 +229,7 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 			// skip variables that we can't parse yet
 			continue
 		}
-		if trustArgOrder && val.Unreadable != nil && val.Addr == 0 && entry.Tag == dwarf.TagFormalParameter {
+		if trustArgOrder && ((val.Unreadable != nil && val.Addr == 0) || val.Flags&VariableFakeAddress != 0) && entry.Tag == dwarf.TagFormalParameter {
 			addr := afterLastArgAddr(vars)
 			if addr == 0 {
 				addr = uintptr(scope.Regs.CFA)

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -658,7 +658,7 @@ func (scope *EvalScope) evalToplevelTypeCast(t ast.Expr, cfg LoadConfig) (*Varia
 			return v, nil
 		case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint, reflect.Uintptr:
 			b, _ := constant.Int64Val(argv.Value)
-			s := string(b)
+			s := string(rune(b))
 			v.Value = constant.MakeString(s)
 			v.Len = int64(len(s))
 			return v, nil

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -524,7 +524,7 @@ func funcCallArgs(fn *Function, bi *BinaryInfo, includeRet bool) (argFrameSize i
 		return 0, nil, fmt.Errorf("DWARF read error: %v", err)
 	}
 
-	varEntries := reader.Variables(dwarfTree, fn.Entry, int(^uint(0)>>1), false, true)
+	varEntries := reader.Variables(dwarfTree, fn.Entry, int(^uint(0)>>1), reader.VariablesSkipInlinedSubroutines)
 
 	trustArgOrder := bi.Producer() != "" && goversion.ProducerAfterOrEqual(bi.Producer(), 1, 12)
 

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -761,13 +761,15 @@ func funcCallStep(callScope *EvalScope, fncall *functionCallState, thread Thread
 			// address of the function pointer itself.
 			thread.SetDX(fncall.closureAddr)
 		}
+		cfa := regs.SP()
+		oldpc := regs.PC()
 		callOP(bi, thread, regs, fncall.fn.Entry)
 
-		err := funcCallEvalArgs(callScope, fncall, regs.SP())
+		err := funcCallEvalArgs(callScope, fncall, cfa)
 		if err != nil {
 			// rolling back the call, note: this works because we called regs.Copy() above
-			thread.SetSP(regs.SP())
-			thread.SetPC(regs.PC())
+			thread.SetSP(cfa)
+			thread.SetPC(oldpc)
 			fncall.err = err
 			fncall.lateCallFailure = true
 			break

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -157,7 +157,7 @@ func (dbp *Target) Continue() error {
 					return err
 				}
 				if dbp.GetDirection() == Forward {
-					text, err := disassembleCurrentInstruction(dbp, curthread)
+					text, err := disassembleCurrentInstruction(dbp, curthread, 0)
 					if err != nil {
 						return err
 					}
@@ -248,12 +248,12 @@ func pickCurrentThread(dbp *Target, trapthread Thread, threads []Thread) error {
 	return dbp.SwitchThread(trapthread.ThreadID())
 }
 
-func disassembleCurrentInstruction(p Process, thread Thread) ([]AsmInstruction, error) {
+func disassembleCurrentInstruction(p Process, thread Thread, off int64) ([]AsmInstruction, error) {
 	regs, err := thread.Registers()
 	if err != nil {
 		return nil, err
 	}
-	pc := regs.PC()
+	pc := regs.PC() + uint64(off)
 	return disassemble(thread, regs, p.Breakpoints(), p.BinInfo(), pc, pc+uint64(p.BinInfo().Arch.MaxInstructionLength()), true)
 }
 

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -135,6 +135,8 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	}
 	if flags&BuildModePIE != 0 {
 		buildFlags = append(buildFlags, "-buildmode=pie")
+	} else {
+		buildFlags = append(buildFlags, "-buildmode=exe")
 	}
 	if flags&BuildModePlugin != 0 {
 		buildFlags = append(buildFlags, "-buildmode=plugin")

--- a/pkg/proc/x86_disasm.go
+++ b/pkg/proc/x86_disasm.go
@@ -30,6 +30,8 @@ func x86AsmDecode(asmInst *AsmInstruction, mem []byte, regs Registers, memrw Mem
 		asmInst.Kind = CallInstruction
 	case x86asm.RET, x86asm.LRET:
 		asmInst.Kind = RetInstruction
+	case x86asm.INT:
+		asmInst.Kind = HardBreakInstruction
 	}
 
 	asmInst.DestLoc = resolveCallArgX86(&inst, asmInst.Loc.PC, asmInst.AtPC, regs, memrw, bi)

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -687,7 +687,7 @@ func TestListCmd(t *testing.T) {
 	withTestTerminal("testvariables", t, func(term *FakeTerminal) {
 		term.MustExec("continue")
 		term.MustExec("continue")
-		listIsAt(t, term, "list", 24, 19, 29)
+		listIsAt(t, term, "list", 25, 20, 30)
 		listIsAt(t, term, "list 69", 69, 64, 70)
 		listIsAt(t, term, "frame 1 list", 62, 57, 67)
 		listIsAt(t, term, "frame 1 list 69", 69, 64, 70)

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -417,7 +417,7 @@ func Test1ClientServer_switchThread(t *testing.T) {
 func Test1ClientServer_infoLocals(t *testing.T) {
 	withTestClient1("testnextprog", t, func(c *rpc1.RPCClient) {
 		fp := testProgPath(t, "testnextprog")
-		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 23})
+		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 24})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1771,6 +1771,9 @@ func TestClientServerFunctionCallStacktrace(t *testing.T) {
 	if runtime.GOARCH == "arm64" {
 		t.Skip("arm64 does not support FunctionCall for now")
 	}
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 15) {
+		t.Skip("Go 1.15 executes function calls in a different goroutine so the stack trace will not contain main.main or runtime.main")
+	}
 	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestClient2("fncall", t, func(c service.Client) {
 		mustHaveDebugCalls(t, c)

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -548,7 +548,7 @@ func TestClientServer_infoLocals(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestClient2("testnextprog", t, func(c service.Client) {
 		fp := testProgPath(t, "testnextprog")
-		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 23})
+		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 24})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}


### PR DESCRIPTION
```
goversion: add Go 1.15 to supported versions

core: support core files for PIEs on windows

Makefile: enable PIE tests on windows/Go 1.15

tests: properly check if cgo is enabled for cgo related tests

proc: silence go vet error

proc: start variable visibility one line after their decl line

In most cases variables shouldn't be visible on their declaration line
because they won't be initialized there.
Function arguments are treated as an exception.

This fix is only applied to programs compiled with Go 1.15 or later as
previous versions of Go did not report the correct declaration line for
variables captured by closures.

Fixes #1134

proc: use cached packageVars in proc.(*EvalScope).PackageVariables

```
