### PR TITLE
teamcity,goversion: drop Go version 1.13 from test matrix

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -34,15 +34,13 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2020.2"
 
 val targets = arrayOf(
-	"linux/amd64/1.13",
 	"linux/amd64/1.14",
         "linux/amd64/1.15",
         "linux/amd64/1.16",
         "linux/amd64/tip",
 
-        "linux/386/1.15",
+        "linux/386/1.16",
 
-        "windows/amd64/1.15",
         "windows/amd64/1.16",
         "windows/amd64/tip"
 )

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	MinSupportedVersionOfGoMajor = 1
-	MinSupportedVersionOfGoMinor = 13
+	MinSupportedVersionOfGoMinor = 14
 	MaxSupportedVersionOfGoMajor = 1
 	MaxSupportedVersionOfGoMinor = 16
 	goTooOldErr                  = fmt.Errorf("Version of Go is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)


### PR DESCRIPTION
Go 1.16 has been released.
