### PR TITLE
TeamCity: set execution timeout so that builds don't hang if agents a…

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -106,6 +106,10 @@ class AggregatorBuild(tests: Collection<BuildType>) : BuildType({
             param("github_oauth_user", "")
         }
     }
+
+    failureConditions {
+        executionTimeoutMin = 60
+    }
 })
 
 class OSProject(os: String, tests: List<TestBuild>) : Project({


### PR DESCRIPTION
…re not available