### PR TITLE
tests: increase stack depth for TestFrameEvaluation

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1278,7 +1278,7 @@ func TestFrameEvaluation(t *testing.T) {
 		found := make([]bool, 10)
 		for _, g := range gs {
 			frame := -1
-			frames, err := g.Stacktrace(10, 0)
+			frames, err := g.Stacktrace(40, 0)
 			if err != nil {
 				t.Logf("could not stacktrace goroutine %d: %v\n", g.ID, err)
 				continue


### PR DESCRIPTION
Sometimes on Windows TestFrameEvaluation fails because the stacktrace
doesn't look deep enough.
