### PR TITLE
proc/native: fix flakyness of TestStepConcurrentDirect on linux/386

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -9,13 +9,14 @@ import (
 type Arch struct {
 	Name string // architecture name
 
-	ptrSize               int
-	maxInstructionLength  int
-	prologues             []opcodeSeq
-	breakpointInstruction []byte
-	breakInstrMovesPC     bool
-	derefTLS              bool
-	usesLR                bool // architecture uses a link register, also called RA on some architectures
+	ptrSize                  int
+	maxInstructionLength     int
+	prologues                []opcodeSeq
+	breakpointInstruction    []byte
+	altBreakpointInstruction []byte
+	breakInstrMovesPC        bool
+	derefTLS                 bool
+	usesLR                   bool // architecture uses a link register, also called RA on some architectures
 
 	// asmDecode decodes the assembly instruction starting at mem[0:] into asmInst.
 	// It assumes that the Loc and AtPC fields of asmInst have already been filled.
@@ -64,6 +65,11 @@ func (a *Arch) MaxInstructionLength() int {
 // the given architecture.
 func (a *Arch) BreakpointInstruction() []byte {
 	return a.breakpointInstruction
+}
+
+// AltBreakpointInstruction returns an alternate encoding for the breakpoint instruction.
+func (a *Arch) AltBreakpointInstruction() []byte {
+	return a.altBreakpointInstruction
 }
 
 // BreakInstrMovesPC is true if hitting the breakpoint instruction advances the

--- a/pkg/proc/i386_arch.go
+++ b/pkg/proc/i386_arch.go
@@ -24,6 +24,7 @@ func I386Arch(goos string) *Arch {
 		ptrSize:                          4,
 		maxInstructionLength:             15,
 		breakpointInstruction:            i386BreakInstruction,
+		altBreakpointInstruction:         []byte{0xcd, 0x03},
 		breakInstrMovesPC:                true,
 		derefTLS:                         false,
 		prologues:                        prologuesI386,

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -59,7 +59,7 @@ func (dbp *nativeProcess) trapWait(pid int) (*nativeThread, error) {
 	panic(ErrNativeBackendDisabled)
 }
 
-func (dbp *nativeProcess) stop(trapthread *nativeThread) (err error) {
+func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
 	panic(ErrNativeBackendDisabled)
 }
 

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -347,19 +347,19 @@ func (dbp *nativeProcess) resume() error {
 
 // Used by ContinueOnce
 // stop stops all running threads and sets breakpoints
-func (dbp *nativeProcess) stop(trapthread *nativeThread) (err error) {
+func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
 	if dbp.exited {
-		return &proc.ErrProcessExited{Pid: dbp.Pid()}
+		return nil, &proc.ErrProcessExited{Pid: dbp.Pid()}
 	}
 	// set breakpoints on all threads
 	for _, th := range dbp.threads {
 		if th.CurrentBreakpoint.Breakpoint == nil {
 			if err := th.SetCurrentBreakpoint(true); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
-	return nil
+	return trapthread, nil
 }
 
 // Used by Detach


### PR DESCRIPTION
TestStepConcurrentDirect will occasionally fail (7% of the time on my
setup) by either causing the target processs to execute an invalid
instruction or (more infrequently) by switching to the wrong thread.

Both of those are caused by receiving SIGTRAPs for threads hitting a
breakpoint after it has been removed (the thread hits the breakpoint,
we stop everything and remove the breakpoint and only after we receive
the signal).

Change native.(*nativeProcess).stop to handle SIGTRAPs that can't be
attributed to a breakpoint, a hardcoded breakpoint in the program's
text, or manual stops (and therefore are likely caused by phantom
breakpoint hits).
