### PR TITLE
TeamCity: select latest patch version of go for mac builds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -49,6 +49,7 @@ val targets = arrayOf(
         "windows/amd64/tip",
 
         "mac/amd64/1.16",
+        "mac/amd64/tip"
 )
 
 project {

--- a/_scripts/latestver.py
+++ b/_scripts/latestver.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python
+import json
+import urllib
+import sys
+
+ver = sys.argv[1]
+d = json.loads(urllib.urlopen('https://golang.org/dl/?mode=json&include=all').read())
+for x in d:
+	if x['version'][:len(ver)] == ver:
+		print x['version']
+		exit(0)

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -8,22 +8,30 @@ ARCH=$2
 TMPDIR=$3
 
 if [ "$GOVERSION" = "gotip" ]; then
-    git clone https://go.googlesource.com/go $TMPDIR/go
-    export GOROOT_BOOTSTRAP=$GOROOT
-    cd $TMPDIR/go/src
+    exit 0
+    bootstrapver=$(curl https://golang.org/VERSION?m=text)
+    curl -sSL "https://storage.googleapis.com/golang/$bootstrapver.darwin-$ARCH.tar.gz" | tar -xz
+    git clone https://go.googlesource.com/go $TMPDIR/go-tip
+    export GOROOT_BOOTSTRAP=$TMPDIR/go
+    export GOROOT=$TMPDIR/go-tip
+    cd $TMPDIR/go-tip/src
     ./make.bash
     cd -
 else
+    echo Finding latest patch version for $GOVERSION
+    GOVERSION=$(python _scripts/latestver.py $GOVERSION)
+    echo Go $GOVERSION on $ARCH
     cd $TMPDIR
-    curl -sSL "https://storage.googleapis.com/golang/$GOVERSION.darwin-$ARCH.tar.gz" | tar -vxz
+    curl -sSL "https://storage.googleapis.com/golang/$GOVERSION.darwin-$ARCH.tar.gz" | tar -xz
     cd -
+    export GOROOT="$TMPDIR/go"
 fi
 
 mkdir -p $TMPDIR/gopath
 
-export GOROOT="$TMPDIR/go"
 export GOPATH="$TMPDIR/gopath"
 export GOARCH="$ARCH"
 export PATH="$GOROOT/bin:$PATH"
+go version
 
 make test


### PR DESCRIPTION
Also adds a disabled tip builder for the next-version support branch.
