### PR TITLE
proc: Remove (*Arch).Prologues method

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -59,12 +59,6 @@ func (a *Arch) MaxInstructionLength() int {
 	return a.maxInstructionLength
 }
 
-// Prologues returns a list of stack split prologues
-// that are inserted at function entry.
-func (a *Arch) Prologues() []opcodeSeq {
-	return a.prologues
-}
-
 // BreakpointInstruction is the instruction that will trigger a breakpoint trap for
 // the given architecture.
 func (a *Arch) BreakpointInstruction() []byte {

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -83,7 +83,7 @@ func firstPCAfterPrologueDisassembly(p Process, fn *Function, sameline bool) (ui
 		return fn.Entry, nil
 	}
 
-	for _, prologue := range p.BinInfo().Arch.Prologues() {
+	for _, prologue := range p.BinInfo().Arch.prologues {
 		if len(prologue) >= len(text) {
 			continue
 		}


### PR DESCRIPTION
It returns an unexported type and is only used in a single place.
