### PR TITLE
terminal: add way to cancel goroutines command with ctrl-C

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -723,7 +723,12 @@ func goroutines(t *Term, ctx callContext, argstr string) error {
 		gslen = 0
 		gs    []*api.Goroutine
 	)
+	t.longCommandStart()
 	for start >= 0 {
+		if t.longCommandCanceled() {
+			fmt.Printf("interrupted\n")
+			return nil
+		}
 		gs, start, err = t.client.ListGoroutines(start, goroutineBatchSize)
 		if err != nil {
 			return err


### PR DESCRIPTION
The goroutines command can take a long time to complete if there are
many goroutines, add the possibility to terminate it early by pressing
ctrl-C.
