### PR TITLE
proc: refactor common code in WriteBreakpoint

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -263,10 +263,7 @@ func (t *Target) SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Expr) 
 		return bp, nil
 	}
 
-	f, l, fn, originalData, err := t.proc.WriteBreakpoint(addr)
-	if err != nil {
-		return nil, err
-	}
+	f, l, fn := t.BinInfo().PCToLine(uint64(addr))
 
 	fnName := ""
 	if fn != nil {
@@ -279,8 +276,12 @@ func (t *Target) SetBreakpoint(addr uint64, kind BreakpointKind, cond ast.Expr) 
 		Line:         l,
 		Addr:         addr,
 		Kind:         kind,
-		OriginalData: originalData,
 		HitCount:     map[int]uint64{},
+	}
+
+	err := t.proc.WriteBreakpoint(newBreakpoint)
+	if err != nil {
+		return nil, err
 	}
 
 	if kind != UserBreakpoint {

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -231,8 +231,8 @@ func (p *process) EntryPoint() (uint64, error) {
 
 // WriteBreakpoint is a noop function since you
 // cannot write breakpoints into core files.
-func (p *process) WriteBreakpoint(addr uint64) (file string, line int, fn *proc.Function, originalData []byte, err error) {
-	return "", 0, nil, nil, errors.New("cannot write a breakpoint to a core file")
+func (p *process) WriteBreakpoint(*proc.Breakpoint) error {
+	return errors.New("cannot write a breakpoint to a core file")
 }
 
 // Recorded returns whether this is a live or recorded process. Always returns true for core files.

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1171,14 +1171,8 @@ func (p *gdbProcess) FindBreakpoint(pc uint64) (*proc.Breakpoint, bool) {
 	return nil, false
 }
 
-func (p *gdbProcess) WriteBreakpoint(addr uint64) (string, int, *proc.Function, []byte, error) {
-	f, l, fn := p.bi.PCToLine(uint64(addr))
-
-	if err := p.conn.setBreakpoint(addr); err != nil {
-		return "", 0, nil, nil, err
-	}
-
-	return f, l, fn, nil, nil
+func (p *gdbProcess) WriteBreakpoint(bp *proc.Breakpoint) error {
+	return p.conn.setBreakpoint(bp.Addr)
 }
 
 func (p *gdbProcess) EraseBreakpoint(bp *proc.Breakpoint) error {

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -33,7 +33,7 @@ type ProcessInternal interface {
 	Detach(bool) error
 	ContinueOnce() (trapthread Thread, stopReason StopReason, err error)
 
-	WriteBreakpoint(addr uint64) (file string, line int, fn *Function, originalData []byte, err error)
+	WriteBreakpoint(*Breakpoint) error
 	EraseBreakpoint(*Breakpoint) error
 }
 

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -203,19 +203,13 @@ func (dbp *nativeProcess) CheckAndClearManualStopRequest() bool {
 	return msr
 }
 
-func (dbp *nativeProcess) WriteBreakpoint(addr uint64) (string, int, *proc.Function, []byte, error) {
-	f, l, fn := dbp.bi.PCToLine(uint64(addr))
-
-	originalData := make([]byte, dbp.bi.Arch.BreakpointSize())
-	_, err := dbp.memthread.ReadMemory(originalData, addr)
+func (dbp *nativeProcess) WriteBreakpoint(bp *proc.Breakpoint) error {
+	bp.OriginalData = make([]byte, dbp.bi.Arch.BreakpointSize())
+	_, err := dbp.memthread.ReadMemory(bp.OriginalData, bp.Addr)
 	if err != nil {
-		return "", 0, nil, nil, err
+		return err
 	}
-	if err := dbp.writeSoftwareBreakpoint(dbp.memthread, addr); err != nil {
-		return "", 0, nil, nil, err
-	}
-
-	return f, l, fn, originalData, nil
+	return dbp.writeSoftwareBreakpoint(dbp.memthread, bp.Addr)
 }
 
 func (dbp *nativeProcess) EraseBreakpoint(bp *proc.Breakpoint) error {


### PR DESCRIPTION
Moves common backend code in WriteBreakpoint to
proc.(*Target).SetBreakpoint.
