### PR TITLE
service/dap: annotate shadowed variable names in variables request

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -981,8 +981,6 @@ func (s *Server) onScopesRequest(request *dap.ScopesRequest) {
 	}
 	locScope := &fullyQualifiedVariable{&proc.Variable{Name: "Locals", Children: slicePtrVarToSliceVar(locals)}, "", true}
 
-	// TODO(polina): Annotate shadowed variables
-
 	scopeArgs := dap.Scope{Name: argScope.Name, VariablesReference: s.variableHandles.create(argScope)}
 	scopeLocals := dap.Scope{Name: locScope.Name, VariablesReference: s.variableHandles.create(locScope)}
 	scopes := []dap.Scope{scopeArgs, scopeLocals}
@@ -1135,8 +1133,17 @@ func (s *Server) onVariablesRequest(request *dap.VariablesRequest) {
 				cfqname = "" // complex children are not struct fields and can't be accessed directly
 			}
 			cvalue, cvarref := s.convertVariable(c, cfqname)
+
+			// Annotate any shadowed variables to "(name)" in order
+			// to distinguish from non-shadowed variables.
+			name := c.Name
+			if c.Flags&proc.VariableShadowed == proc.VariableShadowed {
+				// If the variable is shadowed, update the name with parens
+				name = fmt.Sprintf("(%s)", name)
+			}
+
 			children[i] = dap.Variable{
-				Name:               c.Name,
+				Name:               name,
 				EvaluateName:       cfqname,
 				Value:              cvalue,
 				VariablesReference: cvarref,

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1138,7 +1138,6 @@ func (s *Server) onVariablesRequest(request *dap.VariablesRequest) {
 			// to distinguish from non-shadowed variables.
 			name := c.Name
 			if c.Flags&proc.VariableShadowed == proc.VariableShadowed {
-				// If the variable is shadowed, update the name with parens
 				name = fmt.Sprintf("(%s)", name)
 			}
 


### PR DESCRIPTION
In order to distinguish variables that are shadowed, this change
updates the names from 'name' to '(name)'. This is the same syntax
used in the terminal package.