### PR TITLE
proc/native: increase max size of XSAVE area to support newer CPUs

### DIFF
--- a/pkg/proc/native/registers_freebsd_amd64.go
+++ b/pkg/proc/native/registers_freebsd_amd64.go
@@ -71,7 +71,7 @@ func registers(thread *nativeThread) (proc.Registers, error) {
 }
 
 const (
-	_X86_XSTATE_MAX_SIZE = 2688
+	_X86_XSTATE_MAX_SIZE = 2696
 	_NT_X86_XSTATE       = 0x202
 
 	_XSAVE_HEADER_START          = 512

--- a/pkg/proc/native/registers_linux_amd64.go
+++ b/pkg/proc/native/registers_linux_amd64.go
@@ -66,7 +66,7 @@ func registers(thread *nativeThread) (proc.Registers, error) {
 }
 
 const (
-	_X86_XSTATE_MAX_SIZE = 2688
+	_X86_XSTATE_MAX_SIZE = 2696
 	_NT_X86_XSTATE       = 0x202
 
 	_XSAVE_HEADER_START          = 512


### PR DESCRIPTION
Fixes #2219
