### PR TITLE
gdbserial: for the 'g' command on debugserver treat E74 as unsupported

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1556,7 +1556,8 @@ func (t *gdbThread) reloadRegisters() error {
 
 	if t.p.gcmdok {
 		if err := t.p.conn.readRegisters(t.strID, t.regs.buf); err != nil {
-			if isProtocolErrorUnsupported(err) {
+			gdberr, isProt := err.(*GdbProtocolError)
+			if isProtocolErrorUnsupported(err) || (t.p.conn.isDebugserver && isProt && gdberr.code == "E74") {
 				t.p.gcmdok = false
 			} else {
 				return err


### PR DESCRIPTION
The maintainer of debugserver says he wants to fix the problem with the
'g' command but doesn't know when it will happen. Treat the error 'E74'
for the 'g' command on debugserver as if the server had returned an
unsupported error so that, for this specific problem, the error doesn't
resurface in the future.
