### PR TITLE
proc: move g.stackhi/g.stacklo to a struct

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -436,8 +436,8 @@ func (rbpi *returnBreakpointInfo) Collect(thread Thread) []*Variable {
 		return nil
 	}
 
-	oldFrameOffset := rbpi.frameOffset + int64(g.stackhi)
-	oldSP := uint64(rbpi.spOffset + int64(g.stackhi))
+	oldFrameOffset := rbpi.frameOffset + int64(g.stack.hi)
+	oldSP := uint64(rbpi.spOffset + int64(g.stack.hi))
 	err = fakeFunctionEntryScope(scope, rbpi.fn, oldFrameOffset, oldSP)
 	if err != nil {
 		return returnInfoError("could not read function entry", err, thread)

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -122,13 +122,13 @@ func (g *G) stackIterator(opts StacktraceOptions) (*stackIterator, error) {
 		return newStackIterator(
 			bi, g.Thread,
 			bi.Arch.RegistersToDwarfRegisters(so.StaticBase, regs),
-			g.stackhi, stkbar, g.stkbarPos, g, opts), nil
+			g.stack.hi, stkbar, g.stkbarPos, g, opts), nil
 	}
 	so := g.variable.bi.PCToImage(g.PC)
 	return newStackIterator(
 		bi, g.variable.mem,
 		bi.Arch.addrAndStackRegsToDwarfRegisters(so.StaticBase, g.PC, g.SP, g.BP, g.LR),
-		g.stackhi, stkbar, g.stkbarPos, g, opts), nil
+		g.stack.hi, stkbar, g.stkbarPos, g, opts), nil
 }
 
 type StacktraceOptions uint16

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -195,8 +195,7 @@ type G struct {
 	Status    uint64
 	stkbarVar *Variable // stkbar field of g struct
 	stkbarPos int       // stkbarPos field of g struct
-	stackhi   uint64    // value of stack.hi
-	stacklo   uint64    // value of stack.lo
+	stack     stack     // value of stack
 
 	SystemStack bool // SystemStack is true if this goroutine is currently executing on a system stack.
 
@@ -211,6 +210,11 @@ type G struct {
 	Unreadable error // could not read the G struct
 
 	labels *map[string]string // G's pprof labels, computed on demand in Labels() method
+}
+
+// stack represents a stack span in the target process.
+type stack struct {
+	hi, lo uint64
 }
 
 // GetG returns information on the G (goroutine) that is executing on this thread.
@@ -862,8 +866,7 @@ func (v *Variable) parseG() (*G, error) {
 		variable:   v,
 		stkbarVar:  stkbarVar,
 		stkbarPos:  int(stkbarPos),
-		stackhi:    stackhi,
-		stacklo:    stacklo,
+		stack:      stack{hi: stackhi, lo: stacklo},
 	}
 	return g, nil
 }


### PR DESCRIPTION
```
proc: move g.stackhi/g.stacklo to a struct

Mirroring the way this is implemented in the Go runtime and introducing
a type that will be useful to support the call injection changes in Go
1.15

```
