### PR TITLE
cmd,proc,terminal,debugger:  new command line parameter --exit-on-proc-exited to tell debugger exit when debugging application process exited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 **/*.test
 .tags*
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode/
 **/*.test
 .tags*
 tags

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -41,7 +41,7 @@ var (
 	headless bool
 	// continueOnStart is whether to continue the process on startup
 	continueOnStart bool
-	// exitOnProcExited is whether to terminate debugger when the process on of application gone
+	// exitOnProcExited is whether to terminate debugger when the debugging process exited
 	exitOnProcExited bool
 	// apiVersion is the requested API version while running headless
 	apiVersion int
@@ -126,7 +126,7 @@ func New(docCall bool) *cobra.Command {
 
 	rootCommand.PersistentFlags().BoolVarP(&headless, "headless", "", false, "Run debug server only, in headless mode.")
 	rootCommand.PersistentFlags().BoolVarP(&acceptMulti, "accept-multiclient", "", false, "Allows a headless server to accept multiple client connections.")
-	rootCommand.PersistentFlags().BoolVarP(&exitOnProcExited, "exit-on-proc-exited", "", false, "Debugger exit when the debugged process exited.")
+	rootCommand.PersistentFlags().BoolVarP(&exitOnProcExited, "exit-on-proc-exited", "", false, "Tell the debugger to quit when the debugging process exited.")
 	rootCommand.PersistentFlags().IntVar(&apiVersion, "api-version", 1, "Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md.")
 	rootCommand.PersistentFlags().StringVar(&initFile, "init", "", "Init file, executed by the terminal client.")
 	rootCommand.PersistentFlags().StringVar(&buildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -41,7 +41,7 @@ var (
 	headless bool
 	// continueOnStart is whether to continue the process on startup
 	continueOnStart bool
-	// exitOnProcExited is whether to terminate debugger when the debugging process exited
+	// exitOnProcExited is whether to terminate debugger when the debugging application exited
 	exitOnProcExited bool
 	// apiVersion is the requested API version while running headless
 	apiVersion int
@@ -126,7 +126,7 @@ func New(docCall bool) *cobra.Command {
 
 	rootCommand.PersistentFlags().BoolVarP(&headless, "headless", "", false, "Run debug server only, in headless mode.")
 	rootCommand.PersistentFlags().BoolVarP(&acceptMulti, "accept-multiclient", "", false, "Allows a headless server to accept multiple client connections.")
-	rootCommand.PersistentFlags().BoolVarP(&exitOnProcExited, "exit-on-proc-exited", "", false, "Tell the debugger to quit when the debugging process exited.")
+	rootCommand.PersistentFlags().BoolVarP(&exitOnProcExited, "exit-on-proc-exited", "", false, "Tell the debugger to quit when the debugging application exited.")
 	rootCommand.PersistentFlags().IntVar(&apiVersion, "api-version", 1, "Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md.")
 	rootCommand.PersistentFlags().StringVar(&initFile, "init", "", "Init file, executed by the terminal client.")
 	rootCommand.PersistentFlags().StringVar(&buildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -41,6 +41,8 @@ var (
 	headless bool
 	// continueOnStart is whether to continue the process on startup
 	continueOnStart bool
+	// exitOnProcExited is whether to terminate debugger when the process on of application gone
+	exitOnProcExited bool
 	// apiVersion is the requested API version while running headless
 	apiVersion int
 	// acceptMulti allows multiple clients to connect to the same server
@@ -124,6 +126,7 @@ func New(docCall bool) *cobra.Command {
 
 	rootCommand.PersistentFlags().BoolVarP(&headless, "headless", "", false, "Run debug server only, in headless mode.")
 	rootCommand.PersistentFlags().BoolVarP(&acceptMulti, "accept-multiclient", "", false, "Allows a headless server to accept multiple client connections.")
+	rootCommand.PersistentFlags().BoolVarP(&exitOnProcExited, "exit-on-proc-exited", "", false, "Debugger exit when the debugged process exited.")
 	rootCommand.PersistentFlags().IntVar(&apiVersion, "api-version", 1, "Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md.")
 	rootCommand.PersistentFlags().StringVar(&initFile, "init", "", "Init file, executed by the terminal client.")
 	rootCommand.PersistentFlags().StringVar(&buildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler.")
@@ -830,6 +833,7 @@ func execute(attachPid int, processArgs []string, conf *config.Config, coreFile 
 			ProcessArgs:        processArgs,
 			AcceptMulti:        acceptMulti,
 			APIVersion:         apiVersion,
+			ExitOnProcExited:   exitOnProcExited,
 			CheckLocalConnUser: checkLocalConnUser,
 			DisconnectChan:     disconnectChan,
 			Debugger: debugger.Config{

--- a/service/config.go
+++ b/service/config.go
@@ -27,6 +27,9 @@ type Config struct {
 	// Note that the server API is not reentrant and clients will have to coordinate.
 	AcceptMulti bool
 
+	// ExitOnProcExited exit debugger when application exited
+	ExitOnProcExited bool
+
 	// APIVersion selects which version of the API to serve (default: 1).
 	APIVersion int
 

--- a/service/config.go
+++ b/service/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	// Note that the server API is not reentrant and clients will have to coordinate.
 	AcceptMulti bool
 
-	// ExitOnProcExited exit debugger when application exited
+	// ExitOnProcExited tell debugger to exit when debugging application exited
 	ExitOnProcExited bool
 
 	// APIVersion selects which version of the API to serve (default: 1).

--- a/service/config.go
+++ b/service/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	// Note that the server API is not reentrant and clients will have to coordinate.
 	AcceptMulti bool
 
-	// ExitOnProcExited tell debugger to exit when debugging application exited
+	// ExitOnProcExited tell debugger to quit when debugging application exited
 	ExitOnProcExited bool
 
 	// APIVersion selects which version of the API to serve (default: 1).

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -139,7 +139,9 @@ func (s *RPCServer) Command(command api.DebuggerCommand, cb service.RPCCallback)
 	out.State = *st
 	cb.Return(out, nil)
 	if s.config.ExitOnProcExited && st.Exited {
-		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+			panic(fmt.Sprintf("unexpected error when sending SIGTERM to my self: %v", err))
+		}
 	}
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -138,7 +138,7 @@ func (s *RPCServer) Command(command api.DebuggerCommand, cb service.RPCCallback)
 	var out CommandOut
 	out.State = *st
 	cb.Return(out, nil)
-	if st.Exited && s.config.ExitOnProcExited {
+	if s.config.ExitOnProcExited && st.Exited {
 		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 	}
 }

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -139,7 +139,6 @@ func (s *RPCServer) Command(command api.DebuggerCommand, cb service.RPCCallback)
 	out.State = *st
 	cb.Return(out, nil)
 	if st.Exited && s.config.ExitOnProcExited {
-		time.Sleep(500 * time.Millisecond)
 		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 	}
 }

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"syscall"
 	"time"
 
 	"github.com/go-delve/delve/pkg/dwarf/op"
@@ -137,6 +138,10 @@ func (s *RPCServer) Command(command api.DebuggerCommand, cb service.RPCCallback)
 	var out CommandOut
 	out.State = *st
 	cb.Return(out, nil)
+	if st.Exited && s.config.ExitOnProcExited {
+		time.Sleep(500 * time.Millisecond)
+		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	}
 }
 
 type GetBreakpointIn struct {


### PR DESCRIPTION
cmd,proc,terminal,debugger:  new command line parameter --exit-on-proc-exited to tell debugger exit when debugging application process exited

Currently we have to kill the '--headless' debugger when the when debugging application process exited, discussed in #1057

This change adds the '--exit-on-proc-exited' parameter which will tell debugger exit when debugging application process exited.

Fixes #1057