### PR TITLE
cmd/dlv: subcommand 'dlv test' should switch to package directory

### DIFF
--- a/Documentation/usage/dlv.md
+++ b/Documentation/usage/dlv.md
@@ -31,7 +31,7 @@ Pass flags to the program you are debugging using `--`, for example:
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -37,7 +37,7 @@ dlv attach pid [executable]
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_backend.md
+++ b/Documentation/usage/dlv_backend.md
@@ -30,7 +30,7 @@ are:
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_connect.md
+++ b/Documentation/usage/dlv_connect.md
@@ -26,7 +26,7 @@ dlv connect addr
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_core.md
+++ b/Documentation/usage/dlv_core.md
@@ -32,7 +32,7 @@ dlv core <executable> <core>
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_dap.md
+++ b/Documentation/usage/dlv_dap.md
@@ -33,7 +33,7 @@ dlv dap
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -39,7 +39,7 @@ dlv debug [package]
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -39,7 +39,7 @@ dlv exec <path/to/binary>
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_log.md
+++ b/Documentation/usage/dlv_log.md
@@ -45,7 +45,7 @@ and dap modes.
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_replay.md
+++ b/Documentation/usage/dlv_replay.md
@@ -30,7 +30,7 @@ dlv replay [trace directory]
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_run.md
+++ b/Documentation/usage/dlv_run.md
@@ -26,7 +26,7 @@ dlv run
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -37,7 +37,7 @@ dlv test [package]
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -44,7 +44,7 @@ dlv trace [package] regexp
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -26,7 +26,7 @@ dlv version
       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program. (default ".")
+      --wd string            Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/_fixtures/buildtest/main_test.go
+++ b/_fixtures/buildtest/main_test.go
@@ -8,3 +8,8 @@ import (
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
+
+func TestCurrentDirectory(t *testing.T) {
+	wd, _ := os.Getwd()
+	t.Logf("current directory: %s", wd)
+}

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -728,3 +728,23 @@ func TestTracePrintStack(t *testing.T) {
 		t.Fatal("stacktrace not printed")
 	}
 }
+
+func TestDlvTestChdir(t *testing.T) {
+	dlvbin, tmpdir := getDlvBin(t)
+	defer os.RemoveAll(tmpdir)
+
+	fixtures := protest.FindFixturesDir()
+	cmd := exec.Command(dlvbin, "test", filepath.Join(fixtures, "buildtest"), "--", "-test.v")
+	cmd.Stdin = strings.NewReader("continue\nexit\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("error executing Delve: %v", err)
+	}
+	t.Logf("output: %q", out)
+
+	p, _ := filepath.Abs(filepath.Join(fixtures, "buildtest"))
+	tgt := "current directory: " + p
+	if !strings.Contains(string(out), tgt) {
+		t.Errorf("output did not contain expected string %q", tgt)
+	}
+}


### PR DESCRIPTION
Match 'go test' behaviour and switch to package directory, unless one
is specified with the '--wd' option.

Fixes #2125
