### PR TITLE
cmd/dlv: print error when build fails in 'dlv test'

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -586,6 +586,7 @@ func testCmd(cmd *cobra.Command, args []string) {
 		dlvArgs, targetArgs := splitArgs(cmd, args)
 		err = gobuild.GoTestBuild(debugname, dlvArgs, buildFlags)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			return 1
 		}
 		defer gobuild.Remove(debugname)


### PR DESCRIPTION
Fixes #2126
