### PR TITLE
service/dap + dlv_test: skip Windows 'access denied' failures in tests

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -172,10 +172,12 @@ func testOutput(t *testing.T, dlvbin, output string, delveCmds []string) (stdout
 	if err == nil {
 		// Sometimes delve on Windows can't remove the built binary before
 		// exiting and gets an "Access is denied" error when trying.
-		// This used to make this test flaky. See: https://travis-ci.com/go-delve/delve/jobs/296325131)
-		// But we have now added a delay to gobuild.Remove. If this flakes again,
-		// adjust it. Leaving temporary files behind can be annoying to users.
-		t.Errorf("running %q: file %v was not deleted\nstdout is %q, stderr is %q", delveCmds, debugbin, stdout, stderr)
+		// See: https://travis-ci.com/go-delve/delve/jobs/296325131)
+		// We have added a delay to gobuild.Remove, but to avoid any test
+		// flakiness, we guard against this failure here as well.
+		if runtime.GOOS != "windows" || !strings.Contains(err.Error(), "Access is denied") {
+			t.Errorf("running %q: file %v was not deleted\nstdout is %q, stderr is %q", delveCmds, debugbin, stdout, stderr)
+		}
 		return
 	}
 	if !os.IsNotExist(err) {

--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -20,7 +20,8 @@ func Remove(path string) {
 	for i := 0; i < 20; i++ {
 		err = os.Remove(path)
 		// Open files can be removed on Unix, but not on Windows, where there also appears
-		// to be a delay in releasing the binary when the process exits. So we try again.
+		// to be a delay in releasing the binary when the process exits.
+		// Leaving temporary files behind can be annoying to users, so we try again.
 		if err == nil || runtime.GOOS != "windows" {
 			break
 		}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2282,9 +2282,11 @@ func TestLaunchDebugRequest(t *testing.T) {
 		// On Windows, a file in use cannot be removed, resulting in "Access is denied".
 		// When the process exits, Delve releases the binary by calling
 		// BinaryInfo.Close(), but it appears that it is still in use (by Windows?)
-		// shortly after. gobuild.Remove has a delay to address this.
-		// If this test becomes flaky, see if the delay needs adjusting.
-		t.Fatalf("Binary removal failure:\n%s\n", rmErr)
+		// shortly after. gobuild.Remove has a delay to address this, but
+		// to avoid any test flakiness we guard against this failure here as well.
+		if runtime.GOOS != "windows" || !strings.Contains(rmErr, "Access is denied") {
+			t.Fatalf("Binary removal failure:\n%s\n", rmErr)
+		}
 	}
 }
 


### PR DESCRIPTION
I know #2372 added a longer delay. Do we still want to skip the errors like we discussed eariler?