### PR TITLE
Config option for printfile() line count

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,9 +57,22 @@ type Config struct {
 	// here: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
 	SourceListLineColor int `yaml:"source-list-line-color"`
 
+	// number of lines to list above and below cursor when printfile() is
+	// called (i.e. when execution stops, listCommand is used, etc)
+	SourceListLineCount *int `yaml:"source-list-line-count,omitempty"`
+
 	// DebugFileDirectories is the list of directories Delve will use
 	// in order to resolve external debug info files.
 	DebugInfoDirectories []string `yaml:"debug-info-directories"`
+}
+
+func (c *Config) GetSourceListLineCount() int {
+	n := 5 // default value
+	lcp := c.SourceListLineCount
+	if lcp != nil && *lcp >= 0 {
+		n = *lcp
+	}
+	return n
 }
 
 // LoadConfig attempts to populate a Config object from the config.yml file.
@@ -203,6 +216,10 @@ func writeDefaultConfig(f *os.File) error {
 # for source line numbers in the (list) command (if unset, default is 34,
 # dark blue) See https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit
 # source-list-line-color: 34
+
+# Uncomment to change the number of lines printed above and below cursor when
+# listing source code.
+# source-list-line-count: 5
 
 # Provided aliases will be added to the default aliases for a given command.
 aliases:

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2227,20 +2227,22 @@ func printfile(t *Term, filename string, line int, showArrow bool) error {
 		fmt.Println("Warning: listing may not match stale executable")
 	}
 
+	lineCount := t.conf.GetSourceListLineCount()
+
 	buf := bufio.NewScanner(file)
 	l := line
-	for i := 1; i < l-5; i++ {
+	for i := 1; i < l-lineCount; i++ {
 		if !buf.Scan() {
 			return nil
 		}
 	}
 
-	s := l - 5
+	s := l - lineCount
 	if s < 1 {
 		s = 1
 	}
 
-	for i := s; i <= l+5; i++ {
+	for i := s; i <= l+lineCount; i++ {
 		if !buf.Scan() {
 			return nil
 		}


### PR DESCRIPTION
`printfile()` is called from a bunch of places, like when reaching a breakpoint, or running the `list` command. It's hard coded to print 5 lines before and after the cursor, but I often feel it's convenient to see a bigger window, so I added the `source-list-line-count` config option for this purpose. For instance:
```
 (dlv) config source-list-line-count 20
 (dlv) list
```
Now it will print 20 lines before and after the cursor instead. 0 (zero) also works, in which case it only prints the line under the cursor.

Thanks to the developers; it was really easy to implement this change :-)