### PR TITLE
proc/*: implement proc.(*compositeMemory).WriteMemory

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -1,20 +1,21 @@
 Tests skipped by each supported backend:
 
-* 386 skipped = 2.7% (4/147)
+* 386 skipped = 2.7% (4/148)
 	* 1 broken
 	* 3 broken - cgo stacktraces
-* arm64 skipped = 2.7% (4/147)
+* arm64 skipped = 2.7% (4/148)
 	* 2 broken
 	* 1 broken - cgo stacktraces
 	* 1 broken - global variable symbolication
-* darwin/lldb skipped = 0.68% (1/147)
+* darwin/lldb skipped = 0.68% (1/148)
 	* 1 upstream issue
-* freebsd skipped = 7.5% (11/147)
+* freebsd skipped = 8.1% (12/148)
 	* 11 broken
-* linux/386/pie skipped = 0.68% (1/147)
+	* 1 not implemented
+* linux/386/pie skipped = 0.68% (1/148)
 	* 1 broken
-* pie skipped = 0.68% (1/147)
+* pie skipped = 0.68% (1/148)
 	* 1 upstream issue - https://github.com/golang/go/issues/29322
-* windows skipped = 1.4% (2/147)
+* windows skipped = 1.4% (2/148)
 	* 1 broken
 	* 1 upstream issue

--- a/pkg/dwarf/op/regs.go
+++ b/pkg/dwarf/op/regs.go
@@ -14,11 +14,12 @@ type DwarfRegisters struct {
 	ObjBase   int64
 	regs      []*DwarfRegister
 
-	ByteOrder binary.ByteOrder
-	PCRegNum  uint64
-	SPRegNum  uint64
-	BPRegNum  uint64
-	LRRegNum  uint64
+	ByteOrder  binary.ByteOrder
+	PCRegNum   uint64
+	SPRegNum   uint64
+	BPRegNum   uint64
+	LRRegNum   uint64
+	ChangeFunc RegisterChangeFunc
 
 	FloatLoadError   error // error produced when loading floating point registers
 	loadMoreCallback func()
@@ -28,6 +29,8 @@ type DwarfRegister struct {
 	Uint64Val uint64
 	Bytes     []byte
 }
+
+type RegisterChangeFunc func(regNum uint64, reg *DwarfRegister) error
 
 // NewDwarfRegisters returns a new DwarfRegisters object.
 func NewDwarfRegisters(staticBase uint64, regs []*DwarfRegister, byteOrder binary.ByteOrder, pcRegNum, spRegNum, bpRegNum, lrRegNum uint64) *DwarfRegisters {
@@ -151,4 +154,13 @@ func DwarfRegisterFromBytes(bytes []byte) *DwarfRegister {
 		}
 	}
 	return &DwarfRegister{Uint64Val: v, Bytes: bytes}
+}
+
+// FillBytes fills the Bytes slice of reg using Uint64Val.
+func (reg *DwarfRegister) FillBytes() {
+	if reg.Bytes != nil {
+		return
+	}
+	reg.Bytes = make([]byte, 8)
+	binary.LittleEndian.PutUint64(reg.Bytes, reg.Uint64Val)
 }

--- a/pkg/dwarf/regnum/amd64.go
+++ b/pkg/dwarf/regnum/amd64.go
@@ -1,0 +1,136 @@
+package regnum
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The mapping between hardware registers and DWARF registers is specified
+// in the System V ABI AMD64 Architecture Processor Supplement page 57,
+// figure 3.36
+// https://www.uclibc.org/docs/psABI-x86_64.pdf
+
+const (
+	AMD64_Rax     = 0
+	AMD64_Rdx     = 1
+	AMD64_Rcx     = 2
+	AMD64_Rbx     = 3
+	AMD64_Rsi     = 4
+	AMD64_Rdi     = 5
+	AMD64_Rbp     = 6
+	AMD64_Rsp     = 7
+	AMD64_R8      = 8
+	AMD64_R9      = 9
+	AMD64_R10     = 10
+	AMD64_R11     = 11
+	AMD64_R12     = 12
+	AMD64_R13     = 13
+	AMD64_R14     = 14
+	AMD64_R15     = 15
+	AMD64_Rip     = 16
+	AMD64_XMM0    = 17 // XMM1 through XMM15 follow
+	AMD64_ST0     = 33 // ST(1) through ST(7) follow
+	AMD64_Rflags  = 49
+	AMD64_Es      = 50
+	AMD64_Cs      = 51
+	AMD64_Ss      = 52
+	AMD64_Ds      = 53
+	AMD64_Fs      = 54
+	AMD64_Gs      = 55
+	AMD64_Fs_base = 58
+	AMD64_Gs_base = 59
+	AMD64_MXCSR   = 64
+	AMD64_CW      = 65
+	AMD64_SW      = 66
+)
+
+var amd64DwarfToName = map[uint64]string{
+	AMD64_Rax:       "Rax",
+	AMD64_Rdx:       "Rdx",
+	AMD64_Rcx:       "Rcx",
+	AMD64_Rbx:       "Rbx",
+	AMD64_Rsi:       "Rsi",
+	AMD64_Rdi:       "Rdi",
+	AMD64_Rbp:       "Rbp",
+	AMD64_Rsp:       "Rsp",
+	AMD64_R8:        "R8",
+	AMD64_R9:        "R9",
+	AMD64_R10:       "R10",
+	AMD64_R11:       "R11",
+	AMD64_R12:       "R12",
+	AMD64_R13:       "R13",
+	AMD64_R14:       "R14",
+	AMD64_R15:       "R15",
+	AMD64_Rip:       "Rip",
+	AMD64_XMM0:      "XMM0",
+	AMD64_XMM0 + 1:  "XMM1",
+	AMD64_XMM0 + 2:  "XMM2",
+	AMD64_XMM0 + 3:  "XMM3",
+	AMD64_XMM0 + 4:  "XMM4",
+	AMD64_XMM0 + 5:  "XMM5",
+	AMD64_XMM0 + 6:  "XMM6",
+	AMD64_XMM0 + 7:  "XMM7",
+	AMD64_XMM0 + 8:  "XMM8",
+	AMD64_XMM0 + 9:  "XMM9",
+	AMD64_XMM0 + 10: "XMM10",
+	AMD64_XMM0 + 11: "XMM11",
+	AMD64_XMM0 + 12: "XMM12",
+	AMD64_XMM0 + 13: "XMM13",
+	AMD64_XMM0 + 14: "XMM14",
+	AMD64_XMM0 + 15: "XMM15",
+	AMD64_ST0:       "ST(0)",
+	AMD64_ST0 + 1:   "ST(1)",
+	AMD64_ST0 + 2:   "ST(2)",
+	AMD64_ST0 + 3:   "ST(3)",
+	AMD64_ST0 + 4:   "ST(4)",
+	AMD64_ST0 + 5:   "ST(5)",
+	AMD64_ST0 + 6:   "ST(6)",
+	AMD64_ST0 + 7:   "ST(7)",
+	AMD64_Rflags:    "Rflags",
+	AMD64_Es:        "Es",
+	AMD64_Cs:        "Cs",
+	AMD64_Ss:        "Ss",
+	AMD64_Ds:        "Ds",
+	AMD64_Fs:        "Fs",
+	AMD64_Gs:        "Gs",
+	AMD64_Fs_base:   "Fs_base",
+	AMD64_Gs_base:   "Gs_base",
+	AMD64_MXCSR:     "MXCSR",
+	AMD64_CW:        "CW",
+	AMD64_SW:        "SW",
+}
+
+var AMD64NameToDwarf = func() map[string]int {
+	r := make(map[string]int)
+	for regNum, regName := range amd64DwarfToName {
+		r[strings.ToLower(regName)] = int(regNum)
+	}
+	r["eflags"] = 49
+	r["st0"] = 33
+	r["st1"] = 34
+	r["st2"] = 35
+	r["st3"] = 36
+	r["st4"] = 37
+	r["st5"] = 38
+	r["st6"] = 39
+	r["st7"] = 40
+	return r
+}()
+
+func AMD64MaxRegNum() uint64 {
+	max := uint64(AMD64_Rip)
+	for i := range amd64DwarfToName {
+		if i > max {
+			max = i
+		}
+	}
+	return max
+}
+
+func AMD64ToName(num uint64) string {
+	name, ok := amd64DwarfToName[num]
+	if ok {
+		return name
+	}
+	return fmt.Sprintf("unknown%d", num)
+}

--- a/pkg/dwarf/regnum/arm64.go
+++ b/pkg/dwarf/regnum/arm64.go
@@ -1,0 +1,35 @@
+package regnum
+
+import (
+	"fmt"
+)
+
+// The mapping between hardware registers and DWARF registers is specified
+// in the DWARF for the ARM® Architecture page 7,
+// Table 1
+// http://infocenter.arm.com/help/topic/com.arm.doc.ihi0040b/IHI0040B_aadwarf.pdf
+
+const (
+	ARM64_X0 = 0  // X1 through X30 follow
+	ARM64_BP = 29 // also X29
+	ARM64_LR = 30 // also X30
+	ARM64_SP = 31
+	ARM64_PC = 32
+	ARM64_V0 = 64 // V1 through V31 follow
+
+)
+
+func ARM64ToName(num uint64) string {
+	switch {
+	case num <= 30:
+		return fmt.Sprintf("X%d", num)
+	case num == ARM64_SP:
+		return "SP"
+	case num == ARM64_PC:
+		return "PC"
+	case num >= ARM64_V0 && num <= 95:
+		return fmt.Sprintf("V%d", num-64)
+	default:
+		return fmt.Sprintf("unknown%d", num)
+	}
+}

--- a/pkg/dwarf/regnum/i386.go
+++ b/pkg/dwarf/regnum/i386.go
@@ -1,0 +1,102 @@
+package regnum
+
+import (
+	"fmt"
+	"strings"
+)
+
+// The mapping between hardware registers and DWARF registers is specified
+// in the System V ABI Intel386 Architecture Processor Supplement page 25,
+// table 2.14
+// https://www.uclibc.org/docs/psABI-i386.pdf
+
+const (
+	I386_Eax    = 0
+	I386_Ecx    = 1
+	I386_Edx    = 2
+	I386_Ebx    = 3
+	I386_Esp    = 4
+	I386_Ebp    = 5
+	I386_Esi    = 6
+	I386_Edi    = 7
+	I386_Eip    = 8
+	I386_Eflags = 9
+	I386_ST0    = 11 // ST(1) through ST(7) follow
+	I386_XMM0   = 21 // XMM1 through XMM7 follow
+	I386_Es     = 40
+	I386_Cs     = 41
+	I386_Ss     = 42
+	I386_Ds     = 43
+	I386_Fs     = 44
+	I386_Gs     = 45
+)
+
+var i386DwarfToName = map[int]string{
+	I386_Eax:      "Eax",
+	I386_Ecx:      "Ecx",
+	I386_Edx:      "Edx",
+	I386_Ebx:      "Ebx",
+	I386_Esp:      "Esp",
+	I386_Ebp:      "Ebp",
+	I386_Esi:      "Esi",
+	I386_Edi:      "Edi",
+	I386_Eip:      "Eip",
+	I386_Eflags:   "Eflags",
+	I386_ST0:      "ST(0)",
+	I386_ST0 + 1:  "ST(1)",
+	I386_ST0 + 2:  "ST(2)",
+	I386_ST0 + 3:  "ST(3)",
+	I386_ST0 + 4:  "ST(4)",
+	I386_ST0 + 5:  "ST(5)",
+	I386_ST0 + 6:  "ST(6)",
+	I386_ST0 + 7:  "ST(7)",
+	I386_XMM0:     "XMM0",
+	I386_XMM0 + 1: "XMM1",
+	I386_XMM0 + 2: "XMM2",
+	I386_XMM0 + 3: "XMM3",
+	I386_XMM0 + 4: "XMM4",
+	I386_XMM0 + 5: "XMM5",
+	I386_XMM0 + 6: "XMM6",
+	I386_XMM0 + 7: "XMM7",
+	I386_Es:       "Es",
+	I386_Cs:       "Cs",
+	I386_Ss:       "Ss",
+	I386_Ds:       "Ds",
+	I386_Fs:       "Fs",
+	I386_Gs:       "Gs",
+}
+
+var I386NameToDwarf = func() map[string]int {
+	r := make(map[string]int)
+	for regNum, regName := range i386DwarfToName {
+		r[strings.ToLower(regName)] = regNum
+	}
+	r["eflags"] = 9
+	r["st0"] = 11
+	r["st1"] = 12
+	r["st2"] = 13
+	r["st3"] = 14
+	r["st4"] = 15
+	r["st5"] = 16
+	r["st6"] = 17
+	r["st7"] = 18
+	return r
+}()
+
+func I386MaxRegNum() int {
+	max := int(I386_Eip)
+	for i := range i386DwarfToName {
+		if i > max {
+			max = i
+		}
+	}
+	return max
+}
+
+func I386ToName(num int) string {
+	name, ok := i386DwarfToName[num]
+	if ok {
+		return name
+	}
+	return fmt.Sprintf("unknown%d", num)
+}

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -17,6 +17,10 @@ type Arch struct {
 	breakInstrMovesPC        bool
 	derefTLS                 bool
 	usesLR                   bool // architecture uses a link register, also called RA on some architectures
+	PCRegNum                 uint64
+	SPRegNum                 uint64
+	BPRegNum                 uint64
+	ContextRegNum            uint64 // register used to pass a closure context when calling a function pointer
 
 	// asmDecode decodes the assembly instruction starting at mem[0:] into asmInst.
 	// It assumes that the Loc and AtPC fields of asmInst have already been filled.
@@ -34,7 +38,9 @@ type Arch struct {
 	// addrAndStackRegsToDwarfRegisters returns DWARF registers from the passed in
 	// PC, SP, and BP registers in the format used by the DWARF expression interpreter.
 	addrAndStackRegsToDwarfRegisters func(uint64, uint64, uint64, uint64, uint64) op.DwarfRegisters
-	// DwarfRegisterToString returns the name and value representation of the given register.
+	// DwarfRegisterToString returns the name and value representation of the
+	// given register, the register value can be nil in which case only the
+	// register name will be returned.
 	DwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
 	// inhibitStepInto returns whether StepBreakpoint can be set at pc.
 	inhibitStepInto func(bi *BinaryInfo, pc uint64) bool

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/go-delve/delve/pkg/elfwriter"
+	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/proc"
 )
 
@@ -369,6 +370,12 @@ func (t *thread) SetSP(uint64) error {
 // SetDX will always return an error, you cannot
 // change register values when debugging core files.
 func (t *thread) SetDX(uint64) error {
+	return ErrChangeRegisterCore
+}
+
+// ChangeRegs will always return an error, you cannot
+// change register values when debugging core files.
+func (t *thread) SetReg(regNum uint64, reg *op.DwarfRegister) error {
 	return ErrChangeRegisterCore
 }
 

--- a/pkg/proc/dwarf_export_test.go
+++ b/pkg/proc/dwarf_export_test.go
@@ -1,6 +1,21 @@
 package proc
 
+import "github.com/go-delve/delve/pkg/dwarf/op"
+
 // PackageVars returns bi.packageVars (for tests)
 func (bi *BinaryInfo) PackageVars() []packageVar {
 	return bi.packageVars
+}
+
+func NewCompositeMemory(p *Target, pieces []op.Piece) (*compositeMemory, error) {
+	regs, err := p.CurrentThread().Registers()
+	if err != nil {
+		return nil, err
+	}
+
+	arch := p.BinInfo().Arch
+	dwarfregs := arch.RegistersToDwarfRegisters(0, regs)
+	dwarfregs.ChangeFunc = p.CurrentThread().SetReg
+
+	return newCompositeMemory(p.Memory(), arch, dwarfregs, pieces)
 }

--- a/pkg/proc/linutil/regs_amd64_arch.go
+++ b/pkg/proc/linutil/regs_amd64_arch.go
@@ -1,8 +1,12 @@
 package linutil
 
 import (
+	"fmt"
+
 	"golang.org/x/arch/x86/x86asm"
 
+	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/regnum"
 	"github.com/go-delve/delve/pkg/proc"
 	"github.com/go-delve/delve/pkg/proc/amd64util"
 )
@@ -306,4 +310,72 @@ func (r *AMD64Registers) Copy() (proc.Registers, error) {
 		copy(rr.Fpregs, r.Fpregs)
 	}
 	return &rr, nil
+}
+
+func (r *AMD64Registers) SetReg(regNum uint64, reg *op.DwarfRegister) (bool, error) {
+	var p *uint64
+	switch regNum {
+	case regnum.AMD64_Rax:
+		p = &r.Regs.Rax
+	case regnum.AMD64_Rbx:
+		p = &r.Regs.Rbx
+	case regnum.AMD64_Rcx:
+		p = &r.Regs.Rcx
+	case regnum.AMD64_Rdx:
+		p = &r.Regs.Rdx
+	case regnum.AMD64_Rsi:
+		p = &r.Regs.Rsi
+	case regnum.AMD64_Rdi:
+		p = &r.Regs.Rdi
+	case regnum.AMD64_Rbp:
+		p = &r.Regs.Rbp
+	case regnum.AMD64_Rsp:
+		p = &r.Regs.Rsp
+	case regnum.AMD64_R8:
+		p = &r.Regs.R8
+	case regnum.AMD64_R9:
+		p = &r.Regs.R9
+	case regnum.AMD64_R10:
+		p = &r.Regs.R10
+	case regnum.AMD64_R11:
+		p = &r.Regs.R11
+	case regnum.AMD64_R12:
+		p = &r.Regs.R12
+	case regnum.AMD64_R13:
+		p = &r.Regs.R13
+	case regnum.AMD64_R14:
+		p = &r.Regs.R14
+	case regnum.AMD64_R15:
+		p = &r.Regs.R15
+	case regnum.AMD64_Rip:
+		p = &r.Regs.Rip
+	}
+
+	if p != nil {
+		if reg.Bytes != nil && len(reg.Bytes) != 8 {
+			return false, fmt.Errorf("wrong number of bytes for register %s (%d)", regnum.AMD64ToName(regNum), len(reg.Bytes))
+		}
+		*p = reg.Uint64Val
+		return false, nil
+	}
+
+	if r.loadFpRegs != nil {
+		err := r.loadFpRegs(r)
+		if err != nil {
+			return false, err
+		}
+		r.loadFpRegs = nil
+	}
+
+	if regNum < regnum.AMD64_XMM0 || regNum > regnum.AMD64_XMM0+15 {
+		return false, fmt.Errorf("can not set %s", regnum.AMD64ToName(regNum))
+	}
+
+	reg.FillBytes()
+
+	err := r.Fpregset.SetXmmRegister(int(regNum-regnum.AMD64_XMM0), reg.Bytes)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/proc"
 )
 
@@ -82,17 +83,12 @@ func (dbp *nativeProcess) EntryPoint() (uint64, error) {
 }
 
 // SetPC sets the value of the PC register.
-func (t *nativeThread) SetPC(pc uint64) error {
+func (t *nativeThread) setPC(pc uint64) error {
 	panic(ErrNativeBackendDisabled)
 }
 
-// SetSP sets the value of the SP register.
-func (t *nativeThread) SetSP(sp uint64) error {
-	panic(ErrNativeBackendDisabled)
-}
-
-// SetDX sets the value of the DX register.
-func (t *nativeThread) SetDX(dx uint64) error {
+// SetReg changes the value of the specified register.
+func (thread *nativeThread) SetReg(regNum uint64, reg *op.DwarfRegister) error {
 	panic(ErrNativeBackendDisabled)
 }
 

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -594,7 +594,7 @@ func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) 
 				}
 				if !isHardcodedBreakpoint {
 					// phantom breakpoint hit
-					_ = th.SetPC(pc - uint64(len(dbp.BinInfo().Arch.BreakpointInstruction())))
+					_ = th.setPC(pc - uint64(len(dbp.BinInfo().Arch.BreakpointInstruction())))
 					th.os.setbp = false
 					if trapthread.ThreadID() == th.ThreadID() {
 						// Will switch to a different thread for trapthread because we don't

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -325,7 +325,7 @@ func (dbp *nativeProcess) waitForDebugEvent(flags waitForDebugEventFlags) (threa
 						}
 					}
 					if !atbp {
-						thread.SetPC(uint64(exception.ExceptionRecord.ExceptionAddress))
+						thread.setPC(uint64(exception.ExceptionRecord.ExceptionAddress))
 					}
 				}
 

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -122,7 +122,7 @@ func (t *nativeThread) SetCurrentBreakpoint(adjustPC bool) error {
 
 	if bp, ok := t.dbp.FindBreakpoint(pc, adjustPC); ok {
 		if adjustPC {
-			if err = t.SetPC(bp.Addr); err != nil {
+			if err = t.setPC(bp.Addr); err != nil {
 				return err
 			}
 		}

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -127,7 +127,7 @@ func (dbp *Target) Continue() error {
 				// In linux-arm64, PtraceSingleStep seems cannot step over BRK instruction
 				// (linux-arm64 feature or kernel bug maybe).
 				if !arch.BreakInstrMovesPC() {
-					curthread.SetPC(loc.PC + uint64(arch.BreakpointSize()))
+					setPC(curthread, loc.PC+uint64(arch.BreakpointSize()))
 				}
 				// Single-step current thread until we exit runtime.breakpoint and
 				// runtime.Breakpoint.
@@ -145,7 +145,7 @@ func (dbp *Target) Continue() error {
 					bp := make([]byte, bpsize)
 					_, err = dbp.Memory().ReadMemory(bp, loc.PC)
 					if bytes.Equal(bp, arch.BreakpointInstruction()) {
-						curthread.SetPC(loc.PC + uint64(bpsize))
+						setPC(curthread, loc.PC+uint64(bpsize))
 					}
 				}
 				return conditionErrors(threads)

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -2,6 +2,8 @@ package proc
 
 import (
 	"errors"
+
+	"github.com/go-delve/delve/pkg/dwarf/op"
 )
 
 // Thread represents a thread.
@@ -31,9 +33,10 @@ type Thread interface {
 	// Common returns the CommonThread structure for this thread
 	Common() *CommonThread
 
-	SetPC(uint64) error
-	SetSP(uint64) error
-	SetDX(uint64) error
+	// SetReg changes the value of the specified register. A minimal
+	// implementation of this interface can support just setting the PC
+	// register.
+	SetReg(uint64, *op.DwarfRegister) error
 }
 
 // Location represents the location of a thread.
@@ -82,4 +85,16 @@ func topframe(g *G, thread Thread) (Stackframe, Stackframe, error) {
 	default:
 		return frames[0], frames[1], nil
 	}
+}
+
+func setPC(thread Thread, newPC uint64) error {
+	return thread.SetReg(thread.BinInfo().Arch.PCRegNum, op.DwarfRegisterFromUint64(newPC))
+}
+
+func setSP(thread Thread, newSP uint64) error {
+	return thread.SetReg(thread.BinInfo().Arch.SPRegNum, op.DwarfRegisterFromUint64(newSP))
+}
+
+func setClosureReg(thread Thread, newClosureReg uint64) error {
+	return thread.SetReg(thread.BinInfo().Arch.ContextRegNum, op.DwarfRegisterFromUint64(newClosureReg))
 }

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1147,7 +1147,7 @@ func extractVarInfoFromEntry(bi *BinaryInfo, image *Image, regs op.DwarfRegister
 	if pieces != nil {
 		addr = fakeAddress
 		var cmem *compositeMemory
-		cmem, err = newCompositeMemory(mem, regs, pieces)
+		cmem, err = newCompositeMemory(mem, bi.Arch, regs, pieces)
 		if cmem != nil {
 			mem = cmem
 		}


### PR DESCRIPTION
Delve represents registerized variables (fully or partially) using
compositeMemory, implementing proc.(*compositeMemory).WriteMemory is
necessary to make SetVariable and function calls work when Go will
switch to using the register calling convention in 1.17.

This commit also makes some refactoring by moving the code that
converts between register numbers and register names out of pkg/proc
into a different package.
