### PR TITLE
proc: be more lenient when parsing debug_info

### DIFF
--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -103,6 +103,7 @@ func (ctxt *loadDebugInfoMapsContext) lookupAbstractOrigin(bi *BinaryInfo, off d
 	if !ok {
 		bi.Functions = append(bi.Functions, Function{})
 		r = len(bi.Functions) - 1
+		bi.Functions[r].offset = off
 		ctxt.abstractOriginTable[off] = r
 	}
 	return r


### PR DESCRIPTION
* allow a concrete subprogram to be treated as the abstract origin for an inlined call
* allow nameless concrete and abstract subprograms

Fixes #2393
