### PR TITLE
service/dap: remove unnecessary capability check

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1461,13 +1461,6 @@ func (s *Server) onVariablesRequest(request *dap.VariablesRequest) {
 		s.sendErrorResponse(request.Request, UnableToLookupVariable, "Unable to lookup variable", err.Error())
 		return
 	}
-	if !s.clientCapabilities.supportsVariableType {
-		// If the client does not support variable type
-		// we cannot set the Type field in the response.
-		for i := range children {
-			children[i].Type = ""
-		}
-	}
 	response := &dap.VariablesResponse{
 		Response: *newResponse(request.Request),
 		Body:     dap.VariablesResponseBody{Variables: children},


### PR DESCRIPTION
The Types field is only set in childrenToDAPVariables if the client
capability is supported. There is no need to check again after the
children have been calculated.