### PR TITLE
service/api: do not try to convert unreadable goroutines

### DIFF
--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -257,7 +257,10 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 	if th != nil {
 		tid = th.ThreadID()
 	}
-	r := &Goroutine{
+	if g.Unreadable != nil {
+		return &Goroutine{Unreadable: g.Unreadable.Error()}
+	}
+	return &Goroutine{
 		ID:             g.ID,
 		CurrentLoc:     ConvertLocation(g.CurrentLoc),
 		UserCurrentLoc: ConvertLocation(g.UserCurrent()),
@@ -266,10 +269,6 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 		ThreadID:       tid,
 		Labels:         g.Labels(),
 	}
-	if g.Unreadable != nil {
-		r.Unreadable = g.Unreadable.Error()
-	}
-	return r
 }
 
 // ConvertLocation converts from proc.Location to api.Location.


### PR DESCRIPTION
```
service/api: do not try to convert unreadable goroutines

When reading truncated core files GoroutinesInfo will sometimes produce
some proc.G structs with only the Unreadable field set. These proc.G
can not be used for anything, but the service layer will still try to
convert them.
Since they are not fully initialized parts of the conversion will fail,
api.ConvertGoroutine should not try to call methods of unreadable
goroutines.

Fixes a bug reported on the mailing list.
https://groups.google.com/forum/#!msg/delve-dev/gauDqYaD81c/K5YDNBOhAAAJ

```
