### PR TITLE
TeamCity: add linux/arm64/tip and disable failing arm64 tests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -43,6 +43,7 @@ val targets = arrayOf(
         "linux/386/1.16",
 
         "linux/arm64/1.16",
+        "linux/arm64/tip",
 
         "windows/amd64/1.16",
         "windows/amd64/tip",

--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -1,10 +1,11 @@
 Tests skipped by each supported backend:
 
-* 386 skipped = 2% (3/147)
+* 386 skipped = 2.7% (4/147)
 	* 1 broken
-	* 2 broken - cgo stacktraces
-* arm64 skipped = 2% (3/147)
+	* 3 broken - cgo stacktraces
+* arm64 skipped = 2.7% (4/147)
 	* 2 broken
+	* 1 broken - cgo stacktraces
 	* 1 broken - global variable symbolication
 * darwin/lldb skipped = 0.68% (1/147)
 	* 1 upstream issue

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3289,9 +3289,8 @@ func TestCgoStacktrace(t *testing.T) {
 		}
 	}
 
-	if runtime.GOARCH == "386" {
-		t.Skip("cgo stacktraces not supported on i386 for now")
-	}
+	skipOn(t, "broken - cgo stacktraces", "386")
+	skipOn(t, "broken - cgo stacktraces", "arm64")
 	protest.MustHaveCgo(t)
 
 	// Tests that:

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1550,6 +1550,10 @@ func TestPluginVariables(t *testing.T) {
 func TestCgoEval(t *testing.T) {
 	protest.MustHaveCgo(t)
 
+	if runtime.GOARCH == "arm64" {
+		t.Skip("cgo evaluation broken on arm64")
+	}
+
 	testcases := []varTest{
 		{"s", true, `"a string"`, `"a string"`, "*char", nil},
 		{"longstring", true, `"averylongstring0123456789a0123456789b0123456789c0123456789d01234...+1 more"`, `"averylongstring0123456789a0123456789b0123456789c0123456789d01234...+1 more"`, "*const char", nil},


### PR DESCRIPTION
### tests: disable failing cgo tests on arm64



### TeamCity: add linux/arm64/tip configuration

So that it can be tested when we make the next-version-support-branch.
