### PR TITLE
dap: handle SetVariable requests

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -331,8 +331,8 @@ func main() {
 
 	var nilstruct *astruct = nil
 
+	val := A{val: 1} // val vs val.val
 	var as2 astruct
-
 	s4 := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
 
 	var iface2map interface{} = map[string]interface{}{
@@ -363,5 +363,5 @@ func main() {
 	longslice := make([]int, 100, 100)
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, runeslice, bytearray, runearray, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice)
+	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, runeslice, bytearray, runearray, longstr, nilstruct, as2, as2.NonPointerRecieverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val)
 }

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -100,6 +100,7 @@ func (c *Client) ExpectInitializeResponseAndCapabilities(t *testing.T) *dap.Init
 		SupportsConditionalBreakpoints:   true,
 		SupportsDelayedStackTraceLoading: true,
 		SupportTerminateDebuggee:         true,
+		SupportsSetVariable:              true,
 	}
 	if !reflect.DeepEqual(initResp.Body, wantCapabilities) {
 		t.Errorf("capabilities in initializeResponse: got %+v, want %v", pretty(initResp.Body), pretty(wantCapabilities))

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -345,8 +345,12 @@ func (c *Client) ReverseContinueRequest() {
 }
 
 // SetVariableRequest sends a 'setVariable' request.
-func (c *Client) SetVariableRequest() {
-	c.send(&dap.ReverseContinueRequest{Request: *c.newRequest("setVariable")})
+func (c *Client) SetVariableRequest(variablesRef int, name, value string) {
+	request := &dap.SetVariableRequest{Request: *c.newRequest("setVariable")}
+	request.Arguments.VariablesReference = variablesRef
+	request.Arguments.Name = name
+	request.Arguments.Value = value
+	c.send(request)
 }
 
 // RestartFrameRequest sends a 'restartFrame' request.

--- a/service/dap/error_ids.go
+++ b/service/dap/error_ids.go
@@ -21,6 +21,7 @@ const (
 	UnableToListGlobals        = 2007
 	UnableToLookupVariable     = 2008
 	UnableToEvaluateExpression = 2009
+	UnableToSetVariable        = 2010
 
 	DebuggeeIsRunning = 4000
 	DisconnectError   = 5000

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1955,13 +1955,13 @@ func (s *Server) onReverseContinueRequest(request *dap.ReverseContinueRequest) {
 }
 
 // computeEvaluateName finds the named child, and computes its evaluate name.
-func (s *Server) computeEvaluateName(v *fullyQualifiedVariable, name string) (string, error) {
+func (s *Server) computeEvaluateName(v *fullyQualifiedVariable, cname string) (string, error) {
 	children, err := s.childrenToDAPVariables(v)
 	if err != nil {
 		return "", err
 	}
 	for _, c := range children {
-		if c.Name == name {
+		if c.Name == cname {
 			if c.EvaluateName != "" {
 				return c.EvaluateName, nil
 			}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3313,8 +3313,7 @@ func TestSetVariableWithCall(t *testing.T) {
 					"mode": "exec", "program": fixture.Path, "showGlobalVariables": true,
 				})
 			},
-			// Stop at the breakpoints set within the program, and after returning from barfoo (67)
-			fixture.Source, []int{67},
+			fixture.Source, []int{66, 67},
 			[]onBreakpoint{{
 				execute: func() {
 					tester := &helperForSetVariable{t, client}


### PR DESCRIPTION
The handler invokes debugger.SetVariableInScope, except for
string type variables. For which, we rely on the `call` command.
Moved the call expression handling logic to the new `doCall`
function, so it can be reused by the SetVariable request handler.

Earlier attempt of this PR tried to trigger a Stopped Event whenever
a variable is changed in order to force the editors to refetch data and
refresh UI. But that seems too expensive and some may think annoying
so we decided to not do that. Editors like VSCode tries to make a local
update for the variable after a successful set variable request. However,
if there are aliases, some info may look inconsistent.

```
  i1 := 1
  p1 :=&i1
  pp1 := &p1
``` 
For example, after updating *p1 for the code, users would see

![Screen Shot 2021-05-07 at 1 47 52 PM](https://user-images.githubusercontent.com/4999471/117495916-40849600-af44-11eb-85b4-895973cab4d2.png)

This inconsistency will be corrected as soon as users continue debugging
and the scope variable is reloaded behind the scene. If this becomes a problem
we need to find a more clever way.

Future improvement planned:
  - This PR returns the requested arg as the response. If the value string
  is a function call, another variable, etc, the value isn't necessarily correct.
  We need to reevaluate and return the value.
  - Maybe accepting arbitrary expression as the arg can be dangerous and
  we can consider to limit acceptable values. Also, currently call is used only
  for string type. If we decide to allow a function call expression for string,
  we can consider to open it to other types too. 

Also fixed a small bug in the call expression evaluation -
Previously, dlv dap returned an error "Unable to evaluate
expression: call stopped" if the call expression is for
variable assignment.  (e.g. call animal = "rabbit").

We met a bug in the injected call path used for assignment. Given the arrival
of the new version of injected call support, I don't know how much of effort
we want to make to chase the bug though.

Fixes golang/vscode-go#1173