### PR TITLE
dap: change how noDebug launch request is served

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2549,6 +2549,14 @@ func TestLaunchRequestDefaults(t *testing.T) {
 			// writes to default output dir __debug_bin
 		}, fixture.Source)
 	})
+
+	// if noDebug is not a bool, behave as if it is the default value (false).
+	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
+		runDebugSession(t, client, "launch", func() {
+			client.LaunchRequestWithArgs(map[string]interface{}{
+				"mode": "debug", "program": fixture.Source, "noDebug": "true"})
+		}, fixture.Source)
+	})
 }
 
 func TestLaunchRequestNoDebug(t *testing.T) {


### PR DESCRIPTION
PR #2400 added support for noDebug launch requests - that was done
by directly starting the target program using os/exec.Cmd and blocking
the launch request indefinitely until the program terminates or
is stopped with a disconnect request (when dlv dap can support it).
This PR updates the logic slightly - instead of skipping the launch response,
we now return the launch response. But still we don't send 'initialized' event
hoping that the client not to send any debug-related requests.

Still the handler goroutine will block in the onLaunchRequest handler until
the debugged program terminates.

Updates #2318
