### PR TITLE
Support DWARFv5 location list format

### DIFF
--- a/pkg/dwarf/godwarf/addr.go
+++ b/pkg/dwarf/godwarf/addr.go
@@ -1,0 +1,60 @@
+package godwarf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+
+	"github.com/go-delve/delve/pkg/dwarf/util"
+)
+
+// DebugAddrSection represents the debug_addr section of DWARFv5.
+// See DWARFv5 section 7.27 page 241 and following.
+type DebugAddrSection struct {
+	byteOrder binary.ByteOrder
+	ptrSz     int
+	data      []byte
+}
+
+// ParseAddr parses the header of a debug_addr section.
+func ParseAddr(data []byte) *DebugAddrSection {
+	if len(data) == 0 {
+		return nil
+	}
+	r := &DebugAddrSection{data: data}
+	_, dwarf64, _, byteOrder := util.ReadDwarfLengthVersion(data)
+	r.byteOrder = byteOrder
+	data = data[6:]
+	if dwarf64 {
+		data = data[8:]
+	}
+
+	addrSz := data[0]
+	segSelSz := data[1]
+	r.ptrSz = int(addrSz + segSelSz)
+
+	return r
+}
+
+// GetSubsection returns the subsection of debug_addr starting at addrBase
+func (addr *DebugAddrSection) GetSubsection(addrBase uint64) *DebugAddr {
+	if addr == nil {
+		return nil
+	}
+	return &DebugAddr{DebugAddrSection: addr, addrBase: addrBase}
+}
+
+// DebugAddr represents a subsection of the debug_addr section with a specific base address
+type DebugAddr struct {
+	*DebugAddrSection
+	addrBase uint64
+}
+
+// Get returns the address at index idx starting from addrBase.
+func (addr *DebugAddr) Get(idx uint64) (uint64, error) {
+	if addr == nil || addr.DebugAddrSection == nil {
+		return 0, errors.New("debug_addr section not present")
+	}
+	off := idx*uint64(addr.ptrSz) + addr.addrBase
+	return util.ReadUintRaw(bytes.NewReader(addr.data[off:]), addr.byteOrder, addr.ptrSz)
+}

--- a/pkg/dwarf/loclist/dwarf5_loclist.go
+++ b/pkg/dwarf/loclist/dwarf5_loclist.go
@@ -1,0 +1,193 @@
+package loclist
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/dwarf/util"
+)
+
+// Dwarf5Reader parses and presents DWARF loclist information for DWARF version 5 and later.
+// See DWARFv5 section 7.29 page 243 and following.
+type Dwarf5Reader struct {
+	byteOrder binary.ByteOrder
+	ptrSz     int
+	data      []byte
+}
+
+func NewDwarf5Reader(data []byte) *Dwarf5Reader {
+	if len(data) == 0 {
+		return nil
+	}
+	r := &Dwarf5Reader{data: data}
+
+	_, dwarf64, _, byteOrder := util.ReadDwarfLengthVersion(data)
+	r.byteOrder = byteOrder
+
+	data = data[6:]
+	if dwarf64 {
+		data = data[8:]
+	}
+
+	addrSz := data[0]
+	segSelSz := data[1]
+	r.ptrSz = int(addrSz + segSelSz)
+
+	// Not read:
+	// - offset_entry_count (4 bytes)
+	// - offset table (offset_entry_count*4 or offset_entry_count*8 if dwarf64 is set)
+
+	return r
+}
+
+func (rdr *Dwarf5Reader) Empty() bool {
+	return rdr == nil
+}
+
+// Find returns the loclist entry for the specified PC address, inside the
+// loclist stating at off. Base is the base address of the compile unit and
+// staticBase is the static base at which the image is loaded.
+func (rdr *Dwarf5Reader) Find(off int, staticBase, base, pc uint64, debugAddr *godwarf.DebugAddr) (*Entry, error) {
+	it := &loclistsIterator{rdr: rdr, debugAddr: debugAddr, buf: bytes.NewBuffer(rdr.data), base: base, staticBase: staticBase}
+	it.buf.Next(off)
+
+	for it.next() {
+		if !it.onRange {
+			continue
+		}
+		if it.start <= pc && pc < it.end {
+			return &Entry{it.start, it.end, it.instr}, nil
+		}
+	}
+
+	if it.err != nil {
+		return nil, it.err
+	}
+
+	if it.defaultInstr != nil {
+		return &Entry{pc, pc + 1, it.defaultInstr}, nil
+	}
+
+	return nil, nil
+}
+
+type loclistsIterator struct {
+	rdr        *Dwarf5Reader
+	debugAddr  *godwarf.DebugAddr
+	buf        *bytes.Buffer
+	staticBase uint64
+	base       uint64 // base for offsets in the list
+
+	onRange      bool
+	atEnd        bool
+	start, end   uint64
+	instr        []byte
+	defaultInstr []byte
+	err          error
+}
+
+const (
+	_DW_LLE_end_of_list      uint8 = 0x0
+	_DW_LLE_base_addressx    uint8 = 0x1
+	_DW_LLE_startx_endx      uint8 = 0x2
+	_DW_LLE_startx_length    uint8 = 0x3
+	_DW_LLE_offset_pair      uint8 = 0x4
+	_DW_LLE_default_location uint8 = 0x5
+	_DW_LLE_base_address     uint8 = 0x6
+	_DW_LLE_start_end        uint8 = 0x7
+	_DW_LLE_start_length     uint8 = 0x8
+)
+
+func (it *loclistsIterator) next() bool {
+	if it.err != nil || it.atEnd {
+		return false
+	}
+	opcode, err := it.buf.ReadByte()
+	if err != nil {
+		it.err = err
+		return false
+	}
+	switch opcode {
+	case _DW_LLE_end_of_list:
+		it.atEnd = true
+		it.onRange = false
+		return false
+
+	case _DW_LLE_base_addressx:
+		baseIdx, _ := util.DecodeULEB128(it.buf)
+		if err != nil {
+			it.err = err
+			return false
+		}
+		it.base, it.err = it.debugAddr.Get(baseIdx)
+		it.base += it.staticBase
+		it.onRange = false
+
+	case _DW_LLE_startx_endx:
+		startIdx, _ := util.DecodeULEB128(it.buf)
+		endIdx, _ := util.DecodeULEB128(it.buf)
+		it.readInstr()
+
+		it.start, it.err = it.debugAddr.Get(startIdx)
+		if it.err == nil {
+			it.end, it.err = it.debugAddr.Get(endIdx)
+		}
+		it.onRange = true
+
+	case _DW_LLE_startx_length:
+		startIdx, _ := util.DecodeULEB128(it.buf)
+		length, _ := util.DecodeULEB128(it.buf)
+		it.readInstr()
+
+		it.start, it.err = it.debugAddr.Get(startIdx)
+		it.end = it.start + length
+		it.onRange = true
+
+	case _DW_LLE_offset_pair:
+		off1, _ := util.DecodeULEB128(it.buf)
+		off2, _ := util.DecodeULEB128(it.buf)
+		it.readInstr()
+
+		it.start = it.base + off1
+		it.end = it.base + off2
+		it.onRange = true
+
+	case _DW_LLE_default_location:
+		it.readInstr()
+		it.defaultInstr = it.instr
+		it.onRange = false
+
+	case _DW_LLE_base_address:
+		it.base, it.err = util.ReadUintRaw(it.buf, it.rdr.byteOrder, it.rdr.ptrSz)
+		it.base += it.staticBase
+		it.onRange = false
+
+	case _DW_LLE_start_end:
+		it.start, it.err = util.ReadUintRaw(it.buf, it.rdr.byteOrder, it.rdr.ptrSz)
+		it.end, it.err = util.ReadUintRaw(it.buf, it.rdr.byteOrder, it.rdr.ptrSz)
+		it.readInstr()
+		it.onRange = true
+
+	case _DW_LLE_start_length:
+		it.start, it.err = util.ReadUintRaw(it.buf, it.rdr.byteOrder, it.rdr.ptrSz)
+		length, _ := util.DecodeULEB128(it.buf)
+		it.readInstr()
+		it.end = it.start + length
+		it.onRange = true
+
+	default:
+		it.err = fmt.Errorf("unknown opcode %#x at %#x", opcode, len(it.rdr.data)-it.buf.Len())
+		it.onRange = false
+		it.atEnd = true
+		return false
+	}
+
+	return true
+}
+
+func (it *loclistsIterator) readInstr() {
+	length, _ := util.DecodeULEB128(it.buf)
+	it.instr = it.buf.Next(int(length))
+}

--- a/pkg/dwarf/loclist/loclist5_test.go
+++ b/pkg/dwarf/loclist/loclist5_test.go
@@ -1,0 +1,119 @@
+package loclist
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/go-delve/delve/pkg/dwarf/util"
+)
+
+func TestLoclist5(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	p32 := func(n uint32) { binary.Write(buf, binary.LittleEndian, n) }
+	p16 := func(n uint16) { binary.Write(buf, binary.LittleEndian, n) }
+	p8 := func(n uint8) { binary.Write(buf, binary.LittleEndian, n) }
+	uleb := func(n uint64) { util.EncodeULEB128(buf, n) }
+
+	p32(0x0) // length (use 0 because it is ignored)
+	p16(0x5) // version
+	p8(4)    // address size
+	p8(0)    // segment selector size
+	p32(0)   // offset_entry_count
+
+	off := buf.Len()
+
+	// (offset) start_base+0x10200 .. start_base+0x10300: 0x2
+	p8(_DW_LLE_offset_pair)
+	uleb(0x10200)
+	uleb(0x10300)
+	uleb(4)
+	p32(2)
+
+	// base address -> 0x02000000
+	p8(_DW_LLE_base_address)
+	p32(0x02000000)
+
+	// (offset) 0x02010400 .. 0x02010500: 3
+	p8(_DW_LLE_offset_pair)
+	uleb(0x10400)
+	uleb(0x10500)
+	uleb(4)
+	p32(3)
+
+	// (offset) 0x02010600 .. 0x02010600: 4
+	p8(_DW_LLE_offset_pair)
+	uleb(0x10600)
+	uleb(0x10600)
+	uleb(4)
+	p32(4)
+
+	// (offset) 0x02010800 .. 0x02010900: 5
+	p8(_DW_LLE_offset_pair)
+	uleb(0x10800)
+	uleb(0x10900)
+	uleb(4)
+	p32(5)
+
+	// (start end) 0x2010a00 .. 0x2010b00: 6
+	p8(_DW_LLE_start_end)
+	p32(0x2010a00)
+	p32(0x2010b00)
+	uleb(4)
+	p32(6)
+
+	// (start length) 0x2010c00 .. 0x2010d00: 7
+	p8(_DW_LLE_start_length)
+	p32(0x2010c00)
+	uleb(0x100)
+	uleb(4)
+	p32(7)
+
+	// (offset) 0x02000000 .. 0x02000001: 8
+	p8(_DW_LLE_offset_pair)
+	uleb(0)
+	uleb(1)
+	uleb(4)
+	p32(8)
+
+	// default location 10
+	p8(_DW_LLE_default_location)
+	uleb(4)
+	p32(10)
+
+	// loclist end
+	p8(_DW_LLE_end_of_list)
+
+	type testCase struct {
+		pc  uint64
+		tgt Entry
+	}
+
+	testCases := []testCase{
+		{0x01000000, Entry{0x01000000, 0x01000001, []byte{10, 0, 0, 0}}}, // default entry
+		{0x01010200, Entry{0x01010200, 0x01010300, []byte{2, 0, 0, 0}}},  // offset pair entry
+		{0x01010210, Entry{0x01010200, 0x01010300, []byte{2, 0, 0, 0}}},  // offset pair entry
+		{0x01010300, Entry{0x01010300, 0x01010301, []byte{10, 0, 0, 0}}}, // default entry (one past offset pair entry)
+		{0x02010400, Entry{0x02010400, 0x02010500, []byte{3, 0, 0, 0}}},  // offset pair entry, after base address selection
+		{0x02010600, Entry{0x02010600, 0x02010601, []byte{10, 0, 0, 0}}}, // default entry (beginning of empty offset pair entry)
+		{0x02010800, Entry{0x02010800, 0x02010900, []byte{5, 0, 0, 0}}},  // offset pair entry after empty offset pair
+		{0x02010a00, Entry{0x02010a00, 0x02010b00, []byte{6, 0, 0, 0}}},  // start end entry
+		{0x02010c00, Entry{0x02010c00, 0x02010d00, []byte{7, 0, 0, 0}}},  // start length entry
+		{0x02000000, Entry{0x02000000, 0x02000001, []byte{8, 0, 0, 0}}},  // out of order offset pair entry
+		{0x02000001, Entry{0x02000001, 0x02000002, []byte{10, 0, 0, 0}}}, // default entry (after out of order offset pair)
+	}
+
+	ll := NewDwarf5Reader(buf.Bytes())
+
+	for _, tc := range testCases {
+		e, err := ll.Find(off, 0x0, 0x01000000, tc.pc, nil)
+		if err != nil {
+			t.Errorf("error returned for %#x: %v", tc.pc, err)
+			continue
+		}
+		if e.LowPC != tc.tgt.LowPC || e.HighPC != tc.tgt.HighPC || !bytes.Equal(e.Instr, tc.tgt.Instr) {
+			t.Errorf("output mismatch for %#x,\nexpected %#v,\ngot     %#v", tc.pc, tc.tgt, e)
+		}
+	}
+}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -35,8 +35,9 @@ import (
 )
 
 const (
-	dwarfGoLanguage    = 22  // DW_LANG_Go (from DWARF v5, section 7.12, page 231)
-	dwarfTreeCacheSize = 512 // size of the dwarfTree cache of each image
+	dwarfGoLanguage    = 22   // DW_LANG_Go (from DWARF v5, section 7.12, page 231)
+	dwarfAttrAddrBase  = 0x74 // debug/dwarf.AttrAddrBase in Go 1.14, defined here for compatibility with Go < 1.14
+	dwarfTreeCacheSize = 512  // size of the dwarfTree cache of each image
 )
 
 // BinaryInfo holds information on the binaries being executed (this
@@ -268,9 +269,10 @@ func (e *ErrUnsupportedArch) Error() string {
 }
 
 type compileUnit struct {
-	name   string // univocal name for non-go compile units
-	lowPC  uint64
-	ranges [][2]uint64
+	name    string // univocal name for non-go compile units
+	Version uint8  // DWARF version of this compile unit
+	lowPC   uint64
+	ranges  [][2]uint64
 
 	entry     *dwarf.Entry        // debug_info entry describing this compile unit
 	isgo      bool                // true if this is the go compile unit
@@ -647,7 +649,9 @@ type Image struct {
 
 	dwarf       *dwarf.Data
 	dwarfReader *dwarf.Reader
-	loclist     *loclist.Reader
+	loclist2    *loclist.Dwarf2Reader
+	loclist5    *loclist.Dwarf5Reader
+	debugAddr   *godwarf.DebugAddrSection
 
 	typeCache map[dwarf.Offset]godwarf.Type
 
@@ -807,14 +811,15 @@ func (bi *BinaryInfo) LoadImageFromData(dwdata *dwarf.Data, debugFrameBytes, deb
 		bi.frameEntries = frame.Parse(debugFrameBytes, frame.DwarfEndian(debugFrameBytes), 0, bi.Arch.PtrSize())
 	}
 
-	image.loclist = loclist.New(debugLocBytes, bi.Arch.PtrSize())
+	image.loclist2 = loclist.NewDwarf2Reader(debugLocBytes, bi.Arch.PtrSize())
 
-	bi.loadDebugInfoMaps(image, debugLineBytes, nil, nil)
+	bi.loadDebugInfoMaps(image, nil, debugLineBytes, nil, nil)
 
 	bi.Images = append(bi.Images, image)
 }
 
 func (bi *BinaryInfo) locationExpr(entry godwarf.Entry, attr dwarf.Attr, pc uint64) ([]byte, *locationExpr, error) {
+	//TODO(aarzilli): handle DW_FORM_loclistx attribute form new in DWARFv5
 	a := entry.Val(attr)
 	if a == nil {
 		return nil, nil, fmt.Errorf("no location attribute %s", attr)
@@ -880,17 +885,20 @@ func (bi *BinaryInfo) LocationCovers(entry *dwarf.Entry, attr dwarf.Attr) ([][2]
 	if cu == nil {
 		return nil, errors.New("could not find compile unit")
 	}
+	if cu.Version >= 5 && cu.image.loclist5 != nil {
+		return nil, errors.New("LocationCovers does not support DWARFv5")
+	}
 
 	image := cu.image
 	base := cu.lowPC
-	if image == nil || image.loclist.Empty() {
+	if image == nil || image.loclist2.Empty() {
 		return nil, errors.New("malformed executable")
 	}
 
 	r := [][2]uint64{}
 	var e loclist.Entry
-	image.loclist.Seek(int(off))
-	for image.loclist.Next(&e) {
+	image.loclist2.Seek(int(off))
+	for image.loclist2.Next(&e) {
 		if e.BaseAddressSelection() {
 			base = e.HighPC
 			continue
@@ -918,24 +926,35 @@ func (bi *BinaryInfo) Location(entry godwarf.Entry, attr dwarf.Attr, pc uint64, 
 func (bi *BinaryInfo) loclistEntry(off int64, pc uint64) []byte {
 	var base uint64
 	image := bi.Images[0]
-	if cu := bi.findCompileUnit(pc); cu != nil {
+	cu := bi.findCompileUnit(pc)
+	if cu != nil {
 		base = cu.lowPC
 		image = cu.image
 	}
-	if image == nil || image.loclist.Empty() {
+	if image == nil {
 		return nil
 	}
 
-	image.loclist.Seek(int(off))
-	var e loclist.Entry
-	for image.loclist.Next(&e) {
-		if e.BaseAddressSelection() {
-			base = e.HighPC
-			continue
+	var loclist loclist.Reader = image.loclist2
+	var debugAddr *godwarf.DebugAddr
+	if cu != nil && cu.Version >= 5 && image.loclist5 != nil {
+		loclist = image.loclist5
+		if addrBase, ok := cu.entry.Val(dwarfAttrAddrBase).(int64); ok {
+			debugAddr = image.debugAddr.GetSubsection(uint64(addrBase))
 		}
-		if pc >= e.LowPC+base+image.StaticBase && pc < e.HighPC+base+image.StaticBase {
-			return e.Instr
-		}
+	}
+
+	if loclist.Empty() {
+		return nil
+	}
+
+	e, err := loclist.Find(int(off), image.StaticBase, base, pc, debugAddr)
+	if err != nil {
+		bi.logger.Errorf("error reading loclist section: %v", err)
+		return nil
+	}
+	if e != nil {
+		return e.Instr
 	}
 
 	return nil
@@ -1114,6 +1133,7 @@ func loadBinaryInfoElf(bi *BinaryInfo, image *Image, path string, addr uint64, w
 
 	dwarfFile := elfFile
 
+	var debugInfoBytes []byte
 	image.dwarf, err = elfFile.DWARF()
 	if err != nil {
 		var sepFile *os.File
@@ -1129,6 +1149,11 @@ func loadBinaryInfoElf(bi *BinaryInfo, image *Image, path string, addr uint64, w
 		}
 	}
 
+	debugInfoBytes, err = godwarf.GetDebugSectionElf(dwarfFile, "info")
+	if err != nil {
+		return err
+	}
+
 	image.dwarfReader = image.dwarf.Reader()
 
 	debugLineBytes, err := godwarf.GetDebugSectionElf(dwarfFile, "line")
@@ -1136,11 +1161,15 @@ func loadBinaryInfoElf(bi *BinaryInfo, image *Image, path string, addr uint64, w
 		return err
 	}
 	debugLocBytes, _ := godwarf.GetDebugSectionElf(dwarfFile, "loc")
-	image.loclist = loclist.New(debugLocBytes, bi.Arch.PtrSize())
+	image.loclist2 = loclist.NewDwarf2Reader(debugLocBytes, bi.Arch.PtrSize())
+	debugLoclistBytes, _ := godwarf.GetDebugSectionElf(dwarfFile, "loclists")
+	image.loclist5 = loclist.NewDwarf5Reader(debugLoclistBytes)
+	debugAddrBytes, _ := godwarf.GetDebugSectionElf(dwarfFile, "addr")
+	image.debugAddr = godwarf.ParseAddr(debugAddrBytes)
 
 	wg.Add(3)
-	go bi.parseDebugFrameElf(image, dwarfFile, wg)
-	go bi.loadDebugInfoMaps(image, debugLineBytes, wg, nil)
+	go bi.parseDebugFrameElf(image, dwarfFile, debugInfoBytes, wg)
+	go bi.loadDebugInfoMaps(image, debugInfoBytes, debugLineBytes, wg, nil)
 	go bi.loadSymbolName(image, elfFile, wg)
 	if image.index == 0 {
 		// determine g struct offset only when loading the executable file
@@ -1169,7 +1198,7 @@ func (bi *BinaryInfo) loadSymbolName(image *Image, file *elf.File, wg *sync.Wait
 	}
 }
 
-func (bi *BinaryInfo) parseDebugFrameElf(image *Image, exe *elf.File, wg *sync.WaitGroup) {
+func (bi *BinaryInfo) parseDebugFrameElf(image *Image, exe *elf.File, debugInfoBytes []byte, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	debugFrameData, err := godwarf.GetDebugSectionElf(exe, "frame")
@@ -1177,13 +1206,8 @@ func (bi *BinaryInfo) parseDebugFrameElf(image *Image, exe *elf.File, wg *sync.W
 		image.setLoadError("could not get .debug_frame section: %v", err)
 		return
 	}
-	debugInfoData, err := godwarf.GetDebugSectionElf(exe, "info")
-	if err != nil {
-		image.setLoadError("could not get .debug_info section: %v", err)
-		return
-	}
 
-	bi.frameEntries = bi.frameEntries.Append(frame.Parse(debugFrameData, frame.DwarfEndian(debugInfoData), image.StaticBase, bi.Arch.PtrSize()))
+	bi.frameEntries = bi.frameEntries.Append(frame.Parse(debugFrameData, frame.DwarfEndian(debugInfoBytes), image.StaticBase, bi.Arch.PtrSize()))
 }
 
 func (bi *BinaryInfo) setGStructOffsetElf(image *Image, exe *elf.File, wg *sync.WaitGroup) {
@@ -1252,6 +1276,10 @@ func loadBinaryInfoPE(bi *BinaryInfo, image *Image, path string, entryPoint uint
 	if err != nil {
 		return err
 	}
+	debugInfoBytes, err := godwarf.GetDebugSectionPE(peFile, "info")
+	if err != nil {
+		return err
+	}
 
 	//TODO(aarzilli): actually test this when Go supports PIE buildmode on Windows.
 	opth := peFile.OptionalHeader.(*pe.OptionalHeader64)
@@ -1270,11 +1298,15 @@ func loadBinaryInfoPE(bi *BinaryInfo, image *Image, path string, entryPoint uint
 		return err
 	}
 	debugLocBytes, _ := godwarf.GetDebugSectionPE(peFile, "loc")
-	image.loclist = loclist.New(debugLocBytes, bi.Arch.PtrSize())
+	image.loclist2 = loclist.NewDwarf2Reader(debugLocBytes, bi.Arch.PtrSize())
+	debugLoclistBytes, _ := godwarf.GetDebugSectionPE(peFile, "loclists")
+	image.loclist5 = loclist.NewDwarf5Reader(debugLoclistBytes)
+	debugAddrBytes, _ := godwarf.GetDebugSectionPE(peFile, "addr")
+	image.debugAddr = godwarf.ParseAddr(debugAddrBytes)
 
 	wg.Add(2)
-	go bi.parseDebugFramePE(image, peFile, wg)
-	go bi.loadDebugInfoMaps(image, debugLineBytes, wg, nil)
+	go bi.parseDebugFramePE(image, peFile, debugInfoBytes, wg)
+	go bi.loadDebugInfoMaps(image, debugInfoBytes, debugLineBytes, wg, nil)
 
 	// Use ArbitraryUserPointer (0x28) as pointer to pointer
 	// to G struct per:
@@ -1297,17 +1329,12 @@ func openExecutablePathPE(path string) (*pe.File, io.Closer, error) {
 	return peFile, f, nil
 }
 
-func (bi *BinaryInfo) parseDebugFramePE(image *Image, exe *pe.File, wg *sync.WaitGroup) {
+func (bi *BinaryInfo) parseDebugFramePE(image *Image, exe *pe.File, debugInfoBytes []byte, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	debugFrameBytes, err := godwarf.GetDebugSectionPE(exe, "frame")
 	if err != nil {
 		image.setLoadError("could not get .debug_frame section: %v", err)
-		return
-	}
-	debugInfoBytes, err := godwarf.GetDebugSectionPE(exe, "info")
-	if err != nil {
-		image.setLoadError("could not get .debug_info section: %v", err)
 		return
 	}
 
@@ -1347,6 +1374,10 @@ func loadBinaryInfoMacho(bi *BinaryInfo, image *Image, path string, entryPoint u
 	if err != nil {
 		return err
 	}
+	debugInfoBytes, err := godwarf.GetDebugSectionMacho(exe, "info")
+	if err != nil {
+		return err
+	}
 
 	image.dwarfReader = image.dwarf.Reader()
 
@@ -1355,11 +1386,15 @@ func loadBinaryInfoMacho(bi *BinaryInfo, image *Image, path string, entryPoint u
 		return err
 	}
 	debugLocBytes, _ := godwarf.GetDebugSectionMacho(exe, "loc")
-	image.loclist = loclist.New(debugLocBytes, bi.Arch.PtrSize())
+	image.loclist2 = loclist.NewDwarf2Reader(debugLocBytes, bi.Arch.PtrSize())
+	debugLoclistBytes, _ := godwarf.GetDebugSectionMacho(exe, "loclists")
+	image.loclist5 = loclist.NewDwarf5Reader(debugLoclistBytes)
+	debugAddrBytes, _ := godwarf.GetDebugSectionMacho(exe, "addr")
+	image.debugAddr = godwarf.ParseAddr(debugAddrBytes)
 
 	wg.Add(2)
-	go bi.parseDebugFrameMacho(image, exe, wg)
-	go bi.loadDebugInfoMaps(image, debugLineBytes, wg, bi.setGStructOffsetMacho)
+	go bi.parseDebugFrameMacho(image, exe, debugInfoBytes, wg)
+	go bi.loadDebugInfoMaps(image, debugInfoBytes, debugLineBytes, wg, bi.setGStructOffsetMacho)
 	return nil
 }
 
@@ -1375,17 +1410,12 @@ func (bi *BinaryInfo) setGStructOffsetMacho() {
 	bi.gStructOffset = 0x8a0
 }
 
-func (bi *BinaryInfo) parseDebugFrameMacho(image *Image, exe *macho.File, wg *sync.WaitGroup) {
+func (bi *BinaryInfo) parseDebugFrameMacho(image *Image, exe *macho.File, debugInfoBytes []byte, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	debugFrameBytes, err := godwarf.GetDebugSectionMacho(exe, "frame")
 	if err != nil {
 		image.setLoadError("could not get __debug_frame section: %v", err)
-		return
-	}
-	debugInfoBytes, err := godwarf.GetDebugSectionMacho(exe, "info")
-	if err != nil {
-		image.setLoadError("could not get .debug_info section: %v", err)
 		return
 	}
 
@@ -1499,7 +1529,7 @@ func (bi *BinaryInfo) registerTypeToPackageMap(entry *dwarf.Entry) {
 	bi.PackageMap[name] = []string{path}
 }
 
-func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugLineBytes []byte, wg *sync.WaitGroup, cont func()) {
+func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugInfoBytes, debugLineBytes []byte, wg *sync.WaitGroup, cont func()) {
 	if wg != nil {
 		defer wg.Done()
 	}
@@ -1519,7 +1549,7 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugLineBytes []byte, wg 
 
 	image.runtimeTypeToDIE = make(map[uint64]runtimeTypeDIE)
 
-	ctxt := newLoadDebugInfoMapsContext(bi, image)
+	ctxt := newLoadDebugInfoMapsContext(bi, image, util.ReadUnitVersions(debugInfoBytes))
 
 	reader := image.DwarfReader()
 
@@ -1534,6 +1564,7 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugLineBytes []byte, wg 
 			cu.image = image
 			cu.entry = entry
 			cu.offset = entry.Offset
+			cu.Version = ctxt.offsetToVersion[cu.offset]
 			if lang, _ := entry.Val(dwarf.AttrLanguage).(int64); lang == dwarfGoLanguage {
 				cu.isgo = true
 			}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -80,13 +80,15 @@ type loadDebugInfoMapsContext struct {
 	ardr                *reader.Reader
 	abstractOriginTable map[dwarf.Offset]int
 	knownPackageVars    map[string]struct{}
+	offsetToVersion     map[dwarf.Offset]uint8
 }
 
-func newLoadDebugInfoMapsContext(bi *BinaryInfo, image *Image) *loadDebugInfoMapsContext {
+func newLoadDebugInfoMapsContext(bi *BinaryInfo, image *Image, offsetToVersion map[dwarf.Offset]uint8) *loadDebugInfoMapsContext {
 	ctxt := &loadDebugInfoMapsContext{}
 
 	ctxt.ardr = image.DwarfReader()
 	ctxt.abstractOriginTable = make(map[dwarf.Offset]int)
+	ctxt.offsetToVersion = offsetToVersion
 
 	ctxt.knownPackageVars = map[string]struct{}{}
 	for _, v := range bi.packageVars {


### PR DESCRIPTION
### proc: support DWARFv5 loclist

Parses and uses the new debug_loclists section added to DWARFv5.

### dwarf/loclist,godwarf: support DWARF version 5 loclists and debug_addr


