### PR TITLE
service,terminal: apply substitute path to trace/break argument

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -30,7 +30,7 @@ detach(Kill) | Equivalent to API call [Detach](https://godoc.org/github.com/go-d
 disassemble(Scope, StartPC, EndPC, Flavour) | Equivalent to API call [Disassemble](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Disassemble)
 eval(Scope, Expr, Cfg) | Equivalent to API call [Eval](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Eval)
 examine_memory(Address, Length) | Equivalent to API call [ExamineMemory](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ExamineMemory)
-find_location(Scope, Loc, IncludeNonExecutableLines) | Equivalent to API call [FindLocation](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.FindLocation)
+find_location(Scope, Loc, IncludeNonExecutableLines, SubstitutePathRules) | Equivalent to API call [FindLocation](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.FindLocation)
 function_return_locations(FnName) | Equivalent to API call [FunctionReturnLocations](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.FunctionReturnLocations)
 get_breakpoint(Id, Name) | Equivalent to API call [GetBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.GetBreakpoint)
 get_thread(Id) | Equivalent to API call [GetThread](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.GetThread)

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -247,8 +247,8 @@ func TestExecuteFile(t *testing.T) {
 }
 
 func TestIssue354(t *testing.T) {
-	printStack(os.Stdout, []api.Stackframe{}, "", false)
-	printStack(os.Stdout, []api.Stackframe{
+	printStack(&Term{}, os.Stdout, []api.Stackframe{}, "", false)
+	printStack(&Term{}, os.Stdout, []api.Stackframe{
 		{Location: api.Location{PC: 0, File: "irrelevant.go", Line: 10, Function: nil},
 			Bottom: true}}, "", false)
 }

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -514,6 +514,12 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 3 && args[3] != starlark.None {
+			err := unmarshalStarlarkValue(args[3], &rpcArgs.SubstitutePathRules, "SubstitutePathRules")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
@@ -523,6 +529,8 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Loc, "Loc")
 			case "IncludeNonExecutableLines":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.IncludeNonExecutableLines, "IncludeNonExecutableLines")
+			case "SubstitutePathRules":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.SubstitutePathRules, "SubstitutePathRules")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}

--- a/service/client.go
+++ b/service/client.go
@@ -130,7 +130,7 @@ type Client interface {
 	// * *<address> returns the location corresponding to the specified address
 	// NOTE: this function does not actually set breakpoints.
 	// If findInstruction is true FindLocation will only return locations that correspond to instructions.
-	FindLocation(scope api.EvalScope, loc string, findInstruction bool) ([]api.Location, error)
+	FindLocation(scope api.EvalScope, loc string, findInstruction bool, substitutePathRules [][2]string) ([]api.Location, error)
 
 	// Disassemble code between startPC and endPC
 	DisassembleRange(scope api.EvalScope, startPC, endPC uint64, flavour api.AssemblyFlavour) (api.AsmInstructions, error)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1443,7 +1443,7 @@ func (d *Debugger) CurrentPackage() (string, error) {
 }
 
 // FindLocation will find the location specified by 'locStr'.
-func (d *Debugger) FindLocation(goid, frame, deferredCall int, locStr string, includeNonExecutableLines bool) ([]api.Location, error) {
+func (d *Debugger) FindLocation(goid, frame, deferredCall int, locStr string, includeNonExecutableLines bool, substitutePathRules [][2]string) ([]api.Location, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 
@@ -1458,7 +1458,7 @@ func (d *Debugger) FindLocation(goid, frame, deferredCall int, locStr string, in
 
 	s, _ := proc.ConvertEvalScope(d.target, goid, frame, deferredCall)
 
-	locs, err := loc.Find(d.target, d.processArgs, s, locStr, includeNonExecutableLines)
+	locs, err := loc.Find(d.target, d.processArgs, s, locStr, includeNonExecutableLines, substitutePathRules)
 	for i := range locs {
 		if locs[i].PC == 0 {
 			continue

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -304,7 +304,7 @@ type FindLocationArgs struct {
 
 func (c *RPCServer) FindLocation(args FindLocationArgs, answer *[]api.Location) error {
 	var err error
-	*answer, err = c.debugger.FindLocation(args.Scope.GoroutineID, args.Scope.Frame, args.Scope.DeferredCall, args.Loc, false)
+	*answer, err = c.debugger.FindLocation(args.Scope.GoroutineID, args.Scope.Frame, args.Scope.DeferredCall, args.Loc, false, nil)
 	return err
 }
 

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -356,9 +356,9 @@ func (c *RPCClient) AttachedToExistingProcess() bool {
 	return out.Answer
 }
 
-func (c *RPCClient) FindLocation(scope api.EvalScope, loc string, findInstructions bool) ([]api.Location, error) {
+func (c *RPCClient) FindLocation(scope api.EvalScope, loc string, findInstructions bool, substitutePathRules [][2]string) ([]api.Location, error) {
 	var out FindLocationOut
-	err := c.call("FindLocation", FindLocationIn{scope, loc, !findInstructions}, &out)
+	err := c.call("FindLocation", FindLocationIn{scope, loc, !findInstructions, substitutePathRules}, &out)
 	return out.Locations, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -600,6 +600,13 @@ type FindLocationIn struct {
 	Scope                     api.EvalScope
 	Loc                       string
 	IncludeNonExecutableLines bool
+
+	// SubstitutePathRules is a slice of source code path substitution rules,
+	// the first entry of each pair is the path of a directory as it appears in
+	// the executable file (i.e. the location of a source file when the program
+	// was compiled), the second entry of each pair is the location of the same
+	// directory on the client system.
+	SubstitutePathRules [][2]string
 }
 
 type FindLocationOut struct {
@@ -621,7 +628,7 @@ type FindLocationOut struct {
 // NOTE: this function does not actually set breakpoints.
 func (c *RPCServer) FindLocation(arg FindLocationIn, out *FindLocationOut) error {
 	var err error
-	out.Locations, err = c.debugger.FindLocation(arg.Scope.GoroutineID, arg.Scope.Frame, arg.Scope.DeferredCall, arg.Loc, arg.IncludeNonExecutableLines)
+	out.Locations, err = c.debugger.FindLocation(arg.Scope.GoroutineID, arg.Scope.Frame, arg.Scope.DeferredCall, arg.Loc, arg.IncludeNonExecutableLines, arg.SubstitutePathRules)
 	return err
 }
 

--- a/service/test/common_test.go
+++ b/service/test/common_test.go
@@ -80,7 +80,7 @@ type locationFinder1 interface {
 }
 
 type locationFinder2 interface {
-	FindLocation(api.EvalScope, string, bool) ([]api.Location, error)
+	FindLocation(api.EvalScope, string, bool, [][2]string) ([]api.Location, error)
 }
 
 func findLocationHelper(t *testing.T, c interface{}, loc string, shouldErr bool, count int, checkAddr uint64) []uint64 {
@@ -91,7 +91,7 @@ func findLocationHelper(t *testing.T, c interface{}, loc string, shouldErr bool,
 	case locationFinder1:
 		locs, err = c.FindLocation(api.EvalScope{GoroutineID: -1}, loc)
 	case locationFinder2:
-		locs, err = c.FindLocation(api.EvalScope{GoroutineID: -1}, loc, false)
+		locs, err = c.FindLocation(api.EvalScope{GoroutineID: -1}, loc, false, nil)
 	default:
 		t.Errorf("unexpected type %T passed to findLocationHelper", c)
 	}


### PR DESCRIPTION
Change FindLocation to apply substitute path rules to location
expressions. Changes terminal to always print paths after applying
substitutions.

Implements #2203
