### PR TITLE
service/rpccommon: log error for conns rejected by --only-same-user

### DIFF
--- a/pkg/logflags/logflags.go
+++ b/pkg/logflags/logflags.go
@@ -127,7 +127,7 @@ func WriteAPIListeningMessage(addr string) {
 	writeListeningMessage("API", addr)
 }
 
-func writeListeningMessage(server string, addr string) {
+func writeListeningMessage(server, addr string) {
 	msg := fmt.Sprintf("%s server listening at: %s", server, addr)
 	if logOut != nil {
 		fmt.Fprintln(logOut, msg)
@@ -141,7 +141,7 @@ var errLogstrWithoutLog = errors.New("--log-output specified without --log")
 // Setup sets debugger flags based on the contents of logstr.
 // If logDest is not empty logs will be redirected to the file descriptor or
 // file path specified by logDest.
-func Setup(logFlag bool, logstr string, logDest string) error {
+func Setup(logFlag bool, logstr, logDest string) error {
 	if logDest != "" {
 		n, err := strconv.Atoi(logDest)
 		if err == nil {

--- a/pkg/logflags/logflags.go
+++ b/pkg/logflags/logflags.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var any = false
 var debugger = false
 var gdbWire = false
 var lldbServerOutput = false
@@ -38,6 +39,11 @@ func makeLogger(flag bool, fields logrus.Fields) *logrus.Entry {
 		logger.Logger.Level = logrus.ErrorLevel
 	}
 	return logger
+}
+
+// Any returns true if any logging is enabled.
+func Any() bool {
+	return any
 }
 
 // GdbWire returns true if the gdbserial package should log all the packets
@@ -122,7 +128,7 @@ func WriteAPIListeningMessage(addr string) {
 }
 
 func writeListeningMessage(server string, addr string) {
-        msg := fmt.Sprintf("%s server listening at: %s", server, addr)
+	msg := fmt.Sprintf("%s server listening at: %s", server, addr)
 	if logOut != nil {
 		fmt.Fprintln(logOut, msg)
 	} else {
@@ -159,6 +165,7 @@ func Setup(logFlag bool, logstr string, logDest string) error {
 	if logstr == "" {
 		logstr = "debugger"
 	}
+	any = true
 	v := strings.Split(logstr, ",")
 	for _, logcmd := range v {
 		// If adding another value, do make sure to

--- a/service/rpccommon/sameuser_linux.go
+++ b/service/rpccommon/sameuser_linux.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"os"
 	"strings"
+
+	"github.com/go-delve/delve/pkg/logflags"
 )
 
 // for testing
@@ -108,7 +110,11 @@ func canAccept(listenAddr, remoteAddr net.Addr) bool {
 		log.Printf("cannot check remote address: %v", err)
 	}
 	if !same {
-		log.Printf("closing connection from different user (%v): connections to localhost are only accepted from the same UNIX user for security reasons", addr)
+		if logflags.Any() {
+			log.Printf("closing connection from different user (%v): connections to localhost are only accepted from the same UNIX user for security reasons", addr)
+		} else {
+			fmt.Fprintf(os.Stderr, "closing connection from different user (%v): connections to localhost are only accepted from the same UNIX user for security reasons", addr)
+		}
 		return false
 	}
 	return true


### PR DESCRIPTION
If no logger is enabled manually write to stderr instead.

Fixes #2209
