### PR TITLE
proc/test: fix TestStepCallPtr on linux/386

### DIFF
--- a/_fixtures/teststepprog.go
+++ b/_fixtures/teststepprog.go
@@ -2,12 +2,12 @@ package main
 
 var n = 0
 
-func CallFn2() {
+func CallFn2(x int) {
 	n++
 }
 
-func CallFn(fn func()) {
-	fn()
+func CallFn(x int, fn func(x int)) {
+	fn(x + 1)
 }
 
 func CallEface(eface interface{}) {
@@ -17,6 +17,6 @@ func CallEface(eface interface{}) {
 }
 
 func main() {
-	CallFn(CallFn2)
+	CallFn(0, CallFn2)
 	CallEface(n)
 }


### PR DESCRIPTION
The test needs to set a breakpoint on main.CallFn after the prologue,
on linux/386 this function does not have any instruction after the
prologue on the function header line  because it doesn't need to
allocate space for local variables. Change the fixture so that this
isn't a problem.

This bug results on the test failing a small percentage of the time.
