### PR TITLE
proc/gdbserial: fix redirect bugs with debugserver

### DIFF
--- a/_fixtures/cat.go
+++ b/_fixtures/cat.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	s := bufio.NewScanner(os.Stdin)
+	for s.Scan() {
+		fmt.Printf("read %q\n", s.Text())
+	}
+	os.Stdout.Close()
+}


### PR DESCRIPTION
1. Forward stdin/stdout/stderr to the target process when in foreground
mode instead of always forwarding the current tty (issue #1964)
2. When redirecting a file descriptor make sure to also specify
something for all three otherwise debugserver will misbehave (either
exit on launch or run but giving the target process a closed file
descriptor).

Fixes #1964
