### PR TITLE
Don't call suspend on DbgUiRemoteBreakin threads

### DIFF
--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -16,7 +16,8 @@ type waitStatus sys.WaitStatus
 // osSpecificDetails holds information specific to the Windows
 // operating system / kernel.
 type osSpecificDetails struct {
-	hThread syscall.Handle
+	hThread            syscall.Handle
+	dbgUiRemoteBreakIn bool // whether thread is an auxiliary DbgUiRemoteBreakIn thread created by Windows
 }
 
 func (t *nativeThread) singleStep() error {
@@ -77,9 +78,11 @@ func (t *nativeThread) singleStep() error {
 	}
 
 	for i := 0; i < suspendcnt; i++ {
-		_, err = _SuspendThread(t.os.hThread)
-		if err != nil {
-			return err
+		if !t.os.dbgUiRemoteBreakIn {
+			_, err = _SuspendThread(t.os.hThread)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/proc/native/zsyscall_windows.go
+++ b/pkg/proc/native/zsyscall_windows.go
@@ -14,6 +14,7 @@ var (
 	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
 
 	procNtQueryInformationThread   = modntdll.NewProc("NtQueryInformationThread")
+	dbgUiRemoteBreakin             = modntdll.NewProc("DbgUiRemoteBreakin")
 	procGetThreadContext           = modkernel32.NewProc("GetThreadContext")
 	procSetThreadContext           = modkernel32.NewProc("SetThreadContext")
 	procSuspendThread              = modkernel32.NewProc("SuspendThread")


### PR DESCRIPTION
Sometimes it makes debuggee to hang.

Should fix #2244