### PR TITLE
Slightly better version check for gdb server on newer macOS (arm64)

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -330,10 +330,11 @@ func (p *gdbProcess) Connect(conn net.Conn, path string, pid int, debugInfoDirs 
 
 				// Workaround for darwin arm64. Apple's debugserver seems to have a problem
 				// with not selecting the correct thread in the 'g' command and the returned
-				// registers are empty / an E74 error is thrown.
+				// registers are empty / an E74 error is thrown. This was reported to LLVM
+				// as https://bugs.llvm.org/show_bug.cgi?id=50169
 				version, err := strconv.ParseInt(v[len("version:"):], 10, 32)
 
-				if err == nil && version >= 1200 && p.bi.Arch.Name == "arm64" {
+				if err == nil && version >= 1200 && version <= 1205 && p.bi.Arch.Name == "arm64" {
 					p.gcmdok = false
 				}
 			}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -331,7 +331,9 @@ func (p *gdbProcess) Connect(conn net.Conn, path string, pid int, debugInfoDirs 
 				// Workaround for darwin arm64. Apple's debugserver seems to have a problem
 				// with not selecting the correct thread in the 'g' command and the returned
 				// registers are empty / an E74 error is thrown.
-				if v[len("version:"):] == "1200" && p.bi.Arch.Name == "arm64" {
+				version, err := strconv.ParseInt(v[len("version:"):], 10, 32)
+
+				if err == nil && version >= 1200 && p.bi.Arch.Name == "arm64" {
 					p.gcmdok = false
 				}
 			}


### PR DESCRIPTION
Instead of purely checking for a specific version of gdbserver (`"1200"`), we assume that all versions greater than 1200 are affected and thus `p.gcmdok` needs to be set to false.

Fixes #2436 