### PR TITLE
proc: do not wipe sources list when a plugin is detected

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1599,7 +1599,6 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugLineBytes []byte, wg 
 		bi.LookupFunc[bi.Functions[i].Name] = &bi.Functions[i]
 	}
 
-	bi.Sources = []string{}
 	for _, cu := range image.compileUnits {
 		if cu.lineInfo != nil {
 			for _, fileEntry := range cu.lineInfo.FileNames {


### PR DESCRIPTION
The list of source files must include all files from all images, not
just the files from the last discovered image.

Fixes #2074
