### PR TITLE
service/dap: add "panic" and "fatal error" as stopped reasons

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1173,13 +1173,13 @@ func (s *Server) doCommand(command string) {
 			stopped.Body.Reason = "step"
 		default:
 			stopped.Body.Reason = "breakpoint"
-			if state.CurrentThread.Breakpoint != nil {
-				switch state.CurrentThread.Breakpoint.Name {
-				case proc.FatalThrow:
-					stopped.Body.Reason = "fatal error"
-				case proc.UnrecoveredPanic:
-					stopped.Body.Reason = "panic"
-				}
+		}
+		if state.CurrentThread.Breakpoint != nil {
+			switch state.CurrentThread.Breakpoint.Name {
+			case proc.FatalThrow:
+				stopped.Body.Reason = "fatal error"
+			case proc.UnrecoveredPanic:
+				stopped.Body.Reason = "panic"
 			}
 		}
 		s.send(stopped)

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -962,7 +962,21 @@ func (s *Server) convertVariable(v *proc.Variable) (value string, variablesRefer
 		} else if len(v.Children) == 0 || v.Children[0].Kind == reflect.Invalid && v.Children[0].Addr == 0 {
 			value = "nil <" + typeName + ">"
 		} else {
-			value = "<" + typeName + ">"
+			value = "<" + typeName + "(" + v.Children[0].TypeString() + ")" + ">"
+			// TODO(polina): should we remove one level of indirection and skip "data"?
+			// Then we will have:
+			// Before:
+			//   i: <interface{}(int)>
+			//      data: 123
+			// After:
+			//   i: <interface{}(int)> 123
+			// Before:
+			//   i: <interface{}(main.MyStruct)>
+			//      data: <main.MyStruct>
+			//         field1: ...
+			// After:
+			//   i: <interface{}(main.MyStruct)>
+			//      field1: ...
 			variablesReference = s.variableHandles.create(v)
 		}
 	case reflect.Complex64, reflect.Complex128:
@@ -1152,22 +1166,10 @@ func (s *Server) doCommand(command string) {
 	if err == nil {
 		if state.SelectedGoroutine != nil {
 			stopped.Body.ThreadId = state.SelectedGoroutine.ID
-		} else {
-			// If there is no selectedGoroutine, get the list of goroutines and select the first one.
-			// TODO(polina): validate the assumption in this code that the first goroutine
-			// is the current one. So far it appears to me that this is always the main goroutine
-			// with id 1.
-			gs, _, err := s.debugger.Goroutines(0, 1)
-			if err != nil {
-				s.log.Error(err)
-			}
-			if len(gs) > 0 {
-				stopped.Body.ThreadId = gs[0].ID
-			}
 		}
 
-		switch command {
-		case api.Next, api.Step, api.StepOut:
+		switch s.debugger.StopReason() {
+		case proc.StopNextFinished:
 			stopped.Body.Reason = "step"
 		default:
 			stopped.Body.Reason = "breakpoint"

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1269,12 +1269,31 @@ func TestPanicBreakpointOnNext(t *testing.T) {
 				execute: func() {
 					handleStop(t, client, 1, 5)
 
-					client.NextRequest(1)
-					client.ExpectNextResponse(t)
+					// Send a next request until the panic breakpoint is hit.
+					// We expect to hit the unrecovered panic breakpoint and
+					// return a "panic" stopped event.
+					// In Go 1.13, 'next' will step into the defer in the runtime
+					// main function. This will take multiple steps to reach the
+					// unrecovered panic breakpoint.
+					for {
+						client.NextRequest(1)
+						client.ExpectNextResponse(t)
 
-					se := client.ExpectStoppedEvent(t)
-					if se.Body.ThreadId != 1 || se.Body.Reason != "panic" {
-						t.Errorf("\ngot  %#v\nwant ThreadId=1 Reason=\"panic\"", se)
+						m, err := client.ReadMessage()
+						if err != nil {
+							t.Error(err)
+						}
+						if se, ok := m.(*dap.StoppedEvent); ok {
+							if se.Body.ThreadId == 1 && se.Body.Reason == "panic" {
+								// Successfully reached the unrecovered panic breakpoint.
+								break
+							} else if se.Body.ThreadId != 1 || se.Body.Reason != "step" {
+								t.Errorf("\ngot  %#v\nexpected ThreadId=1 Reason=\"panic\" or ThreadId=1 Reason=\"step\"", se)
+							}
+						} else if _, ok := m.(*dap.TerminatedEvent); ok {
+							t.Errorf("\nended program without \"panic\" event.")
+							break
+						}
 					}
 				},
 				disconnect: true,

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1602,6 +1602,15 @@ func (d *Debugger) StopRecording() error {
 	return d.stopRecording()
 }
 
+// StopReason returns the reason the reason why the target process is stopped.
+// A process could be stopped for multiple simultaneous reasons, in which
+// case only one will be reported.
+func (d *Debugger) StopReason() proc.StopReason {
+	d.targetMutex.Lock()
+	defer d.targetMutex.Unlock()
+	return d.target.StopReason
+}
+
 // LockTarget acquires the target mutex.
 func (d *Debugger) LockTarget() {
 	d.targetMutex.Lock()


### PR DESCRIPTION
The unrecovered panic and fatal throw breakpoints are not set by the
user. We now check for these special breakpoints and send appropriate
stopped reasons to the client.