### PR TITLE
service/*: remove threadID argument of (*Debugger).PackageVariables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 before_install:
   - export GOFLAGS=-mod=vendor
   - if [ $TRAVIS_OS_NAME = "linux" ]; then sudo apt-get -qq update; sudo apt-get install -y dwz; echo "dwz version $(dwz --version)"; fi
-  - if [ $TRAVIS_OS_NAME = "windows" ]; then choco install procdump make; fi
+  - if [ $TRAVIS_OS_NAME = "windows" ]; then choco install procdump make --ignorechecksum; fi
 
 
 # 386 linux

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -769,7 +769,7 @@ func (s *Server) onScopesRequest(request *dap.ScopesRequest) {
 			return
 		}
 		currPkgFilter := fmt.Sprintf("^%s\\.", currPkg)
-		globals, err := s.debugger.PackageVariables(s.debugger.CurrentThread().ThreadID(), currPkgFilter, cfg)
+		globals, err := s.debugger.PackageVariables(currPkgFilter, cfg)
 		if err != nil {
 			s.sendErrorResponse(request.Request, UnableToListGlobals, "Unable to list globals", err.Error())
 			return

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1153,7 +1153,7 @@ func (d *Debugger) Types(filter string) ([]string, error) {
 
 // PackageVariables returns a list of package variables for the thread,
 // optionally regexp filtered using regexp described in 'filter'.
-func (d *Debugger) PackageVariables(threadID int, filter string, cfg proc.LoadConfig) ([]*proc.Variable, error) {
+func (d *Debugger) PackageVariables(filter string, cfg proc.LoadConfig) ([]*proc.Variable, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 
@@ -1162,11 +1162,7 @@ func (d *Debugger) PackageVariables(threadID int, filter string, cfg proc.LoadCo
 		return nil, fmt.Errorf("invalid filter argument: %s", err.Error())
 	}
 
-	thread, found := d.target.FindThread(threadID)
-	if !found {
-		return nil, fmt.Errorf("couldn't find thread %d", threadID)
-	}
-	scope, err := proc.ThreadScope(thread)
+	scope, err := proc.ThreadScope(d.target.CurrentThread())
 	if err != nil {
 		return nil, err
 	}
@@ -1508,13 +1504,6 @@ func (d *Debugger) Recorded() (recorded bool, tracedir string) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 	return d.target.Recorded()
-}
-
-// CurrentThread returns the current thread.
-func (d *Debugger) CurrentThread() proc.Thread {
-	d.targetMutex.Lock()
-	defer d.targetMutex.Unlock()
-	return d.target.CurrentThread()
 }
 
 // Checkpoint will set a checkpoint specified by the locspec.

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -172,17 +172,7 @@ func (s *RPCServer) GetThread(id int, thread *api.Thread) error {
 }
 
 func (s *RPCServer) ListPackageVars(filter string, variables *[]api.Variable) error {
-	state, err := s.debugger.State(false)
-	if err != nil {
-		return err
-	}
-
-	current := state.CurrentThread
-	if current == nil {
-		return fmt.Errorf("no current thread")
-	}
-
-	vars, err := s.debugger.PackageVariables(current.ID, filter, defaultLoadConfig)
+	vars, err := s.debugger.PackageVariables(filter, defaultLoadConfig)
 	if err != nil {
 		return err
 	}
@@ -196,15 +186,7 @@ type ThreadListArgs struct {
 }
 
 func (s *RPCServer) ListThreadPackageVars(args *ThreadListArgs, variables *[]api.Variable) error {
-	thread, err := s.debugger.FindThread(args.Id)
-	if err != nil {
-		return err
-	}
-	if thread == nil {
-		return fmt.Errorf("no thread with id %d", args.Id)
-	}
-
-	vars, err := s.debugger.PackageVariables(args.Id, args.Filter, defaultLoadConfig)
+	vars, err := s.debugger.PackageVariables(args.Filter, defaultLoadConfig)
 	if err != nil {
 		return err
 	}

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -371,17 +371,7 @@ type ListPackageVarsOut struct {
 
 // ListPackageVars lists all package variables in the context of the current thread.
 func (s *RPCServer) ListPackageVars(arg ListPackageVarsIn, out *ListPackageVarsOut) error {
-	state, err := s.debugger.State(false)
-	if err != nil {
-		return err
-	}
-
-	current := state.CurrentThread
-	if current == nil {
-		return fmt.Errorf("no current thread")
-	}
-
-	vars, err := s.debugger.PackageVariables(current.ID, arg.Filter, *api.LoadConfigToProc(&arg.Cfg))
+	vars, err := s.debugger.PackageVariables(arg.Filter, *api.LoadConfigToProc(&arg.Cfg))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Which thread is used doesn't make any difference to the list of package
variables that is returned and this option was only ever used by an old
v1 API call.
