### PR TITLE
proc/native/windows: do not call _DebugBreakProcess on a stopped process

### DIFF
--- a/_fixtures/issue2138.go
+++ b/_fixtures/issue2138.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"time"
+)
+
+func main() {
+	time.Sleep(time.Hour)
+	println("ok")
+}


### PR DESCRIPTION
Fixes #2138
