### PR TITLE
service/dap: switch goroutines when stepping

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -881,16 +881,6 @@ func (s *Server) doStepCommand(command string, threadId int) {
 		sendErrorStoppedEvent(state.SelectedGoroutine.ID)
 		return
 	}
-	if state.NextInProgress {
-		s.log.Debug("NextInProgress when stepping")
-		err := s.debugger.CancelNext()
-		if err != nil {
-			s.log.Errorf("Error cancelling next: %e", err)
-			sendErrorStoppedEvent(state.SelectedGoroutine.ID)
-			return
-		}
-		s.log.Debug("Cancelled next")
-	}
 	// Use SwitchGoroutine to change the current goroutine.
 	if state.SelectedGoroutine == nil || state.SelectedGoroutine.ID != threadId {
 		state, err := s.debugger.Command(&api.DebuggerCommand{Name: api.SwitchGoroutine, GoroutineID: threadId}, nil)

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -875,8 +875,11 @@ func (s *Server) doStepCommand(command string, threadId int) {
 		stopped.Body.AllThreadsStopped = true
 		if state.SelectedGoroutine != nil {
 			stopped.Body.ThreadId = state.SelectedGoroutine.ID
+		} else if state.CurrentThread != nil {
+			stopped.Body.ThreadId = state.CurrentThread.GoroutineID
 		}
 		stopped.Body.Reason = "error"
+		stopped.Body.Text = err.Error()
 		s.send(stopped)
 		return
 	}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -806,7 +806,7 @@ func (s *Server) doStepCommand(command string, threadId int) {
 	}
 	// Use SwitchGoroutine to change the current goroutine.
 	if state.SelectedGoroutine == nil || state.SelectedGoroutine.ID != threadId {
-		state, err := s.debugger.Command(&api.DebuggerCommand{Name: api.SwitchGoroutine, ThreadID: threadId}, nil)
+		state, err := s.debugger.Command(&api.DebuggerCommand{Name: api.SwitchGoroutine, GoroutineID: threadId}, nil)
 		if err != nil {
 			s.log.Errorf("Error switching goroutines while stepping: %e", err)
 			sendErrorStoppedEvent(state.SelectedGoroutine.ID)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2023,6 +2023,142 @@ func TestNextAndStep(t *testing.T) {
 	})
 }
 
+func TestNextParked(t *testing.T) {
+	if runtime.GOOS == "freebsd" {
+		t.SkipNow()
+	}
+	runTest(t, "parallel_next", func(client *daptest.Client, fixture protest.Fixture) {
+		runDebugSessionWithBPs(t, client, "launch",
+			// Launch
+			func() {
+				client.LaunchRequest("exec", fixture.Path, !stopOnEntry)
+			},
+			// Set breakpoints
+			fixture.Source, []int{15},
+			[]onBreakpoint{{ // Stop at line 15
+				execute: func() {
+					goroutineId := testStepParkedHelper(t, client, fixture)
+
+					client.NextRequest(goroutineId)
+					client.ExpectNextResponse(t)
+
+					se := client.ExpectStoppedEvent(t)
+					if se.Body.ThreadId != goroutineId {
+						t.Fatalf("Next did not continue on the selected goroutine, expected %d got %d", goroutineId, se.Body.ThreadId)
+					}
+				},
+				disconnect: false,
+			}})
+	})
+}
+
+func TestStepInParked(t *testing.T) {
+	if runtime.GOOS == "freebsd" {
+		t.SkipNow()
+	}
+	runTest(t, "parallel_next", func(client *daptest.Client, fixture protest.Fixture) {
+		runDebugSessionWithBPs(t, client, "launch",
+			// Launch
+			func() {
+				client.LaunchRequest("exec", fixture.Path, !stopOnEntry)
+			},
+			// Set breakpoints
+			fixture.Source, []int{15},
+			[]onBreakpoint{{ // Stop at line 15
+				execute: func() {
+					goroutineId := testStepParkedHelper(t, client, fixture)
+
+					client.StepInRequest(goroutineId)
+					client.ExpectStepInResponse(t)
+
+					se := client.ExpectStoppedEvent(t)
+					if se.Body.ThreadId != goroutineId {
+						t.Fatalf("StepIn did not continue on the selected goroutine, expected %d got %d", goroutineId, se.Body.ThreadId)
+					}
+				},
+				disconnect: false,
+			}})
+	})
+}
+
+func TestStepOutParked(t *testing.T) {
+	if runtime.GOOS == "freebsd" {
+		t.SkipNow()
+	}
+	runTest(t, "parallel_next", func(client *daptest.Client, fixture protest.Fixture) {
+		runDebugSessionWithBPs(t, client, "launch",
+			// Launch
+			func() {
+				client.LaunchRequest("exec", fixture.Path, !stopOnEntry)
+			},
+			// Set breakpoints
+			fixture.Source, []int{15},
+			[]onBreakpoint{{ // Stop at line 15
+				execute: func() {
+					goroutineId := testStepParkedHelper(t, client, fixture)
+
+					client.StepOutRequest(goroutineId)
+					client.ExpectStepOutResponse(t)
+
+					se := client.ExpectStoppedEvent(t)
+					if se.Body.ThreadId != goroutineId {
+						t.Fatalf("StepOut did not continue on the selected goroutine, expected %d got %d", goroutineId, se.Body.ThreadId)
+					}
+				},
+				disconnect: false,
+			}})
+	})
+}
+
+func testStepParkedHelper(t *testing.T, client *daptest.Client, fixture protest.Fixture) int {
+	t.Helper()
+	// Set a breakpoint at main.sayHi
+	client.SetBreakpointsRequest(fixture.Source, []int{8})
+	client.ExpectSetBreakpointsResponse(t)
+
+	var goroutineId = -1
+	for goroutineId < 0 {
+		client.ContinueRequest(1)
+		client.ExpectContinueResponse(t)
+
+		se := client.ExpectStoppedEvent(t)
+
+		client.ThreadsRequest()
+		threads := client.ExpectThreadsResponse(t)
+
+		// Search for a parked goroutine that we know for sure will have to be
+		// resumed before the program can exit. This is a parked goroutine that:
+		// 1. is executing main.sayhi
+		// 2. hasn't called wg.Done yet
+		// 3. is not the currently selected goroutine
+		for _, g := range threads.Body.Threads {
+			// We do not need to check the thread that the program
+			// is currently stopped on.
+			if g.Id == se.Body.ThreadId {
+				continue
+			}
+			client.StackTraceRequest(g.Id, 0, 5)
+			frames := client.ExpectStackTraceResponse(t)
+			for _, frame := range frames.Body.StackFrames {
+				// line 11 is the line where wg.Done is called
+				if frame.Name == "main.sayhi" && frame.Line < 11 {
+					goroutineId = g.Id
+					break
+				}
+			}
+			if goroutineId >= 0 {
+				break
+			}
+		}
+	}
+
+	// Clear all breakpoints.
+	client.SetBreakpointsRequest(fixture.Source, []int{})
+	client.ExpectSetBreakpointsResponse(t)
+
+	return goroutineId
+}
+
 func TestBadAccess(t *testing.T) {
 	if runtime.GOOS != "darwin" || testBackend != "lldb" {
 		t.Skip("not applicable")


### PR DESCRIPTION
The step in, next, and step out requests all include a specified argument of a threadId.
This change will switch to the specified goroutine, if necessary, before executing
the step command.