### PR TITLE
pkg/proc: fix dlv panic when sameGCond is nil.

### DIFF
--- a/_fixtures/issue2162.go
+++ b/_fixtures/issue2162.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("test dlv")
+}

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -529,7 +529,10 @@ func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 		return err
 	}
 
-	sameFrameCond := astutil.And(sameGCond, frameoffCondition(&topframe))
+	var sameFrameCond ast.Expr
+	if sameGCond != nil {
+		sameFrameCond = astutil.And(sameGCond, frameoffCondition(&topframe))
+	}
 
 	if stepInto && !backward {
 		err := setStepIntoBreakpoints(dbp, topframe.Current.Fn, text, topframe, sameGCond)

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2098,3 +2098,20 @@ func TestRedirects(t *testing.T) {
 		}
 	})
 }
+
+func TestIssue2162(t *testing.T) {
+	if buildMode == "pie" || runtime.GOOS == "windows" {
+		t.Skip("skip it for stepping into one place where no source for pc when on pie mode or windows")
+	}
+	withTestClient2("issue2162", t, func(c service.Client) {
+		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		_, err = c.Step()
+		if err != nil {
+			assertNoError(err, t, "Step()")
+		}
+	})
+}


### PR DESCRIPTION
`sameFrameCond` should not be constructed as one `And Express` when
sameGCond which is the first child of `BinaryExpr` is nil.

Fixes: #2162