### PR TITLE
service/api: Expose WaitSince and WaitReason fields for goroutines

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -201,6 +201,9 @@ type G struct {
 	stkbarPos int       // stkbarPos field of g struct
 	stack     stack     // value of stack
 
+	WaitSince  int64
+	WaitReason int64
+
 	SystemStack bool // SystemStack is true if this goroutine is currently executing on a system stack.
 
 	// Information on goroutine location
@@ -846,6 +849,8 @@ func (v *Variable) parseG() (*G, error) {
 	id := loadInt64Maybe("goid")
 	gopc := loadInt64Maybe("gopc")
 	startpc := loadInt64Maybe("startpc")
+	waitSince := loadInt64Maybe("waitsince")
+	waitReason := loadInt64Maybe("waitreason")
 	var stackhi, stacklo uint64
 	if stackVar := v.loadFieldNamed("stack"); stackVar != nil {
 		if stackhiVar := stackVar.fieldVariable("hi"); stackhiVar != nil {
@@ -882,6 +887,8 @@ func (v *Variable) parseG() (*G, error) {
 		BP:         uint64(bp),
 		LR:         uint64(lr),
 		Status:     uint64(status),
+		WaitSince:  waitSince,
+		WaitReason: waitReason,
 		CurrentLoc: Location{PC: uint64(pc), File: f, Line: l, Fn: fn},
 		variable:   v,
 		stkbarVar:  stkbarVar,

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -295,6 +295,8 @@ func ConvertGoroutine(g *proc.G) *Goroutine {
 		GoStatementLoc: ConvertLocation(g.Go()),
 		StartLoc:       ConvertLocation(g.StartLoc()),
 		ThreadID:       tid,
+		WaitSince:      g.WaitSince,
+		WaitReason:     g.WaitReason,
 		Labels:         g.Labels(),
 	}
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -314,6 +314,8 @@ type Goroutine struct {
 	StartLoc Location `json:"startLoc"`
 	// ID of the associated thread for running goroutines
 	ThreadID   int    `json:"threadID"`
+	WaitSince  int64  `json:"waitSince"`
+	WaitReason int64  `json:"waitReason"`
 	Unreadable string `json:"unreadable"`
 	// Goroutine's pprof labels
 	Labels map[string]string `json:"labels,omitempty"`


### PR DESCRIPTION
This adds the WaitSince and WaitReason fields for the goroutines to allow the users to easily understand why a goroutine is waiting.