### PR TITLE
Add display of floating-point registers under ARM64 

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -34,16 +34,6 @@ type Arch struct {
 	addrAndStackRegsToDwarfRegisters func(uint64, uint64, uint64, uint64, uint64) op.DwarfRegisters
 	// DwarfRegisterToString returns the name and value representation of the given register.
 	DwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
-	//QDwarfRegisterToString returns the Q registers
-	QDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
-	//DDwarfRegisterToString returns the D registers
-	DDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
-	//SDwarfRegisterToString returns the S registers
-	SDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
-	//HDwarfRegisterToString returns the H registers
-	HDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
-	//BDwarfRegisterToString returns the B registers
-	BDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
 	// inhibitStepInto returns whether StepBreakpoint can be set at pc.
 	inhibitStepInto func(bi *BinaryInfo, pc uint64) bool
 

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -34,6 +34,16 @@ type Arch struct {
 	addrAndStackRegsToDwarfRegisters func(uint64, uint64, uint64, uint64, uint64) op.DwarfRegisters
 	// DwarfRegisterToString returns the name and value representation of the given register.
 	DwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
+	//QDwarfRegisterToString returns the Q registers
+	QDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
+	//DDwarfRegisterToString returns the D registers
+	DDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
+	//SDwarfRegisterToString returns the S registers
+	SDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
+	//HDwarfRegisterToString returns the H registers
+	HDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
+	//BDwarfRegisterToString returns the B registers
+	BDwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
 	// inhibitStepInto returns whether StepBreakpoint can be set at pc.
 	inhibitStepInto func(bi *BinaryInfo, pc uint64) bool
 

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"math/big"
 
 	"github.com/go-delve/delve/pkg/dwarf/frame"
 	"github.com/go-delve/delve/pkg/dwarf/op"
@@ -38,6 +39,11 @@ func ARM64Arch(goos string) *Arch {
 		RegistersToDwarfRegisters:        arm64RegistersToDwarfRegisters,
 		addrAndStackRegsToDwarfRegisters: arm64AddrAndStackRegsToDwarfRegisters,
 		DwarfRegisterToString:            arm64DwarfRegisterToString,
+		QDwarfRegisterToString:           arm64qDwarfRegisterToString,
+		DDwarfRegisterToString:           arm64dDwarfRegisterToString,
+		SDwarfRegisterToString:           arm64sDwarfRegisterToString,
+		HDwarfRegisterToString:           arm64hDwarfRegisterToString,
+		BDwarfRegisterToString:           arm64bDwarfRegisterToString,
 		inhibitStepInto:                  func(*BinaryInfo, uint64) bool { return false },
 		asmDecode:                        arm64AsmDecode,
 	}
@@ -391,34 +397,205 @@ func arm64DwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, floa
 		for i := range vi {
 			binary.Read(buf, binary.LittleEndian, &vi[i])
 		}
+        //D
+		fmt.Fprintf(&out, " {\n\tD = {u = {0x%02x%02x%02x%02x%02x%02x%02x%02x,", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
+		fmt.Fprintf(&out, " 0x%02x%02x%02x%02x%02x%02x%02x%02x},", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
+		fmt.Fprintf(&out, " s = {0x%02x%02x%02x%02x%02x%02x%02x%02x,", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
+		fmt.Fprintf(&out, " 0x%02x%02x%02x%02x%02x%02x%02x%02x}},", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
 
-		fmt.Fprintf(&out, "0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8], vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
+		//S
+		fmt.Fprintf(&out, " \n\tS = {u = {0x%02x%02x%02x%02x,0x%02x%02x%02x%02x,", vi[3], vi[2], vi[1], vi[0], vi[7], vi[6], vi[5], vi[4])
+		fmt.Fprintf(&out, " 0x%02x%02x%02x%02x,0x%02x%02x%02x%02x},", vi[11], vi[10], vi[9], vi[8], vi[15], vi[14], vi[13], vi[12])
+		fmt.Fprintf(&out, " s = {0x%02x%02x%02x%02x,0x%02x%02x%02x%02x,", vi[3], vi[2], vi[1], vi[0], vi[7], vi[6], vi[5], vi[4])
+		fmt.Fprintf(&out, " 0x%02x%02x%02x%02x,0x%02x%02x%02x%02x}},", vi[11], vi[10], vi[9], vi[8], vi[15], vi[14], vi[13], vi[12])
 
-		fmt.Fprintf(&out, "\tv2_int={ %02x%02x%02x%02x%02x%02x%02x%02x %02x%02x%02x%02x%02x%02x%02x%02x }", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0], vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
+		//H
+		fmt.Fprintf(&out, " \n\tH = {u = {0x%02x%02x,0x%02x%02x,0x%02x%02x,0x%02x%02x,", vi[1], vi[0], vi[3], vi[2], vi[5], vi[4], vi[7], vi[6])
+		fmt.Fprintf(&out, " 0x%02x%02x,0x%02x%02x,0x%02x%02x,0x%02x%02x},", vi[9], vi[8], vi[11], vi[10], vi[13], vi[12], vi[15], vi[14])
+		fmt.Fprintf(&out, " s = {0x%02x%02x,0x%02x%02x,0x%02x%02x,0x%02x%02x,", vi[1], vi[0], vi[3], vi[2], vi[5], vi[4], vi[7], vi[6])
+		fmt.Fprintf(&out, " 0x%02x%02x,0x%02x%02x,0x%02x%02x,0x%02x%02x}},", vi[9], vi[8], vi[11], vi[10], vi[13], vi[12], vi[15], vi[14])
 
-		fmt.Fprintf(&out, "\tv4_int={ %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x }", vi[3], vi[2], vi[1], vi[0], vi[7], vi[6], vi[5], vi[4], vi[11], vi[10], vi[9], vi[8], vi[15], vi[14], vi[13], vi[12])
+		//B
+		fmt.Fprintf(&out, " \n\tB = {u = {0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,", vi[0], vi[1], vi[2], vi[3], vi[4], vi[5], vi[6], vi[7])
+		fmt.Fprintf(&out, " 0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x},", vi[8], vi[9], vi[10], vi[11], vi[12], vi[13], vi[14], vi[15])
+		fmt.Fprintf(&out, " s = {0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,", vi[0], vi[1], vi[2], vi[3], vi[4], vi[5], vi[6], vi[7])
+		fmt.Fprintf(&out, " 0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x}}", vi[8], vi[9], vi[10], vi[11], vi[12], vi[13], vi[14], vi[15])
 
-		fmt.Fprintf(&out, "\tv8_int={ %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x %02x%02x }", vi[1], vi[0], vi[3], vi[2], vi[5], vi[4], vi[7], vi[6], vi[9], vi[8], vi[11], vi[10], vi[13], vi[12], vi[15], vi[14])
-
-		fmt.Fprintf(&out, "\tv16_int={ %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x }", vi[0], vi[1], vi[2], vi[3], vi[4], vi[5], vi[6], vi[7], vi[8], vi[9], vi[10], vi[11], vi[12], vi[13], vi[14], vi[15])
-
-		buf.Seek(0, io.SeekStart)
-		var v2 [2]float64
-		for i := range v2 {
-			binary.Read(buf, binary.LittleEndian, &v2[i])
-		}
-		fmt.Fprintf(&out, "\tv2_float={ %g %g }", v2[0], v2[1])
-
-		buf.Seek(0, io.SeekStart)
-		var v4 [4]float32
-		for i := range v4 {
-			binary.Read(buf, binary.LittleEndian, &v4[i])
-		}
-		fmt.Fprintf(&out, "\tv4_float={ %g %g %g %g }", v4[0], v4[1], v4[2], v4[3])
+		//Q
+		fmt.Fprintf(&out, " \n\tQ = {u = {0x%02x%02x%02x%02x%02x%02x%02x%02x", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
+		fmt.Fprintf(&out, "%02x%02x%02x%02x%02x%02x%02x%02x},", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
+		fmt.Fprintf(&out, " s = {0x%02x%02x%02x%02x%02x%02x%02x%02x", vi[15], vi[14], vi[13], vi[12], vi[11], vi[10], vi[9], vi[8])
+		fmt.Fprintf(&out, "%02x%02x%02x%02x%02x%02x%02x%02x}}\n\t}", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
 
 		return name, true, out.String()
 	} else if reg.Bytes == nil || (reg.Bytes != nil && len(reg.Bytes) < 16) {
 		return name, false, fmt.Sprintf("%#016x", reg.Uint64Val)
 	}
 	return name, false, fmt.Sprintf("%#x", reg.Bytes)
+}
+
+//get Q registers
+func arm64qDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, floatingPoint bool, repr string) {
+
+	name = fmt.Sprintf("Q%d", i-64)
+	buf := bytes.NewReader(reg.Bytes)
+
+	var out bytes.Buffer
+	var vi [4]uint32
+	for i := range vi {
+		binary.Read(buf, binary.LittleEndian, &vi[i])
+	}
+
+	UnsignRegscat := arm64UnsignBigRegsCate(int64(vi[3]), int64(vi[2]), int64(vi[1]), int64(vi[0]))
+	SignRegscat := arm64SignBigRegsCate(int64(vi[3]), int64(vi[2]), int64(vi[1]), int64(vi[0]))
+
+	fmt.Fprintf(&out, " {u = 0x%x%x%x%x, s = 0x%x%x%x%x}", vi[3], vi[2], vi[1], vi[0], vi[3], vi[2], vi[1], vi[0])
+	fmt.Fprintf(&out, "\n       {u = %d, s = %d}", UnsignRegscat, SignRegscat)
+	buf.Seek(0, io.SeekStart)
+
+	return name, true, out.String()
+}
+
+//get D registers
+func arm64dDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, floatingPoint bool, repr string) {
+
+	name = fmt.Sprintf("D%d", i-64)
+	buf := bytes.NewReader(reg.Bytes)
+
+	var out bytes.Buffer
+	var vi [2]uint64
+	for i := range vi {
+		binary.Read(buf, binary.LittleEndian, &vi[i])
+	}
+
+	UnsignRegsCat := vi[0]
+	SignRegsCat := int64(UnsignRegsCat)
+
+	fmt.Fprintf(&out, " {u = 0x%x s = 0x%x}", vi[0], vi[0])
+	fmt.Fprintf(&out, "\n       {u = %d, s = %d}", UnsignRegsCat, SignRegsCat)
+	buf.Seek(0, io.SeekStart)
+
+	return name, true, out.String()
+}
+
+//get S registers
+func arm64sDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, floatingPoint bool, repr string) {
+
+	name = fmt.Sprintf("S%d", i-64)
+	buf := bytes.NewReader(reg.Bytes)
+
+	var out bytes.Buffer
+	var vi [4]uint32
+	for i := range vi {
+		binary.Read(buf, binary.LittleEndian, &vi[i])
+	}
+	UnsignRegsCat := vi[0]
+	SignRegsCat := int32(UnsignRegsCat)
+
+	fmt.Fprintf(&out, " {u = 0x%x, s =0x%x}", vi[0], vi[0])
+	fmt.Fprintf(&out, "\n       {u = %d, s = %d}", UnsignRegsCat, SignRegsCat)
+	buf.Seek(0, io.SeekStart)
+
+	return name, true, out.String()
+}
+
+//get H registers
+func arm64hDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, floatingPoint bool, repr string) {
+
+	name = fmt.Sprintf("H%d", i-64)
+	buf := bytes.NewReader(reg.Bytes)
+
+	var out bytes.Buffer
+	var vi [8]uint16
+	for i := range vi {
+		binary.Read(buf, binary.LittleEndian, &vi[i])
+	}
+
+	RegNum := vi[0]
+	SignedRegNum := int16(RegNum)
+
+	fmt.Fprintf(&out, " {u = 0x%x, s = 0x%x}", vi[0], vi[0])
+	fmt.Fprintf(&out, "\n       {u = %d, s = %d}", RegNum, SignedRegNum)
+	buf.Seek(0, io.SeekStart)
+
+	return name, true, out.String()
+}
+
+//get B registers
+func arm64bDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, floatingPoint bool, repr string) {
+
+	name = fmt.Sprintf("B%d", i-64)
+	buf := bytes.NewReader(reg.Bytes)
+
+	var out bytes.Buffer
+	var vi [16]uint8
+
+	binary.Read(buf, binary.LittleEndian, &vi[0])
+	RegNum := vi[0]
+	SignedRegNum := int8(RegNum)
+
+	fmt.Fprintf(&out, " {u = 0x%02x, s = 0x%02x}", vi[0], vi[0])
+	fmt.Fprintf(&out, "\n       {u = %d, s = %d}", RegNum, SignedRegNum)
+	buf.Seek(0, io.SeekStart)
+
+	return name, true, out.String()
+}
+
+//catenate regs1,regs2,regs3,regs4 to be a unsigned number
+func arm64UnsignBigRegsCate(vi1 int64, vi2 int64, vi3 int64, vi4 int64) (vi *big.Int) {
+	BigInter1 := big.NewInt(vi1)
+	BigInter2 := big.NewInt(vi2)
+	BigInter3 := big.NewInt(vi3)
+	BigInter4 := big.NewInt(vi4)
+	BigInter := big.NewInt(0)
+
+	BigInter1.Lsh(BigInter1, 96)
+	BigInter2.Lsh(BigInter2, 64)
+	BigInter3.Lsh(BigInter3, 32)
+
+	BigInter.Add(BigInter1, BigInter2).Add(BigInter, BigInter3).Add(BigInter, BigInter4)
+
+	return BigInter
+}
+
+//catenate regs1,regs2,regs3,regs4 to be a signed number
+func arm64SignBigRegsCate(vi1 int64, vi2 int64, vi3 int64, vi4 int64) (vi *big.Int) {
+	//	var IsNegativenum bool
+	var ClearHigh int64 = 0x7FFFFFFF
+	var ClearLow int64 = 0xFFFFFFFF
+	var SignJudge int64 = 0x80000000
+	BigClear := big.NewInt(0)
+	NumOne := big.NewInt(1)
+
+	if (vi1 & SignJudge) == SignJudge { //negative
+		BigClearHigh := big.NewInt(ClearHigh)
+		BigClearLow1 := big.NewInt(ClearLow)
+		BigClearLow2 := big.NewInt(ClearLow)
+		BigClearLow3 := big.NewInt(ClearLow)
+		BigClearHigh.Lsh(BigClearHigh, 96)
+		BigClearLow1.Lsh(BigClearLow1, 64)
+		BigClearLow2.Lsh(BigClearLow2, 32)
+		BigClear.Add(BigClearHigh, BigClearLow1).Add(BigClear, BigClearLow2).Add(BigClear, BigClearLow3)
+
+		vi1 &= ClearHigh
+		BigInter1 := big.NewInt(vi1)
+		BigInter2 := big.NewInt(vi2)
+		BigInter3 := big.NewInt(vi3)
+		BigInter4 := big.NewInt(vi4)
+		BigInter := big.NewInt(0)
+
+		BigInter1.Lsh(BigInter1, 96)
+		BigInter2.Lsh(BigInter2, 64)
+		BigInter3.Lsh(BigInter3, 32)
+
+		BigInter.Add(BigInter1, BigInter2).Add(BigInter, BigInter3).Add(BigInter, BigInter4)
+
+		BigInter.Sub(BigInter, NumOne)
+		BigInter.Not(BigInter)
+		BigInter.And(BigInter, BigClear)
+		BigInter.Neg(BigInter)
+		return BigInter
+	} else {
+		return arm64UnsignBigRegsCate(vi1, vi2, vi3, vi4)
+	}
 }

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -394,7 +394,10 @@ func arm64DwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, floa
 		var out bytes.Buffer
 		var vi [16]uint8
 		for i := range vi {
-			binary.Read(buf, binary.LittleEndian, &vi[i])
+			err := binary.Read(buf, binary.LittleEndian, &vi[i])
+			if err != nil {
+				fmt.Println("binary.Read failed:", err)
+			}
 		}
 		//D
 		fmt.Fprintf(&out, " {\n\tD = {u = {0x%02x%02x%02x%02x%02x%02x%02x%02x,", vi[7], vi[6], vi[5], vi[4], vi[3], vi[2], vi[1], vi[0])
@@ -445,7 +448,10 @@ func arm64qDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, flo
 		var vi [4]uint32
 		var vi64 [4]int64
 		for i := range vi {
-			binary.Read(buf, binary.LittleEndian, &vi[i])
+			err := binary.Read(buf, binary.LittleEndian, &vi[i])
+			if err != nil {
+				fmt.Println("binary.Read failed:", err)
+			}
 		}
 		for i := range vi {
 			vi64[3-i] = int64(vi[i])
@@ -474,7 +480,10 @@ func arm64dDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, flo
 		var out bytes.Buffer
 		var vi [2]uint64
 		for i := range vi {
-			binary.Read(buf, binary.LittleEndian, &vi[i])
+			err := binary.Read(buf, binary.LittleEndian, &vi[i])
+			if err != nil {
+				fmt.Println("binary.Read failed:", err)
+			}
 		}
 
 		UnsignRegsCat := vi[0]
@@ -500,7 +509,10 @@ func arm64sDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, flo
 		var out bytes.Buffer
 		var vi [4]uint32
 		for i := range vi {
-			binary.Read(buf, binary.LittleEndian, &vi[i])
+			err := binary.Read(buf, binary.LittleEndian, &vi[i])
+			if err != nil {
+				fmt.Println("binary.Read failed:", err)
+			}
 		}
 		UnsignRegsCat := vi[0]
 		SignRegsCat := int32(UnsignRegsCat)
@@ -526,7 +538,10 @@ func arm64hDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, flo
 		var out bytes.Buffer
 		var vi [8]uint16
 		for i := range vi {
-			binary.Read(buf, binary.LittleEndian, &vi[i])
+			err := binary.Read(buf, binary.LittleEndian, &vi[i])
+			if err != nil {
+				fmt.Println("binary.Read failed:", err)
+			}
 		}
 
 		RegNum := vi[0]
@@ -553,7 +568,11 @@ func arm64bDwarfRegisterToString(i int, reg *op.DwarfRegister) (name string, flo
 		var out bytes.Buffer
 		var vi [16]uint8
 
-		binary.Read(buf, binary.LittleEndian, &vi[0])
+		err := binary.Read(buf, binary.LittleEndian, &vi[0])
+		if err != nil {
+			fmt.Println("binary.Read failed:", err)
+		}
+		
 		RegNum := vi[0]
 		SignedRegNum := int8(RegNum)
 

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -379,19 +379,10 @@ var canonicalRegisterOrder = map[string]int{
 }
 
 // ConvertRegisters converts proc.Register to api.Register for a slice.
-func ConvertRegisters(in *op.DwarfRegisters, dwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string), floatingPoint bool) (out []Register) {
+func ConvertRegisters(in *op.DwarfRegisters, GetRegs func(*op.DwarfRegisters, *[]Register, bool), floatingPoint bool) (out []Register) {
 	out = make([]Register, 0, in.CurrentSize())
-	for i := 0; i < in.CurrentSize(); i++ {
-		reg := in.Reg(uint64(i))
-		if reg == nil {
-			continue
-		}
-		name, fp, repr := dwarfRegisterToString(i, reg)
-		if !floatingPoint && fp {
-			continue
-		}
-		out = append(out, Register{name, repr, i})
-	}
+	GetRegs(in, &out, floatingPoint)
+
 	// Sort the registers in a canonical order we prefer, this is mostly
 	// because the DWARF register numbering for AMD64 is weird.
 	sort.Slice(out, func(i, j int) bool {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1223,46 +1223,26 @@ func (d *Debugger) RegsToStr(in *op.DwarfRegisters, pout *[]api.Register, Floati
 			*pout = append(*pout, api.Register{Name: name, Value: repr, DwarfNumber: i})
 		}
 	} else if d.target.BinInfo().Arch.Name == "arm64" {
-		for FloatRegType := 0; FloatRegType < 6; FloatRegType++ {
-			GetAllRegs(d.target.BinInfo().Arch, in, FloatRegType, pout, FloatingPoint)
-		}
-	}
-}
-
-//GetAllRegs gets all floating-point registers containing Q,D,S,H,B of arm64
-func GetAllRegs(ArchReg *proc.Arch, In *op.DwarfRegisters, RegsType int, pout *[]api.Register, FloatingPoint bool) {
-	var RegsToString func(int, *op.DwarfRegister) (string, bool, string)
-	var adder int = 0
-	if RegsType == 0 {
-		adder = 0
-	} else {
-		adder = 65 + 32*(RegsType-1)
-	}
-	switch {
-	case RegsType == 0:
-		RegsToString = ArchReg.DwarfRegisterToString
-	case RegsType == 1:
-		RegsToString = ArchReg.QDwarfRegisterToString
-	case RegsType == 2:
-		RegsToString = ArchReg.DDwarfRegisterToString
-	case RegsType == 3:
-		RegsToString = ArchReg.SDwarfRegisterToString
-	case RegsType == 4:
-		RegsToString = ArchReg.HDwarfRegisterToString
-	case RegsType == 5:
-		RegsToString = ArchReg.BDwarfRegisterToString
-	}
-	for i := 0; i < In.CurrentSize(); i++ {
-		reg := In.Reg(uint64(i))
-		if reg == nil {
-			continue
-		}
-		if RegsType == 0 || i >= 64 {
-			RegName, FP, RegRepr := RegsToString(i, reg)
-			if !FloatingPoint && FP {
-				continue
+		for FloatRegType := 0; FloatRegType < 6; FloatRegType++ {	
+			var adder int = 0
+			if FloatRegType == 0 {
+				adder = 0
+			} else {
+				adder = 65 + 32*(FloatRegType-1)
+			}					
+			for i := 0; i < in.CurrentSize(); i++ {
+				reg := in.Reg(uint64(i))
+				if reg == nil {
+					continue
+				}
+				if FloatRegType == 0 || i >= 64 {
+					name, fp, repr := d.target.BinInfo().Arch.DwarfRegisterToString(i, reg)
+					if !FloatingPoint && fp {
+						continue
+					}
+					*pout = append(*pout, api.Register{Name: name, Value: repr, DwarfNumber: (i + adder)})
+				}
 			}
-			*pout = append(*pout, api.Register{Name: RegName, Value: RegRepr, DwarfNumber: (i + adder)})
 		}
 	}
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1209,8 +1209,8 @@ func (d *Debugger) ScopeRegisters(goid, frame, deferredCall int, floatingPoint b
 }
 
 // RegsToStr returns the registers of amd64 or arm64.
-func (d *Debugger) RegsToStr(in *op.DwarfRegisters, pout *[]api.Register,  FloatingPoint bool)  {
-	if d.target.BinInfo().Arch.Name == "amd64"{
+func (d *Debugger) RegsToStr(in *op.DwarfRegisters, pout *[]api.Register, FloatingPoint bool) {
+	if d.target.BinInfo().Arch.Name == "amd64" {
 		for i := 0; i < in.CurrentSize(); i++ {
 			reg := in.Reg(uint64(i))
 			if reg == nil {
@@ -1220,16 +1220,16 @@ func (d *Debugger) RegsToStr(in *op.DwarfRegisters, pout *[]api.Register,  Float
 			if !FloatingPoint && fp {
 				continue
 			}
-			*pout = append(*pout, api.Register{name, repr, i})
+			*pout = append(*pout, api.Register{Name: name, Value: repr, DwarfNumber: i})
 		}
-	}else if d.target.BinInfo().Arch.Name == "arm64"{
+	} else if d.target.BinInfo().Arch.Name == "arm64" {
 		for FloatRegType := 0; FloatRegType < 6; FloatRegType++ {
 			GetAllRegs(d.target.BinInfo().Arch, in, FloatRegType, pout, FloatingPoint)
 		}
 	}
 }
 
-//GetAllRegs gets all floating-point registers containing Q,D,S,H,B of arm64 
+//GetAllRegs gets all floating-point registers containing Q,D,S,H,B of arm64
 func GetAllRegs(ArchReg *proc.Arch, In *op.DwarfRegisters, RegsType int, pout *[]api.Register, FloatingPoint bool) {
 	var RegsToString func(int, *op.DwarfRegister) (string, bool, string)
 	var adder int = 0
@@ -1262,7 +1262,7 @@ func GetAllRegs(ArchReg *proc.Arch, In *op.DwarfRegisters, RegsType int, pout *[
 			if !FloatingPoint && FP {
 				continue
 			}
-			*pout = append(*pout, api.Register{RegName, RegRepr, i + adder})
+			*pout = append(*pout, api.Register{Name: RegName, Value: RegRepr, DwarfNumber: (i + adder)})
 		}
 	}
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1210,19 +1210,7 @@ func (d *Debugger) ScopeRegisters(goid, frame, deferredCall int, floatingPoint b
 
 // RegsToStr returns the registers of amd64 or arm64.
 func (d *Debugger) RegsToStr(in *op.DwarfRegisters, pout *[]api.Register, FloatingPoint bool) {
-	if d.target.BinInfo().Arch.Name == "amd64" {
-		for i := 0; i < in.CurrentSize(); i++ {
-			reg := in.Reg(uint64(i))
-			if reg == nil {
-				continue
-			}
-			name, fp, repr := d.target.BinInfo().Arch.DwarfRegisterToString(i, reg)
-			if !FloatingPoint && fp {
-				continue
-			}
-			*pout = append(*pout, api.Register{Name: name, Value: repr, DwarfNumber: i})
-		}
-	} else if d.target.BinInfo().Arch.Name == "arm64" {
+	if d.target.BinInfo().Arch.Name == "arm64" {
 		for FloatRegType := 0; FloatRegType < 6; FloatRegType++ {	
 			var adder int = 0
 			if FloatRegType == 0 {
@@ -1243,6 +1231,18 @@ func (d *Debugger) RegsToStr(in *op.DwarfRegisters, pout *[]api.Register, Floati
 					*pout = append(*pout, api.Register{Name: name, Value: repr, DwarfNumber: (i + adder)})
 				}
 			}
+		}
+	} else {
+		for i := 0; i < in.CurrentSize(); i++ {
+			reg := in.Reg(uint64(i))
+			if reg == nil {
+				continue
+			}
+			name, fp, repr := d.target.BinInfo().Arch.DwarfRegisterToString(i, reg)
+			if !FloatingPoint && fp {
+				continue
+			}
+			*pout = append(*pout, api.Register{Name: name, Value: repr, DwarfNumber: i})
 		}
 	}
 }

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -204,7 +204,7 @@ func (s *RPCServer) ListRegisters(arg interface{}, registers *string) error {
 	if err != nil {
 		return err
 	}
-	regs := api.Registers(api.ConvertRegisters(dregs, s.debugger.DwarfRegisterToString, false))
+	regs := api.Registers(api.ConvertRegisters(dregs, s.debugger.RegsToStr, false))
 	*registers = regs.String()
 	return nil
 }

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -404,7 +404,7 @@ func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) er
 
 	var regs *op.DwarfRegisters
 	var err error
-	
+
 	if arg.Scope != nil {
 		regs, err = s.debugger.ScopeRegisters(arg.Scope.GoroutineID, arg.Scope.Frame, arg.Scope.DeferredCall, arg.IncludeFp)
 	} else {
@@ -412,7 +412,7 @@ func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) er
 	}
 	if err != nil {
 		return err
-	}   
+	}
 	out.Regs = api.ConvertRegisters(regs, s.debugger.RegsToStr, arg.IncludeFp)
 	out.Registers = out.Regs.String()
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -404,7 +404,7 @@ func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) er
 
 	var regs *op.DwarfRegisters
 	var err error
-
+	
 	if arg.Scope != nil {
 		regs, err = s.debugger.ScopeRegisters(arg.Scope.GoroutineID, arg.Scope.Frame, arg.Scope.DeferredCall, arg.IncludeFp)
 	} else {
@@ -412,8 +412,8 @@ func (s *RPCServer) ListRegisters(arg ListRegistersIn, out *ListRegistersOut) er
 	}
 	if err != nil {
 		return err
-	}
-	out.Regs = api.ConvertRegisters(regs, s.debugger.DwarfRegisterToString, arg.IncludeFp)
+	}   
+	out.Regs = api.ConvertRegisters(regs, s.debugger.RegsToStr, arg.IncludeFp)
 	out.Registers = out.Regs.String()
 
 	return nil


### PR DESCRIPTION
fix #2198  I added the display function for floating-point registers under ARM64. 
Part of the current display effect is:

![图片1](https://user-images.githubusercontent.com/72719532/95870850-8d81fe80-0d9f-11eb-9ce6-d1b5353175ac.png)
![图片3](https://user-images.githubusercontent.com/72719532/95870870-9377df80-0d9f-11eb-9ac1-0d07bc78077f.png)
![图片4](https://user-images.githubusercontent.com/72719532/95870878-970b6680-0d9f-11eb-8c0b-4595bd970b11.png)
![图片5](https://user-images.githubusercontent.com/72719532/95870974-b4d8cb80-0d9f-11eb-827b-80f96e86a212.png)
![图片6](https://user-images.githubusercontent.com/72719532/95871018-c326e780-0d9f-11eb-897f-9109c1e38828.png)
![图片7](https://user-images.githubusercontent.com/72719532/95871089-d76ae480-0d9f-11eb-96f3-42ac0fb7eafd.png)

This shows all 128-bit Q registers, 64-bit D registers, 32-bit S registers, 16-bit H registers, and 8-bit B registers in hexadecimal, decimal signed and unsigned modes.