### PR TITLE
proc,proc/native: avoid context switches by executing Continue in ptrace thread

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -447,3 +447,8 @@ func (p *process) FindThread(threadID int) (proc.Thread, bool) {
 func (p *process) SetCurrentThread(th proc.Thread) {
 	p.currentThread = th.(*thread)
 }
+
+// ExecOnMagicThread calls fn.
+func (p *process) ExecOnMagicThread(fn func()) {
+	fn()
+}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -635,6 +635,11 @@ func (p *gdbProcess) SetCurrentThread(th proc.Thread) {
 	p.currentThread = th.(*gdbThread)
 }
 
+// ExecOnMagicThread calls fn.
+func (p *gdbProcess) ExecOnMagicThread(fn func()) {
+	fn()
+}
+
 const (
 	interruptSignal  = 0x2
 	breakpointSignal = 0x5

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -32,6 +32,12 @@ type ProcessInternal interface {
 
 	WriteBreakpoint(addr uint64) (file string, line int, fn *Function, originalData []byte, err error)
 	EraseBreakpoint(*Breakpoint) error
+
+	// ExecOnMagicThread executes a function on a thread where calls to
+	// other methods of Process will execute faster (maybe).
+	// See the description of this method inside pkg/proc/native for an
+	// explanation.
+	ExecOnMagicThread(func())
 }
 
 // RecordingManipulation is an interface for manipulating process recordings.


### PR DESCRIPTION
```
proc,proc/native: avoid context switches by executing Continue in ptrace thread

Avoids a lot of context switches while executing Continue by running
inside the ptrace thread.

Benchmark before:

BenchmarkConditionalBreakpoints-4   	       1	3554266510 ns/op

After:

BenchmarkConditionalBreakpoints-4   	       1	1807164143 ns/op

Fixes #1549

```
