### PR TITLE
[WIP] fix linux/arm64 on Go 1.15.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
   include:
     -  os: linux
        services: docker
-       env: go_32_version=1.15.2 # Linux/i386 tests will fail on go1.15 prior to 1.15.2 (see issue #2134)
+       env: go_32_version=1.15.4
 
 script: >-
     if [ $TRAVIS_OS_NAME = "linux" ] && [ $go_32_version ]; then

--- a/_scripts/gen-travis.go
+++ b/_scripts/gen-travis.go
@@ -112,7 +112,7 @@ jobs:
   include:
     -  os: linux
        services: docker
-       env: go_32_version={{index .GoVersions 0}}.2 # Linux/i386 tests will fail on go1.15 prior to 1.15.2 (see issue #2134)
+       env: go_32_version={{index .GoVersions 0}}.4
 
 script: >-
     if [ $TRAVIS_OS_NAME = "linux" ] && [ $go_32_version ]; then

--- a/pkg/dwarf/line/line_parser.go
+++ b/pkg/dwarf/line/line_parser.go
@@ -43,6 +43,8 @@ type DebugLineInfo struct {
 	// if normalizeBackslash is true all backslashes (\) will be converted into forward slashes (/)
 	normalizeBackslash bool
 	ptrSize            int
+
+	firstExactMatch bool
 }
 
 type FileEntry struct {
@@ -63,7 +65,7 @@ func ParseAll(data []byte, logfn func(string, ...interface{}), staticBase uint64
 
 	// We have to parse multiple file name tables here.
 	for buf.Len() > 0 {
-		lines = append(lines, Parse("", buf, logfn, staticBase, normalizeBackslash, ptrSize))
+		lines = append(lines, Parse("", buf, logfn, staticBase, normalizeBackslash, false, ptrSize))
 	}
 
 	return lines
@@ -71,7 +73,7 @@ func ParseAll(data []byte, logfn func(string, ...interface{}), staticBase uint64
 
 // Parse parses a single debug_line segment from buf. Compdir is the
 // DW_AT_comp_dir attribute of the associated compile unit.
-func Parse(compdir string, buf *bytes.Buffer, logfn func(string, ...interface{}), staticBase uint64, normalizeBackslash bool, ptrSize int) *DebugLineInfo {
+func Parse(compdir string, buf *bytes.Buffer, logfn func(string, ...interface{}), staticBase uint64, normalizeBackslash, firstExactMatch bool, ptrSize int) *DebugLineInfo {
 	dbl := new(DebugLineInfo)
 	dbl.Logf = logfn
 	dbl.staticBase = staticBase
@@ -82,6 +84,7 @@ func Parse(compdir string, buf *bytes.Buffer, logfn func(string, ...interface{})
 	dbl.stateMachineCache = make(map[uint64]*StateMachine)
 	dbl.lastMachineCache = make(map[uint64]*StateMachine)
 	dbl.normalizeBackslash = normalizeBackslash
+	dbl.firstExactMatch = firstExactMatch
 
 	parseDebugLinePrologue(dbl, buf)
 	if dbl.Prologue.Version >= 5 {

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -225,7 +225,7 @@ func (lineInfo *DebugLineInfo) PCToLine(basePC, pc uint64) (string, int) {
 
 	sm := lineInfo.stateMachineFor(basePC, pc)
 
-	file, line, _ := sm.PCToLine(pc, false)
+	file, line, _ := sm.PCToLine(pc, lineInfo.firstExactMatch)
 	return file, line
 }
 

--- a/pkg/dwarf/line/state_machine_test.go
+++ b/pkg/dwarf/line/state_machine_test.go
@@ -79,7 +79,7 @@ func TestGrafana(t *testing.T) {
 		}
 		cuname, _ := e.Val(dwarf.AttrName).(string)
 
-		lineInfo := Parse(e.Val(dwarf.AttrCompDir).(string), debugLineBuffer, t.Logf, 0, false, 8)
+		lineInfo := Parse(e.Val(dwarf.AttrCompDir).(string), debugLineBuffer, t.Logf, 0, false, false, 8)
 		sm := newStateMachine(lineInfo, lineInfo.Instructions, 8)
 
 		lnrdr, err := data.LineReader(e)

--- a/pkg/dwarf/line/state_machine_test.go
+++ b/pkg/dwarf/line/state_machine_test.go
@@ -236,7 +236,7 @@ func TestMultipleSequences(t *testing.T) {
 		{0x600004, 13},
 	} {
 		sm := newStateMachine(lines, lines.Instructions, lines.ptrSize)
-		file, curline, ok := sm.PCToLine(testCase.pc)
+		file, curline, ok := sm.PCToLine(testCase.pc, true)
 		if !ok {
 			t.Fatalf("Could not find %#x", testCase.pc)
 		}

--- a/pkg/goversion/go_version.go
+++ b/pkg/goversion/go_version.go
@@ -155,11 +155,18 @@ func Installed() (GoVersion, bool) {
 // or go version) is major.minor or a later version, or a development
 // version.
 func VersionAfterOrEqual(version string, major, minor int) bool {
+	return VersionAfterOrEqualRev(version, major, minor, -1)
+}
+
+// VersionAfterOrEqualRev checks that version (as returned by runtime.Version()
+// or go version) is major.minor or a later version, or a development
+// version.
+func VersionAfterOrEqualRev(version string, major, minor, rev int) bool {
 	ver, _ := Parse(version)
 	if ver.IsDevel() {
 		return true
 	}
-	return ver.AfterOrEqual(GoVersion{major, minor, -1, 0, 0, ""})
+	return ver.AfterOrEqual(GoVersion{major, minor, rev, 0, 0, ""})
 }
 
 const producerVersionPrefix = "Go cmd/compile "

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4804,7 +4804,7 @@ func TestStepIntoWrapperForEmbeddedPointer(t *testing.T) {
 		{contStepout, 29}})
 
 	// same test but with next instead of stepout
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 14) && runtime.GOARCH != "386" {
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 14) && runtime.GOARCH != "386" && !goversion.VersionAfterOrEqualRev(runtime.Version(), 1, 15, 4) {
 		testseq2(t, "ifaceembcall", "", []seqTest{
 			{contContinue, 28}, // main.main, the line calling iface.PtrReceiver()
 			{contStep, 18},     // main.(*A).PtrReceiver


### PR DESCRIPTION
### dwarf/line: pick last exact match in PCToLine

When there are multiple exact match entries for a single PC value pick
the last one.

### proc: fix TestStepIntoWrapperForEmbeddedPointer for Go 1.15.4


