### PR TITLE
service/dap: resolve minor error code TODO

### DIFF
--- a/service/dap/error_ids.go
+++ b/service/dap/error_ids.go
@@ -1,18 +1,17 @@
 package dap
 
 // Unique identifiers for messages returned for errors from requests.
+// These values are not mandated by DAP (other than the uniqueness
+// requirement), so each implementation is free to choose their own.
 const (
 	UnsupportedCommand int = 9999
 	InternalError      int = 8888
 	NotYetImplemented  int = 7777
 
-	// The values below come from the vscode-go debug adaptor.
-	// Although the spec says they should be unique, the adaptor
-	// reuses 3000 for launch, attach and program exit failures.
-	// TODO(polina): confirm if the extension expects specific ids
-	// for specific cases, and we must match the existing adaptor
-	// or if these codes can evolve.
-	FailedToContinue          = 3000
+	// Where applicable and for consistency only,
+	// values below are inspired the original vscode-go debug adaptor.
+	FailedToLaunch            = 3000
+	FailedtoAttach            = 3001
 	UnableToDisplayThreads    = 2003
 	UnableToProduceStackTrace = 2004
 	// Add more codes as we support more requests

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -399,7 +399,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 	program, ok := request.Arguments["program"].(string)
 	if !ok || program == "" {
 		s.sendErrorResponse(request.Request,
-			FailedToContinue, "Failed to launch",
+			FailedToLaunch, "Failed to launch",
 			"The program attribute is missing in debug configuration.")
 		return
 	}
@@ -426,7 +426,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 			buildFlags, ok = buildFlagsArg.(string)
 			if !ok {
 				s.sendErrorResponse(request.Request,
-					FailedToContinue, "Failed to launch",
+					FailedToLaunch, "Failed to launch",
 					fmt.Sprintf("'buildFlags' attribute '%v' in debug configuration is not a string.", buildFlagsArg))
 				return
 			}
@@ -440,7 +440,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 		}
 		if err != nil {
 			s.sendErrorResponse(request.Request,
-				FailedToContinue, "Failed to launch",
+				FailedToLaunch, "Failed to launch",
 				fmt.Sprintf("Build error: %s", err.Error()))
 			return
 		}
@@ -451,7 +451,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 	// TODO(polina): support "remote" mode
 	if mode != "exec" && mode != "debug" && mode != "test" {
 		s.sendErrorResponse(request.Request,
-			FailedToContinue, "Failed to launch",
+			FailedToLaunch, "Failed to launch",
 			fmt.Sprintf("Unsupported 'mode' value %q in debug configuration.", mode))
 		return
 	}
@@ -470,7 +470,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 		argsParsed, ok := args.([]interface{})
 		if !ok {
 			s.sendErrorResponse(request.Request,
-				FailedToContinue, "Failed to launch",
+				FailedToLaunch, "Failed to launch",
 				fmt.Sprintf("'args' attribute '%v' in debug configuration is not an array.", args))
 			return
 		}
@@ -478,7 +478,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 			argParsed, ok := arg.(string)
 			if !ok {
 				s.sendErrorResponse(request.Request,
-					FailedToContinue, "Failed to launch",
+					FailedToLaunch, "Failed to launch",
 					fmt.Sprintf("value '%v' in 'args' attribute in debug configuration is not a string.", arg))
 				return
 			}
@@ -492,7 +492,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 	var err error
 	if s.debugger, err = debugger.New(&s.config.Debugger, s.config.ProcessArgs); err != nil {
 		s.sendErrorResponse(request.Request,
-			FailedToContinue, "Failed to launch", err.Error())
+			FailedToLaunch, "Failed to launch", err.Error())
 		return
 	}
 


### PR DESCRIPTION
A while back I was able to clarify with vscode maintainers any questions we had about the error code values. @weinand wrote "The error numbers are private to some of our implementations. You should pick your own. There is no benefit of trying to reuse these numbers".