### PR TITLE
_scripts: change gen-backend_test_health.go to be more stable

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -1,31 +1,31 @@
 Tests skipped by each supported backend:
 
-* 386 skipped = 4% (6/150)
+* 386 skipped = 6
 	* 1 broken
 	* 3 broken - cgo stacktraces
 	* 2 not implemented
-* arm64 skipped = 2.7% (4/150)
+* arm64 skipped = 4
 	* 1 broken
 	* 1 broken - global variable symbolication
 	* 2 not implemented
-* darwin skipped = 1.3% (2/150)
+* darwin skipped = 2
 	* 2 not implemented
-* darwin/arm64 skipped = 0.67% (1/150)
+* darwin/arm64 skipped = 1
 	* 1 broken - cgo stacktraces
-* darwin/lldb skipped = 0.67% (1/150)
+* darwin/lldb skipped = 1
 	* 1 upstream issue
-* freebsd skipped = 9.3% (14/150)
+* freebsd skipped = 14
 	* 11 broken
 	* 3 not implemented
-* linux/386/pie skipped = 0.67% (1/150)
+* linux/386/pie skipped = 1
 	* 1 broken
-* linux/arm64 skipped = 0.67% (1/150)
+* linux/arm64 skipped = 1
 	* 1 broken - cgo stacktraces
-* pie skipped = 0.67% (1/150)
+* pie skipped = 1
 	* 1 upstream issue - https://github.com/golang/go/issues/29322
-* rr skipped = 1.3% (2/150)
+* rr skipped = 2
 	* 2 not implemented
-* windows skipped = 2.7% (4/150)
+* windows skipped = 4
 	* 1 broken
 	* 2 not implemented
 	* 1 upstream issue

--- a/_scripts/gen-backend_test_health.go
+++ b/_scripts/gen-backend_test_health.go
@@ -82,8 +82,7 @@ func main() {
 		for _, v := range skipped[cond] {
 			tot += v
 		}
-		perc := float64(tot) / float64(ntests) * 100
-		fmt.Fprintf(fh, "* %s skipped = %0.02g%% (%d/%d)\n", cond, perc, tot, ntests)
+		fmt.Fprintf(fh, "* %s skipped = %d\n", cond, tot)
 		reasons := []string{}
 		for reason := range skipped[cond] {
 			reasons = append(reasons, reason)


### PR DESCRIPTION
Change gen-backend_test_health.go so that it only prints the number of
tests skipped and not the total or the percentage.

As it is it causes too many merge conflicts.
