### PR TITLE
Go 1.16 support branch

### DIFF
--- a/pkg/dwarf/line/line_parser_test.go
+++ b/pkg/dwarf/line/line_parser_test.go
@@ -11,12 +11,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 	"unsafe"
 
 	"github.com/go-delve/delve/pkg/dwarf/godwarf"
+	"github.com/go-delve/delve/pkg/goversion"
 )
 
 var userTestFile string
@@ -113,8 +115,10 @@ func testDebugLinePrologueParser(p string, t *testing.T) {
 			}
 		}
 
-		if len(dbl.IncludeDirs) != 1 {
-			t.Fatal("Include dirs not parsed correctly")
+		if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 16) {
+			if len(dbl.IncludeDirs) != 1 {
+				t.Fatal("Include dirs not parsed correctly")
+			}
 		}
 
 		for _, ln := range dbl.Lookup {

--- a/pkg/dwarf/line/line_parser_test.go
+++ b/pkg/dwarf/line/line_parser_test.go
@@ -131,6 +131,7 @@ func testDebugLinePrologueParser(p string, t *testing.T) {
 		}
 
 		for _, n := range dbl.FileNames {
+			t.Logf("file %s\n", n.Path)
 			if strings.Contains(n.Path, "/_fixtures/testnextprog.go") {
 				mainFileFound = true
 				break

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -8,7 +8,7 @@ var (
 	MinSupportedVersionOfGoMajor = 1
 	MinSupportedVersionOfGoMinor = 13
 	MaxSupportedVersionOfGoMajor = 1
-	MaxSupportedVersionOfGoMinor = 15
+	MaxSupportedVersionOfGoMinor = 16
 	goTooOldErr                  = fmt.Errorf("Version of Go is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Errorf("Version of Delve is too old for this version of Go (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
 )

--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -161,7 +161,7 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 		it.top = false
 		return true
 
-	case "runtime.cgocallback_gofunc":
+	case "runtime.cgocallback_gofunc", "runtime.cgocallback":
 		// For a detailed description of how this works read the long comment at
 		// the start of $GOROOT/src/runtime/cgocall.go and the source code of
 		// runtime.cgocallback_gofunc in $GOROOT/src/runtime/asm_amd64.s

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -139,7 +139,7 @@ const spAlign = 16
 func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
 	if it.frame.Current.Fn != nil {
 		switch it.frame.Current.Fn.Name {
-		case "runtime.asmcgocall", "runtime.cgocallback_gofunc", "runtime.sigpanic":
+		case "runtime.asmcgocall", "runtime.cgocallback_gofunc", "runtime.sigpanic", "runtime.cgocallback":
 			//do nothing
 		case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":
 			// Look for "top of stack" functions.
@@ -202,7 +202,7 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 		callFrameRegs.Reg(callFrameRegs.SPRegNum).Uint64Val = uint64(int64(newsp))
 		return false
 
-	case "runtime.cgocallback_gofunc":
+	case "runtime.cgocallback_gofunc", "runtime.cgocallback":
 		// For a detailed description of how this works read the long comment at
 		// the start of $GOROOT/src/runtime/cgocall.go and the source code of
 		// runtime.cgocallback_gofunc in $GOROOT/src/runtime/asm_arm64.s

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1709,7 +1709,7 @@ func TestAcceptMulticlient(t *testing.T) {
 			},
 		})
 		if err := server.Run(); err != nil {
-			t.Fatal(err)
+			panic(err)
 		}
 		<-disconnectChan
 		server.Stop()


### PR DESCRIPTION
### proc: fix cgo stacktraces in Go 1.16 with simplified C -> Go call path



### proc: misc test fixes for Go 1.16


