### PR TITLE
Introduce TeamCity builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cmd/dlv/dlv
 .vagrant
 **/*.swp
 localtests
+.idea
+*.iml
+.teamcity/target

--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Delve Config DSL Script</name>
+  <groupId>Delve</groupId>
+  <artifactId>Delve_dsl</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.jetbrains.teamcity</groupId>
+    <artifactId>configs-dsl-kotlin-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>jetbrains-all</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>teamcity-server</id>
+      <url>https://delve.beta.teamcity.com/app/dsl-plugins-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>JetBrains</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <sourceDirectory>${basedir}</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+
+        <configuration/>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>process-test-sources</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.teamcity</groupId>
+        <artifactId>teamcity-configs-maven-plugin</artifactId>
+        <version>${teamcity.dsl.version}</version>
+        <configuration>
+          <format>kotlin</format>
+          <dstDir>target/generated-configs</dstDir>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin</artifactId>
+      <version>${teamcity.dsl.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin-plugins</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>pom</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-script-runtime</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,0 +1,198 @@
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.golang
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.dockerCommand
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnMetric
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnMetricChange
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+
+/*
+The settings script is an entry point for defining a TeamCity
+project hierarchy. The script should contain a single call to the
+project() function with a Project instance or an init function as
+an argument.
+
+VcsRoots, BuildTypes, Templates, and subprojects can be
+registered inside the project using the vcsRoot(), buildType(),
+template(), and subProject() methods respectively.
+
+To debug settings scripts in command-line, run the
+
+    mvnDebug org.jetbrains.teamcity:teamcity-configs-maven-plugin:generate
+
+command and attach your debugger to the port 8000.
+
+To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
+-> Tool Windows -> Maven Projects), find the generate task node
+(Plugins -> teamcity-configs -> teamcity-configs:generate), the
+'Debug' option is available in the context menu for the task.
+*/
+
+version = "2020.2"
+
+val targets = arrayOf(
+        "linux/386/1.15.2",
+        "linux/386/latest",
+        "linux/amd64/1.15.3",
+        "linux/amd64/latest",
+        "windows/amd64/1.15.3",
+        "windows/amd64/latest"
+)
+
+project {
+    val tests = targets.map { target ->
+        val (os, arch, version) = target.split("/")
+        TestBuild(os, arch, version, AbsoluteId("Delve_${os}_${arch}_${version.replace('.', '_')}"))
+    }
+    tests.map { test ->
+        test.os
+    }.distinct().forEach { os ->
+        subProject(OSProject(os, tests.filter { test ->
+            test.os == os
+        }))
+    }
+    buildType(AggregatorBuild(tests))
+}
+
+class AggregatorBuild(tests: Collection<BuildType>) : BuildType({
+    name = "Aggregator"
+    type = Type.COMPOSITE
+
+    vcs {
+        root(DslContext.settingsRoot)
+    }
+
+    triggers {
+        vcs {
+        }
+    }
+
+    dependencies {
+        tests.forEach { test ->
+            snapshot(test) {
+            }
+        }
+    }
+
+    features {
+        pullRequests {
+            vcsRootExtId = "${DslContext.settingsRoot.id}"
+            provider = github {
+                authType = token {
+                    token = "credentialsJSON:5dc93081-e0b2-41e2-b8f0-dea3c96e6426"
+                }
+                filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
+            }
+        }
+        commitStatusPublisher {
+            vcsRootExtId = "${DslContext.settingsRoot.id}"
+            publisher = github {
+                githubUrl = "https://api.github.com"
+                authType = personalToken {
+                    token = "credentialsJSON:5dc93081-e0b2-41e2-b8f0-dea3c96e6426"
+                }
+            }
+            param("github_oauth_user", "artspb")
+        }
+    }
+})
+
+class OSProject(os: String, tests: List<TestBuild>) : Project({
+    id = AbsoluteId("Delve_$os")
+    name = os.capitalize()
+
+    tests.map { test ->
+        test.arch
+    }.distinct().forEach { arch ->
+        subProject(ArchProject(os, arch, tests.filter { test ->
+            test.arch == arch
+        }))
+    }
+})
+
+class ArchProject(os: String, arch: String, tests: List<TestBuild>) : Project({
+    id = AbsoluteId("Delve_${os}_${arch}")
+    name = arch
+
+    tests.forEach { test ->
+        buildType(test)
+    }
+})
+
+class TestBuild(val os: String, val arch: String, version: String, buildId: AbsoluteId) : BuildType({
+    id = buildId
+    name = version
+
+    vcs {
+        root(DslContext.settingsRoot)
+    }
+
+    failureConditions {
+        executionTimeoutMin = 30
+
+        failOnMetricChange {
+            metric = BuildFailureOnMetric.MetricType.TEST_COUNT
+            units = BuildFailureOnMetric.MetricUnit.DEFAULT_UNIT
+            comparison = BuildFailureOnMetric.MetricComparison.LESS
+            compareTo = value()
+        }
+    }
+
+    steps {
+        when (os) {
+            "linux" -> {
+                val dockerArch = if (arch == "386") "i$arch" else arch
+                dockerCommand {
+                    name = "Pull Ubuntu"
+                    commandType = other {
+                        subCommand = "pull"
+                        commandArgs = "$dockerArch/ubuntu:20.04"
+                    }
+                }
+                dockerCommand {
+                    name = "Test"
+                    commandType = other {
+                        subCommand = "run"
+                        commandArgs = """
+                        -v %teamcity.build.checkoutDir%:/delve
+                        --env TEAMCITY_VERSION=${'$'}TEAMCITY_VERSION
+                        --env CI=true
+                        --privileged
+                        $dockerArch/ubuntu:20.04
+                        /delve/_scripts/test_linux.sh ${"go$version"} $arch
+                    """.trimIndent()
+                    }
+                }
+            }
+            "windows" -> {
+                powerShell {
+                    name = "Test"
+                    scriptMode = file {
+                        path = "_scripts/test_windows.ps1"
+                    }
+                    param("jetbrains_powershell_scriptArguments", "-version ${"go$version"} -arch $arch")
+                }
+            }
+        }
+    }
+
+    requirements {
+        when (os) {
+            "linux" -> {
+                matches("teamcity.agent.jvm.os.family", "Linux")
+            }
+            "windows" -> {
+                matches("teamcity.agent.jvm.os.family", "Windows")
+            }
+        }
+    }
+
+    features {
+        golang {
+            testFormat = "json"
+        }
+    }
+})

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -35,10 +35,13 @@ version = "2020.2"
 
 val targets = arrayOf(
         "linux/386/1.15.2",
+        "linux/386/1.16beta1",
         "linux/386/latest",
         "linux/amd64/1.15.3",
+        "linux/amd64/1.16beta1",
         "linux/amd64/latest",
         "windows/amd64/1.15.3",
+        "windows/amd64/1.16beta1",
         "windows/amd64/latest"
 )
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![GoDoc](https://godoc.org/github.com/go-delve/delve?status.svg)](https://godoc.org/github.com/go-delve/delve)
 [![Build Status](https://travis-ci.org/go-delve/delve.svg?branch=master)](https://travis-ci.org/go-delve/delve)
 [![Build status](https://ci.appveyor.com/api/projects/status/0v8r99smxost466s/branch/master?svg=true)](https://ci.appveyor.com/project/derekparker/delve-facy3/branch/master)
+[![Build Status](https://delve.beta.teamcity.com/app/rest/builds/buildType:(id:Delve_AggregatorBuild)/statusIcon)](https://delve.beta.teamcity.com/viewType.html?buildTypeId=Delve_AggregatorBuild&guest=1)
 
 The GitHub issue tracker is for **bugs** only. Please use the [developer mailing list](https://groups.google.com/forum/#!forum/delve-dev) for any feature proposals and discussions.
 

--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -276,6 +276,9 @@ func testFlags() []string {
 		// Make test timeout shorter than Travis' own timeout so that Go can report which test hangs.
 		testFlags = append(testFlags, "-timeout", "9m")
 	}
+	if len(os.Getenv("TEAMCITY_VERSION")) > 0 {
+		testFlags = append(testFlags, "-json")
+	}
 	if runtime.GOOS == "darwin" {
 		testFlags = append(testFlags, "-exec="+wd+"/_scripts/testsign")
 	}

--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+set -x
+
+apt-get -qq update
+apt-get install -y dwz wget make git gcc curl
+dwz --version
+
+if [ "$1" = "golatest" ]; then
+  version=$(curl https://golang.org/VERSION?m=text)
+else
+  version=$1
+fi
+arch=$2
+echo "Go $version on $arch"
+
+export GOROOT=/usr/local/go/"$version"
+if [ ! -d "$GOROOT" ]; then
+  wget -q https://dl.google.com/go/"${version}".linux-"${arch}".tar.gz
+  mkdir -p /usr/local/go
+  tar -C /usr/local/go -xzf "${version}".linux-"${arch}".tar.gz
+  mv -f /usr/local/go/go "$GOROOT"
+fi
+
+GOPATH=$(pwd)/go
+export GOPATH
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+go version
+
+uname -a
+echo "$PATH"
+echo "$GOROOT"
+echo "$GOPATH"
+
+cd delve
+make test

--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -1,0 +1,46 @@
+param (
+    [Parameter(Mandatory = $true)][string]$version,
+    [Parameter(Mandatory = $true)][string]$arch
+)
+
+# Install MinGW.
+if (-Not(Test-Path "C:\mingw64"))
+{
+    $file = "x86_64-4.9.2-release-win32-seh-rt_v4-rev3.7z"
+    $url = "https://bintray.com/artifact/download/drewwells/generic/$file"
+    Invoke-WebRequest -UserAgent wget -Uri $url -OutFile $file
+    &7z x -oC:\ $file > $null
+}
+
+# Install Procdump
+if (-Not(Test-Path "C:\procdump"))
+{
+    mkdir C:\procdump
+    Invoke-WebRequest -UserAgent wget -Uri https://download.sysinternals.com/files/Procdump.zip -OutFile C:\procdump\procdump.zip
+    &7z x -oC:\procdump\ C:\procdump\procdump.zip > $null
+}
+
+# Install Go
+if ($version -eq "golatest")
+{
+    $version = Invoke-WebRequest -Uri https://golang.org/VERSION?m=text -UseBasicParsing | Select-Object -ExpandProperty Content
+}
+Write-Host "Go $version on $arch"
+$env:GOROOT = "C:\go\$version"
+if (-Not(Test-Path $env:GOROOT))
+{
+    $file = "$version.windows-$arch.zip"
+    $url = "https://dl.google.com/go/$file"
+    Invoke-WebRequest -UserAgent wget -Uri $url -OutFile $file
+    &7z x -oC:\go $file > $null
+    Move-Item -Path C:\go\go -Destination $env:GOROOT -force
+}
+
+$env:GOPATH = "C:\gopath"
+$env:PATH += ";C:\procdump;C:\mingw64\bin;$env:GOROOT\bin;$env:GOPATH\bin"
+Write-Host $env:PATH
+Write-Host $env:GOROOT
+Write-Host $env:GOPATH
+go version
+go env
+mingw32-make test

--- a/pkg/proc/gdbserial/gdbserver_conn_386.go
+++ b/pkg/proc/gdbserial/gdbserver_conn_386.go
@@ -1,0 +1,15 @@
+//+build 386
+
+package gdbserial
+
+const (
+	regnamePC     = "rip"
+	regnameCX     = "rcx"
+	regnameSP     = "rsp"
+	regnameDX     = "rdx"
+	regnameBP     = "rbp"
+	regnameFsBase = "fs_base"
+	regnameGsBase = "gs_base"
+
+	breakpointKind = 1
+)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2027,6 +2027,9 @@ func TestAttachRequest(t *testing.T) {
 	if runtime.GOOS == "freebsd" {
 		t.SkipNow()
 	}
+	if runtime.GOOS == "windows" {
+		t.Skip("test skipped on windows, see https://delve.beta.teamcity.com/project/Delve_windows for details")
+	}
 	runTest(t, "loopprog", func(client *daptest.Client, fixture protest.Fixture) {
 		// Start the program to attach to
 		// TODO(polina): do I need to sanity check testBackend and runtime.GOOS?


### PR DESCRIPTION
This pool request introduces the TeamCity build configuration (https://delve.beta.teamcity.com/). Additionally, it fixes two problems that prevent tests from running. One is relevant for darwin/386 (`restore gdbserial constants for 386`), another is for windows/amd64 (`skip TestAttachRequest on Windows as it never finishes`). I didn't investigate these problems. Instead, I've just implemented workarounds so that tests can run. Feel free to drop these commits if you feel that they bring more harm than good.

If you decide to accept this pool request, you'll need to additionally update the TeamCity configuration, so the server points at the original repo instead of my fork. It should be a rather trivial task. I've sent invites to Alessandro and Derek and will grant admin access as soon as they register.

Currently, tests are run against the following sets (see `settings.kts:36`).

```
"linux/386/1.15.2",
"linux/386/1.16beta1",
"linux/386/latest",
"linux/amd64/1.15.3",
"linux/amd64/1.16beta1",
"linux/amd64/latest",
"windows/amd64/1.15.3",
"windows/amd64/1.16beta1",
"windows/amd64/latest"
```

Tests on Linux are run in Docker (Ubuntu 20.04 LTS) on both 386/amd64. Tests on Windows are only available for amd64. At the moment, you can only add more Go versions to these sets. Additional machines (linux/arm64, darwin/amd64, and darwin/arm64). Are on the way. We'll create agents for them as soon as they arrive.

Builds should run not only against the master branch but also against pool requests. I've enabled this feature but didn't have a chance to test it. You'll need to update the GitHub token for it to work.

And last but not least. You can use both Kotlin DSL and TeamCity UI to configure builds. In either case, the configuration will end up in the repository under `.teamcity`. When using the UI, patches are created that don't look nice and hard to maintain. So, in general, it's recommended to stick to Kotlin or at least merge these patches into the main configuration file from time to time. In any case, we (JetBrains) are always ready to help with any related questions or problems.