### PR TITLE
proc/*,service: replace uses of uintptr with uint64

### DIFF
--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -142,7 +142,7 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 		// switches from the goroutine stack to the system stack.
 		// Since we are unwinding the stack from callee to caller we have to switch
 		// from the system stack to the goroutine stack.
-		off, _ := readIntRaw(it.mem, uintptr(it.regs.SP()+amd64cgocallSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize())) // reads "offset of SP from StackHi" from where runtime.asmcgocall saved it
+		off, _ := readIntRaw(it.mem, uint64(it.regs.SP()+amd64cgocallSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize())) // reads "offset of SP from StackHi" from where runtime.asmcgocall saved it
 		oldsp := it.regs.SP()
 		it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(int64(it.stackhi) - off)
 
@@ -155,7 +155,7 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 
 		// advances to the next frame in the call stack
 		it.frame.addrret = uint64(int64(it.regs.SP()) + int64(it.bi.Arch.PtrSize()))
-		it.frame.Ret, _ = readUintRaw(it.mem, uintptr(it.frame.addrret), int64(it.bi.Arch.PtrSize()))
+		it.frame.Ret, _ = readUintRaw(it.mem, it.frame.addrret, int64(it.bi.Arch.PtrSize()))
 		it.pc = it.frame.Ret
 
 		it.top = false
@@ -183,7 +183,7 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 		// entering the system stack
 		it.regs.Reg(it.regs.SPRegNum).Uint64Val = it.g0_sched_sp
 		// reads the previous value of g0.sched.sp that runtime.cgocallback_gofunc saved on the stack
-		it.g0_sched_sp, _ = readUintRaw(it.mem, uintptr(it.regs.SP()), int64(it.bi.Arch.PtrSize()))
+		it.g0_sched_sp, _ = readUintRaw(it.mem, uint64(it.regs.SP()), int64(it.bi.Arch.PtrSize()))
 		it.top = false
 		callFrameRegs, ret, retaddr := it.advanceRegs()
 		frameOnSystemStack := it.newStackframe(ret, retaddr)

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -146,9 +146,9 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 			return true
 		case "crosscall2":
 			//The offsets get from runtime/cgo/asm_arm64.s:10
-			newsp, _ := readUintRaw(it.mem, uintptr(it.regs.SP()+8*24), int64(it.bi.Arch.PtrSize()))
-			newbp, _ := readUintRaw(it.mem, uintptr(it.regs.SP()+8*14), int64(it.bi.Arch.PtrSize()))
-			newlr, _ := readUintRaw(it.mem, uintptr(it.regs.SP()+8*15), int64(it.bi.Arch.PtrSize()))
+			newsp, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*24), int64(it.bi.Arch.PtrSize()))
+			newbp, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*14), int64(it.bi.Arch.PtrSize()))
+			newlr, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*15), int64(it.bi.Arch.PtrSize()))
 			if it.regs.Reg(it.regs.BPRegNum) != nil {
 				it.regs.Reg(it.regs.BPRegNum).Uint64Val = uint64(newbp)
 			} else {
@@ -188,7 +188,7 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 		// switches from the goroutine stack to the system stack.
 		// Since we are unwinding the stack from callee to caller we have to switch
 		// from the system stack to the goroutine stack.
-		off, _ := readIntRaw(it.mem, uintptr(callFrameRegs.SP()+arm64cgocallSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize()))
+		off, _ := readIntRaw(it.mem, uint64(callFrameRegs.SP()+arm64cgocallSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize()))
 		oldsp := callFrameRegs.SP()
 		newsp := uint64(int64(it.stackhi) - off)
 
@@ -223,7 +223,7 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 		callFrameRegs.Reg(callFrameRegs.SPRegNum).Uint64Val = it.g0_sched_sp
 		// reads the previous value of g0.sched.sp that runtime.cgocallback_gofunc saved on the stack
 
-		it.g0_sched_sp, _ = readUintRaw(it.mem, uintptr(callFrameRegs.SP()+prevG0schedSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize()))
+		it.g0_sched_sp, _ = readUintRaw(it.mem, uint64(callFrameRegs.SP()+prevG0schedSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize()))
 		it.systemstack = true
 		return false
 	}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -93,7 +93,7 @@ type BinaryInfo struct {
 	// nameOfRuntimeType maps an address of a runtime._type struct to its
 	// decoded name. Used with versions of Go <= 1.10 to figure out the DIE of
 	// the concrete type of interfaces.
-	nameOfRuntimeType map[uintptr]nameOfRuntimeTypeEntry
+	nameOfRuntimeType map[uint64]nameOfRuntimeTypeEntry
 
 	// consts[off] lists all the constants with the type defined at offset off.
 	consts constantsMap
@@ -425,7 +425,7 @@ type ElfDynamicSection struct {
 
 // NewBinaryInfo returns an initialized but unloaded BinaryInfo struct.
 func NewBinaryInfo(goos, goarch string) *BinaryInfo {
-	r := &BinaryInfo{GOOS: goos, nameOfRuntimeType: make(map[uintptr]nameOfRuntimeTypeEntry), logger: logflags.DebuggerLogger()}
+	r := &BinaryInfo{GOOS: goos, nameOfRuntimeType: make(map[uint64]nameOfRuntimeTypeEntry), logger: logflags.DebuggerLogger()}
 
 	// TODO: find better way to determine proc arch (perhaps use executable file info).
 	switch goarch {

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -50,13 +50,13 @@ func TestSplicedReader(t *testing.T) {
 
 	type region struct {
 		data   []byte
-		off    uintptr
-		length uintptr
+		off    uint64
+		length uint64
 	}
 	tests := []struct {
 		name     string
 		regions  []region
-		readAddr uintptr
+		readAddr uint64
 		readLen  int
 		want     []byte
 	}{

--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -326,9 +326,9 @@ func buildMemory(core, exeELF *elf.File, exe io.ReaderAt, notes []*note) proc.Me
 			for _, entry := range fileNote.entries {
 				r := &offsetReaderAt{
 					reader: exe,
-					offset: uintptr(entry.Start - (entry.FileOfs * fileNote.PageSize)),
+					offset: entry.Start - (entry.FileOfs * fileNote.PageSize),
 				}
-				memory.Add(r, uintptr(entry.Start), uintptr(entry.End-entry.Start))
+				memory.Add(r, entry.Start, entry.End-entry.Start)
 			}
 
 		}
@@ -344,9 +344,9 @@ func buildMemory(core, exeELF *elf.File, exe io.ReaderAt, notes []*note) proc.Me
 				}
 				r := &offsetReaderAt{
 					reader: prog.ReaderAt,
-					offset: uintptr(prog.Vaddr),
+					offset: prog.Vaddr,
 				}
-				memory.Add(r, uintptr(prog.Vaddr), uintptr(prog.Filesz))
+				memory.Add(r, prog.Vaddr, prog.Filesz)
 			}
 		}
 	}

--- a/pkg/proc/core/minidump/minidump.go
+++ b/pkg/proc/core/minidump/minidump.go
@@ -182,7 +182,7 @@ type MemoryRange struct {
 }
 
 // ReadMemory reads len(buf) bytes of memory starting at addr into buf from this memory region.
-func (m *MemoryRange) ReadMemory(buf []byte, addr uintptr) (int, error) {
+func (m *MemoryRange) ReadMemory(buf []byte, addr uint64) (int, error) {
 	if len(buf) == 0 {
 		return 0, nil
 	}

--- a/pkg/proc/core/windows_amd64_minidump.go
+++ b/pkg/proc/core/windows_amd64_minidump.go
@@ -25,7 +25,7 @@ func readAMD64Minidump(minidumpPath, exePath string) (*process, error) {
 
 	for i := range mdmp.MemoryRanges {
 		m := &mdmp.MemoryRanges[i]
-		memory.Add(m, uintptr(m.Addr), uintptr(len(m.Data)))
+		memory.Add(m, m.Addr, uint64(len(m.Data)))
 	}
 
 	entryPoint := uint64(0)

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -125,7 +125,7 @@ func Disassemble(mem MemoryReadWriter, regs Registers, breakpoints *BreakpointMa
 
 func disassemble(memrw MemoryReadWriter, regs Registers, breakpoints *BreakpointMap, bi *BinaryInfo, startAddr, endAddr uint64, singleInstr bool) ([]AsmInstruction, error) {
 	mem := make([]byte, int(endAddr-startAddr))
-	_, err := memrw.ReadMemory(mem, uintptr(startAddr))
+	_, err := memrw.ReadMemory(mem, startAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -64,7 +64,7 @@ func newFakeMemory(base uint64, contents ...interface{}) *fakeMemory {
 	return mem
 }
 
-func (mem *fakeMemory) ReadMemory(data []byte, addr uintptr) (int, error) {
+func (mem *fakeMemory) ReadMemory(data []byte, addr uint64) (int, error) {
 	if uint64(addr) < mem.base {
 		return 0, fmt.Errorf("read out of bounds %d %#x", len(data), addr)
 	}
@@ -77,7 +77,7 @@ func (mem *fakeMemory) ReadMemory(data []byte, addr uintptr) (int, error) {
 	return len(data), nil
 }
 
-func (mem *fakeMemory) WriteMemory(uintptr, []byte) (int, error) {
+func (mem *fakeMemory) WriteMemory(uint64, []byte) (int, error) {
 	return 0, fmt.Errorf("not implemented")
 }
 

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -123,7 +123,7 @@ func FrameToScope(bi *BinaryInfo, thread MemoryReadWriter, g *G, frames ...Stack
 		maxaddr = uint64(frames[0].Regs.CFA)
 	}
 	if maxaddr > minaddr && maxaddr-minaddr < maxFramePrefetchSize {
-		thread = cacheMemory(thread, uintptr(minaddr), int(maxaddr-minaddr))
+		thread = cacheMemory(thread, minaddr, int(maxaddr-minaddr))
 	}
 
 	s := &EvalScope{Location: frames[0].Call, Regs: frames[0].Regs, Mem: thread, g: g, BinInfo: bi, frameOffset: frames[0].FrameOffset()}
@@ -232,9 +232,9 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 		if trustArgOrder && ((val.Unreadable != nil && val.Addr == 0) || val.Flags&VariableFakeAddress != 0) && entry.Tag == dwarf.TagFormalParameter {
 			addr := afterLastArgAddr(vars)
 			if addr == 0 {
-				addr = uintptr(scope.Regs.CFA)
+				addr = uint64(scope.Regs.CFA)
 			}
-			addr = uintptr(alignAddr(int64(addr), val.DwarfType.Align()))
+			addr = uint64(alignAddr(int64(addr), val.DwarfType.Align()))
 			val = newVariable(val.Name, addr, val.DwarfType, scope.BinInfo, scope.Mem)
 		}
 		vars = append(vars, val)
@@ -288,11 +288,11 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 	return vars, nil
 }
 
-func afterLastArgAddr(vars []*Variable) uintptr {
+func afterLastArgAddr(vars []*Variable) uint64 {
 	for i := len(vars) - 1; i >= 0; i-- {
 		v := vars[i]
 		if (v.Flags&VariableArgument != 0) || (v.Flags&VariableReturnArgument != 0) {
-			return v.Addr + uintptr(v.DwarfType.Size())
+			return v.Addr + uint64(v.DwarfType.Size())
 		}
 	}
 	return 0
@@ -520,9 +520,9 @@ func (scope *EvalScope) findGlobalInternal(name string) (*Variable, error) {
 	for _, fn := range scope.BinInfo.Functions {
 		if fn.Name == name || strings.HasSuffix(fn.Name, "/"+name) {
 			//TODO(aarzilli): convert function entry into a function type?
-			r := newVariable(fn.Name, uintptr(fn.Entry), &godwarf.FuncType{}, scope.BinInfo, scope.Mem)
+			r := newVariable(fn.Name, fn.Entry, &godwarf.FuncType{}, scope.BinInfo, scope.Mem)
 			r.Value = constant.MakeString(fn.Name)
-			r.Base = uintptr(fn.Entry)
+			r.Base = fn.Entry
 			r.loaded = true
 			if fn.Entry == 0 {
 				r.Unreadable = fmt.Errorf("function %s is inlined", fn.Name)
@@ -626,7 +626,7 @@ func (scope *EvalScope) evalToplevelTypeCast(t ast.Expr, cfg LoadConfig) (*Varia
 			return nil, converr
 		}
 		for i, ch := range []byte(constant.StringVal(argv.Value)) {
-			e := newVariable("", argv.Addr+uintptr(i), targetType.(*godwarf.SliceType).ElemType, scope.BinInfo, argv.mem)
+			e := newVariable("", argv.Addr+uint64(i), targetType.(*godwarf.SliceType).ElemType, scope.BinInfo, argv.mem)
 			e.loaded = true
 			e.Value = constant.MakeInt64(int64(ch))
 			v.Children = append(v.Children, *e)
@@ -640,7 +640,7 @@ func (scope *EvalScope) evalToplevelTypeCast(t ast.Expr, cfg LoadConfig) (*Varia
 			return nil, converr
 		}
 		for i, ch := range constant.StringVal(argv.Value) {
-			e := newVariable("", argv.Addr+uintptr(i), targetType.(*godwarf.SliceType).ElemType, scope.BinInfo, argv.mem)
+			e := newVariable("", argv.Addr+uint64(i), targetType.(*godwarf.SliceType).ElemType, scope.BinInfo, argv.mem)
 			e.loaded = true
 			e.Value = constant.MakeInt64(int64(ch))
 			v.Children = append(v.Children, *e)
@@ -854,7 +854,7 @@ func (scope *EvalScope) evalTypeCast(node *ast.CallExpr) (*Variable, error) {
 
 		n, _ := constant.Int64Val(argv.Value)
 
-		v.Children = []Variable{*(newVariable("", uintptr(n), ttyp.Type, scope.BinInfo, scope.Mem))}
+		v.Children = []Variable{*(newVariable("", uint64(n), ttyp.Type, scope.BinInfo, scope.Mem))}
 		v.Children[0].OnlyAddr = true
 		return v, nil
 
@@ -1885,7 +1885,7 @@ func (v *Variable) sliceAccess(idx int) (*Variable, error) {
 	if v.Kind != reflect.Array {
 		mem = DereferenceMemory(mem)
 	}
-	return v.newVariable("", v.Base+uintptr(int64(idx)*v.stride), v.fieldType, mem), nil
+	return v.newVariable("", v.Base+uint64(int64(idx)*v.stride), v.fieldType, mem), nil
 }
 
 func (v *Variable) mapAccess(idx *Variable) (*Variable, error) {
@@ -1938,7 +1938,7 @@ func (v *Variable) reslice(low int64, high int64) (*Variable, error) {
 		return nil, fmt.Errorf("index out of bounds")
 	}
 
-	base := v.Base + uintptr(int64(low)*v.stride)
+	base := v.Base + uint64(int64(low)*v.stride)
 	len := high - low
 
 	if high-low < 0 {
@@ -2053,7 +2053,7 @@ func functionToVariable(fn *Function, bi *BinaryInfo, mem MemoryReadWriter) (*Va
 	v := newVariable(fn.Name, 0, typ, bi, mem)
 	v.Value = constant.MakeString(fn.Name)
 	v.loaded = true
-	v.Base = uintptr(fn.Entry)
+	v.Base = fn.Entry
 	return v, nil
 }
 

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -407,7 +407,7 @@ func writePointer(bi *BinaryInfo, mem MemoryReadWriter, addr, val uint64) error 
 	default:
 		panic(fmt.Errorf("unsupported pointer size %d", len(ptrbuf)))
 	}
-	_, err := mem.WriteMemory(uintptr(addr), ptrbuf)
+	_, err := mem.WriteMemory(addr, ptrbuf)
 	return err
 }
 
@@ -555,7 +555,7 @@ func funcCallCopyOneArg(scope *EvalScope, fncall *functionCallState, actualArg *
 	//TODO(aarzilli): autmoatic wrapping in interfaces for cases not handled
 	// by convertToEface.
 
-	formalArgVar := newVariable(formalArg.name, uintptr(formalArg.off+int64(argFrameAddr)), formalArg.typ, scope.BinInfo, scope.Mem)
+	formalArgVar := newVariable(formalArg.name, uint64(formalArg.off+int64(argFrameAddr)), formalArg.typ, scope.BinInfo, scope.Mem)
 	if err := scope.setValue(formalArgVar, actualArg, actualArg.Name); err != nil {
 		return err
 	}
@@ -671,7 +671,7 @@ func escapeCheck(v *Variable, name string, stack stack) error {
 			}
 		}
 	case reflect.Func:
-		if err := escapeCheckPointer(uintptr(v.funcvalAddr()), name, stack); err != nil {
+		if err := escapeCheckPointer(v.funcvalAddr(), name, stack); err != nil {
 			return err
 		}
 	}
@@ -679,7 +679,7 @@ func escapeCheck(v *Variable, name string, stack stack) error {
 	return nil
 }
 
-func escapeCheckPointer(addr uintptr, name string, stack stack) error {
+func escapeCheckPointer(addr uint64, name string, stack stack) error {
 	if uint64(addr) >= stack.lo && uint64(addr) < stack.hi {
 		return fmt.Errorf("stack object passed to escaping pointer: %s", name)
 	}
@@ -856,7 +856,7 @@ func readTopstackVariable(thread Thread, regs Registers, typename string, loadCf
 	if err != nil {
 		return nil, err
 	}
-	v := newVariable("", uintptr(regs.SP()), typ, scope.BinInfo, scope.Mem)
+	v := newVariable("", regs.SP(), typ, scope.BinInfo, scope.Mem)
 	v.loadValue(loadCfg)
 	if v.Unreadable != nil {
 		return nil, v.Unreadable
@@ -932,7 +932,7 @@ func allocString(scope *EvalScope, v *Variable) error {
 	if len(mallocv.Children) != 1 {
 		return errors.New("internal error, could not interpret return value of mallocgc call")
 	}
-	v.Base = uintptr(mallocv.Children[0].Addr)
+	v.Base = mallocv.Children[0].Addr
 	_, err = scope.Mem.WriteMemory(v.Base, []byte(constant.StringVal(v.Value)))
 	return err
 }

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -281,7 +281,7 @@ func (p *gdbProcess) Connect(conn net.Conn, path string, pid int, debugInfoDirs 
 	// If the stub doesn't support memory allocation reloadRegisters will
 	// overwrite some existing memory to store the MOV.
 	if addr, err := p.conn.allocMemory(256); err == nil {
-		if _, err := p.conn.writeMemory(uintptr(addr), p.loadGInstr()); err == nil {
+		if _, err := p.conn.writeMemory(addr, p.loadGInstr()); err == nil {
 			p.loadGInstrAddr = addr
 		}
 	}
@@ -1260,7 +1260,7 @@ func (p *gdbProcess) setCurrentBreakpoints() error {
 }
 
 // ReadMemory will read into 'data' memory at the address provided.
-func (t *gdbThread) ReadMemory(data []byte, addr uintptr) (n int, err error) {
+func (t *gdbThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
 	err = t.p.conn.readMemory(data, addr)
 	if err != nil {
 		return 0, err
@@ -1269,7 +1269,7 @@ func (t *gdbThread) ReadMemory(data []byte, addr uintptr) (n int, err error) {
 }
 
 // WriteMemory will write into the memory at 'addr' the data provided.
-func (t *gdbThread) WriteMemory(addr uintptr, data []byte) (written int, err error) {
+func (t *gdbThread) WriteMemory(addr uint64, data []byte) (written int, err error) {
 	return t.p.conn.writeMemory(addr, data)
 }
 
@@ -1517,18 +1517,18 @@ func (t *gdbThread) reloadGAtPC() error {
 	}
 
 	savedcode := make([]byte, len(movinstr))
-	_, err := t.ReadMemory(savedcode, uintptr(pc))
+	_, err := t.ReadMemory(savedcode, pc)
 	if err != nil {
 		return err
 	}
 
-	_, err = t.WriteMemory(uintptr(pc), movinstr)
+	_, err = t.WriteMemory(pc, movinstr)
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		_, err0 := t.WriteMemory(uintptr(pc), savedcode)
+		_, err0 := t.WriteMemory(pc, savedcode)
 		if err == nil {
 			err = err0
 		}

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -880,7 +880,7 @@ func (conn *gdbConn) appendThreadSelector(threadID string) {
 }
 
 // executes 'm' (read memory) command
-func (conn *gdbConn) readMemory(data []byte, addr uintptr) error {
+func (conn *gdbConn) readMemory(data []byte, addr uint64) error {
 	size := len(data)
 	data = data[:0]
 
@@ -894,7 +894,7 @@ func (conn *gdbConn) readMemory(data []byte, addr uintptr) error {
 		}
 		size = size - sz
 
-		fmt.Fprintf(&conn.outbuf, "$m%x,%x", addr+uintptr(len(data)), sz)
+		fmt.Fprintf(&conn.outbuf, "$m%x,%x", addr+uint64(len(data)), sz)
 		resp, err := conn.exec(conn.outbuf.Bytes(), "memory read")
 		if err != nil {
 			return err
@@ -915,7 +915,7 @@ func writeAsciiBytes(w io.Writer, data []byte) {
 }
 
 // executes 'M' (write memory) command
-func (conn *gdbConn) writeMemory(addr uintptr, data []byte) (written int, err error) {
+func (conn *gdbConn) writeMemory(addr uint64, data []byte) (written int, err error) {
 	if len(data) == 0 {
 		// LLDB can't parse requests for 0-length writes and hangs if we emit them
 		return 0, nil

--- a/pkg/proc/goroutine_cache.go
+++ b/pkg/proc/goroutine_cache.go
@@ -27,12 +27,12 @@ func (gcache *goroutineCache) getRuntimeAllg(bi *BinaryInfo, mem MemoryReadWrite
 	if gcache.allglenAddr == 0 || gcache.allgentryAddr == 0 {
 		return 0, 0, ErrNoRuntimeAllG
 	}
-	allglen, err := readUintRaw(mem, uintptr(gcache.allglenAddr), int64(bi.Arch.PtrSize()))
+	allglen, err := readUintRaw(mem, gcache.allglenAddr, int64(bi.Arch.PtrSize()))
 	if err != nil {
 		return 0, 0, err
 	}
-	
-	allgptr, err := readUintRaw(mem, uintptr(gcache.allgentryAddr), int64(bi.Arch.PtrSize()))
+
+	allgptr, err := readUintRaw(mem, gcache.allgentryAddr, int64(bi.Arch.PtrSize()))
 	if err != nil {
 		return 0, 0, err
 	}

--- a/pkg/proc/linutil/dynamic.go
+++ b/pkg/proc/linutil/dynamic.go
@@ -47,7 +47,7 @@ func dynamicSearchDebug(p proc.Process) (uint64, error) {
 	mem := p.CurrentThread()
 
 	dynbuf := make([]byte, bi.ElfDynamicSection.Size)
-	_, err := mem.ReadMemory(dynbuf, uintptr(bi.ElfDynamicSection.Addr))
+	_, err := mem.ReadMemory(dynbuf, bi.ElfDynamicSection.Addr)
 	if err != nil {
 		return 0, err
 	}
@@ -73,7 +73,7 @@ func dynamicSearchDebug(p proc.Process) (uint64, error) {
 
 func readPtr(p proc.Process, addr uint64) (uint64, error) {
 	ptrbuf := make([]byte, p.BinInfo().Arch.PtrSize())
-	_, err := p.CurrentThread().ReadMemory(ptrbuf, uintptr(addr))
+	_, err := p.CurrentThread().ReadMemory(ptrbuf, addr)
 	if err != nil {
 		return 0, err
 	}
@@ -122,7 +122,7 @@ func readCString(p proc.Process, addr uint64) (string, error) {
 		if len(r) > maxLibraryPathLength {
 			return "", fmt.Errorf("error reading libraries: string too long (%d)", len(r))
 		}
-		_, err := mem.ReadMemory(buf, uintptr(addr))
+		_, err := mem.ReadMemory(buf, addr)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -102,12 +102,12 @@ func (t *nativeThread) SetDX(dx uint64) error {
 }
 
 // ReadMemory reads len(buf) bytes at addr into buf.
-func (t *nativeThread) ReadMemory(buf []byte, addr uintptr) (int, error) {
+func (t *nativeThread) ReadMemory(buf []byte, addr uint64) (int, error) {
 	panic(ErrNativeBackendDisabled)
 }
 
 // WriteMemory writes the contents of data at addr.
-func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (int, error) {
+func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
 	panic(ErrNativeBackendDisabled)
 }
 

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -209,7 +209,7 @@ func (dbp *nativeProcess) WriteBreakpoint(addr uint64) (string, int, *proc.Funct
 	f, l, fn := dbp.bi.PCToLine(uint64(addr))
 
 	originalData := make([]byte, dbp.bi.Arch.BreakpointSize())
-	_, err := dbp.currentThread.ReadMemory(originalData, uintptr(addr))
+	_, err := dbp.currentThread.ReadMemory(originalData, addr)
 	if err != nil {
 		return "", 0, nil, nil, err
 	}
@@ -317,7 +317,7 @@ func (dbp *nativeProcess) postExit() {
 }
 
 func (dbp *nativeProcess) writeSoftwareBreakpoint(thread *nativeThread, addr uint64) error {
-	_, err := thread.WriteMemory(uintptr(addr), dbp.bi.Arch.BreakpointInstruction())
+	_, err := thread.WriteMemory(addr, dbp.bi.Arch.BreakpointInstruction())
 	return err
 }
 

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -310,7 +310,7 @@ func (dbp *nativeProcess) waitForDebugEvent(flags waitForDebugEventFlags) (threa
 				atbp := true
 				if thread, found := dbp.threads[tid]; found {
 					data := make([]byte, dbp.bi.Arch.BreakpointSize())
-					if _, err := thread.ReadMemory(data, exception.ExceptionRecord.ExceptionAddress); err == nil {
+					if _, err := thread.ReadMemory(data, uint64(exception.ExceptionRecord.ExceptionAddress)); err == nil {
 						instr := dbp.bi.Arch.BreakpointInstruction()
 						for i := range instr {
 							if data[i] != instr[i] {

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -150,7 +150,7 @@ func (t *nativeThread) ThreadID() int {
 
 // ClearBreakpoint clears the specified breakpoint.
 func (t *nativeThread) ClearBreakpoint(bp *proc.Breakpoint) error {
-	if _, err := t.WriteMemory(uintptr(bp.Addr), bp.OriginalData); err != nil {
+	if _, err := t.WriteMemory(bp.Addr, bp.OriginalData); err != nil {
 		return fmt.Errorf("could not clear breakpoint %s", err)
 	}
 	return nil

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -110,7 +110,7 @@ func (t *nativeThread) Stopped() bool {
 	return C.thread_blocked(t.os.threadAct) > C.int(0)
 }
 
-func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (int, error) {
+func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
 	}
@@ -128,7 +128,7 @@ func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (int, error) {
 	return len(data), nil
 }
 
-func (t *nativeThread) ReadMemory(buf []byte, addr uintptr) (int, error) {
+func (t *nativeThread) ReadMemory(buf []byte, addr uint64) (int, error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
 	}

--- a/pkg/proc/native/threads_freebsd.go
+++ b/pkg/proc/native/threads_freebsd.go
@@ -110,24 +110,24 @@ func (t *nativeThread) restoreRegisters(savedRegs proc.Registers) error {
 	return restoreRegistersErr
 }
 
-func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (written int, err error) {
+func (t *nativeThread) WriteMemory(addr uint64, data []byte) (written int, err error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
 	}
 	if len(data) == 0 {
 		return 0, nil
 	}
-	t.dbp.execPtraceFunc(func() { written, err = ptraceWriteData(t.ID, addr, data) })
+	t.dbp.execPtraceFunc(func() { written, err = ptraceWriteData(t.ID, uintptr(addr), data) })
 	return written, err
 }
 
-func (t *nativeThread) ReadMemory(data []byte, addr uintptr) (n int, err error) {
+func (t *nativeThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
 	}
 	if len(data) == 0 {
 		return 0, nil
 	}
-	t.dbp.execPtraceFunc(func() { n, err = ptraceReadData(t.ID, addr, data) })
+	t.dbp.execPtraceFunc(func() { n, err = ptraceReadData(t.ID, uintptr(addr), data) })
 	return n, err
 }

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -84,7 +84,7 @@ func (t *nativeThread) Blocked() bool {
 	return false
 }
 
-func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (written int, err error) {
+func (t *nativeThread) WriteMemory(addr uint64, data []byte) (written int, err error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
 	}
@@ -94,24 +94,24 @@ func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (written int, err 
 	// ProcessVmWrite can't poke read-only memory like ptrace, so don't
 	// even bother for small writes -- likely breakpoints and such.
 	if len(data) > sys.SizeofPtr {
-		written, _ = processVmWrite(t.ID, addr, data)
+		written, _ = processVmWrite(t.ID, uintptr(addr), data)
 	}
 	if written == 0 {
-		t.dbp.execPtraceFunc(func() { written, err = sys.PtracePokeData(t.ID, addr, data) })
+		t.dbp.execPtraceFunc(func() { written, err = sys.PtracePokeData(t.ID, uintptr(addr), data) })
 	}
 	return
 }
 
-func (t *nativeThread) ReadMemory(data []byte, addr uintptr) (n int, err error) {
+func (t *nativeThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
 	}
 	if len(data) == 0 {
 		return
 	}
-	n, _ = processVmRead(t.ID, addr, data)
+	n, _ = processVmRead(t.ID, uintptr(addr), data)
 	if n == 0 {
-		t.dbp.execPtraceFunc(func() { n, err = sys.PtracePeekData(t.ID, addr, data) })
+		t.dbp.execPtraceFunc(func() { n, err = sys.PtracePeekData(t.ID, uintptr(addr), data) })
 	}
 	return
 }

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -137,7 +137,7 @@ func (t *nativeThread) Stopped() bool {
 	return true
 }
 
-func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (int, error) {
+func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
 	}
@@ -145,7 +145,7 @@ func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (int, error) {
 		return 0, nil
 	}
 	var count uintptr
-	err := _WriteProcessMemory(t.dbp.os.hProcess, addr, &data[0], uintptr(len(data)), &count)
+	err := _WriteProcessMemory(t.dbp.os.hProcess, uintptr(addr), &data[0], uintptr(len(data)), &count)
 	if err != nil {
 		return 0, err
 	}
@@ -154,7 +154,7 @@ func (t *nativeThread) WriteMemory(addr uintptr, data []byte) (int, error) {
 
 var ErrShortRead = errors.New("short read")
 
-func (t *nativeThread) ReadMemory(buf []byte, addr uintptr) (int, error) {
+func (t *nativeThread) ReadMemory(buf []byte, addr uint64) (int, error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
 	}
@@ -162,7 +162,7 @@ func (t *nativeThread) ReadMemory(buf []byte, addr uintptr) (int, error) {
 		return 0, nil
 	}
 	var count uintptr
-	err := _ReadProcessMemory(t.dbp.os.hProcess, addr, &buf[0], uintptr(len(buf)), &count)
+	err := _ReadProcessMemory(t.dbp.os.hProcess, uintptr(addr), &buf[0], uintptr(len(buf)), &count)
 	if err == nil && count != uintptr(len(buf)) {
 		err = ErrShortRead
 	}

--- a/pkg/proc/proc_general_test.go
+++ b/pkg/proc/proc_general_test.go
@@ -24,7 +24,7 @@ func TestIssue554(t *testing.T) {
 	case 8:
 		addr = 0xffffffffffffffff
 	}
-	if mem.contains(uintptr(addr), 40) {
+	if mem.contains(addr, 40) {
 		t.Fatalf("should be false")
 	}
 }
@@ -41,7 +41,7 @@ type memRead struct {
 	size int
 }
 
-func (dm *dummyMem) ReadMemory(buf []byte, addr uintptr) (int, error) {
+func (dm *dummyMem) ReadMemory(buf []byte, addr uint64) (int, error) {
 	dm.t.Logf("read addr=%#x size=%#x\n", addr, len(buf))
 	dm.reads = append(dm.reads, memRead{uint64(addr), len(buf)})
 	a := int64(addr) - int64(dm.base)
@@ -55,7 +55,7 @@ func (dm *dummyMem) ReadMemory(buf []byte, addr uintptr) (int, error) {
 	return len(buf), nil
 }
 
-func (dm *dummyMem) WriteMemory(uintptr, []byte) (int, error) {
+func (dm *dummyMem) WriteMemory(uint64, []byte) (int, error) {
 	panic("not supported")
 }
 
@@ -80,7 +80,7 @@ func TestReadCStringValue(t *testing.T) {
 		t.Logf("base is %#x\n", tc.base)
 		dm.base = tc.base
 		dm.reads = dm.reads[:0]
-		out, done, err := readCStringValue(dm, uintptr(tc.base), LoadConfig{MaxStringLen: maxstrlen})
+		out, done, err := readCStringValue(dm, tc.base, LoadConfig{MaxStringLen: maxstrlen})
 		if err != nil {
 			t.Errorf("base=%#x readCStringValue: %v", tc.base, err)
 		}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -102,7 +102,7 @@ func getRegisters(p *proc.Target, t *testing.T) proc.Registers {
 
 func dataAtAddr(thread proc.MemoryReadWriter, addr uint64) ([]byte, error) {
 	data := make([]byte, 1)
-	_, err := thread.ReadMemory(data, uintptr(addr))
+	_, err := thread.ReadMemory(data, addr)
 	return data, err
 }
 

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -516,7 +516,7 @@ func (it *stackIterator) executeFrameRegRule(regnum uint64, rule frame.DWRule, c
 
 func (it *stackIterator) readRegisterAt(regnum uint64, addr uint64) (*op.DwarfRegister, error) {
 	buf := make([]byte, it.bi.Arch.regSize(regnum))
-	_, err := it.mem.ReadMemory(buf, uintptr(addr))
+	_, err := it.mem.ReadMemory(buf, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -675,7 +675,7 @@ func (d *Defer) EvalScope(thread Thread) (*EvalScope, error) {
 		return nil, fmt.Errorf("could not read DWARF function entry: %v", err)
 	}
 	scope.Regs.FrameBase, _, _, _ = bi.Location(e, dwarf.AttrFrameBase, scope.PC, scope.Regs)
-	scope.Mem = cacheMemory(scope.Mem, uintptr(scope.Regs.CFA), int(d.argSz))
+	scope.Mem = cacheMemory(scope.Mem, uint64(scope.Regs.CFA), int(d.argSz))
 
 	return scope, nil
 }

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -142,7 +142,7 @@ func (dbp *Target) Continue() error {
 				if !arch.BreakInstrMovesPC() {
 					bpsize := arch.BreakpointSize()
 					bp := make([]byte, bpsize)
-					_, err = dbp.CurrentThread().ReadMemory(bp, uintptr(loc.PC))
+					_, err = dbp.CurrentThread().ReadMemory(bp, loc.PC)
 					if bytes.Equal(bp, arch.BreakpointInstruction()) {
 						curthread.SetPC(loc.PC + uint64(bpsize))
 					}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -86,7 +86,7 @@ const (
 // and the memory of the debugged process.
 // If OnlyAddr is true, the variables value has not been loaded.
 type Variable struct {
-	Addr      uintptr
+	Addr      uint64
 	OnlyAddr  bool
 	Name      string
 	DwarfType godwarf.Type
@@ -107,7 +107,7 @@ type Variable struct {
 	// Base address of the backing byte array for strings
 	// address of the struct backing chan and map variables
 	// address of the function entry point for function variables (0 for nil function pointers)
-	Base      uintptr
+	Base      uint64
 	stride    int64
 	fieldType godwarf.Type
 
@@ -328,7 +328,7 @@ func GoroutinesInfo(dbp *Target, start, count int) ([]*G, int, error) {
 		if count != 0 && len(allg) >= count {
 			return allg, int(i), nil
 		}
-		gvar, err := newGVariable(dbp.CurrentThread(), uintptr(allgptr+(i*uint64(dbp.BinInfo().Arch.PtrSize()))), true)
+		gvar, err := newGVariable(dbp.CurrentThread(), allgptr+(i*uint64(dbp.BinInfo().Arch.PtrSize())), true)
 		if err != nil {
 			allg = append(allg, &G{Unreadable: err})
 			continue
@@ -434,16 +434,16 @@ func getGVariable(thread Thread) (*Variable, error) {
 	gaddr, hasgaddr := regs.GAddr()
 	if !hasgaddr {
 		var err error
-		gaddr, err = readUintRaw(thread, uintptr(regs.TLS()+thread.BinInfo().GStructOffset()), int64(thread.BinInfo().Arch.PtrSize()))
+		gaddr, err = readUintRaw(thread, regs.TLS()+thread.BinInfo().GStructOffset(), int64(thread.BinInfo().Arch.PtrSize()))
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return newGVariable(thread, uintptr(gaddr), thread.BinInfo().Arch.DerefTLS())
+	return newGVariable(thread, gaddr, thread.BinInfo().Arch.DerefTLS())
 }
 
-func newGVariable(thread Thread, gaddr uintptr, deref bool) (*Variable, error) {
+func newGVariable(thread Thread, gaddr uint64, deref bool) (*Variable, error) {
 	typ, err := thread.BinInfo().findType("runtime.g")
 	if err != nil {
 		return nil, err
@@ -567,15 +567,15 @@ func globalScope(bi *BinaryInfo, image *Image, mem MemoryReadWriter) *EvalScope 
 	return &EvalScope{Location: Location{}, Regs: op.DwarfRegisters{StaticBase: image.StaticBase}, Mem: mem, g: nil, BinInfo: bi, frameOffset: 0}
 }
 
-func newVariableFromThread(t Thread, name string, addr uintptr, dwarfType godwarf.Type) *Variable {
+func newVariableFromThread(t Thread, name string, addr uint64, dwarfType godwarf.Type) *Variable {
 	return newVariable(name, addr, dwarfType, t.BinInfo(), t)
 }
 
-func (v *Variable) newVariable(name string, addr uintptr, dwarfType godwarf.Type, mem MemoryReadWriter) *Variable {
+func (v *Variable) newVariable(name string, addr uint64, dwarfType godwarf.Type, mem MemoryReadWriter) *Variable {
 	return newVariable(name, addr, dwarfType, v.bi, mem)
 }
 
-func newVariable(name string, addr uintptr, dwarfType godwarf.Type, bi *BinaryInfo, mem MemoryReadWriter) *Variable {
+func newVariable(name string, addr uint64, dwarfType godwarf.Type, bi *BinaryInfo, mem MemoryReadWriter) *Variable {
 	if styp, isstruct := dwarfType.(*godwarf.StructType); isstruct && !strings.Contains(styp.Name, "<") && !strings.Contains(styp.Name, "{") {
 		// For named structs the compiler will emit a DW_TAG_structure_type entry
 		// and a DW_TAG_typedef entry.
@@ -625,8 +625,7 @@ func newVariable(name string, addr uintptr, dwarfType godwarf.Type, bi *BinaryIn
 				v.Kind = reflect.String
 			}
 			if v.Addr != 0 {
-				n, err := readUintRaw(v.mem, v.Addr, int64(v.bi.Arch.PtrSize()))
-				v.Base, v.Unreadable = uintptr(n), err
+				v.Base, v.Unreadable = readUintRaw(v.mem, v.Addr, int64(v.bi.Arch.PtrSize()))
 			}
 		}
 	case *godwarf.ChanType:
@@ -778,7 +777,7 @@ func (v *Variable) toField(field *godwarf.StructField) (*Variable, error) {
 			name = fmt.Sprintf("%s.%s", v.Name, field.Name)
 		}
 	}
-	return v.newVariable(name, uintptr(int64(v.Addr)+field.ByteOffset), field.Type, v.mem), nil
+	return v.newVariable(name, uint64(int64(v.Addr)+field.ByteOffset), field.Type, v.mem), nil
 }
 
 // ErrNoGoroutine returned when a G could not be found
@@ -800,7 +799,7 @@ func (v *Variable) parseG() (*G, error) {
 
 	if deref {
 		var err error
-		gaddr, err = readUintRaw(mem, uintptr(gaddr), int64(v.bi.Arch.PtrSize()))
+		gaddr, err = readUintRaw(mem, gaddr, int64(v.bi.Arch.PtrSize()))
 		if err != nil {
 			return nil, fmt.Errorf("error derefing *G %s", err)
 		}
@@ -1148,7 +1147,7 @@ func extractVarInfoFromEntry(bi *BinaryInfo, image *Image, regs op.DwarfRegister
 		}
 	}
 
-	v := newVariable(n, uintptr(addr), t, bi, mem)
+	v := newVariable(n, uint64(addr), t, bi, mem)
 	if pieces != nil {
 		v.Flags |= VariableFakeAddress
 	}
@@ -1172,8 +1171,8 @@ func (v *Variable) maybeDereference() *Variable {
 			// fake pointer variable constructed by casting an integer to a pointer type
 			return &v.Children[0]
 		}
-		ptrval, err := readUintRaw(v.mem, uintptr(v.Addr), t.ByteSize)
-		r := v.newVariable("", uintptr(ptrval), t.Type, DereferenceMemory(v.mem))
+		ptrval, err := readUintRaw(v.mem, v.Addr, t.ByteSize)
+		r := v.newVariable("", ptrval, t.Type, DereferenceMemory(v.mem))
 		if err != nil {
 			r.Unreadable = err
 		}
@@ -1341,14 +1340,14 @@ func convertToEface(srcv, dstv *Variable) error {
 	return dstv.writeEmptyInterface(typeAddr, srcv)
 }
 
-func readStringInfo(mem MemoryReadWriter, arch *Arch, addr uintptr) (uintptr, int64, error) {
+func readStringInfo(mem MemoryReadWriter, arch *Arch, addr uint64) (uint64, int64, error) {
 	// string data structure is always two ptrs in size. Addr, followed by len
 	// http://research.swtch.com/godata
 
 	mem = cacheMemory(mem, addr, arch.PtrSize()*2)
 
 	// read len
-	strlen, err := readIntRaw(mem, addr+uintptr(arch.PtrSize()), int64(arch.PtrSize()))
+	strlen, err := readIntRaw(mem, addr+uint64(arch.PtrSize()), int64(arch.PtrSize()))
 	if err != nil {
 		return 0, 0, fmt.Errorf("could not read string len %s", err)
 	}
@@ -1357,18 +1356,17 @@ func readStringInfo(mem MemoryReadWriter, arch *Arch, addr uintptr) (uintptr, in
 	}
 
 	// read addr
-	val, err := readUintRaw(mem, addr, int64(arch.PtrSize()))
+	addr, err = readUintRaw(mem, addr, int64(arch.PtrSize()))
 	if err != nil {
 		return 0, 0, fmt.Errorf("could not read string pointer %s", err)
 	}
-	addr = uintptr(val)
 	if addr == 0 {
 		return 0, 0, nil
 	}
 	return addr, strlen, nil
 }
 
-func readStringValue(mem MemoryReadWriter, addr uintptr, strlen int64, cfg LoadConfig) (string, error) {
+func readStringValue(mem MemoryReadWriter, addr uint64, strlen int64, cfg LoadConfig) (string, error) {
 	if strlen == 0 {
 		return "", nil
 	}
@@ -1387,7 +1385,7 @@ func readStringValue(mem MemoryReadWriter, addr uintptr, strlen int64, cfg LoadC
 	return string(val), nil
 }
 
-func readCStringValue(mem MemoryReadWriter, addr uintptr, cfg LoadConfig) (string, bool, error) {
+func readCStringValue(mem MemoryReadWriter, addr uint64, cfg LoadConfig) (string, bool, error) {
 	buf := make([]byte, cfg.MaxStringLen) //
 	val := buf[:0]                        // part of the string we've already read
 
@@ -1399,7 +1397,7 @@ func readCStringValue(mem MemoryReadWriter, addr uintptr, cfg LoadConfig) (strin
 		// memory we don't even need.
 		// We don't know how big a page is but 1024 is a reasonable minimum common
 		// divisor for all architectures.
-		curaddr := addr + uintptr(len(val))
+		curaddr := addr + uint64(len(val))
 		maxsize := int(alignAddr(int64(curaddr+1), 1024) - int64(curaddr))
 		size := len(buf)
 		if size > maxsize {
@@ -1444,9 +1442,9 @@ func (v *Variable) loadSliceInfo(t *godwarf.SliceType) {
 		switch f.Name {
 		case sliceArrayFieldName:
 			var base uint64
-			base, err = readUintRaw(v.mem, uintptr(int64(v.Addr)+f.ByteOffset), f.Type.Size())
+			base, err = readUintRaw(v.mem, uint64(int64(v.Addr)+f.ByteOffset), f.Type.Size())
 			if err == nil {
-				v.Base = uintptr(base)
+				v.Base = base
 				// Dereference array type to get value type
 				ptrType, ok := f.Type.(*godwarf.PtrType)
 				if !ok {
@@ -1560,7 +1558,7 @@ func (v *Variable) loadArrayValues(recurseLevel int, cfg LoadConfig) {
 	}
 
 	for i := int64(0); i < count; i++ {
-		fieldvar := v.newVariable("", uintptr(int64(v.Base)+(i*v.stride)), v.fieldType, mem)
+		fieldvar := v.newVariable("", uint64(int64(v.Base)+(i*v.stride)), v.fieldType, mem)
 		fieldvar.loadValueInternal(recurseLevel+1, cfg)
 
 		if fieldvar.Unreadable != nil {
@@ -1589,7 +1587,7 @@ func (v *Variable) readComplex(size int64) {
 	ftyp := &godwarf.FloatType{BasicType: godwarf.BasicType{CommonType: godwarf.CommonType{ByteSize: fs, Name: fmt.Sprintf("float%d", fs)}, BitSize: fs * 8, BitOffset: 0}}
 
 	realvar := v.newVariable("real", v.Addr, ftyp, v.mem)
-	imagvar := v.newVariable("imaginary", v.Addr+uintptr(fs), ftyp, v.mem)
+	imagvar := v.newVariable("imaginary", v.Addr+uint64(fs), ftyp, v.mem)
 	realvar.loadValue(loadSingleValue)
 	imagvar.loadValue(loadSingleValue)
 	v.Value = constant.BinaryOp(realvar.Value, token.ADD, constant.MakeImag(imagvar.Value))
@@ -1601,11 +1599,11 @@ func (v *Variable) writeComplex(real, imag float64, size int64) error {
 		return err
 	}
 	imagaddr := *v
-	imagaddr.Addr += uintptr(size / 2)
+	imagaddr.Addr += uint64(size / 2)
 	return imagaddr.writeFloatRaw(imag, int64(size/2))
 }
 
-func readIntRaw(mem MemoryReadWriter, addr uintptr, size int64) (int64, error) {
+func readIntRaw(mem MemoryReadWriter, addr uint64, size int64) (int64, error) {
 	var n int64
 
 	val := make([]byte, int(size))
@@ -1646,7 +1644,7 @@ func (v *Variable) writeUint(value uint64, size int64) error {
 	return err
 }
 
-func readUintRaw(mem MemoryReadWriter, addr uintptr, size int64) (uint64, error) {
+func readUintRaw(mem MemoryReadWriter, addr uint64, size int64) (uint64, error) {
 	var n uint64
 
 	val := make([]byte, int(size))
@@ -1731,7 +1729,7 @@ func (v *Variable) writeEmptyInterface(typeAddr uint64, data *Variable) error {
 	return nil
 }
 
-func (v *Variable) writeSlice(len, cap int64, base uintptr) error {
+func (v *Variable) writeSlice(len, cap int64, base uint64) error {
 	for _, f := range v.RealType.(*godwarf.SliceType).Field {
 		switch f.Name {
 		case sliceArrayFieldName:
@@ -1782,13 +1780,13 @@ func (v *Variable) readFunctionPtr() {
 		return
 	}
 
-	val, err := readUintRaw(v.mem, uintptr(v.closureAddr), int64(v.bi.Arch.PtrSize()))
+	val, err := readUintRaw(v.mem, v.closureAddr, int64(v.bi.Arch.PtrSize()))
 	if err != nil {
 		v.Unreadable = err
 		return
 	}
 
-	v.Base = uintptr(val)
+	v.Base = val
 	fn := v.bi.PCToFunc(uint64(v.Base))
 	if fn == nil {
 		v.Unreadable = fmt.Errorf("could not find function for %#v", v.Base)
@@ -1949,7 +1947,7 @@ func (it *mapIterator) nextBucket() bool {
 
 		for it.bidx < it.numbuckets {
 			it.b = it.buckets.clone()
-			it.b.Addr += uintptr(uint64(it.buckets.DwarfType.Size()) * it.bidx)
+			it.b.Addr += uint64(it.buckets.DwarfType.Size()) * it.bidx
 
 			if it.oldbuckets.Addr <= 0 {
 				break
@@ -1965,7 +1963,7 @@ func (it *mapIterator) nextBucket() bool {
 
 			oldbidx := it.bidx & it.oldmask
 			oldb := it.oldbuckets.clone()
-			oldb.Addr += uintptr(uint64(it.oldbuckets.DwarfType.Size()) * oldbidx)
+			oldb.Addr += uint64(it.oldbuckets.DwarfType.Size()) * oldbidx
 
 			if it.mapEvacuated(oldb) {
 				break

--- a/pkg/proc/x86_disasm.go
+++ b/pkg/proc/x86_disasm.go
@@ -110,7 +110,7 @@ func resolveCallArgX86(inst *x86asm.Inst, instAddr uint64, currentGoroutine bool
 		if err1 != nil || err2 != nil {
 			return nil
 		}
-		addr := uintptr(int64(base) + int64(index*uint64(arg.Scale)) + arg.Disp)
+		addr := uint64(int64(base) + int64(index*uint64(arg.Scale)) + arg.Disp)
 		pc, err = readUintRaw(mem, addr, int64(inst.MemBytes))
 		if err != nil {
 			return nil

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1555,7 +1555,7 @@ func examineMemoryCmd(t *Term, ctx callContext, args string) error {
 	})
 
 	var (
-		address int64
+		address uint64
 		err     error
 		ok      bool
 	)
@@ -1604,7 +1604,7 @@ func examineMemoryCmd(t *Term, ctx callContext, args string) error {
 				return fmt.Errorf("unknown option %q", v[i])
 			}
 			// TODO, maybe we can support expression.
-			address, err = strconv.ParseInt(v[len(v)-1], 0, 64)
+			address, err = strconv.ParseUint(v[len(v)-1], 0, 64)
 			if err != nil {
 				return fmt.Errorf("convert address into uintptr type failed, %s", err)
 			}
@@ -1615,7 +1615,7 @@ func examineMemoryCmd(t *Term, ctx callContext, args string) error {
 		return fmt.Errorf("no address specified")
 	}
 
-	memArea, err := t.client.ExamineMemory(uintptr(address), length)
+	memArea, err := t.client.ExamineMemory(address, length)
 	if err != nil {
 		return err
 	}

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -240,7 +240,7 @@ type Variable struct {
 	// Name of the variable or struct member
 	Name string `json:"name"`
 	// Address of the variable or struct member
-	Addr uintptr `json:"addr"`
+	Addr uint64 `json:"addr"`
 	// Only the address field is filled (result of evaluating expressions like &<expr>)
 	OnlyAddr bool `json:"onlyAddr"`
 	// Go type of the variable
@@ -272,7 +272,7 @@ type Variable struct {
 	// Base address of the backing byte array for strings
 	// address of the struct backing chan and map variables
 	// address of the function entry point for function variables (0 for nil function pointers)
-	Base uintptr `json:"base"`
+	Base uint64 `json:"base"`
 
 	// Unreadable addresses will have this field set
 	Unreadable string `json:"unreadable"`

--- a/service/client.go
+++ b/service/client.go
@@ -160,7 +160,7 @@ type Client interface {
 	// ExamineMemory returns the raw memory stored at the given address.
 	// The amount of data to be read is specified by length which must be less than or equal to 1000.
 	// This function will return an error if it reads less than `length` bytes.
-	ExamineMemory(address uintptr, length int) ([]byte, error)
+	ExamineMemory(address uint64, length int) ([]byte, error)
 
 	// StopRecording stops a recording if one is in progress.
 	StopRecording() error

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1604,7 +1604,7 @@ func (d *Debugger) ListDynamicLibraries() []api.Image {
 // ExamineMemory returns the raw memory stored at the given address.
 // The amount of data to be read is specified by length.
 // This function will return an error if it reads less than `length` bytes.
-func (d *Debugger) ExamineMemory(address uintptr, length int) ([]byte, error) {
+func (d *Debugger) ExamineMemory(address uint64, length int) ([]byte, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -441,7 +441,7 @@ func (c *RPCClient) ListDynamicLibraries() ([]api.Image, error) {
 	return out.List, nil
 }
 
-func (c *RPCClient) ExamineMemory(address uintptr, count int) ([]byte, error) {
+func (c *RPCClient) ExamineMemory(address uint64, count int) ([]byte, error) {
 	out := &ExaminedMemoryOut{}
 
 	err := c.call("ExamineMemory", ExamineMemoryIn{Length: count, Address: address}, out)

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -766,7 +766,7 @@ func (s *RPCServer) ListPackagesBuildInfo(in ListPackagesBuildInfoIn, out *ListP
 
 // ExamineMemoryIn holds the arguments of ExamineMemory
 type ExamineMemoryIn struct {
-	Address uintptr
+	Address uint64
 	Length  int
 }
 


### PR DESCRIPTION
Since proc is supposed to work independently from the target
architecture it shouldn't use architecture-dependent types, like
uintptr. For example when reading a 64bit core file on a 32bit
architecture, uintptr will be 32bit but the addresses proc needs to
represent will be 64bit.
