### PR TITLE
dap: auto-load partially loaded nested variables

### DIFF
--- a/service/dap/handles.go
+++ b/service/dap/handles.go
@@ -24,6 +24,12 @@ type fullyQualifiedVariable struct {
 	fullyQualifiedNameOrExpr string
 	// True if this represents variable scope
 	isScope bool
+	// Goroutine
+	goid int
+	// Frame
+	frame int
+	// True if the current variable is partial.
+	isPartial bool
 }
 
 func newHandlesMap() *handlesMap {
@@ -45,6 +51,18 @@ func (hs *handlesMap) create(value interface{}) int {
 func (hs *handlesMap) get(handle int) (interface{}, bool) {
 	v, ok := hs.handleToVal[handle]
 	return v, ok
+}
+
+func (hs *handlesMap) replace(oldHandle, newHandle int) bool {
+	if _, ok := hs.get(oldHandle); !ok {
+		return false
+	}
+	newValue, ok := hs.get(newHandle)
+	if !ok {
+		return false
+	}
+	hs.handleToVal[oldHandle] = newValue
+	return true
 }
 
 type variablesHandlesMap struct {


### PR DESCRIPTION
Keep track of whether a variable is partially loaded in the variable
handle. When a partial variable is requested (since user manually
expands the variable through UI or debug console), try to load with
the expression, and replace the partially loaded previous variable
with the newly updated one.

Unfortunately, the newly loaded variable may be still partial
if the struct has many fields, or the variable is a map, array, or
struct. They will be addressed separately - probably by utilizing
pagination UI.

Keep track of the goid and frame information, so they are
available when the partially loaded variable is auto-loaded.

Before: 
![Screen Shot 2021-04-26 at 11 25 43 AM](https://user-images.githubusercontent.com/4999471/116108753-316b3180-a682-11eb-948f-aae8169b7397.png)

After:
![Screen Shot 2021-04-26 at 11 25 06 AM](https://user-images.githubusercontent.com/4999471/116108773-36c87c00-a682-11eb-87fb-4c973c2cfb3d.png)

