### PR TITLE
pkg/proc: Enable CGO Stacktrace tests on arm64

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -19,6 +19,8 @@ Tests skipped by each supported backend:
 	* 3 not implemented
 * linux/386/pie skipped = 0.67% (1/150)
 	* 1 broken
+* linux/arm64 skipped = 0.67% (1/150)
+	* 1 broken - cgo stacktraces
 * pie skipped = 0.67% (1/150)
 	* 1 upstream issue - https://github.com/golang/go/issues/29322
 * rr skipped = 1.3% (2/150)

--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -4,9 +4,8 @@ Tests skipped by each supported backend:
 	* 1 broken
 	* 3 broken - cgo stacktraces
 	* 2 not implemented
-* arm64 skipped = 3.3% (5/150)
+* arm64 skipped = 2.7% (4/150)
 	* 1 broken
-	* 1 broken - cgo stacktraces
 	* 1 broken - global variable symbolication
 	* 2 not implemented
 * darwin skipped = 1.3% (2/150)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3251,6 +3251,7 @@ func TestCgoStacktrace(t *testing.T) {
 	}
 
 	skipOn(t, "broken - cgo stacktraces", "386")
+	skipOn(t, "broken - cgo stacktraces", "linux", "arm64")
 	protest.MustHaveCgo(t)
 
 	// Tests that:

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3251,7 +3251,6 @@ func TestCgoStacktrace(t *testing.T) {
 	}
 
 	skipOn(t, "broken - cgo stacktraces", "386")
-	skipOn(t, "broken - cgo stacktraces", "arm64")
 	protest.MustHaveCgo(t)
 
 	// Tests that:


### PR DESCRIPTION
These seem to magically work again on my M1 Mac so, enabling them again.