### PR TITLE
proc: fix support for AVX registers

### DIFF
--- a/_fixtures/fputest/fputest.go
+++ b/_fixtures/fputest/fputest.go
@@ -5,7 +5,8 @@ import (
 	"runtime"
 )
 
-func fputestsetup(f64a, f64b, f64c, f64d float64, f32a, f32b, f32c, f32d float32)
+func fputestsetup(f64a, f64b, f64c, f64d float64, f32a, f32b, f32c, f32d float32, avx2, avx512 bool)
+func getCPUID70() (ebx, ecx uint32)
 
 func main() {
 	var f64a float64 = 1.1
@@ -17,7 +18,11 @@ func main() {
 	var f32c float32 = 1.7
 	var f32d float32 = 1.8
 
-	fputestsetup(f64a, f64b, f64c, f64d, f32a, f32b, f32c, f32d)
+	ebx, _ := getCPUID70()
+	avx2 := ebx&(1<<5) != 0
+	avx512 := ebx&(1<<16) != 0
+
+	fputestsetup(f64a, f64b, f64c, f64d, f32a, f32b, f32c, f32d, avx2, avx512)
 	if len(os.Args) < 2 || os.Args[1] != "panic" {
 		runtime.Breakpoint()
 	} else {

--- a/_fixtures/fputest/fputest_amd64.s
+++ b/_fixtures/fputest/fputest_amd64.s
@@ -1,4 +1,4 @@
-TEXT ·fputestsetup(SB),$0-48
+TEXT ·fputestsetup(SB),$0-50
 	// setup x87 stack
 	FMOVD f64a+0(FP), F0
 	FMOVD f64b+8(FP), F0
@@ -55,5 +55,24 @@ TEXT ·fputestsetup(SB),$0-48
 
 	MOVAPS X1, X9
 	MOVAPS X2, X10
+	
+	CMPB avx2+48(FP), $0x0
+	JE done
+	//copy XMM1 to both halves of YMM11
+	VPERMQ $0x44, Y1, Y11
+	
+	CMPB avx512+49(FP), $0x0
+	JE done
+	//copy YMM11 to both halves of ZMM12
+	VSHUFF64X2 $0x44, Z11, Z11, Z12
 
+done:
+	RET
+
+TEXT ·getCPUID70(SB),$0
+	MOVQ $7, AX
+	MOVQ $0, CX
+	CPUID
+	MOVD BX, ret+0(FP)
+	MOVD CX, ret+4(FP)
 	RET

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1903,7 +1903,11 @@ func (regs *gdbRegisters) Slice(floatingPoint bool) ([]proc.Register, error) {
 
 		case reginfo.Bitsize == 128:
 			if floatingPoint {
-				r = proc.AppendBytesRegister(r, strings.ToUpper(reginfo.Name), regs.regs[reginfo.Name].value)
+				name := reginfo.Name
+				if last := name[len(name)-1]; last == 'h' || last == 'H' {
+					name = name[:len(name)-1]
+				}
+				r = proc.AppendBytesRegister(r, strings.ToUpper(name), regs.regs[reginfo.Name].value)
 			}
 
 		case reginfo.Bitsize == 256:

--- a/pkg/proc/i386_arch.go
+++ b/pkg/proc/i386_arch.go
@@ -284,7 +284,7 @@ func i386DwarfRegisterToString(j int, reg *op.DwarfRegister) (name string, float
 
 	default:
 		if reg.Bytes != nil && strings.HasPrefix(n, "xmm") {
-			return name, true, formatSSEReg(reg.Bytes)
+			return name, true, formatSSEReg(name, reg.Bytes)
 		} else if reg.Bytes != nil && strings.HasPrefix(n, "st(") {
 			return name, true, formatX87Reg(reg.Bytes)
 		} else if reg.Bytes == nil || (reg.Bytes != nil && len(reg.Bytes) <= 8) {

--- a/pkg/proc/linutil/regs_amd64_arch.go
+++ b/pkg/proc/linutil/regs_amd64_arch.go
@@ -331,9 +331,11 @@ type AMD64PtraceFpRegs struct {
 // Manual, Volume 1: Basic Architecture.
 type AMD64Xstate struct {
 	AMD64PtraceFpRegs
-	Xsave    []byte // raw xsave area
-	AvxState bool   // contains AVX state
-	YmmSpace [256]byte
+	Xsave       []byte // raw xsave area
+	AvxState    bool   // contains AVX state
+	YmmSpace    [256]byte
+	Avx512State bool // contains AVX512 state
+	ZmmSpace    [512]byte
 }
 
 // Decode decodes an XSAVE area to a list of name/value pairs of registers.
@@ -358,9 +360,13 @@ func (xsave *AMD64Xstate) Decode() (regs []proc.Register) {
 	regs = proc.AppendUint64Register(regs, "MXCSR_MASK", uint64(xsave.MxcrMask))
 
 	for i := 0; i < len(xsave.XmmSpace); i += 16 {
-		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("XMM%d", i/16), xsave.XmmSpace[i:i+16])
+		n := i / 16
+		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("XMM%d", n), xsave.XmmSpace[i:i+16])
 		if xsave.AvxState {
-			regs = proc.AppendBytesRegister(regs, fmt.Sprintf("YMM%d", i/16), xsave.YmmSpace[i:i+16])
+			regs = proc.AppendBytesRegister(regs, fmt.Sprintf("YMM%d", n), xsave.YmmSpace[i:i+16])
+			if xsave.Avx512State {
+				regs = proc.AppendBytesRegister(regs, fmt.Sprintf("ZMM%d", n), xsave.ZmmSpace[n*32:(n+1)*32])
+			}
 		}
 	}
 
@@ -368,10 +374,11 @@ func (xsave *AMD64Xstate) Decode() (regs []proc.Register) {
 }
 
 const (
-	_XSAVE_HEADER_START          = 512
-	_XSAVE_HEADER_LEN            = 64
-	_XSAVE_EXTENDED_REGION_START = 576
-	_XSAVE_SSE_REGION_LEN        = 416
+	_XSAVE_HEADER_START            = 512
+	_XSAVE_HEADER_LEN              = 64
+	_XSAVE_EXTENDED_REGION_START   = 576
+	_XSAVE_SSE_REGION_LEN          = 416
+	_XSAVE_AVX512_ZMM_REGION_START = 1152
 )
 
 // LinuxX86XstateRead reads a byte array containing an XSAVE area into regset.
@@ -406,6 +413,19 @@ func AMD64XstateRead(xstateargs []byte, readLegacy bool, regset *AMD64Xstate) er
 	avxstate := xstateargs[_XSAVE_EXTENDED_REGION_START:]
 	regset.AvxState = true
 	copy(regset.YmmSpace[:], avxstate[:len(regset.YmmSpace)])
+
+	if xstate_bv&(1<<6) == 0 {
+		// AVX512 state not present
+		return nil
+	}
+
+	avx512state := xstateargs[_XSAVE_AVX512_ZMM_REGION_START:]
+	regset.Avx512State = true
+	copy(regset.ZmmSpace[:], avx512state[:len(regset.ZmmSpace)])
+
+	// TODO(aarzilli): if xstate_bv&(1<<7) is set then xstateargs[1664:2688]
+	// contains ZMM16 through ZMM31, those aren't just the higher 256bits, it's
+	// the full register so each is 64 bytes (512bits)
 
 	return nil
 }


### PR DESCRIPTION
Recent changes to the way registers are handled broke reporting of AVX registers (i.e. YMMx). This change restores the functionality by:
    
- concatenating the higher half of the YMMx registers to their corresponding XMMx lower half (YMMx registers do not have an independent DWARF register number)
- modifying the formatSSEReg function to handle them when they are present.
    
Fixes #2033
