### PR TITLE
terminal: add optional format argument to print, display

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -242,7 +242,7 @@ Aliases: disass
 ## display
 Print value of an expression every time the program stops.
 
-	display -a <expression>
+	display -a [%format] <expression>
 	display -d <number>
 
 The '-a' option adds an expression to the list of expression printed every time the program stops. The '-d' option removes the specified expression from the list.
@@ -409,9 +409,11 @@ Supported commands: print, stack and goroutine)
 ## print
 Evaluate an expression.
 
-	[goroutine <n>] [frame <m>] print <expression>
+	[goroutine <n>] [frame <m>] print [%format] <expression>
 
 See [Documentation/cli/expr.md](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md) for a description of supported expressions.
+
+The optional format argument is a format specifier, like the ones used by the fmt package. For example "print %x v" will print v as an hexadecimal number.
 
 Aliases: p
 

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1151,3 +1151,13 @@ func TestContinueUntil(t *testing.T) {
 		listIsAt(t, term, "continue main.sayhi", 12, -1, -1)
 	})
 }
+
+func TestPrintFormat(t *testing.T) {
+	withTestTerminal("testvariables2", t, func(term *FakeTerminal) {
+		term.MustExec("continue")
+		out := term.MustExec("print %#x m2[1].B")
+		if !strings.Contains(out, "0xb\n") {
+			t.Fatalf("output did not contain '0xb': %q", out)
+		}
+	})
+}

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -1061,7 +1061,7 @@ func Test1Issue406(t *testing.T) {
 		assertNoError(state.Err, t, "Continue()")
 		v, err := c.EvalVariable(api.EvalScope{GoroutineID: -1}, "cfgtree")
 		assertNoError(err, t, "EvalVariable()")
-		vs := v.MultilineString("")
+		vs := v.MultilineString("", "")
 		t.Logf("cfgtree formats to: %s\n", vs)
 	})
 }

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1441,7 +1441,7 @@ func TestIssue406(t *testing.T) {
 		assertNoError(state.Err, t, "Continue()")
 		v, err := c.EvalVariable(api.EvalScope{GoroutineID: -1}, "cfgtree", normalLoadConfig)
 		assertNoError(err, t, "EvalVariable()")
-		vs := v.MultilineString("")
+		vs := v.MultilineString("", "")
 		t.Logf("cfgtree formats to: %s\n", vs)
 	})
 }

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -390,7 +390,7 @@ func TestMultilineVariableEvaluation(t *testing.T) {
 		for _, tc := range testcases {
 			variable, err := evalVariable(p, tc.name, pnormalLoadConfig)
 			assertNoError(err, t, "EvalVariable() returned an error")
-			if ms := api.ConvertVar(variable).MultilineString(""); !matchStringOrPrefix(ms, tc.value) {
+			if ms := api.ConvertVar(variable).MultilineString("", ""); !matchStringOrPrefix(ms, tc.value) {
 				t.Fatalf("Expected %s got %s (variable %s)\n", tc.value, ms, variable.Name)
 			}
 		}
@@ -871,7 +871,6 @@ func TestEvalExpression(t *testing.T) {
 					t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
 				}
 			}
-
 		}
 	})
 }
@@ -910,7 +909,7 @@ func TestMapEvaluation(t *testing.T) {
 		m1v, err := evalVariable(p, "m1", pnormalLoadConfig)
 		assertNoError(err, t, "EvalVariable()")
 		m1 := api.ConvertVar(m1v)
-		t.Logf("m1 = %v", m1.MultilineString(""))
+		t.Logf("m1 = %v", m1.MultilineString("", ""))
 
 		if m1.Type != "map[string]main.astruct" {
 			t.Fatalf("Wrong type: %s", m1.Type)


### PR DESCRIPTION
Changes print so a format argument can be specified by using '%' as
prefix. For example:

print %x d

will print variable 'd' in hexadecimal. The interpretarion of the
format argument is the same as that of fmt's package.

Fixes #1038
Fixes #1800
Fixes #2159
