### PR TITLE
terminal/command: Add [linespec] argument to 'continue' command

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -208,7 +208,12 @@ Run until breakpoint or program termination.
 
 	continue [<linespec>]
 
-Optional linespec argument allows you to set a temporary breakpoint.
+Optional linespec argument allows you to continue until a specific location is reached. The program will halt if a breakpoint is hit before reaching the specified location.
+
+For example:
+
+	continue main.main
+	continue encoding/json.Marshal
 
 
 Aliases: c

--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -206,6 +206,11 @@ Defines <alias> as an alias to <command> or removes an alias.
 ## continue
 Run until breakpoint or program termination.
 
+	continue [<linespec>]
+
+Optional linespec argument allows you to set a temporary breakpoint.
+
+
 Aliases: c
 
 ## deferred
@@ -380,7 +385,7 @@ If regex is specified only local variables with a name matching it will be retur
 ## next
 Step over to next source line.
 
-	 next [count]
+	next [count]
 
 Optional [count] argument allows you to skip multiple lines.
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -156,7 +156,12 @@ A list of file redirections can be specified after the new argument list to over
 
 	continue [<linespec>]
 
-Optional linespec argument allows you to set a temporary breakpoint.
+Optional linespec argument allows you to continue until a specific location is reached. The program will halt if a breakpoint is hit before reaching the specified location.
+
+For example:
+
+	continue main.main
+	continue encoding/json.Marshal
 `},
 		{aliases: []string{"step", "s"}, group: runCmds, cmdFn: c.step, allowedPrefixes: revPrefix, helpMsg: "Single step through program."},
 		{aliases: []string{"step-instruction", "si"}, group: runCmds, allowedPrefixes: revPrefix, cmdFn: c.stepInstruction, helpMsg: "Single step a single cpu instruction."},

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1140,3 +1140,10 @@ func TestParseNewArgv(t *testing.T) {
 		}
 	}
 }
+
+func TestContinueUntil(t *testing.T) {
+	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
+		listIsAt(t, term, "continue main.main", 16, -1, -1)
+		listIsAt(t, term, "continue main.sayhi", 12, -1, -1)
+	})
+}


### PR DESCRIPTION
This change allows specifying an optional linespec after the 'continue' command which sets a temporary breakpoint.

Fixed #2373