### PR TITLE
dap: add sameuser check

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -452,6 +452,7 @@ func dapCmd(cmd *cobra.Command, args []string) {
 				CheckGoVersion:       checkGoVersion,
 				TTY:                  tty,
 			},
+			CheckLocalConnUser: checkLocalConnUser,
 		})
 		defer server.Stop()
 

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/api"
 	"github.com/go-delve/delve/service/debugger"
+	"github.com/go-delve/delve/service/internal/sameuser"
 	"github.com/google/go-dap"
 	"github.com/sirupsen/logrus"
 )
@@ -319,6 +320,13 @@ func (s *Server) Run() {
 				s.triggerServerStop()
 			}
 			return
+		}
+		if s.config.CheckLocalConnUser {
+			if !sameuser.CanAccept(s.listener.Addr(), conn.RemoteAddr()) {
+				s.log.Error("Error accepting client connection: Only connections from the same user that started this instance of Delve are allowed to connect. See --only-same-user.")
+				s.triggerServerStop()
+				return
+			}
 		}
 		s.mu.Lock()
 		s.conn = conn // closed in Stop()

--- a/service/internal/sameuser/doc.go
+++ b/service/internal/sameuser/doc.go
@@ -1,0 +1,3 @@
+// Package sameuser provides utilities for checking users of a local connection.
+// Only works in Linux.
+package sameuser

--- a/service/internal/sameuser/sameuser.go
+++ b/service/internal/sameuser/sameuser.go
@@ -1,0 +1,9 @@
+//+build !linux
+
+package sameuser
+
+import "net"
+
+func CanAccept(_, _ net.Addr) bool {
+	return true
+}

--- a/service/internal/sameuser/sameuser_linux.go
+++ b/service/internal/sameuser/sameuser_linux.go
@@ -1,6 +1,6 @@
 //+build linux
 
-package rpccommon
+package sameuser
 
 import (
 	"bytes"
@@ -96,7 +96,7 @@ func sameUserForRemoteAddr(remoteAddr *net.TCPAddr) (bool, error) {
 	return sameUserForRemoteAddr4(remoteAddr)
 }
 
-func canAccept(listenAddr, remoteAddr net.Addr) bool {
+func CanAccept(listenAddr, remoteAddr net.Addr) bool {
 	laddr, ok := listenAddr.(*net.TCPAddr)
 	if !ok || !laddr.IP.IsLoopback() {
 		return true

--- a/service/internal/sameuser/sameuser_linux_test.go
+++ b/service/internal/sameuser/sameuser_linux_test.go
@@ -1,6 +1,6 @@
 //+build linux
 
-package rpccommon
+package sameuser
 
 import (
 	"net"

--- a/service/rpccommon/sameuser.go
+++ b/service/rpccommon/sameuser.go
@@ -1,9 +1,0 @@
-//+build !linux
-
-package rpccommon
-
-import "net"
-
-func canAccept(_, _ net.Addr) bool {
-	return true
-}

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/api"
 	"github.com/go-delve/delve/service/debugger"
+	"github.com/go-delve/delve/service/internal/sameuser"
 	"github.com/go-delve/delve/service/rpc1"
 	"github.com/go-delve/delve/service/rpc2"
 	"github.com/sirupsen/logrus"
@@ -145,7 +146,7 @@ func (s *ServerImpl) Run() error {
 			}
 
 			if s.config.CheckLocalConnUser {
-				if !canAccept(s.listener.Addr(), c.RemoteAddr()) {
+				if !sameuser.CanAccept(s.listener.Addr(), c.RemoteAddr()) {
 					c.Close()
 					continue
 				}


### PR DESCRIPTION
On linux, delve RPC server allows only connections from the same user
if --only-same-user is set (true, by default). Do the same for DAP
server.

Moved the sameuser check logic to service/internal/sameuser.
Considered importing service/rpccommon from the dap server,
but when we eventually migrate to multiplex rpc and dap from one
port, I am afraid that can cause cyclic imports.