### PR TITLE
prettyprint: fix index out of range error

### DIFF
--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -291,6 +291,9 @@ func (v *Variable) recursiveKind() (reflect.Kind, bool) {
 		kind = v.Kind
 		if kind == reflect.Ptr {
 			hasptr = true
+			if len(v.Children) == 0 {
+				return kind, hasptr
+			}
 			v = &(v.Children[0])
 		} else {
 			break


### PR DESCRIPTION
api.(*Variable).recursiveKind should not assume that a pointer is
always fully loaded.

Fixes #2130
