### PR TITLE
service/dap: Add support for evaluateName for variables

### DIFF
--- a/service/dap/handles.go
+++ b/service/dap/handles.go
@@ -14,6 +14,15 @@ type handlesMap struct {
 	handleToVal map[int]interface{}
 }
 
+type fullyQualifiedVariable struct {
+	*proc.Variable
+	// A way to load this variable by either using all names in the hierarchic
+	// sequence above this variable (most readable when referenced by the UI)
+	// if available or a special expression based on:
+	// https://github.com/go-delve/delve/blob/master/Documentation/api/ClientHowto.md#loading-more-of-a-variable
+	fullyQualifiedNameOrExpr string
+}
+
 func newHandlesMap() *handlesMap {
 	return &handlesMap{startHandle, make(map[int]interface{})}
 }
@@ -43,16 +52,16 @@ func newVariablesHandlesMap() *variablesHandlesMap {
 	return &variablesHandlesMap{newHandlesMap()}
 }
 
-func (hs *variablesHandlesMap) create(value *proc.Variable) int {
+func (hs *variablesHandlesMap) create(value *fullyQualifiedVariable) int {
 	return hs.m.create(value)
 }
 
-func (hs *variablesHandlesMap) get(handle int) (*proc.Variable, bool) {
+func (hs *variablesHandlesMap) get(handle int) (*fullyQualifiedVariable, bool) {
 	v, ok := hs.m.get(handle)
 	if !ok {
 		return nil, false
 	}
-	return v.(*proc.Variable), true
+	return v.(*fullyQualifiedVariable), true
 }
 
 func (hs *variablesHandlesMap) reset() {

--- a/service/dap/handles.go
+++ b/service/dap/handles.go
@@ -20,7 +20,10 @@ type fullyQualifiedVariable struct {
 	// sequence above this variable (most readable when referenced by the UI)
 	// if available or a special expression based on:
 	// https://github.com/go-delve/delve/blob/master/Documentation/api/ClientHowto.md#loading-more-of-a-variable
+	// Empty if the variable cannot or should not be reloaded.
 	fullyQualifiedNameOrExpr string
+	// True if this represents variable scope
+	isScope bool
 }
 
 func newHandlesMap() *handlesMap {

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1125,7 +1125,7 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 								client.VariablesRequest(ref)
 								iface4data0 := client.ExpectVariablesResponse(t)
 								expectChildren(t, iface4data0, "iface4.data[0]", 1)
-								ref = expectVarExact(t, iface4data0, 0, "data", "iface4.(data)[0].(data)", "4", noChildren)
+								expectVarExact(t, iface4data0, 0, "data", "iface4.(data)[0].(data)", "4", noChildren)
 								validateEvaluateName(t, client, iface4data0, 0)
 							}
 						}


### PR DESCRIPTION
Updates #1515

This feature enables "Add to Watch" and "Copy as Expression" in vscode VARIABLES pane.