### PR TITLE
proc/native: report trapWaitInternal errors in nativeProcess.stop

### DIFF
--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -475,7 +475,10 @@ func (dbp *nativeProcess) stop(trapthread *nativeThread) (err error) {
 
 	// check if any other thread simultaneously received a SIGTRAP
 	for {
-		th, _ := dbp.trapWaitInternal(-1, trapWaitNohang)
+		th, err := dbp.trapWaitInternal(-1, trapWaitNohang)
+		if err != nil {
+			return dbp.exitGuard(err)
+		}
 		if th == nil {
 			break
 		}


### PR DESCRIPTION
```
proc/native: report trapWaitInternal errors in nativeProcess.stop

The process could quit while we are inside stop, we should report the
error otherwise the following code will try to send on the closed
ptrace channel.
Fixes a sporadic error in TestIssue1101.

```
