### PR TITLE
proc: resolve symlinks when searching for split debug_info if path is /proc/pid/exe

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1037,6 +1037,11 @@ func (bi *BinaryInfo) openSeparateDebugInfo(image *Image, exe *elf.File, debugIn
 				continue
 			}
 			potentialDebugFilePath = fmt.Sprintf("%s/%s/%s.debug", dir, desc1, desc2)
+		} else if strings.HasPrefix(image.Path, "/proc") {
+			path, err := filepath.EvalSymlinks(image.Path)
+			if err == nil {
+				potentialDebugFilePath = fmt.Sprintf("%s/%s.debug", dir, filepath.Base(path))
+			}
 		} else {
 			potentialDebugFilePath = fmt.Sprintf("%s/%s.debug", dir, filepath.Base(image.Path))
 		}

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -130,12 +130,7 @@ func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
 		return nil, err
 	}
 
-	execPath, err := findExecutable(pid)
-	if err != nil {
-		return nil, err
-	}
-
-	tgt, err := dbp.initialize(execPath, debugInfoDirs)
+	tgt, err := dbp.initialize(findExecutable("", dbp.pid), debugInfoDirs)
 	if err != nil {
 		_ = dbp.Detach(false)
 		return nil, err
@@ -265,9 +260,11 @@ func (dbp *nativeProcess) updateThreadList() error {
 	return linutil.ElfUpdateSharedObjects(dbp)
 }
 
-func findExecutable(pid int) (string, error) {
-	path := fmt.Sprintf("/proc/%d/exe", pid)
-	return filepath.EvalSymlinks(path)
+func findExecutable(path string, pid int) string {
+	if path == "" {
+		path = fmt.Sprintf("/proc/%d/exe", pid)
+	}
+	return path
 }
 
 func (dbp *nativeProcess) trapWait(pid int) (*nativeThread, error) {


### PR DESCRIPTION
### proc: resolve symlinks when searching for split debug_info if path is /proc/pid/exe

Fixes #2168

### Revert "proc: Find executable should follow symbol links."

This reverts commit 3e04ad0fada0c3ab57caf58bc024e4c0f9a3e01a.
