### PR TITLE
proc: set OnlyAddr on variables created by typecast to pointer

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -846,6 +846,7 @@ func (scope *EvalScope) evalTypeCast(node *ast.CallExpr) (*Variable, error) {
 		n, _ := constant.Int64Val(argv.Value)
 
 		v.Children = []Variable{*(newVariable("", uintptr(n), ttyp.Type, scope.BinInfo, scope.Mem))}
+		v.Children[0].OnlyAddr = true
 		return v, nil
 
 	case *godwarf.UintType:
@@ -1348,6 +1349,7 @@ func (scope *EvalScope) evalPointerDeref(node *ast.StarExpr) (*Variable, error) 
 
 	if len(xev.Children) == 1 {
 		// this branch is here to support pointers constructed with typecasts from ints
+		xev.Children[0].OnlyAddr = false
 		return &(xev.Children[0]), nil
 	}
 	rv := xev.maybeDereference()

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1130,3 +1130,11 @@ func TestPrintOnTracepoint(t *testing.T) {
 		}
 	})
 }
+
+func TestPrintCastToInterface(t *testing.T) {
+	withTestTerminal("testvariables2", t, func(term *FakeTerminal) {
+		term.MustExec("continue")
+		out := term.MustExec(`p (*"interface {}")(uintptr(&iface2))`)
+		t.Logf("%q", out)
+	})
+}


### PR DESCRIPTION
If OnlyAddr is not set pretty printing an interface will fail with an
index out of bounds error.
