### PR TITLE
proc: add flag to distinguish ReturnValues

### DIFF
--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -204,6 +204,7 @@ func EvalExpressionWithCalls(t *Target, g *G, expr string, retLoadCfg LoadConfig
 
 func finishEvalExpressionWithCalls(t *Target, g *G, contReq continueRequest, ok bool) error {
 	fncallLog("stashing return values for %d in thread=%d", g.ID, g.Thread.ThreadID())
+	g.Thread.Common().CallReturn = true
 	var err error
 	if !ok {
 		err = errors.New("internal error EvalExpressionWithCalls didn't return anything")

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -50,6 +50,7 @@ func (dbp *Target) Continue() error {
 		return err
 	}
 	for _, thread := range dbp.ThreadList() {
+		thread.Common().CallReturn = false
 		thread.Common().returnValues = nil
 	}
 	dbp.CheckAndClearManualStopRequest()

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -49,6 +49,7 @@ type Location struct {
 // CommonThread contains fields used by this package, common to all
 // implementations of the Thread interface.
 type CommonThread struct {
+	CallReturn   bool // returnValues are the return values of a call injection
 	returnValues []*Variable
 	g            *G // cached g for this thread
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -128,6 +128,8 @@ type Thread struct {
 
 	// ReturnValues contains the return values of the function we just stepped out of
 	ReturnValues []Variable
+	// CallReturn is true if ReturnValues are the return values of an injected call.
+	CallReturn bool
 }
 
 // Location holds program location information.

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1123,7 +1123,7 @@ func (s *Server) onEvaluateRequest(request *dap.EvaluateRequest) {
 		var retVars []*proc.Variable
 		for _, t := range state.Threads {
 			if t.GoroutineID == stateBeforeCall.SelectedGoroutine.ID &&
-				t.Line == stateBeforeCall.SelectedGoroutine.CurrentLoc.Line && t.ReturnValues != nil {
+				t.Line == stateBeforeCall.SelectedGoroutine.CurrentLoc.Line && t.CallReturn {
 				// The call completed. Get the return values.
 				retVars, err = s.debugger.FindThreadReturnValues(t.ID, prcCfg)
 				if err != nil {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -562,6 +562,7 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 	for _, thread := range d.target.ThreadList() {
 		th := api.ConvertThread(thread)
 
+		th.CallReturn = thread.Common().CallReturn
 		if retLoadCfg != nil {
 			th.ReturnValues = api.ConvertVars(thread.Common().ReturnValues(*retLoadCfg))
 		}


### PR DESCRIPTION
Adds a flag that distinguishes the return values of an injected
function call from the return values of a function call executed by the
target program.
