### PR TITLE
cmd/dlv: Fix trace output

### DIFF
--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -12,6 +12,9 @@ provided regular expression and output information when tracepoint is hit.  This
 is useful if you do not want to begin an entire debug session, but merely want
 to know what functions your process is executing.
 
+The output of the trace sub command is printed to stderr, so if you would like to
+only see the output of the trace operations you can redirect stdout.
+
 ```
 dlv trace [package] regexp
 ```

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -252,7 +252,10 @@ that package instead.`,
 The trace sub command will set a tracepoint on every function matching the
 provided regular expression and output information when tracepoint is hit.  This
 is useful if you do not want to begin an entire debug session, but merely want
-to know what functions your process is executing.`,
+to know what functions your process is executing.
+
+The output of the trace sub command is printed to stderr, so if you would like to
+only see the output of the trace operations you can redirect stdout.`,
 		Run: traceCmd,
 	}
 	traceCommand.Flags().IntVarP(&traceAttachPid, "pid", "p", 0, "Pid to attach to.")

--- a/pkg/locspec/doc.go
+++ b/pkg/locspec/doc.go
@@ -1,0 +1,15 @@
+// Package locspec implements code to parse a string into a specific
+// location specification.
+//
+// Location spec examples:
+//
+// locStr ::= <filename>:<line> | <function>[:<line>] | /<regex>/ | (+|-)<offset> | <line> | *<address>
+// * <filename> can be the full path of a file or just a suffix
+// * <function> ::= <package>.<receiver type>.<name> | <package>.(*<receiver type>).<name> | <receiver type>.<name> | <package>.<name> | (*<receiver type>).<name> | <name>
+// * <function> must be unambiguous
+// * /<regex>/ will return a location for each function matched by regex
+// * +<offset> returns a location for the line that is <offset> lines after the current line
+// * -<offset> returns a location for the line that is <offset> lines before the current line
+// * <line> returns a location for a line in the current file
+// * *<address> returns the location corresponding to the specified address
+package locspec

--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -98,7 +98,7 @@ func Parse(locStr string) (LocationSpec, error) {
 		}
 
 	case '*':
-		return &AddrLocationSpec{rest[1:]}, nil
+		return &AddrLocationSpec{AddrExpr: rest[1:]}, nil
 
 	default:
 		return parseLocationSpecDefault(locStr, rest)
@@ -337,9 +337,8 @@ func partialPathMatch(expr, path string) bool {
 func partialPackageMatch(expr, path string) bool {
 	if len(expr) < len(path)-1 {
 		return strings.HasSuffix(path, expr) && (path[len(path)-len(expr)-1] == '/')
-	} else {
-		return expr == path
 	}
+	return expr == path
 }
 
 // AmbiguousLocationError is returned when the location spec
@@ -399,13 +398,13 @@ func (loc *NormalLocationSpec) Find(t *proc.Target, processArgs []string, scope 
 	}
 
 	if matching := len(candidateFiles) + len(candidateFuncs); matching == 0 {
-		// if no result was found treat this locations string could be an
+		// if no result was found this locations string could be an
 		// expression that the user forgot to prefix with '*', try treating it as
 		// such.
-		addrSpec := &AddrLocationSpec{locStr}
+		addrSpec := &AddrLocationSpec{AddrExpr: locStr}
 		locs, err := addrSpec.Find(t, processArgs, scope, locStr, includeNonExecutableLines)
 		if err != nil {
-			return nil, fmt.Errorf("Location \"%s\" not found", locStr)
+			return nil, fmt.Errorf("location \"%s\" not found", locStr)
 		}
 		return locs, nil
 	} else if matching > 1 {
@@ -489,7 +488,7 @@ func regexFilterFuncs(filter string, allFuncs []proc.Function) ([]string, error)
 
 	funcs := []string{}
 	for _, f := range allFuncs {
-		if regex.Match([]byte(f.Name)) {
+		if regex.MatchString(f.Name) {
 			funcs = append(funcs, f.Name)
 		}
 	}

--- a/pkg/locspec/locations_test.go
+++ b/pkg/locspec/locations_test.go
@@ -1,11 +1,11 @@
-package debugger
+package locspec
 
 import (
 	"testing"
 )
 
 func parseLocationSpecNoError(t *testing.T, locstr string) LocationSpec {
-	spec, err := parseLocationSpec(locstr)
+	spec, err := Parse(locstr)
 	if err != nil {
 		t.Fatalf("Error parsing %q: %v", locstr, err)
 	}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -22,9 +22,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/cosiner/argv"
+	"github.com/go-delve/delve/pkg/locspec"
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/api"
-	"github.com/go-delve/delve/service/debugger"
 )
 
 const optimizedFunctionWarning = "Warning: debugging optimized function"
@@ -1872,7 +1872,7 @@ func getLocation(t *Term, ctx callContext, args string, showContext bool) (file 
 			return "", 0, false, err
 		}
 		if len(locs) > 1 {
-			return "", 0, false, debugger.AmbiguousLocationError{Location: args, CandidatesLocation: locs}
+			return "", 0, false, locspec.AmbiguousLocationError{Location: args, CandidatesLocation: locs}
 		}
 		loc := locs[0]
 		if showContext {

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -585,7 +585,7 @@ func TestOnPrefixLocals(t *testing.T) {
 	})
 }
 
-func countOccurrences(s string, needle string) int {
+func countOccurrences(s, needle string) int {
 	count := 0
 	for {
 		idx := strings.Index(s, needle)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -141,6 +141,9 @@ type Location struct {
 	Line     int       `json:"line"`
 	Function *Function `json:"function,omitempty"`
 	PCs      []uint64  `json:"pcs,omitempty"`
+	// IsFunctionEntry is true if this location
+	// represents the location of a function.
+	IsFunctionEntry bool
 }
 
 // Stackframe describes one frame in a stack trace.
@@ -252,8 +255,8 @@ type Variable struct {
 
 	Kind reflect.Kind `json:"kind"`
 
-	//Strings have their length capped at proc.maxArrayValues, use Len for the real length of a string
-	//Function variables will store the name of the function in this field
+	// Strings have their length capped at proc.maxArrayValues, use Len for the real length of a string
+	// Function variables will store the name of the function in this field
 	Value string `json:"value"`
 
 	// Number of elements in an array or a slice, number of keys for a map, number of struct members for a struct, length of strings

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -141,9 +141,6 @@ type Location struct {
 	Line     int       `json:"line"`
 	Function *Function `json:"function,omitempty"`
 	PCs      []uint64  `json:"pcs,omitempty"`
-	// IsFunctionEntry is true if this location
-	// represents the location of a function.
-	IsFunctionEntry bool
 }
 
 // Stackframe describes one frame in a stack trace.

--- a/service/config.go
+++ b/service/config.go
@@ -36,8 +36,4 @@ type Config struct {
 
 	// DisconnectChan will be closed by the server when the client disconnects
 	DisconnectChan chan<- struct{}
-
-	// TTY is passed along to the target process on creation. Used to specify a
-	// TTY for that process.
-	TTY string
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1447,6 +1447,14 @@ func (d *Debugger) FindLocation(scope api.EvalScope, locStr string, includeNonEx
 
 	s, _ := proc.ConvertEvalScope(d.target, scope.GoroutineID, scope.Frame, scope.DeferredCall)
 
+	var isFunctionLocation bool
+	switch t := loc.(type) {
+	case *locspec.NormalLocationSpec:
+		isFunctionLocation = t.LineOffset == -1 && t.FuncBase != nil
+	case *locspec.RegexLocationSpec:
+		isFunctionLocation = true
+	}
+
 	locs, err := loc.Find(d.target, d.processArgs, s, locStr, includeNonExecutableLines)
 	for i := range locs {
 		if locs[i].PC == 0 {
@@ -1456,6 +1464,7 @@ func (d *Debugger) FindLocation(scope api.EvalScope, locStr string, includeNonEx
 		locs[i].File = file
 		locs[i].Line = line
 		locs[i].Function = api.ConvertFunction(fn)
+		locs[i].IsFunctionEntry = isFunctionLocation
 	}
 	return locs, err
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/locspec"
 	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/go-delve/delve/pkg/proc"
 	"github.com/go-delve/delve/pkg/proc/core"
@@ -1069,7 +1070,18 @@ func (d *Debugger) Functions(filter string) ([]string, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 
-	return regexFilterFuncs(filter, d.target.BinInfo().Functions)
+	regex, err := regexp.Compile(filter)
+	if err != nil {
+		return nil, fmt.Errorf("invalid filter argument: %s", err.Error())
+	}
+
+	funcs := []string{}
+	for _, f := range d.target.BinInfo().Functions {
+		if regex.Match([]byte(f.Name)) {
+			funcs = append(funcs, f.Name)
+		}
+	}
+	return funcs, nil
 }
 
 // Types returns all type information in the binary.
@@ -1095,21 +1107,6 @@ func (d *Debugger) Types(filter string) ([]string, error) {
 	}
 
 	return r, nil
-}
-
-func regexFilterFuncs(filter string, allFuncs []proc.Function) ([]string, error) {
-	regex, err := regexp.Compile(filter)
-	if err != nil {
-		return nil, fmt.Errorf("invalid filter argument: %s", err.Error())
-	}
-
-	funcs := []string{}
-	for _, f := range allFuncs {
-		if regex.Match([]byte(f.Name)) {
-			funcs = append(funcs, f.Name)
-		}
-	}
-	return funcs, nil
 }
 
 // PackageVariables returns a list of package variables for the thread,
@@ -1443,14 +1440,14 @@ func (d *Debugger) FindLocation(scope api.EvalScope, locStr string, includeNonEx
 		return nil, err
 	}
 
-	loc, err := parseLocationSpec(locStr)
+	loc, err := locspec.Parse(locStr)
 	if err != nil {
 		return nil, err
 	}
 
 	s, _ := proc.ConvertEvalScope(d.target, scope.GoroutineID, scope.Frame, scope.DeferredCall)
 
-	locs, err := loc.Find(d, s, locStr, includeNonExecutableLines)
+	locs, err := loc.Find(d.target, d.processArgs, s, locStr, includeNonExecutableLines)
 	for i := range locs {
 		if locs[i].PC == 0 {
 			continue

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1077,7 +1077,7 @@ func (d *Debugger) Functions(filter string) ([]string, error) {
 
 	funcs := []string{}
 	for _, f := range d.target.BinInfo().Functions {
-		if regex.Match([]byte(f.Name)) {
+		if regex.MatchString(f.Name) {
 			funcs = append(funcs, f.Name)
 		}
 	}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1447,14 +1447,6 @@ func (d *Debugger) FindLocation(scope api.EvalScope, locStr string, includeNonEx
 
 	s, _ := proc.ConvertEvalScope(d.target, scope.GoroutineID, scope.Frame, scope.DeferredCall)
 
-	var isFunctionLocation bool
-	switch t := loc.(type) {
-	case *locspec.NormalLocationSpec:
-		isFunctionLocation = t.LineOffset == -1 && t.FuncBase != nil
-	case *locspec.RegexLocationSpec:
-		isFunctionLocation = true
-	}
-
 	locs, err := loc.Find(d.target, d.processArgs, s, locStr, includeNonExecutableLines)
 	for i := range locs {
 		if locs[i].PC == 0 {
@@ -1464,7 +1456,6 @@ func (d *Debugger) FindLocation(scope api.EvalScope, locStr string, includeNonEx
 		locs[i].File = file
 		locs[i].Line = line
 		locs[i].Function = api.ConvertFunction(fn)
-		locs[i].IsFunctionEntry = isFunctionLocation
 	}
 	return locs, err
 }


### PR DESCRIPTION
This patch improves the `dlv trace` subcommand output by reducing the
noise that is generated and providing clearer more concise information.

Also adds new tests closing a gap in our testing (we previously never
really tested this subcommand).

This patch also fixes the `dlv trace` REPL command to behave like the
subcommand in certain situations. If the tracepoint is for a function,
we now show function arguements and return values properly.

Also makes the overall output of the trace subcommand clearer.