### PR TITLE
service/dap: include optional breakpoint info in setBreakpoints responses

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -599,7 +599,9 @@ func (s *Server) onSetBreakpointsRequest(request *dap.SetBreakpointsRequest) {
 			response.Body.Breakpoints[i].Line = want.Line
 			response.Body.Breakpoints[i].Message = err.Error()
 		} else {
+			response.Body.Breakpoints[i].Id = got.ID
 			response.Body.Breakpoints[i].Line = got.Line
+			response.Body.Breakpoints[i].Source = dap.Source{Name: request.Arguments.Source.Name, Path: request.Arguments.Source.Path}
 		}
 	}
 	s.send(response)


### PR DESCRIPTION
Updates https://github.com/golang/vscode-go/issues/1212

Following the same response pattern as the original vscode-go adapter seems to no longer result in the same vscode UI behavior - see BREAKPOINTS and margin marker. Adding optional information fixes that.

Before
![image](https://user-images.githubusercontent.com/51177946/108320272-6be2ba80-7177-11eb-9221-11e5b23f28f9.png)
After
![image](https://user-images.githubusercontent.com/51177946/108320486-b6643700-7177-11eb-9a9d-e0c42c144adc.png)
