### PR TITLE
terminal: fix nil pointer dereference when printing tracepoints

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2269,7 +2269,7 @@ func printTracepoint(th *api.Thread, bpname string, fn *api.Function, args strin
 		fmt.Fprintf(os.Stderr, " => (%s)\n", strings.Join(retVals, ","))
 	}
 	if th.Breakpoint.TraceReturn || !hasReturnValue {
-		if th.BreakpointInfo.Stacktrace != nil {
+		if th.BreakpointInfo != nil && th.BreakpointInfo.Stacktrace != nil {
 			fmt.Fprintf(os.Stderr, "\tStack:\n")
 			printStack(os.Stderr, th.BreakpointInfo.Stacktrace, "\t\t", false)
 		}


### PR DESCRIPTION
```
terminal: fix nil pointer dereference when printing tracepoints

This issue causes a failure of TestTracePid that was observed in CI:

https://travis-ci.com/github/go-delve/delve/jobs/343053383

I'm not sure what causes it in this particular instance but there are
several ways in which a thread stopped at a breakpoint might have a
BreakpointInfo == nil field (see variable withBreakpointInfo in
debugger.Debugger.Command).

```
