### PR TITLE
Makefile: reduce test timeout when TRAVIS==true

### DIFF
--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -278,6 +278,9 @@ func testFlags() []string {
 	}
 	if NOTimeout {
 		testFlags = append(testFlags, "-timeout", "0")
+	} else if os.Getenv("TRAVIS") == "true" {
+		// Make test timeout shorter than Travis' own timeout so that Go can report which test hangs.
+		testFlags = append(testFlags, "-timeout", "9m")
 	}
 	if runtime.GOOS == "darwin" {
 		testFlags = append(testFlags, "-exec="+wd+"/_scripts/testsign")


### PR DESCRIPTION
```
Makefile: reduce test timeout when TRAVIS==true

Reduces test timeout by one minute so that Go will timeout before
Travis-CI and report useful informations about the hang.

```
