### PR TITLE
dwarf/line: ignore end_of_sequence entry if AllPCsBetween

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 before_install:
   - export GOFLAGS=-mod=vendor
   - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo apt-get -qq update; sudo apt-get install -y dwz; echo "dwz version $(dwz --version)"; fi
-  - if [ $TRAVIS_OS_NAME = "windows" ]; then choco install procdump make; fi
+  - if [ $TRAVIS_OS_NAME = "windows" ]; then choco install procdump make --ignorechecksum; fi
 
 
 # 386 linux

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -182,7 +182,7 @@ func (lineInfo *DebugLineInfo) AllPCsBetween(begin, end uint64, excludeFile stri
 		if (sm.address > end) && (end >= sm.lastAddress) {
 			break
 		}
-		if sm.address >= begin && sm.address <= end && sm.address > lastaddr && sm.isStmt && ((sm.file != excludeFile) || (sm.line != excludeLine)) {
+		if sm.address >= begin && sm.address <= end && sm.address > lastaddr && sm.isStmt && !sm.endSeq && ((sm.file != excludeFile) || (sm.line != excludeLine)) {
 			lastaddr = sm.address
 			pcs = append(pcs, sm.address)
 		}


### PR DESCRIPTION
Go 1.15 (but possibly prior versions of Go too) has a tendency to use
an address in the middle of an instruction for this entry, but if it
was correct it would be after the last instruction of the function
anyway.

This problem manifests especially frequently as a target crash in
TestStepConcurrentPtr on linux/arm64 (~6% of the runs).
