### PR TITLE
Documentation: Add FreeBSD under main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The GitHub issue tracker is for **bugs** only. Please use the [developer mailing
   - [Linux](Documentation/installation/linux/install.md)
   - [macOS](Documentation/installation/osx/install.md)
   - [Windows](Documentation/installation/windows/install.md)
+  - [FreeBSD](Documentation/installation/freebsd/install.md)
 - [Getting Started](Documentation/cli/getting_started.md)
 - [Documentation](Documentation)
   - [Command line options](Documentation/usage/dlv.md)


### PR DESCRIPTION
I noticed that the [Installation](https://github.com/go-delve/delve/tree/master/Documentation/installation) page has FreeBSD listed, but the main README doesn't. So here's the PR to add FreeBSD to the root README.