### PR TITLE
tests: fix flakiness of of TestIssue414 on windows

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1815,7 +1815,15 @@ func TestIssue414(t *testing.T) {
 			pc := currentPC(p, t)
 			f, ln := currentLineNumber(p, t)
 			t.Logf("at %s:%d %#x\n", f, ln, pc)
-			err := p.Step()
+			var err error
+			// Stepping through the runtime is not generally safe so after we are out
+			// of main.main just use Next.
+			// See: https://github.com/go-delve/delve/pull/2082
+			if f == fixture.Source {
+				err = p.Step()
+			} else {
+				err = p.Next()
+			}
 			if err != nil {
 				if _, exited := err.(proc.ErrProcessExited); exited {
 					break


### PR DESCRIPTION
Recent change #2061:

292f5c6
proc: step into unexported runtime funcs when already inside runtime

means that TestIssue414 (which tries to step repeatedly until the
program exits) can now steps through way more runtime code than it ever
did before. This causes this test to occasionally fail. Stepping
blindly through runtime code has never been particularly safe as the
runtime can switch to a different goroutine causing Delve to misbehave.

This change restores the previous behavior of TestIssue414 where Step
behaved like Next inside runtime code.
