### PR TITLE
Documentation: correct the flag name used to configure log destination

### DIFF
--- a/Documentation/api/ClientHowto.md
+++ b/Documentation/api/ClientHowto.md
@@ -33,7 +33,7 @@ This will, however, cause problems if you actually spawn multiple instances of t
 
 It's probably better to let Delve pick a random unused port number on its own. To do this do not specify any `--listen` option and read one line of output from dlv's stdout. If the first line emitted by dlv starts with "API server listening at: " then dlv started correctly and the rest of the line specifies the address that Delve is listening at.
 
-The `--log-to-file` and `--log-to-fd` options can be used to redirect the "API server listening at:" message to a file or to a file descriptor. If neither is specified the message will be output to stdout.
+The `--log-dest` option can be used to redirect the "API server listening at:" message to a file or to a file descriptor. If the flag is not specified, the message will be output to stdout while other log messages are output to stderr.
 
 ## Controlling the backend
 


### PR DESCRIPTION
The documentation mentions flags that do not exist. Replace them with
the existing, --log-dest flag.