### PR TITLE
proc: correctly truncate the result of binary ops on integers

### DIFF
--- a/pkg/proc/proc_unexported_test.go
+++ b/pkg/proc/proc_unexported_test.go
@@ -73,3 +73,26 @@ func TestAlignAddr(t *testing.T) {
 		c(example.align, example.in+0x10000, example.tgt+0x10000)
 	}
 }
+
+func TestConvertInt(t *testing.T) {
+	var testCases = []struct {
+		in     uint64
+		signed bool
+		size   int64
+		tgt    uint64
+	}{
+		{1, false, 1, 1},
+		{uint64(0xf0), true, 1, 0xfffffffffffffff0},
+		{uint64(0xf0), false, 1, 0xf0},
+		{uint64(0x70), true, 1, 0x70},
+		{uint64(0x90f0), true, 2, 0xffffffffffff90f0},
+		{uint64(0x90f0), false, 2, 0x90f0},
+	}
+	for _, tc := range testCases {
+		out := convertInt(tc.in, tc.signed, tc.size)
+		t.Logf("in=%#016x signed=%v size=%d -> %#016x\n", tc.in, tc.signed, tc.size, out)
+		if out != tc.tgt {
+			t.Errorf("expected=%#016x got=%#016x\n", tc.tgt, out)
+		}
+	}
+}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -836,6 +836,10 @@ func TestEvalExpression(t *testing.T) {
 		{`iface2map.(data)`, false, "…", "…", "map[string]interface {}", nil},
 
 		{"issue1578", false, "main.Block {cache: *main.Cache nil}", "main.Block {cache: *main.Cache nil}", "main.Block", nil},
+		{"ni8 << 2", false, "-20", "-20", "int8", nil},
+		{"ni8 << 8", false, "0", "0", "int8", nil},
+		{"ni8 >> 1", false, "-3", "-3", "int8", nil},
+		{"bytearray[0] * bytearray[0]", false, "144", "144", "uint8", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())


### PR DESCRIPTION
Truncates the result of binary operations on integers to the size of
the resulting type.

Also rewrites convertInt to not require allocations.

Fixes #2454
