### PR TITLE
service/dap: add go build stderr to error response

### DIFF
--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -54,32 +54,58 @@ func optflags(args []string) []string {
 // GoBuild builds non-test files in 'pkgs' with the specified 'buildflags'
 // and writes the output at 'debugname'.
 func GoBuild(debugname string, pkgs []string, buildflags string) error {
-	args := []string{"-o", debugname}
-	args = optflags(args)
-	if buildflags != "" {
-		args = append(args, config.SplitQuotedFields(buildflags, '\'')...)
-	}
-	args = append(args, pkgs...)
-	return gocommand("build", args...)
+	args := goBuildArgs(debugname, pkgs, buildflags, false)
+	return gocommandRun("build", args...)
 }
 
-// GoBuild builds test files 'pkgs' with the specified 'buildflags'
+// GoBuildCombinedOutput builds non-test files in 'pkgs' with the specified 'buildflags'
+// and writes the output at 'debugname'.
+func GoBuildCombinedOutput(debugname string, pkgs []string, buildflags string) ([]byte, error) {
+	args := goBuildArgs(debugname, pkgs, buildflags, false)
+	return gocommandCombinedOutput("build", args...)
+}
+
+// GoTestBuild builds test files 'pkgs' with the specified 'buildflags'
 // and writes the output at 'debugname'.
 func GoTestBuild(debugname string, pkgs []string, buildflags string) error {
-	args := []string{"-c", "-o", debugname}
+	args := goBuildArgs(debugname, pkgs, buildflags, true)
+	return gocommandRun("test", args...)
+}
+
+// GoTestBuildCombinedOutput builds test files 'pkgs' with the specified 'buildflags'
+// and writes the output at 'debugname'.
+func GoTestBuildCombinedOutput(debugname string, pkgs []string, buildflags string) ([]byte, error) {
+	args := goBuildArgs(debugname, pkgs, buildflags, true)
+	return gocommandCombinedOutput("test", args...)
+}
+
+func goBuildArgs(debugname string, pkgs []string, buildflags string, isTest bool) []string {
+	args := []string{"-o", debugname}
+	if isTest {
+		args = append([]string{"-c"}, args...)
+	}
 	args = optflags(args)
 	if buildflags != "" {
 		args = append(args, config.SplitQuotedFields(buildflags, '\'')...)
 	}
 	args = append(args, pkgs...)
-	return gocommand("test", args...)
+	return args
 }
 
-func gocommand(command string, args ...string) error {
+func gocommandRun(command string, args ...string) error {
+	goBuild := gocommandExecCmd(command, args...)
+	goBuild.Stderr = os.Stdout
+	goBuild.Stdout = os.Stderr
+	return goBuild.Run()
+}
+
+func gocommandCombinedOutput(command string, args ...string) ([]byte, error) {
+	return gocommandExecCmd(command, args...).CombinedOutput()
+}
+
+func gocommandExecCmd(command string, args ...string) *exec.Cmd {
 	allargs := []string{command}
 	allargs = append(allargs, args...)
 	goBuild := exec.Command("go", allargs...)
-	goBuild.Stderr = os.Stderr
-	goBuild.Stdout = os.Stdout
-	return goBuild.Run()
+	return goBuild
 }

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -606,13 +606,13 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 	s.config.Debugger.WorkingDir = filepath.Dir(program)
 
 	// Set the WorkingDir for this program to the one specified in the request arguments.
-	wd, ok := request.Arguments["wd"]
+	wd, ok := request.Arguments["cwd"]
 	if ok {
 		wdParsed, ok := wd.(string)
 		if !ok {
 			s.sendErrorResponse(request.Request,
 				FailedToLaunch, "Failed to launch",
-				fmt.Sprintf("'wd' attribute '%v' in debug configuration is not a string.", wd))
+				fmt.Sprintf("'cwd' attribute '%v' in debug configuration is not a string.", wd))
 			return
 		}
 		s.config.Debugger.WorkingDir = wdParsed

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -554,16 +554,17 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 		}
 
 		s.log.Debugf("building binary at %s", debugbinary)
+		var out []byte
 		switch mode {
 		case "debug":
-			err = gobuild.GoBuild(debugbinary, []string{program}, buildFlags)
+			out, err = gobuild.GoBuildCombinedOutput(debugbinary, []string{program}, buildFlags)
 		case "test":
-			err = gobuild.GoTestBuild(debugbinary, []string{program}, buildFlags)
+			out, err = gobuild.GoTestBuildCombinedOutput(debugbinary, []string{program}, buildFlags)
 		}
 		if err != nil {
 			s.sendErrorResponse(request.Request,
 				FailedToLaunch, "Failed to launch",
-				fmt.Sprintf("Build error: %s", err.Error()))
+				fmt.Sprintf("Build error: %s (%s)", strings.TrimSpace(string(out)), err.Error()))
 			return
 		}
 		program = debugbinary

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3081,18 +3081,18 @@ func TestBadLaunchRequests(t *testing.T) {
 		expectFailedToLaunch(client.ExpectErrorResponse(t)) // No such file or directory
 
 		client.LaunchRequest("debug", fixture.Path+"_does_not_exist", stopOnEntry)
-		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: exit status 1")
+		expectFailedToLaunch(client.ExpectErrorResponse(t))
 
 		client.LaunchRequest("" /*debug by default*/, fixture.Path+"_does_not_exist", stopOnEntry)
-		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: exit status 1")
+		expectFailedToLaunch(client.ExpectErrorResponse(t))
 
 		client.LaunchRequest("exec", fixture.Source, stopOnEntry)
 		expectFailedToLaunch(client.ExpectErrorResponse(t)) // Not an executable
 
-		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "buildFlags": "bad flags"})
-		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: exit status 1")
-		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": true, "buildFlags": "bad flags"})
-		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: exit status 1")
+		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "buildFlags": "-bad -flags"})
+		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: flag provided but not defined: -bad\nusage: go build [-o output] [build flags] [packages]\nRun 'go help build' for details. (exit status 2)")
+		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": true, "buildFlags": "-bad -flags"})
+		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: flag provided but not defined: -bad\nusage: go build [-o output] [build flags] [packages]\nRun 'go help build' for details. (exit status 2)")
 
 		// Bad "wd".
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": false, "cwd": "dir/invalid"})

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3089,9 +3089,9 @@ func TestBadLaunchRequests(t *testing.T) {
 		expectFailedToLaunch(client.ExpectErrorResponse(t)) // Not an executable
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "buildFlags": "-bad -flags"})
-		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: flag provided but not defined: -bad\nusage: go build [-o output] [build flags] [packages]\nRun 'go help build' for details. (exit status 2)")
+		expectFailedToLaunch(client.ExpectErrorResponse(t))
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": true, "buildFlags": "-bad -flags"})
-		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: flag provided but not defined: -bad\nusage: go build [-o output] [build flags] [packages]\nRun 'go help build' for details. (exit status 2)")
+		expectFailedToLaunch(client.ExpectErrorResponse(t))
 
 		// Bad "wd".
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": false, "cwd": "dir/invalid"})

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1848,7 +1848,7 @@ func TestWorkingDir(t *testing.T) {
 					"mode":        "exec",
 					"program":     fixture.Path,
 					"stopOnEntry": false,
-					"wd":          wd,
+					"cwd":         wd,
 				})
 			},
 			// Set breakpoints
@@ -3072,9 +3072,9 @@ func TestBadLaunchRequests(t *testing.T) {
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "substitutePath": []interface{}{map[string]interface{}{"from": "path1", "to": 123}}})
 		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t),
 			"Failed to launch: 'substitutePath' attribute '[map[from:path1 to:123]]' in debug configuration is not a []{'from': string, 'to': string}")
-		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "wd": 123})
+		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "cwd": 123})
 		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t),
-			"Failed to launch: 'wd' attribute '123' in debug configuration is not a string.")
+			"Failed to launch: 'cwd' attribute '123' in debug configuration is not a string.")
 
 		// Skip detailed message checks for potentially different OS-specific errors.
 		client.LaunchRequest("exec", fixture.Path+"_does_not_exist", stopOnEntry)
@@ -3095,9 +3095,9 @@ func TestBadLaunchRequests(t *testing.T) {
 		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t), "Failed to launch: Build error: exit status 1")
 
 		// Bad "wd".
-		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": false, "wd": "dir/invalid"})
+		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": false, "cwd": "dir/invalid"})
 		expectFailedToLaunch(client.ExpectErrorResponse(t)) // invalid directory, the error message is system-dependent.
-		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": true, "wd": "dir/invalid"})
+		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": true, "cwd": "dir/invalid"})
 		expectFailedToLaunch(client.ExpectErrorResponse(t)) // invalid directory, the error message is system-dependent.
 
 		// We failed to launch the program. Make sure shutdown still works.


### PR DESCRIPTION
When there is a build error, the error returned by the go command includes the exit code,
but not much detail. This change adds the information from stderr to the error message
to provide more useful information to the client.

Updates golang/vscode-go#1425