### PR TITLE
proc: use argument position for addr only when injecting function calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 before_install:
   - export GOFLAGS=-mod=vendor
   - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo apt-get -qq update; sudo apt-get install -y dwz; echo "dwz version $(dwz --version)"; fi
-  - if [ $TRAVIS_OS_NAME = "windows" ]; then choco install procdump make; fi
+  - if [ $TRAVIS_OS_NAME = "windows" ]; then choco install procdump make --ignorechecksum; fi
 
 
 # 386 linux

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -51,6 +51,11 @@ type EvalScope struct {
 	// The goroutine executing the expression evaluation shall signal that the
 	// evaluation is complete by closing the continueRequest channel.
 	callCtx *callContext
+
+	// If trustArgOrder is true function arguments that don't have an address
+	// will have one assigned by looking at their position in the argument
+	// list.
+	trustArgOrder bool
 }
 
 // ConvertEvalScope returns a new EvalScope in the context of the
@@ -208,7 +213,7 @@ func (scope *EvalScope) Locals() ([]*Variable, error) {
 		return nil, errors.New("unable to find function context")
 	}
 
-	trustArgOrder := scope.BinInfo.Producer() != "" && goversion.ProducerAfterOrEqual(scope.BinInfo.Producer(), 1, 12)
+	trustArgOrder := scope.trustArgOrder && scope.BinInfo.Producer() != "" && goversion.ProducerAfterOrEqual(scope.BinInfo.Producer(), 1, 12) && scope.Fn != nil && (scope.PC == scope.Fn.Entry)
 
 	dwarfTree, err := scope.image().getDwarfTree(scope.Fn.offset)
 	if err != nil {

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -806,6 +806,7 @@ func funcCallStep(callScope *EvalScope, fncall *functionCallState, thread Thread
 
 		// pretend we are still inside the function we called
 		fakeFunctionEntryScope(retScope, fncall.fn, int64(regs.SP()), regs.SP()-uint64(bi.Arch.PtrSize()))
+		retScope.trustArgOrder = true
 
 		fncall.retvars, err = retScope.Locals()
 		if err != nil {


### PR DESCRIPTION
We can not, in general, use the argument position to determine the
address of a formal parameter, it will not work in presence of
optimizations or inlining. In those cases formal arguments could be
stored in registers.

Fixes #2176
