### PR TITLE
feature(examinemem): x -fmt <?> -count <?> -size <?> <address>, works like gdb `x/FMT`

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -259,15 +259,15 @@ Aliases: ed
 ## examinemem
 Examine memory:
 
-	examinemem [-fmt <format>] [-len <length>] <address>
+	examinemem [-fmt <format>] [-count|-len <count>] [-size <size>] <address>
 
-Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal),.
+Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal), addr(address).
 Length is the number of bytes (default 1) and must be less than or equal to 1000.
-Address is the memory location of the target to examine.
+Address is the memory location of the target to examine. Please note '-len' is deprecated by '-count and -size'.
 
 For example:
 
-    x -fmt hex -len 20 0xc00008af38
+    x -fmt hex -count 20 -size 1 0xc00008af38
 
 Aliases: x
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1627,12 +1627,11 @@ func examineMemoryCmd(t *Term, ctx callContext, args string) error {
 		return fmt.Errorf("no address specified")
 	}
 
-	memArea, err := t.client.ExamineMemory(uintptr(address), count*size)
+	memArea, isLittleEndian, err := t.client.ExamineMemory(uintptr(address), count*size)
 	if err != nil {
 		return err
 	}
-
-	fmt.Print(api.PrettyExamineMemory(uintptr(address), memArea, priFmt, size))
+	fmt.Print(api.PrettyExamineMemory(uintptr(address), memArea, isLittleEndian, priFmt, size))
 	return nil
 }
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1627,7 +1627,7 @@ func examineMemoryCmd(t *Term, ctx callContext, args string) error {
 		return fmt.Errorf("no address specified")
 	}
 
-	memArea, isLittleEndian, err := t.client.ExamineMemory(uintptr(address), count*size)
+	memArea, isLittleEndian, err := t.client.ExamineMemory(address, count*size)
 	if err != nil {
 		return err
 	}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1093,7 +1093,7 @@ func TestExamineMemoryCmd(t *testing.T) {
 			t.Fatalf("could convert %s into int64, err %s", addressStr, err)
 		}
 
-		res := term.MustExec("examinemem  -len 52 -fmt hex " + addressStr)
+		res := term.MustExec("examinemem  -count 52 -fmt hex " + addressStr)
 		t.Logf("the result of examining memory \n%s", res)
 		// check first line
 		firstLine := fmt.Sprintf("%#x:   0x0a   0x0b   0x0c   0x0d   0x0e   0x0f   0x10   0x11", address)
@@ -1109,7 +1109,7 @@ func TestExamineMemoryCmd(t *testing.T) {
 
 		// second examining memory
 		term.MustExec("continue")
-		res = term.MustExec("x -len 52 -fmt bin " + addressStr)
+		res = term.MustExec("x -count 52 -fmt bin " + addressStr)
 		t.Logf("the second result of examining memory result \n%s", res)
 
 		// check first line

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -380,16 +380,16 @@ func PrettyExamineMemory(address uintptr, memArea []byte, isLittleEndian bool, f
 	switch format {
 	case 'b':
 		cols = 4 // Avoid emitting rows that are too long when using binary format
-		colFormat = "%08b"
+		colFormat = fmt.Sprintf("%%0%db", colBytes*8)
 	case 'o':
 		cols = 8
-		colFormat = "0%03o" // Always keep one leading zero for octal.
+		colFormat = fmt.Sprintf("0%%0%do", colBytes*3) // Always keep one leading zero for octal.
 	case 'd':
 		cols = 8
-		colFormat = "%03d"
+		colFormat = fmt.Sprintf("%%0%dd", colBytes*3)
 	case 'x':
 		cols = 8
-		colFormat = "0x%02x" // Always keep one leading '0x' for hex.
+		colFormat = fmt.Sprintf("0x%%0%dx", colBytes*2) // Always keep one leading '0x' for hex.
 	default:
 		return fmt.Sprintf("not supprted format %q\n", string(format))
 	}

--- a/service/api/prettyprint_test.go
+++ b/service/api/prettyprint_test.go
@@ -40,7 +40,6 @@ func Test_byteArrayToUInt64(t *testing.T) {
 		args []byte
 		want uint64
 	}{
-		// TODO: Add test cases.
 		{"case-nil", nil, 0},
 		{"case-empty", []byte{}, 0},
 		{"case-1", []byte{0x1}, 1},

--- a/service/api/prettyprint_test.go
+++ b/service/api/prettyprint_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -17,7 +18,7 @@ func TestPrettyExamineMemory(t *testing.T) {
 		"0x10007:   0151   0152   0153   0154   0155   0156   0157   0160   ",
 		"0x1000f:   0161   0162   0163   0164   0165   0166   0167   0170   ",
 		"0x10017:   0171   0172"}
-	res := strings.Split(strings.TrimSpace(PrettyExamineMemory(addr, memArea, format)), "\n")
+	res := strings.Split(strings.TrimSpace(PrettyExamineMemory(addr, memArea, format, 1)), "\n")
 
 	if len(display) != len(res) {
 		t.Fatalf("wrong lines return, expected %d but got %d", len(display), len(res))
@@ -30,5 +31,26 @@ func TestPrettyExamineMemory(t *testing.T) {
 			errInfo += fmt.Sprintf("but got:\n   %q\n", res[i])
 			t.Fatal(errInfo)
 		}
+	}
+}
+
+func Test_reverse(t *testing.T) {
+	tests := []struct {
+		name string
+		args []byte
+		want []byte
+	}{
+		{"case-1-byte", []byte{1}, []byte{1}},
+		{"case-2-bytes", []byte{1, 2}, []byte{2, 1}},
+		{"case-3-bytes", []byte{1, 2, 3}, []byte{3, 2, 1}},
+		{"case-4-bytes", []byte{1, 2, 3, 4}, []byte{4, 3, 2, 1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reverse(tt.args)
+			if !reflect.DeepEqual(tt.args, tt.want) {
+				t.Errorf("reverse failed, want = %v, got = %v", tt.want, tt.args)
+			}
+		})
 	}
 }

--- a/service/api/prettyprint_test.go
+++ b/service/api/prettyprint_test.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"fmt"
-	"reflect"
+	"math"
 	"strings"
 	"testing"
 )
@@ -34,22 +34,31 @@ func TestPrettyExamineMemory(t *testing.T) {
 	}
 }
 
-func Test_reverse(t *testing.T) {
+func Test_byteArrayToUInt64(t *testing.T) {
 	tests := []struct {
-		name string
-		args []byte
-		want []byte
+		name    string
+		args    []byte
+		want    uint64
+		wantErr bool
 	}{
-		{"case-1-byte", []byte{1}, []byte{1}},
-		{"case-2-bytes", []byte{1, 2}, []byte{2, 1}},
-		{"case-3-bytes", []byte{1, 2, 3}, []byte{3, 2, 1}},
-		{"case-4-bytes", []byte{1, 2, 3, 4}, []byte{4, 3, 2, 1}},
+		// TODO: Add test cases.
+		{"case-nil", nil, 0, true},
+		{"case-empty", []byte{}, 0, true},
+		{"case-1", []byte{0x1}, 1, false},
+		{"case-2", []byte{0x12}, 18, false},
+		{"case-3", []byte{0x1, 0x2}, 513, false},
+		{"case-4", []byte{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x2}, 144397766876004609, false},
+		{"case-5", []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, math.MaxUint64, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reverse(tt.args)
-			if !reflect.DeepEqual(tt.args, tt.want) {
-				t.Errorf("reverse failed, want = %v, got = %v", tt.want, tt.args)
+			got, err := byteArrayToUInt64(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("byteArrayToUInt64() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("byteArrayToUInt64() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/service/api/prettyprint_test.go
+++ b/service/api/prettyprint_test.go
@@ -18,7 +18,7 @@ func TestPrettyExamineMemory(t *testing.T) {
 		"0x10007:   0151   0152   0153   0154   0155   0156   0157   0160   ",
 		"0x1000f:   0161   0162   0163   0164   0165   0166   0167   0170   ",
 		"0x10017:   0171   0172"}
-	res := strings.Split(strings.TrimSpace(PrettyExamineMemory(addr, memArea, format, 1)), "\n")
+	res := strings.Split(strings.TrimSpace(PrettyExamineMemory(addr, memArea, true, format, 1)), "\n")
 
 	if len(display) != len(res) {
 		t.Fatalf("wrong lines return, expected %d but got %d", len(display), len(res))
@@ -36,27 +36,22 @@ func TestPrettyExamineMemory(t *testing.T) {
 
 func Test_byteArrayToUInt64(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []byte
-		want    uint64
-		wantErr bool
+		name string
+		args []byte
+		want uint64
 	}{
 		// TODO: Add test cases.
-		{"case-nil", nil, 0, true},
-		{"case-empty", []byte{}, 0, true},
-		{"case-1", []byte{0x1}, 1, false},
-		{"case-2", []byte{0x12}, 18, false},
-		{"case-3", []byte{0x1, 0x2}, 513, false},
-		{"case-4", []byte{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x2}, 144397766876004609, false},
-		{"case-5", []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, math.MaxUint64, false},
+		{"case-nil", nil, 0},
+		{"case-empty", []byte{}, 0},
+		{"case-1", []byte{0x1}, 1},
+		{"case-2", []byte{0x12}, 18},
+		{"case-3", []byte{0x1, 0x2}, 513},
+		{"case-4", []byte{0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x2}, 144397766876004609},
+		{"case-5", []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, math.MaxUint64},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := byteArrayToUInt64(tt.args)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("byteArrayToUInt64() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := byteArrayToUInt64(tt.args, true)
 			if got != tt.want {
 				t.Errorf("byteArrayToUInt64() got = %v, want %v", got, tt.want)
 			}

--- a/service/client.go
+++ b/service/client.go
@@ -160,7 +160,7 @@ type Client interface {
 	// ExamineMemory returns the raw memory stored at the given address.
 	// The amount of data to be read is specified by length which must be less than or equal to 1000.
 	// This function will return an error if it reads less than `length` bytes.
-	ExamineMemory(address uint64, length int) ([]byte, error)
+	ExamineMemory(address uintptr, length int) ([]byte, bool, error)
 
 	// StopRecording stops a recording if one is in progress.
 	StopRecording() error

--- a/service/client.go
+++ b/service/client.go
@@ -160,7 +160,7 @@ type Client interface {
 	// ExamineMemory returns the raw memory stored at the given address.
 	// The amount of data to be read is specified by length which must be less than or equal to 1000.
 	// This function will return an error if it reads less than `length` bytes.
-	ExamineMemory(address uintptr, length int) ([]byte, bool, error)
+	ExamineMemory(address uint64, length int) ([]byte, bool, error)
 
 	// StopRecording stops a recording if one is in progress.
 	StopRecording() error

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -441,15 +441,14 @@ func (c *RPCClient) ListDynamicLibraries() ([]api.Image, error) {
 	return out.List, nil
 }
 
-func (c *RPCClient) ExamineMemory(address uint64, count int) ([]byte, error) {
+func (c *RPCClient) ExamineMemory(address uintptr, count int) ([]byte, bool, error) {
 	out := &ExaminedMemoryOut{}
 
 	err := c.call("ExamineMemory", ExamineMemoryIn{Length: count, Address: address}, out)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-
-	return out.Mem, nil
+	return out.Mem, out.IsLittleEndian, nil
 }
 
 func (c *RPCClient) StopRecording() error {

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -441,7 +441,7 @@ func (c *RPCClient) ListDynamicLibraries() ([]api.Image, error) {
 	return out.List, nil
 }
 
-func (c *RPCClient) ExamineMemory(address uintptr, count int) ([]byte, bool, error) {
+func (c *RPCClient) ExamineMemory(address uint64, count int) ([]byte, bool, error) {
 	out := &ExaminedMemoryOut{}
 
 	err := c.call("ExamineMemory", ExamineMemoryIn{Length: count, Address: address}, out)

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"time"
-	"unsafe"
 
 	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/proc"
@@ -848,7 +847,8 @@ func (s *RPCServer) ExamineMemory(arg ExamineMemoryIn, out *ExaminedMemoryOut) e
 	}
 
 	out.Mem = Mem
-	out.IsLittleEndian = isLittleEndian()
+	out.IsLittleEndian = true //TODO: get byte order from debugger.target.BinInfo().Arch
+
 	return nil
 }
 
@@ -866,17 +866,4 @@ func (s *RPCServer) StopRecording(arg StopRecordingIn, cb service.RPCCallback) {
 		return
 	}
 	cb.Return(out, nil)
-}
-
-const intSize = int(unsafe.Sizeof(0))
-
-func isLittleEndian() bool {
-	i := 0x1
-	bs := (*[intSize]byte)(unsafe.Pointer(&i))
-
-	if bs[0] == 1 {
-		return true
-	} else {
-		return false
-	}
 }


### PR DESCRIPTION
Make `examinemem` works like gdb x/FMT, in which FMT contains
- a number, represents a repeat times, similar to -count in examinemem
- a format letter, similar to -fmt in examinemem
- a size letter(b,d,w,h..), similar to -size in examinemem

Besides, I add a new format `address`, which has fixed size of sizeof(uintptr).

We can use it like:

1.address `x -fmt addr [-count ?]  <address>`
2.hex `x -fmt hex -count 16 -size 8  <address>`