### PR TITLE
proc/gdbserial: Use the active xcode-select path instead of a hardcoded Xcode path

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -107,25 +107,18 @@ var debugserverExecutablePaths = []string{
 			return ""
 		}
 
-		cmd := exec.Command("xcode-select", "--print-path")
-		cmd.Stdout = &bytes.Buffer{}
-
-		if err := cmd.Run(); err != nil {
+		stdout, err := exec.Command("xcode-select", "--print-path").Output()
+		if err != nil {
 			return ""
 		}
 
-		if stdout, ok := cmd.Stdout.(*bytes.Buffer); ok {
-			xcodePath := strings.TrimSpace(stdout.String())
-
-			if xcodePath == "" {
-				return ""
-			}
-
-			// xcode-select prints the path to the active Developer directory, which is typically a sibling to SharedFrameworks.
-			return filepath.Join(xcodePath, "..", debugserverXcodeRelativeExecutablePath)
+		xcodePath := strings.TrimSpace(string(stdout))
+		if xcodePath == "" {
+			return ""
 		}
 
-		return ""
+		// xcode-select prints the path to the active Developer directory, which is typically a sibling to SharedFrameworks.
+		return filepath.Join(xcodePath, "..", debugserverXcodeRelativeExecutablePath)
 	}(),
 }
 

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -70,6 +70,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -93,10 +94,39 @@ const (
 
 const heartbeatInterval = 10 * time.Second
 
+// Relative to $(xcode-select --print-path)/../
+// xcode-select typically returns the path to the Developer directory, which is a sibling to SharedFrameworks.
+var debugserverXcodeRelativeExecutablePath = "SharedFrameworks/LLDB.framework/Versions/A/Resources/debugserver"
+
 var debugserverExecutablePaths = []string{
 	"debugserver",
 	"/Library/Developer/CommandLineTools/Library/PrivateFrameworks/LLDB.framework/Versions/A/Resources/debugserver",
-	"/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/Resources/debugserver",
+	// Function returns the active developer directory provided by xcode-select to compute a debugserver path.
+	func() string {
+		if _, err := exec.LookPath("xcode-select"); err != nil {
+			return ""
+		}
+
+		cmd := exec.Command("xcode-select", "--print-path")
+		cmd.Stdout = &bytes.Buffer{}
+
+		if err := cmd.Run(); err != nil {
+			return ""
+		}
+
+		if stdout, ok := cmd.Stdout.(*bytes.Buffer); ok {
+			xcodePath := strings.TrimSpace(stdout.String())
+
+			if xcodePath == "" {
+				return ""
+			}
+
+			// xcode-select prints the path to the active Developer directory, which is typically a sibling to SharedFrameworks.
+			return filepath.Join(xcodePath, "..", debugserverXcodeRelativeExecutablePath)
+		}
+
+		return ""
+	}(),
 }
 
 // ErrDirChange is returned when trying to change execution direction
@@ -308,6 +338,9 @@ func unusedPort() string {
 // found in the system path ($PATH), the Xcode bundle or the standalone CLT location.
 func getDebugServerAbsolutePath() string {
 	for _, debugServerPath := range debugserverExecutablePaths {
+		if debugServerPath == "" {
+			continue
+		}
 		if _, err := exec.LookPath(debugServerPath); err == nil {
 			return debugServerPath
 		}


### PR DESCRIPTION
Calculate a possible debugserver path in the Xcode.app command line tools using xcode-select instead of a hardcoded path. The path is cached in the same manner as the existing implementation for continued use. 

Tested by adding a fmt.Println comment locally and running against my own environment:

```
checking: debugserver
checking: /Library/Developer/CommandLineTools/Library/PrivateFrameworks/LLDB.framework/Versions/A/Resources/debugserver
checking: /Applications/Xcode/12B45b/Xcode.app/Contents/SharedFrameworks/LLDB.framework/Versions/A/Resources/debugserver
```

Fixes #2227 