### PR TITLE
test: increase num of frames examined by TestClientServer_FullStacktrace

### DIFF
--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -728,7 +728,7 @@ func Test1ClientServer_FullStacktrace(t *testing.T) {
 		assertNoError(err, t, "GoroutinesInfo()")
 		found := make([]bool, 10)
 		for _, g := range gs {
-			frames, err := c.Stacktrace(g.ID, 10, true)
+			frames, err := c.Stacktrace(g.ID, 40, true)
 			assertNoError(err, t, fmt.Sprintf("Stacktrace(%d)", g.ID))
 			t.Logf("goroutine %d", g.ID)
 			for i, frame := range frames {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -923,7 +923,7 @@ func TestClientServer_FullStacktrace(t *testing.T) {
 		assertNoError(err, t, "GoroutinesInfo()")
 		found := make([]bool, 10)
 		for _, g := range gs {
-			frames, err := c.Stacktrace(g.ID, 10, 0, &normalLoadConfig)
+			frames, err := c.Stacktrace(g.ID, 40, 0, &normalLoadConfig)
 			assertNoError(err, t, fmt.Sprintf("Stacktrace(%d)", g.ID))
 			t.Logf("goroutine %d", g.ID)
 			for i, frame := range frames {


### PR DESCRIPTION
When the runtime is allocating memory the stack trace needed to reach
user code might be greater than 10 frames.
