### PR TITLE
proc: add way to use CPU registers in expressions

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -431,7 +431,7 @@ Print contents of CPU registers.
 
 	regs [-a]
 
-Argument -a shows more registers.
+Argument -a shows more registers. Individual registers can also be displayed by 'print' and 'display'. See [Documentation/cli/expr.md.](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md.)
 
 
 ## restart

--- a/Documentation/cli/expr.md
+++ b/Documentation/cli/expr.md
@@ -110,3 +110,22 @@ Packages with the same name can be disambiguated by using the full package path.
 # Pointers in Cgo
 
 Char pointers are always treated as NUL terminated strings, both indexing and the slice operator can be applied to them. Other C pointers can also be used similarly to Go slices, with indexing and the slice operator. In both of these cases it is up to the user to respect array bounds.
+
+
+# CPU Registers
+
+The name of a CPU register, in all uppercase letters, will resolve to the value of that CPU register in the current frame. For example on AMD64 the expression `RAX` will evaluate to the value of the RAX register. 
+
+Register names are shadowed by both local and global variables, so if a local variable called "RAX" exists, the `RAX` expression will evaluate to it instead of the CPU register.
+
+Register names can optionally be prefixed by any number of underscore characters, so `RAX`, `_RAX`, `__RAX`, etc... can all be used to refer to the same RAX register and, in absence of shadowing from other variables, will all evaluate to the same value.
+
+Registers of 64bits or less are returned as uint64 variables. Larger registers are returned as strings of hexadecimal digits.
+
+Because many architectures have SIMD registers that can be used by the application in different ways the following syntax is also available:
+
+* `REGNAME.intN` returns the register REGNAME as an array of intN elements.
+* `REGNAME.uintN` returns the register REGNAME as an array of uintN elements.
+* `REGNAME.floatN` returns the register REGNAME as an array fo floatN elements.
+
+In all cases N must be a power of 2.

--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -39,6 +39,7 @@ func AMD64Arch(goos string) *Arch {
 		BPRegNum:                         regnum.AMD64_Rbp,
 		ContextRegNum:                    regnum.AMD64_Rdx,
 		asmRegisters:                     amd64AsmRegisters,
+		RegisterNameToDwarf:              nameToDwarfFunc(regnum.AMD64NameToDwarf),
 	}
 }
 

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -2,6 +2,7 @@ package proc
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-delve/delve/pkg/dwarf/frame"
 	"github.com/go-delve/delve/pkg/dwarf/op"
@@ -45,7 +46,8 @@ type Arch struct {
 	// register name will be returned.
 	DwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
 	// inhibitStepInto returns whether StepBreakpoint can be set at pc.
-	inhibitStepInto func(bi *BinaryInfo, pc uint64) bool
+	inhibitStepInto     func(bi *BinaryInfo, pc uint64) bool
+	RegisterNameToDwarf func(s string) (int, bool)
 
 	// asmRegisters maps assembly register numbers to dwarf registers.
 	asmRegisters map[int]asmRegister
@@ -129,6 +131,13 @@ func (arch *Arch) getAsmRegister(regs *op.DwarfRegisters, asmreg int) (uint64, e
 		n = n & hwreg.mask
 	}
 	return n, nil
+}
+
+func nameToDwarfFunc(n2d map[string]int) func(string) (int, bool) {
+	return func(name string) (int, bool) {
+		r, ok := n2d[strings.ToLower(name)]
+		return r, ok
+	}
 }
 
 // crosscall2 is defined in $GOROOT/src/runtime/cgo/asm_amd64.s.

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -36,6 +36,7 @@ func ARM64Arch(goos string) *Arch {
 		PCRegNum:                         regnum.ARM64_PC,
 		SPRegNum:                         regnum.ARM64_SP,
 		asmRegisters:                     arm64AsmRegisters,
+		RegisterNameToDwarf:              nameToDwarfFunc(regnum.ARM64NameToDwarf),
 	}
 }
 

--- a/pkg/proc/i386_arch.go
+++ b/pkg/proc/i386_arch.go
@@ -35,6 +35,7 @@ func I386Arch(goos string) *Arch {
 		PCRegNum:                         regnum.I386_Eip,
 		SPRegNum:                         regnum.I386_Esp,
 		asmRegisters:                     i386AsmRegisters,
+		RegisterNameToDwarf:              nameToDwarfFunc(regnum.I386NameToDwarf),
 	}
 }
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -278,7 +278,7 @@ If regex is specified only package variables with a name matching it will be ret
 
 	regs [-a]
 
-Argument -a shows more registers.`},
+Argument -a shows more registers. Individual registers can also be displayed by 'print' and 'display'. See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/expr.md.`},
 		{aliases: []string{"exit", "quit", "q"}, cmdFn: exitCommand, helpMsg: `Exit the debugger.
 		
 	exit [-c]
@@ -1830,6 +1830,10 @@ func whatisCommand(t *Term, ctx callContext, args string) error {
 	val, err := t.client.EvalVariable(ctx.Scope, args, ShortLoadConfig)
 	if err != nil {
 		return err
+	}
+	if val.Flags&api.VariableCPURegister != 0 {
+		fmt.Println("CPU Register")
+		return nil
 	}
 	if val.Type != "" {
 		fmt.Println(val.Type)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -239,6 +239,12 @@ const (
 	// the variable is the return value of a function call and allocated on a
 	// frame that no longer exists)
 	VariableFakeAddress
+
+	// VariableCPrt means the variable is a C pointer
+	VariableCPtr
+
+	// VariableCPURegister means this variable is a CPU register.
+	VariableCPURegister
 )
 
 // Variable describes a variable.


### PR DESCRIPTION
Changes the expression evaluation code so that register names, when not
shadowed by local or global variables, will evaluate to the current
value of the corresponding CPU register.

This allows a greater flexibility with displaying CPU registers than is
possible with using the ListRegisters API call. Also it allows
debuggers users to view register values even if the frontend they are
using does not implement a register view.
