### PR TITLE
terminal,service: Add filtering and grouping to goroutines command

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -364,7 +364,7 @@ Print out info for every goroutine. The flag controls what information is shown 
 	-t	displays goroutine's stacktrace (an optional depth value can be specified, default: 10)
 	-l	displays goroutine's labels
 
-If no flag is specified the default is -u.
+If no flag is specified the default is -u, i.e. the first frame within the first 30 frames that is not executing a runtime private function.
 
 FILTERING
 

--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -394,16 +394,16 @@ To only display goroutines that are running (or are not running) on a OS thread,
 	goroutines -with running
 	goroutines -without running
 	
-To only display goroutines that are classified as system (or non-system), use:
+To only display user (or runtime) goroutines, use:
 
-	goroutines -with system
-	goroutines -without system
+	goroutines -with user
+	goroutines -without user
 
 GROUPING
 
-	goroutines -group (userloc|curloc|goloc|startloc|running|system)
+	goroutines -group (userloc|curloc|goloc|startloc|running|user)
 
-Groups goroutines by the given location, running status or system classification, up to 5 goroutines per group will be displayed as well as the total number of goroutines in the group.
+Groups goroutines by the given location, running status or user classification, up to 5 goroutines per group will be displayed as well as the total number of goroutines in the group.
 
 	goroutines -group label key
 

--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -353,18 +353,62 @@ Aliases: gr
 ## goroutines
 List program goroutines.
 
-	goroutines [-u (default: user location)|-r (runtime location)|-g (go statement location)|-s (start location)] [-t (stack trace)] [-l (labels)]
+	goroutines [-u|-r|-g|-s] [-t [depth]] [-l] [-with loc expr] [-without loc expr] [-group argument]
 
 Print out info for every goroutine. The flag controls what information is shown along with each goroutine:
 
-	-u	displays location of topmost stackframe in user code
+	-u	displays location of topmost stackframe in user code (default)
 	-r	displays location of topmost stackframe (including frames inside private runtime functions)
 	-g	displays location of go instruction that created the goroutine
 	-s	displays location of the start function
-	-t	displays goroutine's stacktrace
+	-t	displays goroutine's stacktrace (an optional depth value can be specified, default: 10)
 	-l	displays goroutine's labels
 
 If no flag is specified the default is -u.
+
+FILTERING
+
+If -with or -without are specified only goroutines that match the given condition are returned.
+
+To only display goroutines where the specified location contains (or does not contain, for -without and -wo) expr as a substring, use:
+
+	goroutines -with (userloc|curloc|goloc|startloc) expr
+	goroutines -w (userloc|curloc|goloc|startloc) expr
+	goroutines -without (userloc|curloc|goloc|startloc) expr
+	goroutines -wo (userloc|curloc|goloc|startloc) expr
+	
+To only display goroutines that have (or do not have) the specified label key and value, use:
+	
+
+	goroutines -with label key=value
+	goroutines -without label key=value
+	
+To only display goroutines that have (or do not have) the specified label key, use:
+
+	goroutines -with label key
+	goroutines -without label key
+	
+To only display goroutines that are running (or are not running) on a OS thread, use:
+
+
+	goroutines -with running
+	goroutines -without running
+	
+To only display goroutines that are classified as system (or non-system), use:
+
+	goroutines -with system
+	goroutines -without system
+
+GROUPING
+
+	goroutines -group (userloc|curloc|goloc|startloc|running|system)
+
+Groups goroutines by the given location, running status or system classification, up to 5 goroutines per group will be displayed as well as the total number of goroutines in the group.
+
+	goroutines -group label key
+
+Groups goroutines by the value of the label with the specified key.
+
 
 Aliases: grs
 

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -45,7 +45,7 @@ checkpoints() | Equivalent to API call [ListCheckpoints](https://godoc.org/githu
 dynamic_libraries() | Equivalent to API call [ListDynamicLibraries](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListDynamicLibraries)
 function_args(Scope, Cfg) | Equivalent to API call [ListFunctionArgs](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListFunctionArgs)
 functions(Filter) | Equivalent to API call [ListFunctions](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListFunctions)
-goroutines(Start, Count) | Equivalent to API call [ListGoroutines](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListGoroutines)
+goroutines(Start, Count, Filters, GoroutineGroupingOptions) | Equivalent to API call [ListGoroutines](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListGoroutines)
 local_vars(Scope, Cfg) | Equivalent to API call [ListLocalVars](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListLocalVars)
 package_vars(Filter, Cfg) | Equivalent to API call [ListPackageVars](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListPackageVars)
 packages_build_info(IncludeFiles) | Equivalent to API call [ListPackagesBuildInfo](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListPackagesBuildInfo)

--- a/_fixtures/goroutinegroup.go
+++ b/_fixtures/goroutinegroup.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"runtime"
+	"runtime/pprof"
+	"sync"
+	"time"
+)
+
+func sleepyfunc(wg *sync.WaitGroup, lbl string) {
+	defer wg.Done()
+	pprof.SetGoroutineLabels(pprof.WithLabels(context.Background(), pprof.Labels("name", lbl)))
+	time.Sleep(10 * 60 * time.Second)
+}
+
+func gopoint1(wg *sync.WaitGroup, lbl string, f func(*sync.WaitGroup, string)) {
+	go f(wg, lbl)
+}
+
+func gopoint2(wg *sync.WaitGroup, lbl string, f func(*sync.WaitGroup, string)) {
+	go f(wg, lbl)
+}
+
+func gopoint3(wg *sync.WaitGroup, lbl string, f func(*sync.WaitGroup, string)) {
+	go f(wg, lbl)
+}
+
+func gopoint4(wg *sync.WaitGroup, lbl string, f func(*sync.WaitGroup, string)) {
+	go f(wg, lbl)
+}
+
+func gopoint5(wg *sync.WaitGroup, lbl string, f func(*sync.WaitGroup, string)) {
+	go f(wg, lbl)
+}
+
+func startpoint1(wg *sync.WaitGroup, lbl string) {
+	sleepyfunc(wg, lbl)
+}
+
+func startpoint2(wg *sync.WaitGroup, lbl string) {
+	sleepyfunc(wg, lbl)
+}
+
+func startpoint3(wg *sync.WaitGroup, lbl string) {
+	sleepyfunc(wg, lbl)
+}
+
+func startpoint4(wg *sync.WaitGroup, lbl string) {
+	sleepyfunc(wg, lbl)
+}
+
+func startpoint5(wg *sync.WaitGroup, lbl string) {
+	sleepyfunc(wg, lbl)
+}
+
+func main() {
+	var wg sync.WaitGroup
+
+	for _, lbl := range []string{"one", "two", "three", "four", "five"} {
+		for _, f := range []func(*sync.WaitGroup, string){startpoint1, startpoint2, startpoint3, startpoint4, startpoint5} {
+			for i := 0; i < 1000; i++ {
+				wg.Add(5)
+				gopoint1(&wg, lbl, f)
+				gopoint2(&wg, lbl, f)
+				gopoint3(&wg, lbl, f)
+				gopoint4(&wg, lbl, f)
+				gopoint5(&wg, lbl, f)
+			}
+		}
+	}
+	time.Sleep(2 * time.Second)
+	runtime.Breakpoint()
+	wg.Wait()
+}

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -326,6 +326,8 @@ func TestRedirect(t *testing.T) {
 	cmd.Wait()
 }
 
+const checkAutogenDocLongOutput = false
+
 func checkAutogenDoc(t *testing.T, filename, gencommand string, generated []byte) {
 	saved := slurpFile(t, filepath.Join(projectRoot(), filename))
 
@@ -333,13 +335,17 @@ func checkAutogenDoc(t *testing.T, filename, gencommand string, generated []byte
 	generated = bytes.ReplaceAll(generated, []byte("\r\n"), []byte{'\n'})
 
 	if len(saved) != len(generated) {
-		t.Logf("generated %q saved %q\n", generated, saved)
+		if checkAutogenDocLongOutput {
+			t.Logf("generated %q saved %q\n", generated, saved)
+		}
 		t.Fatalf("%s: needs to be regenerated; run %s", filename, gencommand)
 	}
 
 	for i := range saved {
 		if saved[i] != generated[i] {
-			t.Logf("generated %q saved %q\n", generated, saved)
+			if checkAutogenDocLongOutput {
+				t.Logf("generated %q saved %q\n", generated, saved)
+			}
 			t.Fatalf("%s: needs to be regenerated; run %s", filename, gencommand)
 		}
 	}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -521,6 +521,20 @@ func (g *G) StartLoc() Location {
 	return Location{PC: g.StartPC, File: f, Line: l, Fn: fn}
 }
 
+// System returns true if g is a system goroutine. See isSystemGoroutine in
+// $GOROOT/src/runtime/traceback.go.
+func (g *G) System() bool {
+	loc := g.StartLoc()
+	if loc.Fn == nil {
+		return false
+	}
+	switch loc.Fn.Name {
+	case "runtime.main", "runtime.handleAsyncEvent", "runtime.runfinq":
+		return false
+	}
+	return strings.HasPrefix(loc.Fn.Name, "runtime.")
+}
+
 func (g *G) Labels() map[string]string {
 	if g.labels != nil {
 		return *g.labels

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -231,7 +231,7 @@ Print out info for every goroutine. The flag controls what information is shown 
 	-t	displays goroutine's stacktrace (an optional depth value can be specified, default: 10)
 	-l	displays goroutine's labels
 
-If no flag is specified the default is -u.
+If no flag is specified the default is -u, i.e. the first frame within the first 30 frames that is not executing a runtime private function.
 
 FILTERING
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -261,16 +261,16 @@ To only display goroutines that are running (or are not running) on a OS thread,
 	goroutines -with running
 	goroutines -without running
 	
-To only display goroutines that are classified as system (or non-system), use:
+To only display user (or runtime) goroutines, use:
 
-	goroutines -with system
-	goroutines -without system
+	goroutines -with user
+	goroutines -without user
 
 GROUPING
 
-	goroutines -group (userloc|curloc|goloc|startloc|running|system)
+	goroutines -group (userloc|curloc|goloc|startloc|running|user)
 
-Groups goroutines by the given location, running status or system classification, up to 5 goroutines per group will be displayed as well as the total number of goroutines in the group.
+Groups goroutines by the given location, running status or user classification, up to 5 goroutines per group will be displayed as well as the total number of goroutines in the group.
 
 	goroutines -group label key
 
@@ -930,8 +930,8 @@ func readGoroutinesFilterKind(args []string, i int) (api.GoroutineField, error) 
 		return api.GoroutineLabel, nil
 	case "running":
 		return api.GoroutineRunning, nil
-	case "system":
-		return api.GoroutineSystem, nil
+	case "user":
+		return api.GoroutineUser, nil
 	default:
 		return api.GoroutineFieldNone, fmt.Errorf("unrecognized argument to %s %s", args[i-1], args[i])
 	}
@@ -946,7 +946,7 @@ func readGoroutinesFilter(args []string, pi *int) (*api.ListGoroutinesFilter, er
 	}
 	*pi++
 	switch r.Kind {
-	case api.GoroutineRunning, api.GoroutineSystem:
+	case api.GoroutineRunning, api.GoroutineUser:
 		return r, nil
 	}
 	if *pi+1 >= len(args) {

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -912,6 +912,18 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 2 && args[2] != starlark.None {
+			err := unmarshalStarlarkValue(args[2], &rpcArgs.Filters, "Filters")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
+		if len(args) > 3 && args[3] != starlark.None {
+			err := unmarshalStarlarkValue(args[3], &rpcArgs.GoroutineGroupingOptions, "GoroutineGroupingOptions")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
@@ -919,6 +931,10 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Start, "Start")
 			case "Count":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Count, "Count")
+			case "Filters":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Filters, "Filters")
+			case "GoroutineGroupingOptions":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.GoroutineGroupingOptions, "GoroutineGroupingOptions")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -606,7 +606,7 @@ const (
 	GoroutineStartLoc                  // the goroutine's StartLoc
 	GoroutineLabel                     // the goroutine's label
 	GoroutineRunning                   // the goroutine is running
-	GoroutineSystem                    // the goroutine is a system goroutine
+	GoroutineUser                      // the goroutine is a user goroutine
 )
 
 // GoroutineGroup represents a group of goroutines in the return value of

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -586,3 +586,41 @@ type DumpState struct {
 
 	Err string
 }
+
+// ListGoroutinesFilter describes a filtering condition for the
+// ListGoroutines API call.
+type ListGoroutinesFilter struct {
+	Kind    GoroutineField
+	Negated bool
+	Arg     string
+}
+
+// GoroutineField allows referring to a field of a goroutine object.
+type GoroutineField uint8
+
+const (
+	GoroutineFieldNone  GoroutineField = iota
+	GoroutineCurrentLoc                // the goroutine's CurrentLoc
+	GoroutineUserLoc                   // the goroutine's UserLoc
+	GoroutineGoLoc                     // the goroutine's GoStatementLoc
+	GoroutineStartLoc                  // the goroutine's StartLoc
+	GoroutineLabel                     // the goroutine's label
+	GoroutineRunning                   // the goroutine is running
+	GoroutineSystem                    // the goroutine is a system goroutine
+)
+
+// GoroutineGroup represents a group of goroutines in the return value of
+// the ListGoroutines API call.
+type GoroutineGroup struct {
+	Name   string // name of this group
+	Offset int    // start offset in the list of goroutines of this group
+	Count  int    // number of goroutines that belong to this group in the list of goroutines
+	Total  int    // total number of goroutines that belong to this group
+}
+
+type GoroutineGroupingOptions struct {
+	GroupBy         GoroutineField
+	GroupByKey      string
+	MaxGroupMembers int
+	MaxGroups       int
+}

--- a/service/client.go
+++ b/service/client.go
@@ -114,6 +114,8 @@ type Client interface {
 
 	// ListGoroutines lists all goroutines.
 	ListGoroutines(start, count int) ([]*api.Goroutine, int, error)
+	// ListGoroutinesWithFilter lists goroutines matching the filters
+	ListGoroutinesWithFilter(start, count int, filters []api.ListGoroutinesFilter, group *api.GoroutineGroupingOptions) ([]*api.Goroutine, []api.GoroutineGroup, int, bool, error)
 
 	// Returns stacktrace
 	Stacktrace(goroutineID int, depth int, opts api.StacktraceOptions, cfg *api.LoadConfig) ([]api.Stackframe, error)

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1549,7 +1549,6 @@ func (s *Server) onStackTraceRequest(request *dap.StackTraceRequest) {
 	}
 
 	// Determine if the goroutine is a system goroutine.
-	// TODO(suzmue): Use the System() method defined in: https://github.com/go-delve/delve/pull/2504
 	g, err := s.debugger.FindGoroutine(goroutineID)
 	isSystemGoroutine := g.System()
 

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1549,8 +1549,10 @@ func (s *Server) onStackTraceRequest(request *dap.StackTraceRequest) {
 	}
 
 	// Determine if the goroutine is a system goroutine.
-	g, err := s.debugger.FindGoroutine(goroutineID)
-	isSystemGoroutine := g.System()
+	isSystemGoroutine := true
+	if g, _ := s.debugger.FindGoroutine(goroutineID); g != nil {
+		isSystemGoroutine = g.System()
+	}
 
 	stackFrames := make([]dap.StackFrame, len(frames))
 	for i, frame := range frames {

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1551,11 +1551,7 @@ func (s *Server) onStackTraceRequest(request *dap.StackTraceRequest) {
 	// Determine if the goroutine is a system goroutine.
 	// TODO(suzmue): Use the System() method defined in: https://github.com/go-delve/delve/pull/2504
 	g, err := s.debugger.FindGoroutine(goroutineID)
-	var isSystemGoroutine bool
-	if err == nil {
-		userLoc := g.UserCurrent()
-		isSystemGoroutine = fnPackageName(&userLoc) == "runtime"
-	}
+	isSystemGoroutine := g.System()
 
 	stackFrames := make([]dap.StackFrame, len(frames))
 	for i, frame := range frames {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1540,8 +1540,8 @@ func matchGoroutineFilter(g *proc.G, filter *api.ListGoroutinesFilter) bool {
 		}
 	case api.GoroutineRunning:
 		val = g.Thread != nil
-	case api.GoroutineSystem:
-		val = g.System()
+	case api.GoroutineUser:
+		val = !g.System()
 	}
 	if filter.Negated {
 		val = !val
@@ -1589,8 +1589,8 @@ func (d *Debugger) GroupGoroutines(gs []*proc.G, group *api.GoroutineGroupingOpt
 			key = fmt.Sprintf("%s=%s", group.GroupByKey, g.Labels()[group.GroupByKey])
 		case api.GoroutineRunning:
 			key = fmt.Sprintf("running=%v", g.Thread != nil)
-		case api.GoroutineSystem:
-			key = fmt.Sprintf("system=%v", g.System())
+		case api.GoroutineUser:
+			key = fmt.Sprintf("user=%v", !g.System())
 		}
 		if len(groupMembers[key]) < group.MaxGroupMembers {
 			groupMembers[key] = append(groupMembers[key], g)

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -352,8 +352,17 @@ func (c *RPCClient) ListFunctionArgs(scope api.EvalScope, cfg api.LoadConfig) ([
 
 func (c *RPCClient) ListGoroutines(start, count int) ([]*api.Goroutine, int, error) {
 	var out ListGoroutinesOut
-	err := c.call("ListGoroutines", ListGoroutinesIn{start, count}, &out)
+	err := c.call("ListGoroutines", ListGoroutinesIn{start, count, nil, api.GoroutineGroupingOptions{}}, &out)
 	return out.Goroutines, out.Nextg, err
+}
+
+func (c *RPCClient) ListGoroutinesWithFilter(start, count int, filters []api.ListGoroutinesFilter, group *api.GoroutineGroupingOptions) ([]*api.Goroutine, []api.GoroutineGroup, int, bool, error) {
+	if group == nil {
+		group = &api.GoroutineGroupingOptions{}
+	}
+	var out ListGoroutinesOut
+	err := c.call("ListGoroutines", ListGoroutinesIn{start, count, filters, *group}, &out)
+	return out.Goroutines, out.Groups, out.Nextg, out.TooManyGroups, err
 }
 
 func (c *RPCClient) Stacktrace(goroutineId, depth int, opts api.StacktraceOptions, cfg *api.LoadConfig) ([]api.Stackframe, error) {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -594,11 +594,16 @@ func (s *RPCServer) ListTypes(arg ListTypesIn, out *ListTypesOut) error {
 type ListGoroutinesIn struct {
 	Start int
 	Count int
+
+	Filters []api.ListGoroutinesFilter
+	api.GoroutineGroupingOptions
 }
 
 type ListGoroutinesOut struct {
-	Goroutines []*api.Goroutine
-	Nextg      int
+	Goroutines    []*api.Goroutine
+	Nextg         int
+	Groups        []api.GoroutineGroup
+	TooManyGroups bool
 }
 
 // ListGoroutines lists all goroutines.
@@ -607,11 +612,37 @@ type ListGoroutinesOut struct {
 // parameter, to get more goroutines from ListGoroutines.
 // Passing a value of Start that wasn't returned by ListGoroutines will skip
 // an undefined number of goroutines.
+//
+// If arg.Filters are specified the list of returned goroutines is filtered
+// applying the specified filters.
+// For example:
+//    ListGoroutinesFilter{ Kind: ListGoroutinesFilterUserLoc, Negated: false, Arg: "afile.go" }
+// will only return goroutines whose UserLoc contains "afile.go" as a substring.
+// More specifically a goroutine matches a location filter if the specified
+// location, formatted like this:
+//    filename:lineno in function
+// contains Arg[0] as a substring.
+//
+// Filters can also be applied to goroutine labels:
+//    ListGoroutineFilter{ Kind: ListGoroutinesFilterLabel, Negated: false, Arg: "key=value" }
+// this filter will only return goroutines that have a key=value label.
+//
+// If arg.GroupBy is not GoroutineFieldNone then the goroutines will
+// be grouped with the specified criterion.
+// If the value of arg.GroupBy is GoroutineLabel goroutines will
+// be grouped by the value of the label with key GroupByKey.
+// For each group a maximum of MaxExamples example goroutines are
+// returned, as well as the total number of goroutines in the group.
 func (s *RPCServer) ListGoroutines(arg ListGoroutinesIn, out *ListGoroutinesOut) error {
+	//TODO(aarzilli): if arg contains a running goroutines filter (not negated)
+	// and start == 0 and count == 0 then we can optimize this by just looking
+	// at threads directly.
 	gs, nextg, err := s.debugger.Goroutines(arg.Start, arg.Count)
 	if err != nil {
 		return err
 	}
+	gs = s.debugger.FilterGoroutines(gs, arg.Filters)
+	gs, out.Groups, out.TooManyGroups = s.debugger.GroupGoroutines(gs, &arg.GoroutineGroupingOptions)
 	s.debugger.LockTarget()
 	defer s.debugger.UnlockTarget()
 	out.Goroutines = api.ConvertGoroutines(gs)


### PR DESCRIPTION
Adds filtering and grouping to the goroutines command.

The current implementation of the goroutines command is modeled after
the threads command of gdb. It works well for programs that have up to
a couple dozen goroutines but becomes unusable quickly after that.

This commit adds the ability to filter and group goroutines by several
different properties, allowing a better debugging experience on
programs that have hundreds or thousands of goroutines.
