### PR TITLE
cmd/dlv/tests: fix TestGeneratedDoc on Windows

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -329,12 +329,17 @@ func TestRedirect(t *testing.T) {
 func checkAutogenDoc(t *testing.T, filename, gencommand string, generated []byte) {
 	saved := slurpFile(t, filepath.Join(projectRoot(), filename))
 
+	saved = bytes.ReplaceAll(saved, []byte("\r\n"), []byte{'\n'})
+	generated = bytes.ReplaceAll(generated, []byte("\r\n"), []byte{'\n'})
+
 	if len(saved) != len(generated) {
+		t.Logf("generated %q saved %q\n", generated, saved)
 		t.Fatalf("%s: needs to be regenerated; run %s", filename, gencommand)
 	}
 
 	for i := range saved {
 		if saved[i] != generated[i] {
+			t.Logf("generated %q saved %q\n", generated, saved)
 			t.Fatalf("%s: needs to be regenerated; run %s", filename, gencommand)
 		}
 	}


### PR DESCRIPTION
Change TestGeneratedDoc to ignore differences in line terminators.
