### PR TITLE
Travis-CI: bump version of Go used to test linux/386 to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
   include:
     -  os: linux
        services: docker
-       env: go_32_version=1.14 # Linux/i386 tests held back to Go1.14 until issue #2134 is fixed
+       env: go_32_version=1.15.2 # Linux/i386 tests will fail on go1.15 prior to 1.15.2 (see issue #2134)
 
 script: >-
     if [ $TRAVIS_OS_NAME = "linux" ] && [ $go_32_version ]; then

--- a/_scripts/gen-travis.go
+++ b/_scripts/gen-travis.go
@@ -112,7 +112,7 @@ jobs:
   include:
     -  os: linux
        services: docker
-       env: go_32_version={{index .GoVersions 1}} # Linux/i386 tests held back to Go1.14 until issue #2134 is fixed
+       env: go_32_version={{index .GoVersions 0}}.2 # Linux/i386 tests will fail on go1.15 prior to 1.15.2 (see issue #2134)
 
 script: >-
     if [ $TRAVIS_OS_NAME = "linux" ] && [ $go_32_version ]; then


### PR DESCRIPTION
Fixes #2134
