### PR TITLE
proc: fix runtimeTypeToDIE setup

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -670,7 +670,7 @@ type Image struct {
 func (image *Image) registerRuntimeTypeToDIE(entry *dwarf.Entry, ardr *reader.Reader) {
 	if off, ok := entry.Val(godwarf.AttrGoRuntimeType).(uint64); ok {
 		if _, ok := image.runtimeTypeToDIE[off]; !ok {
-			image.runtimeTypeToDIE[off+image.StaticBase] = runtimeTypeDIE{entry.Offset, -1}
+			image.runtimeTypeToDIE[off] = runtimeTypeDIE{entry.Offset, -1}
 		}
 	}
 }

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-delve/delve/pkg/dwarf/godwarf"
 	"github.com/go-delve/delve/pkg/dwarf/reader"
+	"github.com/go-delve/delve/pkg/goversion"
 )
 
 // The kind field in runtime._type is a reflect.Kind value plus
@@ -148,6 +149,15 @@ func runtimeTypeToDIE(_type *Variable, dataAddr uint64) (typ godwarf.Type, kind 
 	}
 
 	// go1.7 to go1.10 implementation: convert runtime._type structs to type names
+
+	if goversion.ProducerAfterOrEqual(_type.bi.Producer(), 1, 17) {
+		// Go 1.17 changed the encoding of names in runtime._type breaking the
+		// code below, but the codepath above, using runtimeTypeToDIE should be
+		// enough.
+		// The change happened in commit 287025925f66f90ad9b30aea2e533928026a8376
+		// reviewed in https://go-review.googlesource.com/c/go/+/318249
+		return nil, 0, fmt.Errorf("could not resolve interface type")
+	}
 
 	typename, kind, err := nameOfRuntimeType(mds, _type)
 	if err != nil {


### PR DESCRIPTION
The code populating runtimeTypeToDIE was incorrectly adding StaticBase
to the offset. We never noticed because on statically compiled
executables StaticBase is always zero and on PIE and plugins the
fallback code took care of the problem anyway.

A change in Go 1.17 broke the fallback code, making the issue apparent.

This commit fixes the setup of runtimeTypeToDIE and disables the
fallback code for Go 1.17 and later.

This change also fixes a rare failure in TestPluginVariables when PIE
is enabled.
