### PR TITLE
service/dap: support setting breakpoints while running

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -431,7 +431,7 @@ func (s *Server) handleRequest(request dap.Message) {
 			if inProgress == api.Continue {
 				s.overrideStopReason <- skipStop
 			} else {
-				// This would one of the step commands, which get  cancelled by debugger.
+				// This would be one of the step commands, which get cancelled by debugger.
 				// We do not support any other running commands at this time, but if a new one
 				// gets added and this code doesn't get updated, the safest default behavior
 				// would be to declare the operation cancelled and let the user resume manually,

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -427,9 +427,14 @@ func (s *Server) handleRequest(request dap.Message) {
 		case *dap.SetBreakpointsRequest:
 			// Halt running command
 			inProgress := s.debugger.RunningCommand()
+			// TODO(polina): once api.Call is run asynchronously, treat it like api.Continue as well
 			if inProgress == api.Continue {
 				s.overrideStopReason <- skipStop
 			} else {
+				// This would one of the step commands, which get  cancelled by debugger.
+				// We do not support any other running commands at this time, but if a new one
+				// gets added and this code doesn't get updated, the safest default behavior
+				// would be to declare the operation cancelled and let the user resume manually,
 				s.overrideStopReason <- fmt.Sprintf("cancelled %s", inProgress)
 			}
 			s.log.Debug("halting execution to set breakpoints")

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1920,7 +1920,7 @@ func TestSetBreakpointWhileRunning(t *testing.T) {
 					client.SetBreakpointsRequest(fixture.Source, []int{9})
 					expectSetBreakpointsResponse(t, client, []Breakpoint{{9, fixture.Source, true, ""}})
 
-					// 9: Continue stops at line 9 (verifies that setting breakpoint during continue worked)
+					// 9: Continue loops and stops at line 9 (verifies that setting breakpoint during continue worked)
 					se = client.ExpectStoppedEvent(t)
 					if se.Body.Reason != "breakpoint" || !se.Body.AllThreadsStopped || se.Body.ThreadId != 1 {
 						t.Errorf("\ngot  %#v\nwant Reason='breakpoint' AllThreadsStopped=true ThreadId=1", se)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -63,9 +63,8 @@ type Debugger struct {
 
 	log *logrus.Entry
 
-	running        bool
-	runningCommand string
-	runningMutex   sync.Mutex
+	running      bool
+	runningMutex sync.Mutex
 
 	stopRecording func() error
 	recordMutex   sync.Mutex
@@ -968,10 +967,9 @@ func (d *Debugger) FindThread(id int) (proc.Thread, error) {
 	return nil, nil
 }
 
-func (d *Debugger) setRunning(running bool, command string) {
+func (d *Debugger) setRunning(running bool) {
 	d.runningMutex.Lock()
 	d.running = running
-	d.runningCommand = command
 	d.runningMutex.Unlock()
 }
 
@@ -979,12 +977,6 @@ func (d *Debugger) IsRunning() bool {
 	d.runningMutex.Lock()
 	defer d.runningMutex.Unlock()
 	return d.running
-}
-
-func (d *Debugger) RunningCommand() string {
-	d.runningMutex.Lock()
-	defer d.runningMutex.Unlock()
-	return d.runningCommand
 }
 
 // Command handles commands which control the debugger lifecycle
@@ -1008,8 +1000,8 @@ func (d *Debugger) Command(command *api.DebuggerCommand, resumeNotify chan struc
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 
-	d.setRunning(true, command.Name)
-	defer d.setRunning(false, "")
+	d.setRunning(true)
+	defer d.setRunning(false)
 
 	if command.Name != api.SwitchGoroutine && command.Name != api.SwitchThread && command.Name != api.Halt {
 		d.target.ResumeNotify(resumeNotify)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -63,8 +63,9 @@ type Debugger struct {
 
 	log *logrus.Entry
 
-	running      bool
-	runningMutex sync.Mutex
+	running        bool
+	runningCommand string
+	runningMutex   sync.Mutex
 
 	stopRecording func() error
 	recordMutex   sync.Mutex
@@ -967,9 +968,10 @@ func (d *Debugger) FindThread(id int) (proc.Thread, error) {
 	return nil, nil
 }
 
-func (d *Debugger) setRunning(running bool) {
+func (d *Debugger) setRunning(running bool, command string) {
 	d.runningMutex.Lock()
 	d.running = running
+	d.runningCommand = command
 	d.runningMutex.Unlock()
 }
 
@@ -977,6 +979,12 @@ func (d *Debugger) IsRunning() bool {
 	d.runningMutex.Lock()
 	defer d.runningMutex.Unlock()
 	return d.running
+}
+
+func (d *Debugger) RunningCommand() string {
+	d.runningMutex.Lock()
+	defer d.runningMutex.Unlock()
+	return d.runningCommand
 }
 
 // Command handles commands which control the debugger lifecycle
@@ -1000,8 +1008,8 @@ func (d *Debugger) Command(command *api.DebuggerCommand, resumeNotify chan struc
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 
-	d.setRunning(true)
-	defer d.setRunning(false)
+	d.setRunning(true, command.Name)
+	defer d.setRunning(false, "")
 
 	if command.Name != api.SwitchGoroutine && command.Name != api.SwitchThread && command.Name != api.Halt {
 		d.target.ResumeNotify(resumeNotify)


### PR DESCRIPTION
Unlike vscode-go, this implementation does not resume execution after halting and setting breakpoints. Resuming automatically turns out to be much trickier than just skipping a stopped event and continuing. It is possible that the stop occurred due to reasons other than our manual stop (breakpoint, call return), so we would need to detect thtat and report any stops that the user might be interested in. In addition, next would be cancelled by the halt command, so to resume it, we would need to implement an alternative version of halt that doesn't cancel next. So for now, we will just be reporting the pause to the user and let them decide when and how to resume execution manually.

Updates #1515
Updates https://github.com/golang/vscode-go/issues/1475
