### PR TITLE
gobuild: pass-through stdout to 'go' command invocation

### DIFF
--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -68,5 +68,6 @@ func gocommand(command string, args ...string) error {
 	allargs = append(allargs, args...)
 	goBuild := exec.Command("go", allargs...)
 	goBuild.Stderr = os.Stderr
+	goBuild.Stdout = os.Stdout
 	return goBuild.Run()
 }


### PR DESCRIPTION
```
gobuild: pass-through stdout to 'go' command invocation

When trying to compile tests in a package that does not contain tests
'go' emits an error message on stdout instead of stderr. Let the 'go'
command write to stdout too.

Fixes #2042

```
