### PR TITLE
proc: fix dlv can't find the g in runtime.gopark

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -310,9 +310,6 @@ func GoroutinesInfo(dbp *Target, start, count int) ([]*G, int, error) {
 
 	threads := dbp.ThreadList()
 	for _, th := range threads {
-		if th.Blocked() {
-			continue
-		}
 		g, _ := GetG(th)
 		if g != nil {
 			threadg[g.ID] = g


### PR DESCRIPTION
fix #2151. I find the g can't be geted because of `th.Blocked()`