### PR TITLE
native/proc/linux: wait for the target process to be killed in kill

### DIFF
--- a/pkg/proc/proc_unix_test.go
+++ b/pkg/proc/proc_unix_test.go
@@ -54,6 +54,8 @@ func TestIssue419(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		err := <-errChan
 
+		t.Logf("error %T %#v\n", err, err)
+
 		if v, ok := err.(errIssue419); ok {
 			assertNoError(v.err, t, "syscall.Kill")
 			continue


### PR DESCRIPTION
Waits for the target process to have received the kill signal in
native.nativeProcess.kill. Fixes an infrequent error in TestKill.
