### PR TITLE
Run linux/386 builds only on amd64 agents

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -204,7 +204,7 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
 
     requirements {
         when (arch) {
-            "amd64" -> equals("teamcity.agent.jvm.os.arch", if (os == "mac") "x86_64" else "amd64")
+            "386", "amd64" -> equals("teamcity.agent.jvm.os.arch", if (os == "mac") "x86_64" else "amd64")
             "arm64" -> equals("teamcity.agent.jvm.os.arch", "aarch64")
         }
         when (os) {


### PR DESCRIPTION
Should finally fix https://delve.beta.teamcity.com/viewLog.html?buildId=2158&tab=buildResultsDiv&buildTypeId=Delve_linux_386_1_16&branch_Delve_linux_386=%3Cdefault%3E