### PR TITLE
proc: fix embedded field search

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -106,6 +106,38 @@ type List struct {
 	Next *List
 }
 
+type T struct {
+	F string
+}
+
+type W1 struct {
+	T
+}
+
+func (*W1) M() {}
+
+type I interface{ M() }
+
+type W2 struct {
+	W1
+	T
+}
+
+type W3 struct {
+	I
+	T
+}
+
+type W4 struct {
+	I
+}
+
+type W5 struct {
+	*W5
+}
+
+var _ I = (*W2)(nil)
+
 func main() {
 	i1 := 1
 	i2 := 2
@@ -312,6 +344,12 @@ func main() {
 	ll := &List{0, &List{1, &List{2, &List{3, &List{4, nil}}}}}
 	unread := (*int)(unsafe.Pointer(uintptr(12345)))
 
+	w2 := &W2{W1{T{"T-inside-W1"}}, T{"T-inside-W2"}}
+	w3 := &W3{&W1{T{"T-inside-W1"}}, T{"T-inside-W3"}}
+	w4 := &W4{&W1{T{"T-inside-W1"}}}
+	w5 := &W5{nil}
+	w5.W5 = w5
+
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
@@ -319,5 +357,5 @@ func main() {
 	}
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, bytearray, runearray, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4, iface2map, issue1578, ll, unread)
+	fmt.Println(i1, i2, i3, p1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, errtypednil, emptyslice, emptymap, byteslice, runeslice, bytearray, runearray, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5)
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1026,7 +1026,7 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 				execute: func() {
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "main.main", 317, 1000, 3, 3)
+					expectStackFrames(t, stack, "main.main", -1, 1000, 3, 3)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
@@ -1039,7 +1039,7 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 				execute: func() {
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "main.main", 322, 1000, 3, 3)
+					expectStackFrames(t, stack, "main.main", -1, 1000, 3, 3)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -504,6 +504,20 @@ func TestEmbeddedStruct(t *testing.T) {
 			{"b.C.s", true, "\"hello\"", "\"hello\"", "string", nil},
 			{"b.s", true, "\"hello\"", "\"hello\"", "string", nil},
 			{"b2", true, "main.B {A: main.A {val: 42}, C: *main.C nil, a: main.A {val: 47}, ptr: *main.A nil}", "main.B {A: (*main.A)(0x…", "main.B", nil},
+
+			// Issue 2316: field promotion is breadth first and embedded interfaces never get promoted
+			{"w2.W1.T.F", true, `"T-inside-W1"`, `"T-inside-W1"`, "string", nil},
+			{"w2.W1.F", true, `"T-inside-W1"`, `"T-inside-W1"`, "string", nil},
+			{"w2.T.F", true, `"T-inside-W2"`, `"T-inside-W2"`, "string", nil},
+			{"w2.F", true, `"T-inside-W2"`, `"T-inside-W2"`, "string", nil},
+			{"w3.I.T.F", false, `"T-inside-W1"`, `"T-inside-W1"`, "string", nil},
+			{"w3.I.F", false, `"T-inside-W1"`, `"T-inside-W1"`, "string", nil},
+			{"w3.T.F", true, `"T-inside-W3"`, `"T-inside-W3"`, "string", nil},
+			{"w3.F", true, `"T-inside-W3"`, `"T-inside-W3"`, "string", nil},
+			{"w4.I.T.F", false, `"T-inside-W1"`, `"T-inside-W1"`, "string", nil},
+			{"w4.I.F", false, `"T-inside-W1"`, `"T-inside-W1"`, "string", nil},
+			{"w4.F", false, ``, ``, "", errors.New("w4 has no member F")},
+			{"w5.F", false, ``, ``, "", errors.New("w5 has no member F")},
 		}
 		assertNoError(p.Continue(), t, "Continue()")
 


### PR DESCRIPTION
Both structMember and findMethod implemented a depth-first search in
embedded fields but the Go specification requires a breadth-first
search. They also allowed promotion of fields in the concrete type of
embedded interfaces even though this is not allowed by Go.

Furthermore they both lacked protection from infinite recursion
when a type embeds itself and the user requests a non-existent field.

Fixes #2316
