### PR TITLE
proc: keep track of nesting depth while reading compile units

### DIFF
--- a/pkg/proc/dwarf_export_test.go
+++ b/pkg/proc/dwarf_export_test.go
@@ -1,0 +1,6 @@
+package proc
+
+// PackageVars returns bi.packageVars (for tests)
+func (bi *BinaryInfo) PackageVars() []packageVar {
+	return bi.packageVars
+}

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -337,3 +337,19 @@ func TestUnsupportedType(t *testing.T) {
 		t.Errorf("unexpected error reading unsupported type: %#v", err)
 	}
 }
+
+func TestNestedCompileUnts(t *testing.T) {
+	// Tests that a compile unit with a nested entry that we don't care about
+	// (such as a DW_TAG_namespace) is read fully.
+	dwb := dwarfbuilder.New()
+	dwb.AddCompileUnit("main", 0x0)
+	dwb.TagOpen(dwarf.TagNamespace, "namespace")
+	dwb.AddVariable("var1", 0x0, uint64(0x0))
+	dwb.TagClose()
+	dwb.AddVariable("var2", 0x0, uint64(0x0))
+	dwb.TagClose()
+	bi, _ := fakeBinaryInfo(t, dwb)
+	if n := len(bi.PackageVars()); n != 2 {
+		t.Errorf("expected 2 variables, got %d", n)
+	}
+}


### PR DESCRIPTION
Fully read compile units that contain nested entries we don't
understand (such as DW_TAG_namespace) by keeping track of the depth
we're at.
