### PR TITLE
fix/pmem: prettyprint outputs wrong starting address

### DIFF
--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -421,7 +421,7 @@ func PrettyExamineMemory(address uintptr, memArea []byte, isLittleEndian bool, f
 			}
 		}
 		fmt.Fprintln(w, "")
-		address += uintptr(cols)
+		address += uintptr(cols * colBytes)
 	}
 	w.Flush()
 	return b.String()


### PR DESCRIPTION
The starting address should be incremented by `address += uintptr(cols*colBytes)`.