### PR TITLE
proc: refresh cur thread/sel g after ContineOnce errors

### DIFF
--- a/_fixtures/issue2078.go
+++ b/_fixtures/issue2078.go
@@ -1,0 +1,10 @@
+package main
+
+func main() {
+	f(nil) //break
+	println("ok")
+}
+
+func f(x *int) {
+	println(*x)
+}


### PR DESCRIPTION
On platforms other than macOS this doesn't matter but on macOS a
segmentation fault will cause ContinueOnce to return an error, before
returning it we should still fix the current thread and selected
goroutine values.

Fixes #2078
