### PR TITLE
service/dap: make interface variable to dap.Variable conversion more readable

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -963,6 +963,20 @@ func (s *Server) convertVariable(v *proc.Variable) (value string, variablesRefer
 			value = "nil <" + typeName + ">"
 		} else {
 			value = "<" + typeName + "(" + v.Children[0].TypeString() + ")" + ">"
+			// TODO(polina): should we remove one level of indirection and skip "data"?
+			// Then we will have:
+			// Before:
+			//   i: <interface{}(int)>
+			//      data: 123
+			// After:
+			//   i: <interface{}(int)> 123
+			// Before:
+			//   i: <interface{}(main.MyStruct)>
+			//      data: <main.MyStruct>
+			//         field1: ...
+			// After:
+			//   i: <interface{}(main.MyStruct)>
+			//      field1: ...
 			variablesReference = s.variableHandles.create(v)
 		}
 	case reflect.Complex64, reflect.Complex128:

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -962,7 +962,7 @@ func (s *Server) convertVariable(v *proc.Variable) (value string, variablesRefer
 		} else if len(v.Children) == 0 || v.Children[0].Kind == reflect.Invalid && v.Children[0].Addr == 0 {
 			value = "nil <" + typeName + ">"
 		} else {
-			value = "<" + typeName + ">"
+			value = "<" + typeName + "(" + v.Children[0].TypeString() + ")" + ">"
 			variablesReference = s.variableHandles.create(v)
 		}
 	case reflect.Complex64, reflect.Complex128:

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -909,14 +909,14 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 					expectVarExact(t, locals, -1, "fn2", "<main.functype>", noChildren)
 					// reflect.Kind == Interface
 					expectVarExact(t, locals, -1, "ifacenil", "nil <interface {}>", noChildren)
-					ref = expectVarExact(t, locals, -1, "iface2", "<interface {}>", hasChildren)
+					ref = expectVarExact(t, locals, -1, "iface2", "<interface {}(string)>", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						iface2 := client.ExpectVariablesResponse(t)
 						expectChildren(t, iface2, "iface2", 1)
 						expectVarExact(t, iface2, 0, "data", `"test"`, noChildren)
 					}
-					ref = expectVarExact(t, locals, -1, "iface4", "<interface {}>", hasChildren)
+					ref = expectVarExact(t, locals, -1, "iface4", "<interface {}([]go/constant.Value)>", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						iface4 := client.ExpectVariablesResponse(t)
@@ -926,10 +926,12 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 							client.VariablesRequest(ref)
 							iface4data := client.ExpectVariablesResponse(t)
 							expectChildren(t, iface4data, "iface4.data", 1)
-							expectVarExact(t, iface4data, 0, "[0]", "<go/constant.Value>", hasChildren)
+							expectVarExact(t, iface4data, 0, "[0]", "<go/constant.Value(go/constant.int64Val)>", hasChildren)
 
 						}
 					}
+					expectVarExact(t, locals, -1, "errnil", "nil <error>", noChildren)
+					expectVarExact(t, locals, -1, "err1", "<error(*main.astruct)>", hasChildren)
 					// reflect.Kind == Map
 					expectVarExact(t, locals, -1, "mnil", "nil <map[string]main.astruct>", noChildren)
 					ref = expectVarExact(t, locals, -1, "m2", "<map[int]*main.astruct> (length: 1)", hasChildren)


### PR DESCRIPTION
- Add underlying type.
- Consider "collapsing" data level.
