### PR TITLE
cmd/dlv: fix bug when tracing pid

### DIFF
--- a/_fixtures/issue2023.go
+++ b/_fixtures/issue2023.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func A() {
+	fmt.Printf("hello delve\n")
+}
+
+func main() {
+	count := 0
+	for {
+		A()
+		time.Sleep(time.Millisecond * time.Duration(100))
+		if count >= 30 {
+			break
+		}
+		count++
+	}
+}

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -466,20 +466,19 @@ func traceCmd(cmd *cobra.Command, args []string) {
 		var processArgs []string
 
 		dlvArgs, targetArgs := splitArgs(cmd, args)
+		var dlvArgsLen = len(dlvArgs)
+		if dlvArgsLen == 1 {
+			regexp = args[0]
+			dlvArgs = dlvArgs[0:0]
+		} else if dlvArgsLen >= 2 {
+			regexp = dlvArgs[dlvArgsLen-1]
+			dlvArgs = dlvArgs[:dlvArgsLen-1]
+		}
 
 		if traceAttachPid == 0 {
-			var dlvArgsLen = len(dlvArgs)
-
-			if dlvArgsLen == 1 {
-				regexp = args[0]
-				dlvArgs = dlvArgs[0:0]
-			} else if dlvArgsLen >= 2 {
-				if traceExecFile != "" {
-					fmt.Fprintln(os.Stderr, "Cannot specify package when using exec.")
-					return 1
-				}
-				regexp = dlvArgs[dlvArgsLen-1]
-				dlvArgs = dlvArgs[:dlvArgsLen-1]
+			if dlvArgsLen >= 2 && traceExecFile != "" {
+				fmt.Fprintln(os.Stderr, "Cannot specify package when using exec.")
+				return 1
 			}
 
 			debugname := traceExecFile


### PR DESCRIPTION
`regexp` are always resolved to "" when tracing pid. And client set
breakpoint on all functions.

fix #2023