### PR TITLE
Update eval.go

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -473,7 +473,7 @@ func (scope *EvalScope) PackageVariables(cfg LoadConfig) ([]*Variable, error) {
 
 		// Ignore errors trying to extract values
 		val, err := extractVarInfoFromEntry(scope.BinInfo, pkgvar.cu.image, regsReplaceStaticBase(scope.Regs, pkgvar.cu.image), scope.Mem, godwarf.EntryToTree(entry))
-		if val.Kind == reflect.Invalid {
+		if val != nil && val.Kind == reflect.Invalid {
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
Check val != nil to ignore possible crash.
Related to #2101