### PR TITLE
Target redirects

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -412,16 +412,22 @@ Restart process.
 
 For recorded targets the command takes the following forms:
 
-	restart				resets ot the start of the recording
-	restart [checkpoint]		resets the recording to the given checkpoint
-	restart -r [newargv...]		re-records the target process
+	restart					resets ot the start of the recording
+	restart [checkpoint]			resets the recording to the given checkpoint
+	restart -r [newargv...]	[redirects...]	re-records the target process
 	
 For live targets the command takes the following forms:
 
-	restart [newargv...]		restarts the process
+	restart [newargv...] [redirects...]	restarts the process
 
 If newargv is omitted the process is restarted (or re-recorded) with the same argument vector.
 If -noargs is specified instead, the argument vector is cleared.
+
+A list of file redirections can be specified after the new argument list to override the redirections defined using the '--redirect' command line option. A syntax similar to Unix shells is used:
+
+	<input.txt	redirects the standard input of the target process from input.txt
+	>output.txt	redirects the standard output of the target process to output.txt
+	2>error.txt	redirects the standard error of the target process to error.txt
 
 
 Aliases: r

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -51,7 +51,7 @@ threads() | Equivalent to API call [ListThreads](https://godoc.org/github.com/go
 types(Filter) | Equivalent to API call [ListTypes](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListTypes)
 process_pid() | Equivalent to API call [ProcessPid](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ProcessPid)
 recorded() | Equivalent to API call [Recorded](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Recorded)
-restart(Position, ResetArgs, NewArgs, Rerecord, Rebuild) | Equivalent to API call [Restart](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Restart)
+restart(Position, ResetArgs, NewArgs, Rerecord, Rebuild, NewRedirects) | Equivalent to API call [Restart](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Restart)
 set_expr(Scope, Symbol, Value) | Equivalent to API call [Set](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Set)
 stacktrace(Id, Depth, Full, Defers, Opts, Cfg) | Equivalent to API call [Stacktrace](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Stacktrace)
 state(NonBlocking) | Equivalent to API call [State](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.State)

--- a/Documentation/usage/dlv.md
+++ b/Documentation/usage/dlv.md
@@ -19,19 +19,21 @@ Pass flags to the program you are debugging using `--`, for example:
 ### Options
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -25,19 +25,21 @@ dlv attach pid [executable]
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_connect.md
+++ b/Documentation/usage/dlv_connect.md
@@ -14,19 +14,21 @@ dlv connect addr
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_core.md
+++ b/Documentation/usage/dlv_core.md
@@ -20,19 +20,21 @@ dlv core <executable> <core>
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_dap.md
+++ b/Documentation/usage/dlv_dap.md
@@ -21,19 +21,21 @@ dlv dap
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -27,19 +27,21 @@ dlv debug [package]
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -27,19 +27,21 @@ dlv exec <path/to/binary>
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_log.md
+++ b/Documentation/usage/dlv_log.md
@@ -33,19 +33,21 @@ and dap modes.
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_redirect.md
+++ b/Documentation/usage/dlv_redirect.md
@@ -1,18 +1,21 @@
-## dlv backend
+## dlv redirect
 
-Help about the --backend flag.
+Help about file redirection.
 
 ### Synopsis
 
 
-The --backend flag specifies which backend should be used, possible values
-are:
+The standard file descriptors of the target process can be controlled using the '-r' and '--tty' arguments. 
 
-	default		Uses lldb on macOS, native everywhere else.
-	native		Native backend.
-	lldb		Uses lldb-server or debugserver.
-	rr		Uses mozilla rr (https://github.com/mozilla/rr).
+The --tty argument allows redirecting all standard descriptors to a terminal, specified as an argument to --tty.
 
+The syntax for '-r' argument is:
+
+		-r [source:]destination
+
+Where source is one of 'stdin', 'stdout' or 'stderr' and destination is the path to a file. If the source is omitted stdin is used implicitly.
+
+File redirects can also be changed using the 'restart' command.
 
 
 ### Options inherited from parent commands

--- a/Documentation/usage/dlv_replay.md
+++ b/Documentation/usage/dlv_replay.md
@@ -18,19 +18,21 @@ dlv replay [trace directory]
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_run.md
+++ b/Documentation/usage/dlv_run.md
@@ -14,19 +14,21 @@ dlv run
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -25,19 +25,21 @@ dlv test [package]
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -32,19 +32,21 @@ dlv trace [package] regexp
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -14,19 +14,21 @@ dlv version
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient   Allows a headless server to accept multiple client connections.
-      --api-version int      Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string       Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string   Build flags, to be passed to the compiler.
-      --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
-      --headless             Run debug server only, in headless mode.
-      --init string          Init file, executed by the terminal client.
-  -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
-      --log                  Enable debugging server logging.
-      --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
-      --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
-      --only-same-user       Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
-      --wd string            Working directory for running the program.
+      --accept-multiclient               Allows a headless server to accept multiple client connections.
+      --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
+      --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
+      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
+      --build-flags string               Build flags, to be passed to the compiler.
+      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --headless                         Run debug server only, in headless mode.
+      --init string                      Init file, executed by the terminal client.
+  -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
+      --log                              Enable debugging server logging.
+      --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
+      --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
+      --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
+  -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
+      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO

--- a/_fixtures/redirect-input.txt
+++ b/_fixtures/redirect-input.txt
@@ -1,0 +1,1 @@
+Redirect test

--- a/_fixtures/redirect.go
+++ b/_fixtures/redirect.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+)
+
+func main() {
+	buf, _ := ioutil.ReadAll(os.Stdin)
+	fmt.Fprintf(os.Stdout, "%s %v\n", buf, time.Now())
+}

--- a/cmd/dlv/cmds/cmds_test.go
+++ b/cmd/dlv/cmds/cmds_test.go
@@ -1,0 +1,59 @@
+package cmds
+
+import (
+	"testing"
+)
+
+func TestParseRedirects(t *testing.T) {
+	testCases := []struct {
+		in     []string
+		tgt    [3]string
+		tgterr string
+	}{
+		{
+			[]string{"one.txt"},
+			[3]string{"one.txt", "", ""},
+			"",
+		},
+		{
+			[]string{"one.txt", "two.txt"},
+			[3]string{},
+			"redirect error: stdin redirected twice",
+		},
+		{
+			[]string{"stdout:one.txt"},
+			[3]string{"", "one.txt", ""},
+			"",
+		},
+		{
+			[]string{"stdout:one.txt", "stderr:two.txt", "stdin:three.txt"},
+			[3]string{"three.txt", "one.txt", "two.txt"},
+			"",
+		},
+		{
+			[]string{"stdout:one.txt", "stderr:two.txt", "three.txt"},
+			[3]string{"three.txt", "one.txt", "two.txt"},
+			"",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("input: %q", tc.in)
+		out, err := parseRedirects(tc.in)
+		t.Logf("output: %q error %v", out, err)
+		if tc.tgterr != "" {
+			if err == nil {
+				t.Errorf("Expected error %q, got output %q", tc.tgterr, out)
+			} else if errstr := err.Error(); errstr != tc.tgterr {
+				t.Errorf("Expected error %q, got error %q", tc.tgterr, errstr)
+			}
+		} else {
+			for i := range tc.tgt {
+				if tc.tgt[i] != out[i] {
+					t.Errorf("Expected %q, got %q (mismatch at index %d)", tc.tgt, out, i)
+					break
+				}
+			}
+		}
+	}
+}

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -121,7 +121,7 @@ func testOutput(t *testing.T, dlvbin, output string, delveCmds []string) (stdout
 	var stdoutBuf, stderrBuf bytes.Buffer
 	buildtestdir := filepath.Join(protest.FindFixturesDir(), "buildtest")
 
-	c := []string{dlvbin, "debug"}
+	c := []string{dlvbin, "debug", "--allow-non-terminal-interactive=true"}
 	debugbin := filepath.Join(buildtestdir, "__debug_bin")
 	if output != "" {
 		c = append(c, "--output", output)
@@ -734,7 +734,7 @@ func TestDlvTestChdir(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 
 	fixtures := protest.FindFixturesDir()
-	cmd := exec.Command(dlvbin, "test", filepath.Join(fixtures, "buildtest"), "--", "-test.v")
+	cmd := exec.Command(dlvbin, "--allow-non-terminal-interactive=true", "test", filepath.Join(fixtures, "buildtest"), "--", "-test.v")
 	cmd.Stdin = strings.NewReader("continue\nexit\n")
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -30,7 +30,7 @@ func withTestRecording(name string, t testing.TB, fn func(t *proc.Target, fixtur
 		t.Skip("test skipped, rr not found")
 	}
 	t.Log("recording")
-	p, tracedir, err := gdbserial.RecordAndReplay([]string{fixture.Path}, ".", true, []string{})
+	p, tracedir, err := gdbserial.RecordAndReplay([]string{fixture.Path}, ".", true, []string{}, [3]string{})
 	if err != nil {
 		t.Fatal("Launch():", err)
 	}

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -12,7 +12,7 @@ import (
 var ErrNativeBackendDisabled = errors.New("native backend disabled during compilation")
 
 // Launch returns ErrNativeBackendDisabled.
-func Launch(_ []string, _ string, _ bool, _ []string, _ string) (*proc.Target, error) {
+func Launch(_ []string, _ string, _ bool, _ []string, _ string, _ [3]string) (*proc.Target, error) {
 	return nil, ErrNativeBackendDisabled
 }
 

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -37,7 +37,7 @@ type osProcessDetails struct {
 // custom fork/exec process in order to take advantage of
 // PT_SIGEXC on Darwin which will turn Unix signals into
 // Mach exceptions.
-func Launch(cmd []string, wd string, foreground bool, _ []string, _ string) (*proc.Target, error) {
+func Launch(cmd []string, wd string, foreground bool, _ []string, _ string, _ [3]string) (*proc.Target, error) {
 	argv0Go, err := filepath.Abs(cmd[0])
 	if err != nil {
 		return nil, err

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -49,13 +49,18 @@ type osProcessDetails struct {
 // to be supplied to that process. `wd` is working directory of the program.
 // If the DWARF information cannot be found in the binary, Delve will look
 // for external debug files in the directories passed in.
-func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string, tty string) (*proc.Target, error) {
+func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string, tty string, redirects [3]string) (*proc.Target, error) {
 	var (
 		process *exec.Cmd
 		err     error
 	)
 
-	if !isatty.IsTerminal(os.Stdin.Fd()) {
+	stdin, stdout, stderr, closefn, err := openRedirects(redirects, foreground)
+	if err != nil {
+		return nil, err
+	}
+
+	if stdin == nil || !isatty.IsTerminal(stdin.Fd()) {
 		// exec.(*Process).Start will fail if we try to send a process to
 		// foreground but we are not attached to a terminal.
 		foreground = false
@@ -70,8 +75,9 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string, tt
 	dbp.execPtraceFunc(func() {
 		process = exec.Command(cmd[0])
 		process.Args = cmd
-		process.Stdout = os.Stdout
-		process.Stderr = os.Stderr
+		process.Stdin = stdin
+		process.Stdout = stdout
+		process.Stderr = stderr
 		process.SysProcAttr = &syscall.SysProcAttr{
 			Ptrace:     true,
 			Setpgid:    true,
@@ -79,7 +85,6 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string, tt
 		}
 		if foreground {
 			signal.Ignore(syscall.SIGTTOU, syscall.SIGTTIN)
-			process.Stdin = os.Stdin
 		}
 		if tty != "" {
 			dbp.ctty, err = attachProcessToTTY(process, tty)
@@ -92,6 +97,7 @@ func Launch(cmd []string, wd string, foreground bool, debugInfoDirs []string, tt
 		}
 		err = process.Start()
 	})
+	closefn()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/proc_linux_test.go
+++ b/pkg/proc/proc_linux_test.go
@@ -14,7 +14,7 @@ func TestLoadingExternalDebugInfo(t *testing.T) {
 	fixture := protest.BuildFixture("locationsprog", 0)
 	defer os.Remove(fixture.Path)
 	stripAndCopyDebugInfo(fixture, t)
-	p, err := native.Launch(append([]string{fixture.Path}, ""), "", false, []string{filepath.Dir(fixture.Path)}, "")
+	p, err := native.Launch(append([]string{fixture.Path}, ""), "", false, []string{filepath.Dir(fixture.Path)}, "", [3]string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -69,13 +69,13 @@ func withTestProcessArgs(name string, t testing.TB, wd string, args []string, bu
 
 	switch testBackend {
 	case "native":
-		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, false, []string{}, "")
+		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, false, []string{}, "", [3]string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, false, []string{}, "")
+		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, false, []string{}, "", [3]string{})
 	case "rr":
 		protest.MustHaveRecordingAllowed(t)
 		t.Log("recording")
-		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), wd, true, []string{})
+		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), wd, true, []string{}, [3]string{})
 		t.Logf("replaying %q", tracedir)
 	default:
 		t.Fatal("unknown backend")
@@ -2102,9 +2102,9 @@ func TestUnsupportedArch(t *testing.T) {
 
 	switch testBackend {
 	case "native":
-		p, err = native.Launch([]string{outfile}, ".", false, []string{}, "")
+		p, err = native.Launch([]string{outfile}, ".", false, []string{}, "", [3]string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch([]string{outfile}, ".", false, []string{}, "")
+		p, err = gdbserial.LLDBLaunch([]string{outfile}, ".", false, []string{}, "", [3]string{})
 	default:
 		t.Skip("test not valid for this backend")
 	}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -132,16 +132,22 @@ See also: "help on", "help cond" and "help clear"`},
 
 For recorded targets the command takes the following forms:
 
-	restart				resets ot the start of the recording
-	restart [checkpoint]		resets the recording to the given checkpoint
-	restart -r [newargv...]		re-records the target process
+	restart					resets ot the start of the recording
+	restart [checkpoint]			resets the recording to the given checkpoint
+	restart -r [newargv...]	[redirects...]	re-records the target process
 	
 For live targets the command takes the following forms:
 
-	restart [newargv...]		restarts the process
+	restart [newargv...] [redirects...]	restarts the process
 
 If newargv is omitted the process is restarted (or re-recorded) with the same argument vector.
 If -noargs is specified instead, the argument vector is cleared.
+
+A list of file redirections can be specified after the new argument list to override the redirections defined using the '--redirect' command line option. A syntax similar to Unix shells is used:
+
+	<input.txt	redirects the standard input of the target process from input.txt
+	>output.txt	redirects the standard output of the target process to output.txt
+	2>error.txt	redirects the standard error of the target process to error.txt
 `},
 		{aliases: []string{"rebuild"}, group: runCmds, cmdFn: c.rebuild, allowedPrefixes: revPrefix, helpMsg: "Rebuild the target executable and restarts it. It does not work if the executable was not built by delve."},
 		{aliases: []string{"continue", "c"}, group: runCmds, cmdFn: c.cont, allowedPrefixes: revPrefix, helpMsg: "Run until breakpoint or program termination."},
@@ -971,6 +977,7 @@ func restartRecorded(t *Term, ctx callContext, args string) error {
 	rerecord := false
 	resetArgs := false
 	newArgv := []string{}
+	newRedirects := [3]string{}
 	restartPos := ""
 
 	if len(v) > 0 {
@@ -978,7 +985,7 @@ func restartRecorded(t *Term, ctx callContext, args string) error {
 			rerecord = true
 			if len(v) == 2 {
 				var err error
-				resetArgs, newArgv, err = parseNewArgv(v[1])
+				resetArgs, newArgv, newRedirects, err = parseNewArgv(v[1])
 				if err != nil {
 					return err
 				}
@@ -991,7 +998,7 @@ func restartRecorded(t *Term, ctx callContext, args string) error {
 		}
 	}
 
-	if err := restartIntl(t, rerecord, restartPos, resetArgs, newArgv); err != nil {
+	if err := restartIntl(t, rerecord, restartPos, resetArgs, newArgv, newRedirects); err != nil {
 		return err
 	}
 
@@ -1015,12 +1022,12 @@ func parseOptionalCount(arg string) (int64, error) {
 }
 
 func restartLive(t *Term, ctx callContext, args string) error {
-	resetArgs, newArgv, err := parseNewArgv(args)
+	resetArgs, newArgv, newRedirects, err := parseNewArgv(args)
 	if err != nil {
 		return err
 	}
 
-	if err := restartIntl(t, false, "", resetArgs, newArgv); err != nil {
+	if err := restartIntl(t, false, "", resetArgs, newArgv, newRedirects); err != nil {
 		return err
 	}
 
@@ -1028,8 +1035,8 @@ func restartLive(t *Term, ctx callContext, args string) error {
 	return nil
 }
 
-func restartIntl(t *Term, rerecord bool, restartPos string, resetArgs bool, newArgv []string) error {
-	discarded, err := t.client.RestartFrom(rerecord, restartPos, resetArgs, newArgv, false)
+func restartIntl(t *Term, rerecord bool, restartPos string, resetArgs bool, newArgv []string, newRedirects [3]string) error {
+	discarded, err := t.client.RestartFrom(rerecord, restartPos, resetArgs, newArgv, newRedirects, false)
 	if err != nil {
 		return err
 	}
@@ -1039,9 +1046,9 @@ func restartIntl(t *Term, rerecord bool, restartPos string, resetArgs bool, newA
 	return nil
 }
 
-func parseNewArgv(args string) (resetArgs bool, newArgv []string, err error) {
+func parseNewArgv(args string) (resetArgs bool, newArgv []string, newRedirects [3]string, err error) {
 	if args == "" {
-		return false, nil, nil
+		return false, nil, [3]string{}, nil
 	}
 	v, err := argv.Argv(args,
 		func(s string) (string, error) {
@@ -1049,22 +1056,58 @@ func parseNewArgv(args string) (resetArgs bool, newArgv []string, err error) {
 		},
 		nil)
 	if err != nil {
-		return false, nil, err
+		return false, nil, [3]string{}, err
 	}
 	if len(v) != 1 {
-		return false, nil, fmt.Errorf("Illegal commandline '%s'", args)
+		return false, nil, [3]string{}, fmt.Errorf("illegal commandline '%s'", args)
 	}
 	w := v[0]
 	if len(w) == 0 {
-		return false, nil, nil
+		return false, nil, [3]string{}, nil
 	}
 	if w[0] == "-noargs" {
 		if len(w) > 1 {
-			return false, nil, fmt.Errorf("Too many arguments to restart")
+			return false, nil, [3]string{}, fmt.Errorf("too many arguments to restart")
 		}
-		return true, nil, nil
+		return true, nil, [3]string{}, nil
 	}
-	return true, w, nil
+	redirs := [3]string{}
+	for len(w) > 0 {
+		var found bool
+		var err error
+		w, found, err = parseOneRedirect(w, &redirs)
+		if err != nil {
+			return false, nil, [3]string{}, err
+		}
+		if !found {
+			break
+		}
+	}
+	return true, w, redirs, nil
+}
+
+func parseOneRedirect(w []string, redirs *[3]string) ([]string, bool, error) {
+	prefixes := []string{"<", ">", "2>"}
+	names := []string{"stdin", "stdout", "stderr"}
+	if len(w) >= 2 {
+		for _, prefix := range prefixes {
+			if w[len(w)-2] == prefix {
+				w[len(w)-2] += w[len(w)-1]
+				w = w[:len(w)-1]
+				break
+			}
+		}
+	}
+	for i, prefix := range prefixes {
+		if strings.HasPrefix(w[len(w)-1], prefix) {
+			if redirs[i] != "" {
+				return nil, false, fmt.Errorf("redirect error: %s redirected twice", names[i])
+			}
+			redirs[i] = w[len(w)-1][len(prefix):]
+			return w[:len(w)-1], true, nil
+		}
+	}
+	return w, false, nil
 }
 
 func printcontextNoState(t *Term) {

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -1097,6 +1097,12 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 5 && args[5] != starlark.None {
+			err := unmarshalStarlarkValue(args[5], &rpcArgs.NewRedirects, "NewRedirects")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
@@ -1110,6 +1116,8 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Rerecord, "Rerecord")
 			case "Rebuild":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Rebuild, "Rebuild")
+			case "NewRedirects":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.NewRedirects, "NewRedirects")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}

--- a/service/client.go
+++ b/service/client.go
@@ -21,7 +21,7 @@ type Client interface {
 	// Restarts program. Set true if you want to rebuild the process we are debugging.
 	Restart(rebuild bool) ([]api.DiscardedBreakpoint, error)
 	// Restarts program from the specified position.
-	RestartFrom(rerecord bool, pos string, resetArgs bool, newArgs []string, rebuild bool) ([]api.DiscardedBreakpoint, error)
+	RestartFrom(rerecord bool, pos string, resetArgs bool, newArgs []string, newRedirects [3]string, rebuild bool) ([]api.DiscardedBreakpoint, error)
 
 	// GetState returns the current debugger state.
 	GetState() (*api.DebuggerState, error)

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -46,7 +46,7 @@ func (s *RPCServer) Restart(arg1 interface{}, arg2 *int) error {
 	if s.config.Debugger.AttachPid != 0 {
 		return errors.New("cannot restart process Delve did not create")
 	}
-	_, err := s.debugger.Restart(false, "", false, nil, false)
+	_, err := s.debugger.Restart(false, "", false, nil, [3]string{}, false)
 	return err
 }
 

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -62,13 +62,13 @@ func (c *RPCClient) Detach(kill bool) error {
 
 func (c *RPCClient) Restart(rebuild bool) ([]api.DiscardedBreakpoint, error) {
 	out := new(RestartOut)
-	err := c.call("Restart", RestartIn{"", false, nil, false, rebuild}, out)
+	err := c.call("Restart", RestartIn{"", false, nil, false, rebuild, [3]string{}}, out)
 	return out.DiscardedBreakpoints, err
 }
 
-func (c *RPCClient) RestartFrom(rerecord bool, pos string, resetArgs bool, newArgs []string, rebuild bool) ([]api.DiscardedBreakpoint, error) {
+func (c *RPCClient) RestartFrom(rerecord bool, pos string, resetArgs bool, newArgs []string, newRedirects [3]string, rebuild bool) ([]api.DiscardedBreakpoint, error) {
 	out := new(RestartOut)
-	err := c.call("Restart", RestartIn{pos, resetArgs, newArgs, rerecord, rebuild}, out)
+	err := c.call("Restart", RestartIn{pos, resetArgs, newArgs, rerecord, rebuild, newRedirects}, out)
 	return out.DiscardedBreakpoints, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -68,7 +68,7 @@ type RestartIn struct {
 	// otherwise it's an event number. Only valid for recorded targets.
 	Position string
 
-	// ResetArgs tell whether NewArgs should take effect.
+	// ResetArgs tell whether NewArgs and NewRedirects should take effect.
 	ResetArgs bool
 	// NewArgs are arguments to launch a new process.  They replace only the
 	// argv[1] and later. Argv[0] cannot be changed.
@@ -79,6 +79,8 @@ type RestartIn struct {
 
 	// When Rebuild is set the process will be build again
 	Rebuild bool
+
+	NewRedirects [3]string
 }
 
 type RestartOut struct {
@@ -93,7 +95,7 @@ func (s *RPCServer) Restart(arg RestartIn, cb service.RPCCallback) {
 	}
 	var out RestartOut
 	var err error
-	out.DiscardedBreakpoints, err = s.debugger.Restart(arg.Rerecord, arg.Position, arg.ResetArgs, arg.NewArgs, arg.Rebuild)
+	out.DiscardedBreakpoints, err = s.debugger.Restart(arg.Rerecord, arg.Position, arg.ResetArgs, arg.NewArgs, arg.NewRedirects, arg.Rebuild)
 	cb.Return(out, err)
 }
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -131,13 +131,13 @@ func withTestProcessArgs(name string, t *testing.T, wd string, args []string, bu
 	var tracedir string
 	switch testBackend {
 	case "native":
-		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, false, []string{}, "")
+		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, false, []string{}, "", [3]string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, false, []string{}, "")
+		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, false, []string{}, "", [3]string{})
 	case "rr":
 		protest.MustHaveRecordingAllowed(t)
 		t.Log("recording")
-		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), wd, true, []string{})
+		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), wd, true, []string{}, [3]string{})
 		t.Logf("replaying %q", tracedir)
 	default:
 		t.Fatalf("unknown backend %q", testBackend)


### PR DESCRIPTION
cmd,proc,terminal,debugger: Support default file descriptor redirects

Adds features to support default file descriptor redirects for the
target process:

1. A new command line flag '--redirect' and '-r' are added to specify file redirects for the target process
2. New syntax is added to the 'restart' command to specify file redirects.
3. Interactive instances will check if stdin/stdout and stderr are terminals and print a helpful error message if they aren't.
