### PR TITLE
dwarf/line: do not consider end of sequence entries valid

### DIFF
--- a/pkg/dwarf/line/line_parser.go
+++ b/pkg/dwarf/line/line_parser.go
@@ -43,6 +43,7 @@ type DebugLineInfo struct {
 	// if normalizeBackslash is true all backslashes (\) will be converted into forward slashes (/)
 	normalizeBackslash bool
 	ptrSize            int
+	endSeqIsValid      bool
 }
 
 type FileEntry struct {

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -543,7 +543,7 @@ func fixedadvancepc(sm *StateMachine, buf *bytes.Buffer) {
 
 func endsequence(sm *StateMachine, buf *bytes.Buffer) {
 	sm.endSeq = true
-	sm.valid = true
+	sm.valid = sm.dbl.endSeqIsValid
 }
 
 func setaddress(sm *StateMachine, buf *bytes.Buffer) {

--- a/pkg/dwarf/line/state_machine_test.go
+++ b/pkg/dwarf/line/state_machine_test.go
@@ -80,6 +80,7 @@ func TestGrafana(t *testing.T) {
 		cuname, _ := e.Val(dwarf.AttrName).(string)
 
 		lineInfo := Parse(e.Val(dwarf.AttrCompDir).(string), debugLineBuffer, t.Logf, 0, false, 8)
+		lineInfo.endSeqIsValid = true
 		sm := newStateMachine(lineInfo, lineInfo.Instructions, 8)
 
 		lnrdr, err := data.LineReader(e)


### PR DESCRIPTION
This is needed to fix the problem we have with 1.15.4+ after the
backport is applied to it. The DWARF standard isn't clear on what
should happen with the end_of_sequence opcode but this is consistent
with debug/dwarf.LineReader as well as gdb.
