### PR TITLE
service/dap: refactor mode validation on onLaunchRequest

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2559,6 +2559,10 @@ func TestBadLaunchRequests(t *testing.T) {
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "buildFlags": "123"})
 		expectFailedToLaunch(client.ExpectErrorResponse(t)) // Build error
 
+		client.LaunchRequest("", fixture.Path, stopOnEntry)
+		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t),
+			"Failed to launch: Build error: exit status 1")
+
 		// We failed to launch the program. Make sure shutdown still works.
 		client.DisconnectRequest()
 		dresp := client.ExpectDisconnectResponse(t)


### PR DESCRIPTION
This PR does the following actions on the dap/onLaunchRequest method:

- Refactor and move to the start of the method the launch mode argument validation
- Removes the redundant validation on https://github.com/go-delve/delve/blob/2e80b32c417494ab3fabe929e7051076a7049f7c/service/dap/server.go#L490

PTAL @polinasok