### PR TITLE
proc: make nested function calls work when stopped at a sw breakpoint

### DIFF
--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -193,7 +193,7 @@ func main() {
 
 	d := &Derived{3, Base{4}}
 
-	runtime.Breakpoint()
+	runtime.Breakpoint() // breakpoint here
 	call1(one, two)
 	fn2clos(2)
 	strings.LastIndexByte(stringslice[1], 'w')

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -315,6 +315,7 @@ func evalFunctionCall(scope *EvalScope, node *ast.CallExpr) (*Variable, error) {
 
 	fncallLog("function call initiated %v frame size %d goroutine %d (thread %d)", fncall.fn, fncall.argFrameSize, scope.g.ID, thread.ThreadID())
 
+	thread.Breakpoint().Clear() // since we moved address in PC the thread is no longer stopped at a breakpoint, leaving the breakpoint set will confuse Continue
 	p.fncallForG[scope.g.ID].startThreadID = thread.ThreadID()
 
 	spoff := int64(scope.Regs.Uint64Val(scope.Regs.SPRegNum)) - int64(scope.g.stack.hi)
@@ -943,6 +944,10 @@ func isCallInjectionStop(t *Target, thread Thread, loc *Location) bool {
 		return false
 	}
 	if !strings.HasPrefix(loc.Fn.Name, debugCallFunctionNamePrefix1) && !strings.HasPrefix(loc.Fn.Name, debugCallFunctionNamePrefix2) {
+		return false
+	}
+	if loc.PC == loc.Fn.Entry {
+		// call injection just started, did not make any progress before being interrupted by a concurrent breakpoint.
 		return false
 	}
 	text, err := disassembleCurrentInstruction(t, thread, -1)


### PR DESCRIPTION
evalFunctionCall needs to remove the breakpoint from the current thread
after starting the function call injection, otherwise Continue will
think that the thread is stopped at a breakpoint and return to the user
instead of continuing the call injection.
