### PR TITLE
proc/test: enable TestCgoStacktrace2

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -1,9 +1,10 @@
 Tests skipped by each supported backend:
 
-* 386 skipped = 1.4% (2/145)
-	* 2 broken - cgo stacktraces
-* arm64 skipped = 2.1% (3/145)
+* 386 skipped = 2.1% (3/145)
 	* 1 broken
+	* 2 broken - cgo stacktraces
+* arm64 skipped = 2.8% (4/145)
+	* 2 broken
 	* 1 broken - global variable symbolication
 	* 1 broken - reading defers
 * darwin/lldb skipped = 0.69% (1/145)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4519,6 +4519,8 @@ func TestIssue1615(t *testing.T) {
 
 func TestCgoStacktrace2(t *testing.T) {
 	skipOn(t, "upstream issue", "windows")
+	skipOn(t, "broken", "386")
+	skipOn(t, "broken", "arm64")
 	protest.MustHaveCgo(t)
 	// If a panic happens during cgo execution the stacktrace should show the C
 	// function that caused the problem.
@@ -4527,7 +4529,10 @@ func TestCgoStacktrace2(t *testing.T) {
 		frames, err := proc.ThreadStacktrace(p.CurrentThread(), 100)
 		assertNoError(err, t, "Stacktrace()")
 		logStacktrace(t, p.BinInfo(), frames)
-		stacktraceCheck(t, []string{"C.sigsegv", "C.testfn", "main.main"}, frames)
+		m := stacktraceCheck(t, []string{"C.sigsegv", "C.testfn", "main.main"}, frames)
+		if m == nil {
+			t.Fatal("see previous loglines")
+		}
 	})
 }
 


### PR DESCRIPTION
Due to a missing check TestCgoStacktrace2 didn't actually check
anything. Enable it and then skip it on linux/386 where it's broken.
