### PR TITLE
proc: do not assume abstract origins precede their uses

### DIFF
--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -98,6 +98,16 @@ func newLoadDebugInfoMapsContext(bi *BinaryInfo, image *Image, offsetToVersion m
 	return ctxt
 }
 
+func (ctxt *loadDebugInfoMapsContext) lookupAbstractOrigin(bi *BinaryInfo, off dwarf.Offset) int {
+	r, ok := ctxt.abstractOriginTable[off]
+	if !ok {
+		bi.Functions = append(bi.Functions, Function{})
+		r = len(bi.Functions) - 1
+		ctxt.abstractOriginTable[off] = r
+	}
+	return r
+}
+
 // runtimeTypeToDIE returns the DIE corresponding to the runtime._type.
 // This is done in three different ways depending on the version of go.
 // * Before go1.7 the type name is retrieved directly from the runtime._type


### PR DESCRIPTION
The DWARF standard does not say that a DW_ATTR_abstract_origin can only
reference entries that appear before it, this change fixes BinaryInfo
to comply. See #2284 for an example of this happening.
