### PR TITLE
service/dap: test refactoring

### DIFF
--- a/service/dap/daptest/gen/main.go
+++ b/service/dap/daptest/gen/main.go
@@ -34,6 +34,12 @@ import (
 func (c *Client) Expect{{.}}(t *testing.T) *dap.{{.}} {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.Check{{.}}(t, m)
+}
+
+// Check{{.}} fails the test if m is not *{{.}}.
+func (c *Client) Check{{.}}(t *testing.T, m dap.Message) *dap.{{.}} {
+	t.Helper()
 	r, ok := m.(*dap.{{.}})
 	if !ok {
 		t.Fatalf("got %#v, want *dap.{{.}}", m)

--- a/service/dap/daptest/resp.go
+++ b/service/dap/daptest/resp.go
@@ -14,6 +14,12 @@ import (
 func (c *Client) ExpectAttachResponse(t *testing.T) *dap.AttachResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckAttachResponse(t, m)
+}
+
+// CheckAttachResponse fails the test if m is not *AttachResponse.
+func (c *Client) CheckAttachResponse(t *testing.T, m dap.Message) *dap.AttachResponse {
+	t.Helper()
 	r, ok := m.(*dap.AttachResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.AttachResponse", m)
@@ -26,6 +32,12 @@ func (c *Client) ExpectAttachResponse(t *testing.T) *dap.AttachResponse {
 func (c *Client) ExpectBreakpointEvent(t *testing.T) *dap.BreakpointEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckBreakpointEvent(t, m)
+}
+
+// CheckBreakpointEvent fails the test if m is not *BreakpointEvent.
+func (c *Client) CheckBreakpointEvent(t *testing.T, m dap.Message) *dap.BreakpointEvent {
+	t.Helper()
 	r, ok := m.(*dap.BreakpointEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.BreakpointEvent", m)
@@ -38,6 +50,12 @@ func (c *Client) ExpectBreakpointEvent(t *testing.T) *dap.BreakpointEvent {
 func (c *Client) ExpectBreakpointLocationsResponse(t *testing.T) *dap.BreakpointLocationsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckBreakpointLocationsResponse(t, m)
+}
+
+// CheckBreakpointLocationsResponse fails the test if m is not *BreakpointLocationsResponse.
+func (c *Client) CheckBreakpointLocationsResponse(t *testing.T, m dap.Message) *dap.BreakpointLocationsResponse {
+	t.Helper()
 	r, ok := m.(*dap.BreakpointLocationsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.BreakpointLocationsResponse", m)
@@ -50,6 +68,12 @@ func (c *Client) ExpectBreakpointLocationsResponse(t *testing.T) *dap.Breakpoint
 func (c *Client) ExpectCancelResponse(t *testing.T) *dap.CancelResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckCancelResponse(t, m)
+}
+
+// CheckCancelResponse fails the test if m is not *CancelResponse.
+func (c *Client) CheckCancelResponse(t *testing.T, m dap.Message) *dap.CancelResponse {
+	t.Helper()
 	r, ok := m.(*dap.CancelResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.CancelResponse", m)
@@ -62,6 +86,12 @@ func (c *Client) ExpectCancelResponse(t *testing.T) *dap.CancelResponse {
 func (c *Client) ExpectCapabilitiesEvent(t *testing.T) *dap.CapabilitiesEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckCapabilitiesEvent(t, m)
+}
+
+// CheckCapabilitiesEvent fails the test if m is not *CapabilitiesEvent.
+func (c *Client) CheckCapabilitiesEvent(t *testing.T, m dap.Message) *dap.CapabilitiesEvent {
+	t.Helper()
 	r, ok := m.(*dap.CapabilitiesEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.CapabilitiesEvent", m)
@@ -74,6 +104,12 @@ func (c *Client) ExpectCapabilitiesEvent(t *testing.T) *dap.CapabilitiesEvent {
 func (c *Client) ExpectCompletionsResponse(t *testing.T) *dap.CompletionsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckCompletionsResponse(t, m)
+}
+
+// CheckCompletionsResponse fails the test if m is not *CompletionsResponse.
+func (c *Client) CheckCompletionsResponse(t *testing.T, m dap.Message) *dap.CompletionsResponse {
+	t.Helper()
 	r, ok := m.(*dap.CompletionsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.CompletionsResponse", m)
@@ -86,6 +122,12 @@ func (c *Client) ExpectCompletionsResponse(t *testing.T) *dap.CompletionsRespons
 func (c *Client) ExpectConfigurationDoneResponse(t *testing.T) *dap.ConfigurationDoneResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckConfigurationDoneResponse(t, m)
+}
+
+// CheckConfigurationDoneResponse fails the test if m is not *ConfigurationDoneResponse.
+func (c *Client) CheckConfigurationDoneResponse(t *testing.T, m dap.Message) *dap.ConfigurationDoneResponse {
+	t.Helper()
 	r, ok := m.(*dap.ConfigurationDoneResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ConfigurationDoneResponse", m)
@@ -98,6 +140,12 @@ func (c *Client) ExpectConfigurationDoneResponse(t *testing.T) *dap.Configuratio
 func (c *Client) ExpectContinueResponse(t *testing.T) *dap.ContinueResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckContinueResponse(t, m)
+}
+
+// CheckContinueResponse fails the test if m is not *ContinueResponse.
+func (c *Client) CheckContinueResponse(t *testing.T, m dap.Message) *dap.ContinueResponse {
+	t.Helper()
 	r, ok := m.(*dap.ContinueResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ContinueResponse", m)
@@ -110,6 +158,12 @@ func (c *Client) ExpectContinueResponse(t *testing.T) *dap.ContinueResponse {
 func (c *Client) ExpectContinuedEvent(t *testing.T) *dap.ContinuedEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckContinuedEvent(t, m)
+}
+
+// CheckContinuedEvent fails the test if m is not *ContinuedEvent.
+func (c *Client) CheckContinuedEvent(t *testing.T, m dap.Message) *dap.ContinuedEvent {
+	t.Helper()
 	r, ok := m.(*dap.ContinuedEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ContinuedEvent", m)
@@ -122,6 +176,12 @@ func (c *Client) ExpectContinuedEvent(t *testing.T) *dap.ContinuedEvent {
 func (c *Client) ExpectDataBreakpointInfoResponse(t *testing.T) *dap.DataBreakpointInfoResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckDataBreakpointInfoResponse(t, m)
+}
+
+// CheckDataBreakpointInfoResponse fails the test if m is not *DataBreakpointInfoResponse.
+func (c *Client) CheckDataBreakpointInfoResponse(t *testing.T, m dap.Message) *dap.DataBreakpointInfoResponse {
+	t.Helper()
 	r, ok := m.(*dap.DataBreakpointInfoResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.DataBreakpointInfoResponse", m)
@@ -134,6 +194,12 @@ func (c *Client) ExpectDataBreakpointInfoResponse(t *testing.T) *dap.DataBreakpo
 func (c *Client) ExpectDisassembleResponse(t *testing.T) *dap.DisassembleResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckDisassembleResponse(t, m)
+}
+
+// CheckDisassembleResponse fails the test if m is not *DisassembleResponse.
+func (c *Client) CheckDisassembleResponse(t *testing.T, m dap.Message) *dap.DisassembleResponse {
+	t.Helper()
 	r, ok := m.(*dap.DisassembleResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.DisassembleResponse", m)
@@ -146,6 +212,12 @@ func (c *Client) ExpectDisassembleResponse(t *testing.T) *dap.DisassembleRespons
 func (c *Client) ExpectDisconnectResponse(t *testing.T) *dap.DisconnectResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckDisconnectResponse(t, m)
+}
+
+// CheckDisconnectResponse fails the test if m is not *DisconnectResponse.
+func (c *Client) CheckDisconnectResponse(t *testing.T, m dap.Message) *dap.DisconnectResponse {
+	t.Helper()
 	r, ok := m.(*dap.DisconnectResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.DisconnectResponse", m)
@@ -158,6 +230,12 @@ func (c *Client) ExpectDisconnectResponse(t *testing.T) *dap.DisconnectResponse 
 func (c *Client) ExpectErrorResponse(t *testing.T) *dap.ErrorResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckErrorResponse(t, m)
+}
+
+// CheckErrorResponse fails the test if m is not *ErrorResponse.
+func (c *Client) CheckErrorResponse(t *testing.T, m dap.Message) *dap.ErrorResponse {
+	t.Helper()
 	r, ok := m.(*dap.ErrorResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ErrorResponse", m)
@@ -170,6 +248,12 @@ func (c *Client) ExpectErrorResponse(t *testing.T) *dap.ErrorResponse {
 func (c *Client) ExpectEvaluateResponse(t *testing.T) *dap.EvaluateResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckEvaluateResponse(t, m)
+}
+
+// CheckEvaluateResponse fails the test if m is not *EvaluateResponse.
+func (c *Client) CheckEvaluateResponse(t *testing.T, m dap.Message) *dap.EvaluateResponse {
+	t.Helper()
 	r, ok := m.(*dap.EvaluateResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.EvaluateResponse", m)
@@ -182,6 +266,12 @@ func (c *Client) ExpectEvaluateResponse(t *testing.T) *dap.EvaluateResponse {
 func (c *Client) ExpectExceptionInfoResponse(t *testing.T) *dap.ExceptionInfoResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckExceptionInfoResponse(t, m)
+}
+
+// CheckExceptionInfoResponse fails the test if m is not *ExceptionInfoResponse.
+func (c *Client) CheckExceptionInfoResponse(t *testing.T, m dap.Message) *dap.ExceptionInfoResponse {
+	t.Helper()
 	r, ok := m.(*dap.ExceptionInfoResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ExceptionInfoResponse", m)
@@ -194,6 +284,12 @@ func (c *Client) ExpectExceptionInfoResponse(t *testing.T) *dap.ExceptionInfoRes
 func (c *Client) ExpectExitedEvent(t *testing.T) *dap.ExitedEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckExitedEvent(t, m)
+}
+
+// CheckExitedEvent fails the test if m is not *ExitedEvent.
+func (c *Client) CheckExitedEvent(t *testing.T, m dap.Message) *dap.ExitedEvent {
+	t.Helper()
 	r, ok := m.(*dap.ExitedEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ExitedEvent", m)
@@ -206,6 +302,12 @@ func (c *Client) ExpectExitedEvent(t *testing.T) *dap.ExitedEvent {
 func (c *Client) ExpectGotoResponse(t *testing.T) *dap.GotoResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckGotoResponse(t, m)
+}
+
+// CheckGotoResponse fails the test if m is not *GotoResponse.
+func (c *Client) CheckGotoResponse(t *testing.T, m dap.Message) *dap.GotoResponse {
+	t.Helper()
 	r, ok := m.(*dap.GotoResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.GotoResponse", m)
@@ -218,6 +320,12 @@ func (c *Client) ExpectGotoResponse(t *testing.T) *dap.GotoResponse {
 func (c *Client) ExpectGotoTargetsResponse(t *testing.T) *dap.GotoTargetsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckGotoTargetsResponse(t, m)
+}
+
+// CheckGotoTargetsResponse fails the test if m is not *GotoTargetsResponse.
+func (c *Client) CheckGotoTargetsResponse(t *testing.T, m dap.Message) *dap.GotoTargetsResponse {
+	t.Helper()
 	r, ok := m.(*dap.GotoTargetsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.GotoTargetsResponse", m)
@@ -230,6 +338,12 @@ func (c *Client) ExpectGotoTargetsResponse(t *testing.T) *dap.GotoTargetsRespons
 func (c *Client) ExpectInitializeResponse(t *testing.T) *dap.InitializeResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckInitializeResponse(t, m)
+}
+
+// CheckInitializeResponse fails the test if m is not *InitializeResponse.
+func (c *Client) CheckInitializeResponse(t *testing.T, m dap.Message) *dap.InitializeResponse {
+	t.Helper()
 	r, ok := m.(*dap.InitializeResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.InitializeResponse", m)
@@ -242,6 +356,12 @@ func (c *Client) ExpectInitializeResponse(t *testing.T) *dap.InitializeResponse 
 func (c *Client) ExpectInitializedEvent(t *testing.T) *dap.InitializedEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckInitializedEvent(t, m)
+}
+
+// CheckInitializedEvent fails the test if m is not *InitializedEvent.
+func (c *Client) CheckInitializedEvent(t *testing.T, m dap.Message) *dap.InitializedEvent {
+	t.Helper()
 	r, ok := m.(*dap.InitializedEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.InitializedEvent", m)
@@ -254,6 +374,12 @@ func (c *Client) ExpectInitializedEvent(t *testing.T) *dap.InitializedEvent {
 func (c *Client) ExpectInvalidatedEvent(t *testing.T) *dap.InvalidatedEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckInvalidatedEvent(t, m)
+}
+
+// CheckInvalidatedEvent fails the test if m is not *InvalidatedEvent.
+func (c *Client) CheckInvalidatedEvent(t *testing.T, m dap.Message) *dap.InvalidatedEvent {
+	t.Helper()
 	r, ok := m.(*dap.InvalidatedEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.InvalidatedEvent", m)
@@ -266,6 +392,12 @@ func (c *Client) ExpectInvalidatedEvent(t *testing.T) *dap.InvalidatedEvent {
 func (c *Client) ExpectLaunchResponse(t *testing.T) *dap.LaunchResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckLaunchResponse(t, m)
+}
+
+// CheckLaunchResponse fails the test if m is not *LaunchResponse.
+func (c *Client) CheckLaunchResponse(t *testing.T, m dap.Message) *dap.LaunchResponse {
+	t.Helper()
 	r, ok := m.(*dap.LaunchResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.LaunchResponse", m)
@@ -278,6 +410,12 @@ func (c *Client) ExpectLaunchResponse(t *testing.T) *dap.LaunchResponse {
 func (c *Client) ExpectLoadedSourceEvent(t *testing.T) *dap.LoadedSourceEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckLoadedSourceEvent(t, m)
+}
+
+// CheckLoadedSourceEvent fails the test if m is not *LoadedSourceEvent.
+func (c *Client) CheckLoadedSourceEvent(t *testing.T, m dap.Message) *dap.LoadedSourceEvent {
+	t.Helper()
 	r, ok := m.(*dap.LoadedSourceEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.LoadedSourceEvent", m)
@@ -290,6 +428,12 @@ func (c *Client) ExpectLoadedSourceEvent(t *testing.T) *dap.LoadedSourceEvent {
 func (c *Client) ExpectLoadedSourcesResponse(t *testing.T) *dap.LoadedSourcesResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckLoadedSourcesResponse(t, m)
+}
+
+// CheckLoadedSourcesResponse fails the test if m is not *LoadedSourcesResponse.
+func (c *Client) CheckLoadedSourcesResponse(t *testing.T, m dap.Message) *dap.LoadedSourcesResponse {
+	t.Helper()
 	r, ok := m.(*dap.LoadedSourcesResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.LoadedSourcesResponse", m)
@@ -302,6 +446,12 @@ func (c *Client) ExpectLoadedSourcesResponse(t *testing.T) *dap.LoadedSourcesRes
 func (c *Client) ExpectModuleEvent(t *testing.T) *dap.ModuleEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckModuleEvent(t, m)
+}
+
+// CheckModuleEvent fails the test if m is not *ModuleEvent.
+func (c *Client) CheckModuleEvent(t *testing.T, m dap.Message) *dap.ModuleEvent {
+	t.Helper()
 	r, ok := m.(*dap.ModuleEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ModuleEvent", m)
@@ -314,6 +464,12 @@ func (c *Client) ExpectModuleEvent(t *testing.T) *dap.ModuleEvent {
 func (c *Client) ExpectModulesResponse(t *testing.T) *dap.ModulesResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckModulesResponse(t, m)
+}
+
+// CheckModulesResponse fails the test if m is not *ModulesResponse.
+func (c *Client) CheckModulesResponse(t *testing.T, m dap.Message) *dap.ModulesResponse {
+	t.Helper()
 	r, ok := m.(*dap.ModulesResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ModulesResponse", m)
@@ -326,6 +482,12 @@ func (c *Client) ExpectModulesResponse(t *testing.T) *dap.ModulesResponse {
 func (c *Client) ExpectNextResponse(t *testing.T) *dap.NextResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckNextResponse(t, m)
+}
+
+// CheckNextResponse fails the test if m is not *NextResponse.
+func (c *Client) CheckNextResponse(t *testing.T, m dap.Message) *dap.NextResponse {
+	t.Helper()
 	r, ok := m.(*dap.NextResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.NextResponse", m)
@@ -338,6 +500,12 @@ func (c *Client) ExpectNextResponse(t *testing.T) *dap.NextResponse {
 func (c *Client) ExpectOutputEvent(t *testing.T) *dap.OutputEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckOutputEvent(t, m)
+}
+
+// CheckOutputEvent fails the test if m is not *OutputEvent.
+func (c *Client) CheckOutputEvent(t *testing.T, m dap.Message) *dap.OutputEvent {
+	t.Helper()
 	r, ok := m.(*dap.OutputEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.OutputEvent", m)
@@ -350,6 +518,12 @@ func (c *Client) ExpectOutputEvent(t *testing.T) *dap.OutputEvent {
 func (c *Client) ExpectPauseResponse(t *testing.T) *dap.PauseResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckPauseResponse(t, m)
+}
+
+// CheckPauseResponse fails the test if m is not *PauseResponse.
+func (c *Client) CheckPauseResponse(t *testing.T, m dap.Message) *dap.PauseResponse {
+	t.Helper()
 	r, ok := m.(*dap.PauseResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.PauseResponse", m)
@@ -362,6 +536,12 @@ func (c *Client) ExpectPauseResponse(t *testing.T) *dap.PauseResponse {
 func (c *Client) ExpectProcessEvent(t *testing.T) *dap.ProcessEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckProcessEvent(t, m)
+}
+
+// CheckProcessEvent fails the test if m is not *ProcessEvent.
+func (c *Client) CheckProcessEvent(t *testing.T, m dap.Message) *dap.ProcessEvent {
+	t.Helper()
 	r, ok := m.(*dap.ProcessEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ProcessEvent", m)
@@ -374,6 +554,12 @@ func (c *Client) ExpectProcessEvent(t *testing.T) *dap.ProcessEvent {
 func (c *Client) ExpectProgressEndEvent(t *testing.T) *dap.ProgressEndEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckProgressEndEvent(t, m)
+}
+
+// CheckProgressEndEvent fails the test if m is not *ProgressEndEvent.
+func (c *Client) CheckProgressEndEvent(t *testing.T, m dap.Message) *dap.ProgressEndEvent {
+	t.Helper()
 	r, ok := m.(*dap.ProgressEndEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ProgressEndEvent", m)
@@ -386,6 +572,12 @@ func (c *Client) ExpectProgressEndEvent(t *testing.T) *dap.ProgressEndEvent {
 func (c *Client) ExpectProgressStartEvent(t *testing.T) *dap.ProgressStartEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckProgressStartEvent(t, m)
+}
+
+// CheckProgressStartEvent fails the test if m is not *ProgressStartEvent.
+func (c *Client) CheckProgressStartEvent(t *testing.T, m dap.Message) *dap.ProgressStartEvent {
+	t.Helper()
 	r, ok := m.(*dap.ProgressStartEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ProgressStartEvent", m)
@@ -398,6 +590,12 @@ func (c *Client) ExpectProgressStartEvent(t *testing.T) *dap.ProgressStartEvent 
 func (c *Client) ExpectProgressUpdateEvent(t *testing.T) *dap.ProgressUpdateEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckProgressUpdateEvent(t, m)
+}
+
+// CheckProgressUpdateEvent fails the test if m is not *ProgressUpdateEvent.
+func (c *Client) CheckProgressUpdateEvent(t *testing.T, m dap.Message) *dap.ProgressUpdateEvent {
+	t.Helper()
 	r, ok := m.(*dap.ProgressUpdateEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ProgressUpdateEvent", m)
@@ -410,6 +608,12 @@ func (c *Client) ExpectProgressUpdateEvent(t *testing.T) *dap.ProgressUpdateEven
 func (c *Client) ExpectReadMemoryResponse(t *testing.T) *dap.ReadMemoryResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckReadMemoryResponse(t, m)
+}
+
+// CheckReadMemoryResponse fails the test if m is not *ReadMemoryResponse.
+func (c *Client) CheckReadMemoryResponse(t *testing.T, m dap.Message) *dap.ReadMemoryResponse {
+	t.Helper()
 	r, ok := m.(*dap.ReadMemoryResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ReadMemoryResponse", m)
@@ -422,6 +626,12 @@ func (c *Client) ExpectReadMemoryResponse(t *testing.T) *dap.ReadMemoryResponse 
 func (c *Client) ExpectRestartFrameResponse(t *testing.T) *dap.RestartFrameResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckRestartFrameResponse(t, m)
+}
+
+// CheckRestartFrameResponse fails the test if m is not *RestartFrameResponse.
+func (c *Client) CheckRestartFrameResponse(t *testing.T, m dap.Message) *dap.RestartFrameResponse {
+	t.Helper()
 	r, ok := m.(*dap.RestartFrameResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.RestartFrameResponse", m)
@@ -434,6 +644,12 @@ func (c *Client) ExpectRestartFrameResponse(t *testing.T) *dap.RestartFrameRespo
 func (c *Client) ExpectRestartResponse(t *testing.T) *dap.RestartResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckRestartResponse(t, m)
+}
+
+// CheckRestartResponse fails the test if m is not *RestartResponse.
+func (c *Client) CheckRestartResponse(t *testing.T, m dap.Message) *dap.RestartResponse {
+	t.Helper()
 	r, ok := m.(*dap.RestartResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.RestartResponse", m)
@@ -446,6 +662,12 @@ func (c *Client) ExpectRestartResponse(t *testing.T) *dap.RestartResponse {
 func (c *Client) ExpectReverseContinueResponse(t *testing.T) *dap.ReverseContinueResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckReverseContinueResponse(t, m)
+}
+
+// CheckReverseContinueResponse fails the test if m is not *ReverseContinueResponse.
+func (c *Client) CheckReverseContinueResponse(t *testing.T, m dap.Message) *dap.ReverseContinueResponse {
+	t.Helper()
 	r, ok := m.(*dap.ReverseContinueResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ReverseContinueResponse", m)
@@ -458,6 +680,12 @@ func (c *Client) ExpectReverseContinueResponse(t *testing.T) *dap.ReverseContinu
 func (c *Client) ExpectRunInTerminalResponse(t *testing.T) *dap.RunInTerminalResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckRunInTerminalResponse(t, m)
+}
+
+// CheckRunInTerminalResponse fails the test if m is not *RunInTerminalResponse.
+func (c *Client) CheckRunInTerminalResponse(t *testing.T, m dap.Message) *dap.RunInTerminalResponse {
+	t.Helper()
 	r, ok := m.(*dap.RunInTerminalResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.RunInTerminalResponse", m)
@@ -470,6 +698,12 @@ func (c *Client) ExpectRunInTerminalResponse(t *testing.T) *dap.RunInTerminalRes
 func (c *Client) ExpectScopesResponse(t *testing.T) *dap.ScopesResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckScopesResponse(t, m)
+}
+
+// CheckScopesResponse fails the test if m is not *ScopesResponse.
+func (c *Client) CheckScopesResponse(t *testing.T, m dap.Message) *dap.ScopesResponse {
+	t.Helper()
 	r, ok := m.(*dap.ScopesResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ScopesResponse", m)
@@ -482,6 +716,12 @@ func (c *Client) ExpectScopesResponse(t *testing.T) *dap.ScopesResponse {
 func (c *Client) ExpectSetBreakpointsResponse(t *testing.T) *dap.SetBreakpointsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckSetBreakpointsResponse(t, m)
+}
+
+// CheckSetBreakpointsResponse fails the test if m is not *SetBreakpointsResponse.
+func (c *Client) CheckSetBreakpointsResponse(t *testing.T, m dap.Message) *dap.SetBreakpointsResponse {
+	t.Helper()
 	r, ok := m.(*dap.SetBreakpointsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.SetBreakpointsResponse", m)
@@ -494,6 +734,12 @@ func (c *Client) ExpectSetBreakpointsResponse(t *testing.T) *dap.SetBreakpointsR
 func (c *Client) ExpectSetDataBreakpointsResponse(t *testing.T) *dap.SetDataBreakpointsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckSetDataBreakpointsResponse(t, m)
+}
+
+// CheckSetDataBreakpointsResponse fails the test if m is not *SetDataBreakpointsResponse.
+func (c *Client) CheckSetDataBreakpointsResponse(t *testing.T, m dap.Message) *dap.SetDataBreakpointsResponse {
+	t.Helper()
 	r, ok := m.(*dap.SetDataBreakpointsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.SetDataBreakpointsResponse", m)
@@ -506,6 +752,12 @@ func (c *Client) ExpectSetDataBreakpointsResponse(t *testing.T) *dap.SetDataBrea
 func (c *Client) ExpectSetExceptionBreakpointsResponse(t *testing.T) *dap.SetExceptionBreakpointsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckSetExceptionBreakpointsResponse(t, m)
+}
+
+// CheckSetExceptionBreakpointsResponse fails the test if m is not *SetExceptionBreakpointsResponse.
+func (c *Client) CheckSetExceptionBreakpointsResponse(t *testing.T, m dap.Message) *dap.SetExceptionBreakpointsResponse {
+	t.Helper()
 	r, ok := m.(*dap.SetExceptionBreakpointsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.SetExceptionBreakpointsResponse", m)
@@ -518,6 +770,12 @@ func (c *Client) ExpectSetExceptionBreakpointsResponse(t *testing.T) *dap.SetExc
 func (c *Client) ExpectSetExpressionResponse(t *testing.T) *dap.SetExpressionResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckSetExpressionResponse(t, m)
+}
+
+// CheckSetExpressionResponse fails the test if m is not *SetExpressionResponse.
+func (c *Client) CheckSetExpressionResponse(t *testing.T, m dap.Message) *dap.SetExpressionResponse {
+	t.Helper()
 	r, ok := m.(*dap.SetExpressionResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.SetExpressionResponse", m)
@@ -530,6 +788,12 @@ func (c *Client) ExpectSetExpressionResponse(t *testing.T) *dap.SetExpressionRes
 func (c *Client) ExpectSetFunctionBreakpointsResponse(t *testing.T) *dap.SetFunctionBreakpointsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckSetFunctionBreakpointsResponse(t, m)
+}
+
+// CheckSetFunctionBreakpointsResponse fails the test if m is not *SetFunctionBreakpointsResponse.
+func (c *Client) CheckSetFunctionBreakpointsResponse(t *testing.T, m dap.Message) *dap.SetFunctionBreakpointsResponse {
+	t.Helper()
 	r, ok := m.(*dap.SetFunctionBreakpointsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.SetFunctionBreakpointsResponse", m)
@@ -542,6 +806,12 @@ func (c *Client) ExpectSetFunctionBreakpointsResponse(t *testing.T) *dap.SetFunc
 func (c *Client) ExpectSetInstructionBreakpointsResponse(t *testing.T) *dap.SetInstructionBreakpointsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckSetInstructionBreakpointsResponse(t, m)
+}
+
+// CheckSetInstructionBreakpointsResponse fails the test if m is not *SetInstructionBreakpointsResponse.
+func (c *Client) CheckSetInstructionBreakpointsResponse(t *testing.T, m dap.Message) *dap.SetInstructionBreakpointsResponse {
+	t.Helper()
 	r, ok := m.(*dap.SetInstructionBreakpointsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.SetInstructionBreakpointsResponse", m)
@@ -554,6 +824,12 @@ func (c *Client) ExpectSetInstructionBreakpointsResponse(t *testing.T) *dap.SetI
 func (c *Client) ExpectSetVariableResponse(t *testing.T) *dap.SetVariableResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckSetVariableResponse(t, m)
+}
+
+// CheckSetVariableResponse fails the test if m is not *SetVariableResponse.
+func (c *Client) CheckSetVariableResponse(t *testing.T, m dap.Message) *dap.SetVariableResponse {
+	t.Helper()
 	r, ok := m.(*dap.SetVariableResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.SetVariableResponse", m)
@@ -566,6 +842,12 @@ func (c *Client) ExpectSetVariableResponse(t *testing.T) *dap.SetVariableRespons
 func (c *Client) ExpectSourceResponse(t *testing.T) *dap.SourceResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckSourceResponse(t, m)
+}
+
+// CheckSourceResponse fails the test if m is not *SourceResponse.
+func (c *Client) CheckSourceResponse(t *testing.T, m dap.Message) *dap.SourceResponse {
+	t.Helper()
 	r, ok := m.(*dap.SourceResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.SourceResponse", m)
@@ -578,6 +860,12 @@ func (c *Client) ExpectSourceResponse(t *testing.T) *dap.SourceResponse {
 func (c *Client) ExpectStackTraceResponse(t *testing.T) *dap.StackTraceResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckStackTraceResponse(t, m)
+}
+
+// CheckStackTraceResponse fails the test if m is not *StackTraceResponse.
+func (c *Client) CheckStackTraceResponse(t *testing.T, m dap.Message) *dap.StackTraceResponse {
+	t.Helper()
 	r, ok := m.(*dap.StackTraceResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.StackTraceResponse", m)
@@ -590,6 +878,12 @@ func (c *Client) ExpectStackTraceResponse(t *testing.T) *dap.StackTraceResponse 
 func (c *Client) ExpectStepBackResponse(t *testing.T) *dap.StepBackResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckStepBackResponse(t, m)
+}
+
+// CheckStepBackResponse fails the test if m is not *StepBackResponse.
+func (c *Client) CheckStepBackResponse(t *testing.T, m dap.Message) *dap.StepBackResponse {
+	t.Helper()
 	r, ok := m.(*dap.StepBackResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.StepBackResponse", m)
@@ -602,6 +896,12 @@ func (c *Client) ExpectStepBackResponse(t *testing.T) *dap.StepBackResponse {
 func (c *Client) ExpectStepInResponse(t *testing.T) *dap.StepInResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckStepInResponse(t, m)
+}
+
+// CheckStepInResponse fails the test if m is not *StepInResponse.
+func (c *Client) CheckStepInResponse(t *testing.T, m dap.Message) *dap.StepInResponse {
+	t.Helper()
 	r, ok := m.(*dap.StepInResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.StepInResponse", m)
@@ -614,6 +914,12 @@ func (c *Client) ExpectStepInResponse(t *testing.T) *dap.StepInResponse {
 func (c *Client) ExpectStepInTargetsResponse(t *testing.T) *dap.StepInTargetsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckStepInTargetsResponse(t, m)
+}
+
+// CheckStepInTargetsResponse fails the test if m is not *StepInTargetsResponse.
+func (c *Client) CheckStepInTargetsResponse(t *testing.T, m dap.Message) *dap.StepInTargetsResponse {
+	t.Helper()
 	r, ok := m.(*dap.StepInTargetsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.StepInTargetsResponse", m)
@@ -626,6 +932,12 @@ func (c *Client) ExpectStepInTargetsResponse(t *testing.T) *dap.StepInTargetsRes
 func (c *Client) ExpectStepOutResponse(t *testing.T) *dap.StepOutResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckStepOutResponse(t, m)
+}
+
+// CheckStepOutResponse fails the test if m is not *StepOutResponse.
+func (c *Client) CheckStepOutResponse(t *testing.T, m dap.Message) *dap.StepOutResponse {
+	t.Helper()
 	r, ok := m.(*dap.StepOutResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.StepOutResponse", m)
@@ -638,6 +950,12 @@ func (c *Client) ExpectStepOutResponse(t *testing.T) *dap.StepOutResponse {
 func (c *Client) ExpectStoppedEvent(t *testing.T) *dap.StoppedEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckStoppedEvent(t, m)
+}
+
+// CheckStoppedEvent fails the test if m is not *StoppedEvent.
+func (c *Client) CheckStoppedEvent(t *testing.T, m dap.Message) *dap.StoppedEvent {
+	t.Helper()
 	r, ok := m.(*dap.StoppedEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.StoppedEvent", m)
@@ -650,6 +968,12 @@ func (c *Client) ExpectStoppedEvent(t *testing.T) *dap.StoppedEvent {
 func (c *Client) ExpectTerminateResponse(t *testing.T) *dap.TerminateResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckTerminateResponse(t, m)
+}
+
+// CheckTerminateResponse fails the test if m is not *TerminateResponse.
+func (c *Client) CheckTerminateResponse(t *testing.T, m dap.Message) *dap.TerminateResponse {
+	t.Helper()
 	r, ok := m.(*dap.TerminateResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.TerminateResponse", m)
@@ -662,6 +986,12 @@ func (c *Client) ExpectTerminateResponse(t *testing.T) *dap.TerminateResponse {
 func (c *Client) ExpectTerminateThreadsResponse(t *testing.T) *dap.TerminateThreadsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckTerminateThreadsResponse(t, m)
+}
+
+// CheckTerminateThreadsResponse fails the test if m is not *TerminateThreadsResponse.
+func (c *Client) CheckTerminateThreadsResponse(t *testing.T, m dap.Message) *dap.TerminateThreadsResponse {
+	t.Helper()
 	r, ok := m.(*dap.TerminateThreadsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.TerminateThreadsResponse", m)
@@ -674,6 +1004,12 @@ func (c *Client) ExpectTerminateThreadsResponse(t *testing.T) *dap.TerminateThre
 func (c *Client) ExpectTerminatedEvent(t *testing.T) *dap.TerminatedEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckTerminatedEvent(t, m)
+}
+
+// CheckTerminatedEvent fails the test if m is not *TerminatedEvent.
+func (c *Client) CheckTerminatedEvent(t *testing.T, m dap.Message) *dap.TerminatedEvent {
+	t.Helper()
 	r, ok := m.(*dap.TerminatedEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.TerminatedEvent", m)
@@ -686,6 +1022,12 @@ func (c *Client) ExpectTerminatedEvent(t *testing.T) *dap.TerminatedEvent {
 func (c *Client) ExpectThreadEvent(t *testing.T) *dap.ThreadEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckThreadEvent(t, m)
+}
+
+// CheckThreadEvent fails the test if m is not *ThreadEvent.
+func (c *Client) CheckThreadEvent(t *testing.T, m dap.Message) *dap.ThreadEvent {
+	t.Helper()
 	r, ok := m.(*dap.ThreadEvent)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ThreadEvent", m)
@@ -698,6 +1040,12 @@ func (c *Client) ExpectThreadEvent(t *testing.T) *dap.ThreadEvent {
 func (c *Client) ExpectThreadsResponse(t *testing.T) *dap.ThreadsResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckThreadsResponse(t, m)
+}
+
+// CheckThreadsResponse fails the test if m is not *ThreadsResponse.
+func (c *Client) CheckThreadsResponse(t *testing.T, m dap.Message) *dap.ThreadsResponse {
+	t.Helper()
 	r, ok := m.(*dap.ThreadsResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.ThreadsResponse", m)
@@ -710,6 +1058,12 @@ func (c *Client) ExpectThreadsResponse(t *testing.T) *dap.ThreadsResponse {
 func (c *Client) ExpectVariablesResponse(t *testing.T) *dap.VariablesResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	return c.CheckVariablesResponse(t, m)
+}
+
+// CheckVariablesResponse fails the test if m is not *VariablesResponse.
+func (c *Client) CheckVariablesResponse(t *testing.T, m dap.Message) *dap.VariablesResponse {
+	t.Helper()
 	r, ok := m.(*dap.VariablesResponse)
 	if !ok {
 		t.Fatalf("got %#v, want *dap.VariablesResponse", m)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -369,14 +369,10 @@ func TestAttachStopOnEntry(t *testing.T) {
 		client.DisconnectRequestWithKillOption(true)
 
 		msg := expectMessageFilterStopped(t, client)
-		if _, ok := msg.(*dap.OutputEvent); !ok {
-			// want detach kill output message
-			t.Errorf("got %#v, want *dap.OutputEvent", msg)
-		}
+		client.CheckOutputEvent(t, msg)
 		msg = expectMessageFilterStopped(t, client)
-		if _, ok := msg.(*dap.DisconnectResponse); !ok {
-			t.Errorf("got %#v, want *dap.DisconnectResponse", msg)
-		}
+		client.CheckDisconnectResponse(t, msg)
+
 		// If this call to KeepAlive isn't here there's a chance that stdout will
 		// be garbage collected (since it is no longer alive long before this
 		// point), when that happens, on unix-like OSes, the read end of the pipe
@@ -529,7 +525,7 @@ func TestPreSetBreakpoint(t *testing.T) {
 		if len(stResp.Body.StackFrames) != 6 {
 			t.Errorf("\ngot %#v\nwant len(StackFrames)=6", stResp.Body.StackFrames)
 		} else {
-			expectFrame := func(got dap.StackFrame, id int, name string, sourceName string, line int) {
+			checkFrame := func(got dap.StackFrame, id int, name string, sourceName string, line int) {
 				t.Helper()
 				if got.Id != id || got.Name != name {
 					t.Errorf("\ngot  %#v\nwant Id=%d Name=%s", got, id, name)
@@ -538,12 +534,12 @@ func TestPreSetBreakpoint(t *testing.T) {
 					t.Errorf("\ngot  %#v\nwant Source.Name=%s Line=%d", got, sourceName, line)
 				}
 			}
-			expectFrame(stResp.Body.StackFrames[0], 1000, "main.Increment", "increment.go", 8)
-			expectFrame(stResp.Body.StackFrames[1], 1001, "main.Increment", "increment.go", 11)
-			expectFrame(stResp.Body.StackFrames[2], 1002, "main.Increment", "increment.go", 11)
-			expectFrame(stResp.Body.StackFrames[3], 1003, "main.main", "increment.go", 17)
-			expectFrame(stResp.Body.StackFrames[4], 1004, "runtime.main", "proc.go", -1)
-			expectFrame(stResp.Body.StackFrames[5], 1005, "runtime.goexit", "", -1)
+			checkFrame(stResp.Body.StackFrames[0], 1000, "main.Increment", "increment.go", 8)
+			checkFrame(stResp.Body.StackFrames[1], 1001, "main.Increment", "increment.go", 11)
+			checkFrame(stResp.Body.StackFrames[2], 1002, "main.Increment", "increment.go", 11)
+			checkFrame(stResp.Body.StackFrames[3], 1003, "main.main", "increment.go", 17)
+			checkFrame(stResp.Body.StackFrames[4], 1004, "runtime.main", "proc.go", -1)
+			checkFrame(stResp.Body.StackFrames[5], 1005, "runtime.goexit", "", -1)
 		}
 
 		client.ScopesRequest(1000)
@@ -551,18 +547,18 @@ func TestPreSetBreakpoint(t *testing.T) {
 		if len(scopes.Body.Scopes) > 2 {
 			t.Errorf("\ngot  %#v\nwant len(Scopes)=2 (Arguments & Locals)", scopes)
 		}
-		expectScope(t, scopes, 0, "Arguments", 1000)
-		expectScope(t, scopes, 1, "Locals", 1001)
+		checkScope(t, scopes, 0, "Arguments", 1000)
+		checkScope(t, scopes, 1, "Locals", 1001)
 
 		client.VariablesRequest(1000) // Arguments
 		args := client.ExpectVariablesResponse(t)
-		expectChildren(t, args, "Arguments", 2)
-		expectVarExact(t, args, 0, "y", "y", "0", "uint", noChildren)
-		expectVarExact(t, args, 1, "~r1", "", "0", "uint", noChildren)
+		checkChildren(t, args, "Arguments", 2)
+		checkVarExact(t, args, 0, "y", "y", "0", "uint", noChildren)
+		checkVarExact(t, args, 1, "~r1", "", "0", "uint", noChildren)
 
 		client.VariablesRequest(1001) // Locals
 		locals := client.ExpectVariablesResponse(t)
-		expectChildren(t, locals, "Locals", 0)
+		checkChildren(t, locals, "Locals", 0)
 
 		client.ContinueRequest(1)
 		ctResp := client.ExpectContinueResponse(t)
@@ -593,19 +589,19 @@ func TestPreSetBreakpoint(t *testing.T) {
 	})
 }
 
-// expectStackFrames is a helper for verifying the values within StackTraceResponse.
+// checkStackFrames is a helper for verifying the values within StackTraceResponse.
 //     wantStartName - name of the first returned frame (ignored if "")
 //     wantStartLine - file line of the first returned frame (ignored if <0).
 //     wantStartID - id of the first frame returned (ignored if wantFrames is 0).
 //     wantFrames - number of frames returned (length of StackTraceResponse.Body.StackFrames array).
 //     wantTotalFrames - total number of stack frames available (StackTraceResponse.Body.TotalFrames).
-func expectStackFrames(t *testing.T, got *dap.StackTraceResponse,
+func checkStackFrames(t *testing.T, got *dap.StackTraceResponse,
 	wantStartName string, wantStartLine, wantStartID, wantFrames, wantTotalFrames int) {
 	t.Helper()
-	expectStackFramesNamed("", t, got, wantStartName, wantStartLine, wantStartID, wantFrames, wantTotalFrames)
+	checkStackFramesNamed("", t, got, wantStartName, wantStartLine, wantStartID, wantFrames, wantTotalFrames)
 }
 
-func expectStackFramesNamed(testName string, t *testing.T, got *dap.StackTraceResponse,
+func checkStackFramesNamed(testName string, t *testing.T, got *dap.StackTraceResponse,
 	wantStartName string, wantStartLine, wantStartID, wantFrames, wantTotalFrames int) {
 	t.Helper()
 	if got.Body.TotalFrames != wantTotalFrames {
@@ -633,11 +629,11 @@ func expectStackFramesNamed(testName string, t *testing.T, got *dap.StackTraceRe
 	}
 }
 
-// expectScope is a helper for verifying the values within a ScopesResponse.
+// checkScope is a helper for verifying the values within a ScopesResponse.
 //     i - index of the scope within ScopesRespose.Body.Scopes array
 //     name - name of the scope
 //     varRef - reference to retrieve variables of this scope
-func expectScope(t *testing.T, got *dap.ScopesResponse, i int, name string, varRef int) {
+func checkScope(t *testing.T, got *dap.ScopesResponse, i int, name string, varRef int) {
 	t.Helper()
 	if len(got.Body.Scopes) <= i {
 		t.Errorf("\ngot  %d\nwant len(Scopes)>%d", len(got.Body.Scopes), i)
@@ -648,17 +644,17 @@ func expectScope(t *testing.T, got *dap.ScopesResponse, i int, name string, varR
 	}
 }
 
-// expectChildren is a helper for verifying the number of variables within a VariablesResponse.
+// checkChildren is a helper for verifying the number of variables within a VariablesResponse.
 //      parentName - pseudoname of the enclosing variable or scope (used for error message only)
 //      numChildren - number of variables/fields/elements of this variable
-func expectChildren(t *testing.T, got *dap.VariablesResponse, parentName string, numChildren int) {
+func checkChildren(t *testing.T, got *dap.VariablesResponse, parentName string, numChildren int) {
 	t.Helper()
 	if len(got.Body.Variables) != numChildren {
 		t.Errorf("\ngot  len(%s)=%d (children=%#v)\nwant len=%d", parentName, len(got.Body.Variables), got.Body.Variables, numChildren)
 	}
 }
 
-// expectVar is a helper for verifying the values within a VariablesResponse.
+// checkVar is a helper for verifying the values within a VariablesResponse.
 //     i - index of the variable within VariablesRespose.Body.Variables array (-1 will search all vars for a match)
 //     name - name of the variable
 //     evalName - fully qualified variable name or alternative expression to load this variable
@@ -666,7 +662,7 @@ func expectChildren(t *testing.T, got *dap.VariablesResponse, parentName string,
 //     useExactMatch - true if name, evalName and value are to be compared to exactly, false if to be used as regex
 //     hasRef - true if the variable should have children and therefore a non-0 variable reference
 //     ref - reference to retrieve children of this variable (0 if none)
-func expectVar(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, value, typ string, useExactMatch, hasRef bool) (ref int) {
+func checkVar(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, value, typ string, useExactMatch, hasRef bool) (ref int) {
 	t.Helper()
 	if len(got.Body.Variables) <= i {
 		t.Errorf("\ngot  len=%d (children=%#v)\nwant len>%d", len(got.Body.Variables), got.Body.Variables, i)
@@ -725,16 +721,16 @@ func expectVar(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, 
 	return goti.VariablesReference
 }
 
-// expectVarExact is a helper like expectVar that matches value exactly.
-func expectVarExact(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, value, typ string, hasRef bool) (ref int) {
+// checkVarExact is a helper like checkVar that matches value exactly.
+func checkVarExact(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, value, typ string, hasRef bool) (ref int) {
 	t.Helper()
-	return expectVar(t, got, i, name, evalName, value, typ, true, hasRef)
+	return checkVar(t, got, i, name, evalName, value, typ, true, hasRef)
 }
 
-// expectVarRegex is a helper like expectVar that treats value, evalName or name as a regex.
-func expectVarRegex(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, value, typ string, hasRef bool) (ref int) {
+// checkVarRegex is a helper like checkVar that treats value, evalName or name as a regex.
+func checkVarRegex(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, value, typ string, hasRef bool) (ref int) {
 	t.Helper()
-	return expectVar(t, got, i, name, evalName, value, typ, false, hasRef)
+	return checkVar(t, got, i, name, evalName, value, typ, false, hasRef)
 }
 
 func expectMessageFilterStopped(t *testing.T, client *daptest.Client) dap.Message {
@@ -817,7 +813,7 @@ func TestStackTraceRequest(t *testing.T) {
 					for name, tc := range tests {
 						client.StackTraceRequest(1, tc.startFrame, tc.levels)
 						stResp = client.ExpectStackTraceResponse(t)
-						expectStackFramesNamed(name, t, stResp,
+						checkStackFramesNamed(name, t, stResp,
 							tc.wantStartName, tc.wantStartLine, frameID(tc.wantStartFrame), tc.wantFramesReturned, tc.wantFramesAvailable)
 					}
 				},
@@ -828,7 +824,7 @@ func TestStackTraceRequest(t *testing.T) {
 					// Frame ids get reset at each breakpoint.
 					client.StackTraceRequest(1, 0, 0)
 					stResp = client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stResp, "main.main", 18, startHandle, 3, 3)
+					checkStackFrames(t, stResp, "main.main", 18, startHandle, 3, 3)
 				},
 				disconnect: false,
 			}})
@@ -862,27 +858,27 @@ func TestScopesAndVariablesRequests(t *testing.T) {
 						startLineno = -1
 					}
 
-					expectStackFrames(t, stack, "main.foobar", startLineno, 1000, 4, 4)
+					checkStackFrames(t, stack, "main.foobar", startLineno, 1000, 4, 4)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
-					expectScope(t, scopes, 0, "Arguments", 1000)
-					expectScope(t, scopes, 1, "Locals", 1001)
-					expectScope(t, scopes, 2, "Globals (package main)", 1002)
+					checkScope(t, scopes, 0, "Arguments", 1000)
+					checkScope(t, scopes, 1, "Locals", 1001)
+					checkScope(t, scopes, 2, "Globals (package main)", 1002)
 
 					// Arguments
 
 					client.VariablesRequest(1000)
 					args := client.ExpectVariablesResponse(t)
-					expectChildren(t, args, "Arguments", 2)
-					expectVarExact(t, args, 0, "baz", "baz", `"bazburzum"`, "string", noChildren)
-					ref := expectVarExact(t, args, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
+					checkChildren(t, args, "Arguments", 2)
+					checkVarExact(t, args, 0, "baz", "baz", `"bazburzum"`, "string", noChildren)
+					ref := checkVarExact(t, args, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						bar := client.ExpectVariablesResponse(t)
-						expectChildren(t, bar, "bar", 2)
-						expectVarExact(t, bar, 0, "Baz", "bar.Baz", "10", "int", noChildren)
-						expectVarExact(t, bar, 1, "Bur", "bar.Bur", `"lorem"`, "string", noChildren)
+						checkChildren(t, bar, "bar", 2)
+						checkVarExact(t, bar, 0, "Baz", "bar.Baz", "10", "int", noChildren)
+						checkVarExact(t, bar, 1, "Bur", "bar.Bur", `"lorem"`, "string", noChildren)
 						validateEvaluateName(t, client, bar, 0)
 						validateEvaluateName(t, client, bar, 1)
 					}
@@ -891,84 +887,84 @@ func TestScopesAndVariablesRequests(t *testing.T) {
 
 					client.VariablesRequest(1002)
 					globals := client.ExpectVariablesResponse(t)
-					expectVarExact(t, globals, 0, "p1", "main.p1", "10", "int", noChildren)
+					checkVarExact(t, globals, 0, "p1", "main.p1", "10", "int", noChildren)
 
 					// Locals
 
 					client.VariablesRequest(1001)
 					locals := client.ExpectVariablesResponse(t)
-					expectChildren(t, locals, "Locals", 31)
+					checkChildren(t, locals, "Locals", 31)
 
 					// reflect.Kind == Bool
-					expectVarExact(t, locals, -1, "b1", "b1", "true", "bool", noChildren)
-					expectVarExact(t, locals, -1, "b2", "b2", "false", "bool", noChildren)
+					checkVarExact(t, locals, -1, "b1", "b1", "true", "bool", noChildren)
+					checkVarExact(t, locals, -1, "b2", "b2", "false", "bool", noChildren)
 					// reflect.Kind == Int
-					expectVarExact(t, locals, -1, "a2", "a2", "6", "int", noChildren)
-					expectVarExact(t, locals, -1, "neg", "neg", "-1", "int", noChildren)
+					checkVarExact(t, locals, -1, "a2", "a2", "6", "int", noChildren)
+					checkVarExact(t, locals, -1, "neg", "neg", "-1", "int", noChildren)
 					// reflect.Kind == Int8
-					expectVarExact(t, locals, -1, "i8", "i8", "1", "int8", noChildren)
+					checkVarExact(t, locals, -1, "i8", "i8", "1", "int8", noChildren)
 					// reflect.Kind == Int16 - see testvariables2
 					// reflect.Kind == Int32 - see testvariables2
 					// reflect.Kind == Int64 - see testvariables2
 					// reflect.Kind == Uint
 					// reflect.Kind == Uint8
-					expectVarExact(t, locals, -1, "u8", "u8", "255", "uint8", noChildren)
+					checkVarExact(t, locals, -1, "u8", "u8", "255", "uint8", noChildren)
 					// reflect.Kind == Uint16
-					expectVarExact(t, locals, -1, "u16", "u16", "65535", "uint16", noChildren)
+					checkVarExact(t, locals, -1, "u16", "u16", "65535", "uint16", noChildren)
 					// reflect.Kind == Uint32
-					expectVarExact(t, locals, -1, "u32", "u32", "4294967295", "uint32", noChildren)
+					checkVarExact(t, locals, -1, "u32", "u32", "4294967295", "uint32", noChildren)
 					// reflect.Kind == Uint64
-					expectVarExact(t, locals, -1, "u64", "u64", "18446744073709551615", "uint64", noChildren)
+					checkVarExact(t, locals, -1, "u64", "u64", "18446744073709551615", "uint64", noChildren)
 					// reflect.Kind == Uintptr
-					expectVarExact(t, locals, -1, "up", "up", "5", "uintptr", noChildren)
+					checkVarExact(t, locals, -1, "up", "up", "5", "uintptr", noChildren)
 					// reflect.Kind == Float32
-					expectVarExact(t, locals, -1, "f32", "f32", "1.2", "float32", noChildren)
+					checkVarExact(t, locals, -1, "f32", "f32", "1.2", "float32", noChildren)
 					// reflect.Kind == Float64
-					expectVarExact(t, locals, -1, "a3", "a3", "7.23", "float64", noChildren)
+					checkVarExact(t, locals, -1, "a3", "a3", "7.23", "float64", noChildren)
 					// reflect.Kind == Complex64
-					ref = expectVarExact(t, locals, -1, "c64", "c64", "(1 + 2i)", "complex64", hasChildren)
+					ref = checkVarExact(t, locals, -1, "c64", "c64", "(1 + 2i)", "complex64", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						c64 := client.ExpectVariablesResponse(t)
-						expectChildren(t, c64, "c64", 2)
-						expectVarExact(t, c64, 0, "real", "", "1", "float32", noChildren)
-						expectVarExact(t, c64, 1, "imaginary", "", "2", "float32", noChildren)
+						checkChildren(t, c64, "c64", 2)
+						checkVarExact(t, c64, 0, "real", "", "1", "float32", noChildren)
+						checkVarExact(t, c64, 1, "imaginary", "", "2", "float32", noChildren)
 					}
 					// reflect.Kind == Complex128
-					ref = expectVarExact(t, locals, -1, "c128", "c128", "(2 + 3i)", "complex128", hasChildren)
+					ref = checkVarExact(t, locals, -1, "c128", "c128", "(2 + 3i)", "complex128", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						c128 := client.ExpectVariablesResponse(t)
-						expectChildren(t, c128, "c128", 2)
-						expectVarExact(t, c128, 0, "real", "", "2", "float64", noChildren)
-						expectVarExact(t, c128, 1, "imaginary", "", "3", "float64", noChildren)
+						checkChildren(t, c128, "c128", 2)
+						checkVarExact(t, c128, 0, "real", "", "2", "float64", noChildren)
+						checkVarExact(t, c128, 1, "imaginary", "", "3", "float64", noChildren)
 					}
 					// reflect.Kind == Array
-					ref = expectVarExact(t, locals, -1, "a4", "a4", "[2]int [1,2]", "[2]int", hasChildren)
+					ref = checkVarExact(t, locals, -1, "a4", "a4", "[2]int [1,2]", "[2]int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a4 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a4, "a4", 2)
-						expectVarExact(t, a4, 0, "[0]", "a4[0]", "1", "int", noChildren)
-						expectVarExact(t, a4, 1, "[1]", "a4[1]", "2", "int", noChildren)
+						checkChildren(t, a4, "a4", 2)
+						checkVarExact(t, a4, 0, "[0]", "a4[0]", "1", "int", noChildren)
+						checkVarExact(t, a4, 1, "[1]", "a4[1]", "2", "int", noChildren)
 					}
-					ref = expectVarExact(t, locals, -1, "a11", "a11", `[3]main.FooBar [{Baz: 1, Bur: "a"},{Baz: 2, Bur: "b"},{Baz: 3, Bur: "c"}]`, "[3]main.FooBar", hasChildren)
+					ref = checkVarExact(t, locals, -1, "a11", "a11", `[3]main.FooBar [{Baz: 1, Bur: "a"},{Baz: 2, Bur: "b"},{Baz: 3, Bur: "c"}]`, "[3]main.FooBar", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a11 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a11, "a11", 3)
-						expectVarExact(t, a11, 0, "[0]", "a11[0]", `main.FooBar {Baz: 1, Bur: "a"}`, "main.FooBar", hasChildren)
-						ref = expectVarExact(t, a11, 1, "[1]", "a11[1]", `main.FooBar {Baz: 2, Bur: "b"}`, "main.FooBar", hasChildren)
+						checkChildren(t, a11, "a11", 3)
+						checkVarExact(t, a11, 0, "[0]", "a11[0]", `main.FooBar {Baz: 1, Bur: "a"}`, "main.FooBar", hasChildren)
+						ref = checkVarExact(t, a11, 1, "[1]", "a11[1]", `main.FooBar {Baz: 2, Bur: "b"}`, "main.FooBar", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							a11_1 := client.ExpectVariablesResponse(t)
-							expectChildren(t, a11_1, "a11[1]", 2)
-							expectVarExact(t, a11_1, 0, "Baz", "a11[1].Baz", "2", "int", noChildren)
-							expectVarExact(t, a11_1, 1, "Bur", "a11[1].Bur", `"b"`, "string", noChildren)
+							checkChildren(t, a11_1, "a11[1]", 2)
+							checkVarExact(t, a11_1, 0, "Baz", "a11[1].Baz", "2", "int", noChildren)
+							checkVarExact(t, a11_1, 1, "Bur", "a11[1].Bur", `"b"`, "string", noChildren)
 							validateEvaluateName(t, client, a11_1, 0)
 							validateEvaluateName(t, client, a11_1, 1)
 						}
-						expectVarExact(t, a11, 2, "[2]", "a11[2]", `main.FooBar {Baz: 3, Bur: "c"}`, "main.FooBar", hasChildren)
+						checkVarExact(t, a11, 2, "[2]", "a11[2]", `main.FooBar {Baz: 3, Bur: "c"}`, "main.FooBar", hasChildren)
 					}
 
 					// reflect.Kind == Chan - see testvariables2
@@ -976,96 +972,96 @@ func TestScopesAndVariablesRequests(t *testing.T) {
 					// reflect.Kind == Interface - see testvariables2
 					// reflect.Kind == Map - see testvariables2
 					// reflect.Kind == Ptr
-					ref = expectVarExact(t, locals, -1, "a7", "a7", `*main.FooBar {Baz: 5, Bur: "strum"}`, "*main.FooBar", hasChildren)
+					ref = checkVarExact(t, locals, -1, "a7", "a7", `*main.FooBar {Baz: 5, Bur: "strum"}`, "*main.FooBar", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a7 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a7, "a7", 1)
-						ref = expectVarExact(t, a7, 0, "", "(*a7)", `main.FooBar {Baz: 5, Bur: "strum"}`, "main.FooBar", hasChildren)
+						checkChildren(t, a7, "a7", 1)
+						ref = checkVarExact(t, a7, 0, "", "(*a7)", `main.FooBar {Baz: 5, Bur: "strum"}`, "main.FooBar", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							a7val := client.ExpectVariablesResponse(t)
-							expectChildren(t, a7val, "*a7", 2)
-							expectVarExact(t, a7val, 0, "Baz", "(*a7).Baz", "5", "int", noChildren)
-							expectVarExact(t, a7val, 1, "Bur", "(*a7).Bur", `"strum"`, "string", noChildren)
+							checkChildren(t, a7val, "*a7", 2)
+							checkVarExact(t, a7val, 0, "Baz", "(*a7).Baz", "5", "int", noChildren)
+							checkVarExact(t, a7val, 1, "Bur", "(*a7).Bur", `"strum"`, "string", noChildren)
 							validateEvaluateName(t, client, a7val, 0)
 							validateEvaluateName(t, client, a7val, 1)
 						}
 					}
 					// TODO(polina): how to test for "nil" (without type) and "void"?
-					expectVarExact(t, locals, -1, "a9", "a9", "*main.FooBar nil", "*main.FooBar", noChildren)
+					checkVarExact(t, locals, -1, "a9", "a9", "*main.FooBar nil", "*main.FooBar", noChildren)
 					// reflect.Kind == Slice
-					ref = expectVarExact(t, locals, -1, "a5", "a5", "[]int len: 5, cap: 5, [1,2,3,4,5]", "[]int", hasChildren)
+					ref = checkVarExact(t, locals, -1, "a5", "a5", "[]int len: 5, cap: 5, [1,2,3,4,5]", "[]int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a5 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a5, "a5", 5)
-						expectVarExact(t, a5, 0, "[0]", "a5[0]", "1", "int", noChildren)
-						expectVarExact(t, a5, 4, "[4]", "a5[4]", "5", "int", noChildren)
+						checkChildren(t, a5, "a5", 5)
+						checkVarExact(t, a5, 0, "[0]", "a5[0]", "1", "int", noChildren)
+						checkVarExact(t, a5, 4, "[4]", "a5[4]", "5", "int", noChildren)
 						validateEvaluateName(t, client, a5, 0)
 						validateEvaluateName(t, client, a5, 1)
 					}
-					ref = expectVarExact(t, locals, -1, "a12", "a12", `[]main.FooBar len: 2, cap: 2, [{Baz: 4, Bur: "d"},{Baz: 5, Bur: "e"}]`, "[]main.FooBar", hasChildren)
+					ref = checkVarExact(t, locals, -1, "a12", "a12", `[]main.FooBar len: 2, cap: 2, [{Baz: 4, Bur: "d"},{Baz: 5, Bur: "e"}]`, "[]main.FooBar", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a12 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a12, "a12", 2)
-						expectVarExact(t, a12, 0, "[0]", "a12[0]", `main.FooBar {Baz: 4, Bur: "d"}`, "main.FooBar", hasChildren)
-						ref = expectVarExact(t, a12, 1, "[1]", "a12[1]", `main.FooBar {Baz: 5, Bur: "e"}`, "main.FooBar", hasChildren)
+						checkChildren(t, a12, "a12", 2)
+						checkVarExact(t, a12, 0, "[0]", "a12[0]", `main.FooBar {Baz: 4, Bur: "d"}`, "main.FooBar", hasChildren)
+						ref = checkVarExact(t, a12, 1, "[1]", "a12[1]", `main.FooBar {Baz: 5, Bur: "e"}`, "main.FooBar", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							a12_1 := client.ExpectVariablesResponse(t)
-							expectChildren(t, a12_1, "a12[1]", 2)
-							expectVarExact(t, a12_1, 0, "Baz", "a12[1].Baz", "5", "int", noChildren)
-							expectVarExact(t, a12_1, 1, "Bur", "a12[1].Bur", `"e"`, "string", noChildren)
+							checkChildren(t, a12_1, "a12[1]", 2)
+							checkVarExact(t, a12_1, 0, "Baz", "a12[1].Baz", "5", "int", noChildren)
+							checkVarExact(t, a12_1, 1, "Bur", "a12[1].Bur", `"e"`, "string", noChildren)
 							validateEvaluateName(t, client, a12_1, 0)
 							validateEvaluateName(t, client, a12_1, 1)
 						}
 					}
-					ref = expectVarExact(t, locals, -1, "a13", "a13", `[]*main.FooBar len: 3, cap: 3, [*{Baz: 6, Bur: "f"},*{Baz: 7, Bur: "g"},*{Baz: 8, Bur: "h"}]`, "[]*main.FooBar", hasChildren)
+					ref = checkVarExact(t, locals, -1, "a13", "a13", `[]*main.FooBar len: 3, cap: 3, [*{Baz: 6, Bur: "f"},*{Baz: 7, Bur: "g"},*{Baz: 8, Bur: "h"}]`, "[]*main.FooBar", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a13 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a13, "a13", 3)
-						expectVarExact(t, a13, 0, "[0]", "a13[0]", `*main.FooBar {Baz: 6, Bur: "f"}`, "*main.FooBar", hasChildren)
-						expectVarExact(t, a13, 1, "[1]", "a13[1]", `*main.FooBar {Baz: 7, Bur: "g"}`, "*main.FooBar", hasChildren)
-						ref = expectVarExact(t, a13, 2, "[2]", "a13[2]", `*main.FooBar {Baz: 8, Bur: "h"}`, "*main.FooBar", hasChildren)
+						checkChildren(t, a13, "a13", 3)
+						checkVarExact(t, a13, 0, "[0]", "a13[0]", `*main.FooBar {Baz: 6, Bur: "f"}`, "*main.FooBar", hasChildren)
+						checkVarExact(t, a13, 1, "[1]", "a13[1]", `*main.FooBar {Baz: 7, Bur: "g"}`, "*main.FooBar", hasChildren)
+						ref = checkVarExact(t, a13, 2, "[2]", "a13[2]", `*main.FooBar {Baz: 8, Bur: "h"}`, "*main.FooBar", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							a13_2 := client.ExpectVariablesResponse(t)
-							expectChildren(t, a13_2, "a13[2]", 1)
-							ref = expectVarExact(t, a13_2, 0, "", "(*a13[2])", `main.FooBar {Baz: 8, Bur: "h"}`, "main.FooBar", hasChildren)
+							checkChildren(t, a13_2, "a13[2]", 1)
+							ref = checkVarExact(t, a13_2, 0, "", "(*a13[2])", `main.FooBar {Baz: 8, Bur: "h"}`, "main.FooBar", hasChildren)
 							validateEvaluateName(t, client, a13_2, 0)
 							if ref > 0 {
 								client.VariablesRequest(ref)
 								val := client.ExpectVariablesResponse(t)
-								expectChildren(t, val, "*a13[2]", 2)
-								expectVarExact(t, val, 0, "Baz", "(*a13[2]).Baz", "8", "int", noChildren)
-								expectVarExact(t, val, 1, "Bur", "(*a13[2]).Bur", `"h"`, "string", noChildren)
+								checkChildren(t, val, "*a13[2]", 2)
+								checkVarExact(t, val, 0, "Baz", "(*a13[2]).Baz", "8", "int", noChildren)
+								checkVarExact(t, val, 1, "Bur", "(*a13[2]).Bur", `"h"`, "string", noChildren)
 								validateEvaluateName(t, client, val, 0)
 								validateEvaluateName(t, client, val, 1)
 							}
 						}
 					}
 					// reflect.Kind == String
-					expectVarExact(t, locals, -1, "a1", "a1", `"foofoofoofoofoofoo"`, "string", noChildren)
-					expectVarExact(t, locals, -1, "a10", "a10", `"ofo"`, "string", noChildren)
+					checkVarExact(t, locals, -1, "a1", "a1", `"foofoofoofoofoofoo"`, "string", noChildren)
+					checkVarExact(t, locals, -1, "a10", "a10", `"ofo"`, "string", noChildren)
 					// reflect.Kind == Struct
-					ref = expectVarExact(t, locals, -1, "a6", "a6", `main.FooBar {Baz: 8, Bur: "word"}`, "main.FooBar", hasChildren)
+					ref = checkVarExact(t, locals, -1, "a6", "a6", `main.FooBar {Baz: 8, Bur: "word"}`, "main.FooBar", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a6 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a6, "a6", 2)
-						expectVarExact(t, a6, 0, "Baz", "a6.Baz", "8", "int", noChildren)
-						expectVarExact(t, a6, 1, "Bur", "a6.Bur", `"word"`, "string", noChildren)
+						checkChildren(t, a6, "a6", 2)
+						checkVarExact(t, a6, 0, "Baz", "a6.Baz", "8", "int", noChildren)
+						checkVarExact(t, a6, 1, "Bur", "a6.Bur", `"word"`, "string", noChildren)
 					}
-					ref = expectVarExact(t, locals, -1, "a8", "a8", `main.FooBar2 {Bur: 10, Baz: "feh"}`, "main.FooBar2", hasChildren)
+					ref = checkVarExact(t, locals, -1, "a8", "a8", `main.FooBar2 {Bur: 10, Baz: "feh"}`, "main.FooBar2", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a8 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a8, "a8", 2)
-						expectVarExact(t, a8, 0, "Bur", "a8.Bur", "10", "int", noChildren)
-						expectVarExact(t, a8, 1, "Baz", "a8.Baz", `"feh"`, "string", noChildren)
+						checkChildren(t, a8, "a8", 2)
+						checkVarExact(t, a8, 0, "Bur", "a8.Bur", "10", "int", noChildren)
+						checkVarExact(t, a8, 1, "Baz", "a8.Baz", `"feh"`, "string", noChildren)
 					}
 					// reflect.Kind == UnsafePointer - see testvariables2
 				},
@@ -1076,13 +1072,13 @@ func TestScopesAndVariablesRequests(t *testing.T) {
 					// Frame ids get reset at each breakpoint.
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "main.barfoo", 27, 1000, 5, 5)
+					checkStackFrames(t, stack, "main.barfoo", 27, 1000, 5, 5)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
-					expectScope(t, scopes, 0, "Arguments", 1000)
-					expectScope(t, scopes, 1, "Locals", 1001)
-					expectScope(t, scopes, 2, "Globals (package main)", 1002)
+					checkScope(t, scopes, 0, "Arguments", 1000)
+					checkScope(t, scopes, 1, "Locals", 1001)
+					checkScope(t, scopes, 2, "Globals (package main)", 1002)
 
 					client.ScopesRequest(1111)
 					erres := client.ExpectInvisibleErrorResponse(t)
@@ -1092,16 +1088,16 @@ func TestScopesAndVariablesRequests(t *testing.T) {
 
 					client.VariablesRequest(1000) // Arguments
 					args := client.ExpectVariablesResponse(t)
-					expectChildren(t, args, "Arguments", 0)
+					checkChildren(t, args, "Arguments", 0)
 
 					client.VariablesRequest(1001) // Locals
 					locals := client.ExpectVariablesResponse(t)
-					expectChildren(t, locals, "Locals", 1)
-					expectVarExact(t, locals, -1, "a1", "a1", `"bur"`, "string", noChildren)
+					checkChildren(t, locals, "Locals", 1)
+					checkVarExact(t, locals, -1, "a1", "a1", `"bur"`, "string", noChildren)
 
 					client.VariablesRequest(1002) // Globals
 					globals := client.ExpectVariablesResponse(t)
-					expectVarExact(t, globals, 0, "p1", "main.p1", "10", "int", noChildren)
+					checkVarExact(t, globals, 0, "p1", "main.p1", "10", "int", noChildren)
 
 					client.VariablesRequest(7777)
 					erres = client.ExpectInvisibleErrorResponse(t)
@@ -1129,33 +1125,33 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 				execute: func() {
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "main.main", -1, 1000, 3, 3)
+					checkStackFrames(t, stack, "main.main", -1, 1000, 3, 3)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
-					expectScope(t, scopes, 0, "Arguments", 1000)
-					expectScope(t, scopes, 1, "Locals", 1001)
+					checkScope(t, scopes, 0, "Arguments", 1000)
+					checkScope(t, scopes, 1, "Locals", 1001)
 				},
 				disconnect: false,
 			}, {
 				execute: func() {
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "main.main", -1, 1000, 3, 3)
+					checkStackFrames(t, stack, "main.main", -1, 1000, 3, 3)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
 					if len(scopes.Body.Scopes) > 2 {
 						t.Errorf("\ngot  %#v\nwant len(scopes)=2 (Argumes & Locals)", scopes)
 					}
-					expectScope(t, scopes, 0, "Arguments", 1000)
-					expectScope(t, scopes, 1, "Locals", 1001)
+					checkScope(t, scopes, 0, "Arguments", 1000)
+					checkScope(t, scopes, 1, "Locals", 1001)
 
 					// Arguments
 
 					client.VariablesRequest(1000)
 					args := client.ExpectVariablesResponse(t)
-					expectChildren(t, args, "Arguments", 0)
+					checkChildren(t, args, "Arguments", 0)
 
 					// Locals
 
@@ -1165,13 +1161,13 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 					// reflect.Kind == Bool - see testvariables
 					// reflect.Kind == Int - see testvariables
 					// reflect.Kind == Int8
-					expectVarExact(t, locals, -1, "ni8", "ni8", "-5", "int8", noChildren)
+					checkVarExact(t, locals, -1, "ni8", "ni8", "-5", "int8", noChildren)
 					// reflect.Kind == Int16
-					expectVarExact(t, locals, -1, "ni16", "ni16", "-5", "int16", noChildren)
+					checkVarExact(t, locals, -1, "ni16", "ni16", "-5", "int16", noChildren)
 					// reflect.Kind == Int32
-					expectVarExact(t, locals, -1, "ni32", "ni32", "-5", "int32", noChildren)
+					checkVarExact(t, locals, -1, "ni32", "ni32", "-5", "int32", noChildren)
 					// reflect.Kind == Int64
-					expectVarExact(t, locals, -1, "ni64", "ni64", "-5", "int64", noChildren)
+					checkVarExact(t, locals, -1, "ni64", "ni64", "-5", "int64", noChildren)
 					// reflect.Kind == Uint
 					// reflect.Kind == Uint8 - see testvariables
 					// reflect.Kind == Uint16 - see testvariables
@@ -1180,209 +1176,209 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 					// reflect.Kind == Uintptr - see testvariables
 					// reflect.Kind == Float32 - see testvariables
 					// reflect.Kind == Float64
-					expectVarExact(t, locals, -1, "pinf", "pinf", "+Inf", "float64", noChildren)
-					expectVarExact(t, locals, -1, "ninf", "ninf", "-Inf", "float64", noChildren)
-					expectVarExact(t, locals, -1, "nan", "nan", "NaN", "float64", noChildren)
+					checkVarExact(t, locals, -1, "pinf", "pinf", "+Inf", "float64", noChildren)
+					checkVarExact(t, locals, -1, "ninf", "ninf", "-Inf", "float64", noChildren)
+					checkVarExact(t, locals, -1, "nan", "nan", "NaN", "float64", noChildren)
 					// reflect.Kind == Complex64 - see testvariables
 					// reflect.Kind == Complex128 - see testvariables
 					// reflect.Kind == Array
-					expectVarExact(t, locals, -1, "a0", "a0", "[0]int []", "[0]int", noChildren)
+					checkVarExact(t, locals, -1, "a0", "a0", "[0]int []", "[0]int", noChildren)
 					// reflect.Kind == Chan
-					ref := expectVarExact(t, locals, -1, "ch1", "ch1", "chan int 4/11", "chan int", hasChildren)
+					ref := checkVarExact(t, locals, -1, "ch1", "ch1", "chan int 4/11", "chan int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						ch1 := client.ExpectVariablesResponse(t)
-						expectChildren(t, ch1, "ch1", 11)
-						expectVarExact(t, ch1, 0, "qcount", "ch1.qcount", "4", "uint", noChildren)
-						expectVarRegex(t, ch1, 10, "lock", "ch1.lock", `runtime\.mutex {.*key: 0.*}`, `runtime\.mutex`, hasChildren)
+						checkChildren(t, ch1, "ch1", 11)
+						checkVarExact(t, ch1, 0, "qcount", "ch1.qcount", "4", "uint", noChildren)
+						checkVarRegex(t, ch1, 10, "lock", "ch1.lock", `runtime\.mutex {.*key: 0.*}`, `runtime\.mutex`, hasChildren)
 						validateEvaluateName(t, client, ch1, 0)
 						validateEvaluateName(t, client, ch1, 10)
 					}
-					expectVarExact(t, locals, -1, "chnil", "chnil", "chan int nil", "chan int", noChildren)
+					checkVarExact(t, locals, -1, "chnil", "chnil", "chan int nil", "chan int", noChildren)
 					// reflect.Kind == Func
-					expectVarExact(t, locals, -1, "fn1", "fn1", "main.afunc", "main.functype", noChildren)
-					expectVarExact(t, locals, -1, "fn2", "fn2", "nil", "main.functype", noChildren)
+					checkVarExact(t, locals, -1, "fn1", "fn1", "main.afunc", "main.functype", noChildren)
+					checkVarExact(t, locals, -1, "fn2", "fn2", "nil", "main.functype", noChildren)
 					// reflect.Kind == Interface
-					expectVarExact(t, locals, -1, "ifacenil", "ifacenil", "interface {} nil", "interface {}", noChildren)
-					ref = expectVarExact(t, locals, -1, "iface2", "iface2", "interface {}(string) \"test\"", "interface {}", hasChildren)
+					checkVarExact(t, locals, -1, "ifacenil", "ifacenil", "interface {} nil", "interface {}", noChildren)
+					ref = checkVarExact(t, locals, -1, "iface2", "iface2", "interface {}(string) \"test\"", "interface {}", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						iface2 := client.ExpectVariablesResponse(t)
-						expectChildren(t, iface2, "iface2", 1)
-						expectVarExact(t, iface2, 0, "data", "iface2.(data)", `"test"`, "string", noChildren)
+						checkChildren(t, iface2, "iface2", 1)
+						checkVarExact(t, iface2, 0, "data", "iface2.(data)", `"test"`, "string", noChildren)
 						validateEvaluateName(t, client, iface2, 0)
 					}
-					ref = expectVarExact(t, locals, -1, "iface4", "iface4", "interface {}([]go/constant.Value) [4]", "interface {}", hasChildren)
+					ref = checkVarExact(t, locals, -1, "iface4", "iface4", "interface {}([]go/constant.Value) [4]", "interface {}", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						iface4 := client.ExpectVariablesResponse(t)
-						expectChildren(t, iface4, "iface4", 1)
-						ref = expectVarExact(t, iface4, 0, "data", "iface4.(data)", "[]go/constant.Value len: 1, cap: 1, [4]", "[]go/constant.Value", hasChildren)
+						checkChildren(t, iface4, "iface4", 1)
+						ref = checkVarExact(t, iface4, 0, "data", "iface4.(data)", "[]go/constant.Value len: 1, cap: 1, [4]", "[]go/constant.Value", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							iface4data := client.ExpectVariablesResponse(t)
-							expectChildren(t, iface4data, "iface4.data", 1)
-							ref = expectVarExact(t, iface4data, 0, "[0]", "iface4.(data)[0]", "go/constant.Value(go/constant.int64Val) 4", "go/constant.Value", hasChildren)
+							checkChildren(t, iface4data, "iface4.data", 1)
+							ref = checkVarExact(t, iface4data, 0, "[0]", "iface4.(data)[0]", "go/constant.Value(go/constant.int64Val) 4", "go/constant.Value", hasChildren)
 							if ref > 0 {
 								client.VariablesRequest(ref)
 								iface4data0 := client.ExpectVariablesResponse(t)
-								expectChildren(t, iface4data0, "iface4.data[0]", 1)
-								expectVarExact(t, iface4data0, 0, "data", "iface4.(data)[0].(data)", "4", "go/constant.int64Val", noChildren)
+								checkChildren(t, iface4data0, "iface4.data[0]", 1)
+								checkVarExact(t, iface4data0, 0, "data", "iface4.(data)[0].(data)", "4", "go/constant.int64Val", noChildren)
 								validateEvaluateName(t, client, iface4data0, 0)
 							}
 						}
 					}
-					expectVarExact(t, locals, -1, "errnil", "errnil", "error nil", "error", noChildren)
-					ref = expectVarExact(t, locals, -1, "err1", "err1", "error(*main.astruct) *{A: 1, B: 2}", "error", hasChildren)
+					checkVarExact(t, locals, -1, "errnil", "errnil", "error nil", "error", noChildren)
+					ref = checkVarExact(t, locals, -1, "err1", "err1", "error(*main.astruct) *{A: 1, B: 2}", "error", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						err1 := client.ExpectVariablesResponse(t)
-						expectChildren(t, err1, "err1", 1)
-						expectVarExact(t, err1, 0, "data", "err1.(data)", "*main.astruct {A: 1, B: 2}", "*main.astruct", hasChildren)
+						checkChildren(t, err1, "err1", 1)
+						checkVarExact(t, err1, 0, "data", "err1.(data)", "*main.astruct {A: 1, B: 2}", "*main.astruct", hasChildren)
 						validateEvaluateName(t, client, err1, 0)
 					}
-					ref = expectVarExact(t, locals, -1, "ptrinf", "ptrinf", "*interface {}(**interface {}) **...", "*interface {}", hasChildren)
+					ref = checkVarExact(t, locals, -1, "ptrinf", "ptrinf", "*interface {}(**interface {}) **...", "*interface {}", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						ptrinf_val := client.ExpectVariablesResponse(t)
-						expectChildren(t, ptrinf_val, "*ptrinf", 1)
-						ref = expectVarExact(t, ptrinf_val, 0, "", "(*ptrinf)", "interface {}(**interface {}) **...", "interface {}", hasChildren)
+						checkChildren(t, ptrinf_val, "*ptrinf", 1)
+						ref = checkVarExact(t, ptrinf_val, 0, "", "(*ptrinf)", "interface {}(**interface {}) **...", "interface {}", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							ptrinf_val_data := client.ExpectVariablesResponse(t)
-							expectChildren(t, ptrinf_val_data, "(*ptrinf).data", 1)
-							expectVarExact(t, ptrinf_val_data, 0, "data", "(*ptrinf).(data)", "**interface {}(**interface {}) ...", "**interface {}", hasChildren)
+							checkChildren(t, ptrinf_val_data, "(*ptrinf).data", 1)
+							checkVarExact(t, ptrinf_val_data, 0, "data", "(*ptrinf).(data)", "**interface {}(**interface {}) ...", "**interface {}", hasChildren)
 							validateEvaluateName(t, client, ptrinf_val_data, 0)
 						}
 					}
 					// reflect.Kind == Map
-					expectVarExact(t, locals, -1, "mnil", "mnil", "map[string]main.astruct nil", "map[string]main.astruct", noChildren)
+					checkVarExact(t, locals, -1, "mnil", "mnil", "map[string]main.astruct nil", "map[string]main.astruct", noChildren)
 					// key - scalar, value - compound
-					ref = expectVarExact(t, locals, -1, "m2", "m2", "map[int]*main.astruct [1: *{A: 10, B: 11}, ]", "map[int]*main.astruct", hasChildren)
+					ref = checkVarExact(t, locals, -1, "m2", "m2", "map[int]*main.astruct [1: *{A: 10, B: 11}, ]", "map[int]*main.astruct", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						m2 := client.ExpectVariablesResponse(t)
-						expectChildren(t, m2, "m2", 1) // each key-value represented by a single child
-						ref = expectVarExact(t, m2, 0, "1", "m2[1]", "*main.astruct {A: 10, B: 11}", "int: *main.astruct", hasChildren)
+						checkChildren(t, m2, "m2", 1) // each key-value represented by a single child
+						ref = checkVarExact(t, m2, 0, "1", "m2[1]", "*main.astruct {A: 10, B: 11}", "int: *main.astruct", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							m2kv1 := client.ExpectVariablesResponse(t)
-							expectChildren(t, m2kv1, "m2[1]", 1)
-							ref = expectVarExact(t, m2kv1, 0, "", "(*m2[1])", "main.astruct {A: 10, B: 11}", "main.astruct", hasChildren)
+							checkChildren(t, m2kv1, "m2[1]", 1)
+							ref = checkVarExact(t, m2kv1, 0, "", "(*m2[1])", "main.astruct {A: 10, B: 11}", "main.astruct", hasChildren)
 							if ref > 0 {
 								client.VariablesRequest(ref)
 								m2kv1deref := client.ExpectVariablesResponse(t)
-								expectChildren(t, m2kv1deref, "*m2[1]", 2)
-								expectVarExact(t, m2kv1deref, 0, "A", "(*m2[1]).A", "10", "int", noChildren)
-								expectVarExact(t, m2kv1deref, 1, "B", "(*m2[1]).B", "11", "int", noChildren)
+								checkChildren(t, m2kv1deref, "*m2[1]", 2)
+								checkVarExact(t, m2kv1deref, 0, "A", "(*m2[1]).A", "10", "int", noChildren)
+								checkVarExact(t, m2kv1deref, 1, "B", "(*m2[1]).B", "11", "int", noChildren)
 								validateEvaluateName(t, client, m2kv1deref, 0)
 								validateEvaluateName(t, client, m2kv1deref, 1)
 							}
 						}
 					}
 					// key - compound, value - scalar
-					ref = expectVarExact(t, locals, -1, "m3", "m3", "map[main.astruct]int [{A: 1, B: 1}: 42, {A: 2, B: 2}: 43, ]", "map[main.astruct]int", hasChildren)
+					ref = checkVarExact(t, locals, -1, "m3", "m3", "map[main.astruct]int [{A: 1, B: 1}: 42, {A: 2, B: 2}: 43, ]", "map[main.astruct]int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						m3 := client.ExpectVariablesResponse(t)
-						expectChildren(t, m3, "m3", 2) // each key-value represented by a single child
-						ref = expectVarRegex(t, m3, 0, `main\.astruct {A: 1, B: 1}`, `m3\[\(\*\(\*"main.astruct"\)\(0x[0-9a-f]+\)\)\]`, "42", "int", hasChildren)
+						checkChildren(t, m3, "m3", 2) // each key-value represented by a single child
+						ref = checkVarRegex(t, m3, 0, `main\.astruct {A: 1, B: 1}`, `m3\[\(\*\(\*"main.astruct"\)\(0x[0-9a-f]+\)\)\]`, "42", "int", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							m3kv0 := client.ExpectVariablesResponse(t)
-							expectChildren(t, m3kv0, "m3[0]", 2)
-							expectVarRegex(t, m3kv0, 0, "A", `\(*\(*"main\.astruct"\)\(0x[0-9a-f]+\)\)\.A`, "1", "int", noChildren)
+							checkChildren(t, m3kv0, "m3[0]", 2)
+							checkVarRegex(t, m3kv0, 0, "A", `\(*\(*"main\.astruct"\)\(0x[0-9a-f]+\)\)\.A`, "1", "int", noChildren)
 							validateEvaluateName(t, client, m3kv0, 0)
 						}
-						ref = expectVarRegex(t, m3, 1, `main\.astruct {A: 2, B: 2}`, `m3\[\(\*\(\*"main.astruct"\)\(0x[0-9a-f]+\)\)\]`, "43", "", hasChildren)
+						ref = checkVarRegex(t, m3, 1, `main\.astruct {A: 2, B: 2}`, `m3\[\(\*\(\*"main.astruct"\)\(0x[0-9a-f]+\)\)\]`, "43", "", hasChildren)
 						if ref > 0 { // inspect another key from another key-value child
 							client.VariablesRequest(ref)
 							m3kv1 := client.ExpectVariablesResponse(t)
-							expectChildren(t, m3kv1, "m3[1]", 2)
-							expectVarRegex(t, m3kv1, 1, "B", `\(*\(*"main\.astruct"\)\(0x[0-9a-f]+\)\)\.B`, "2", "int", noChildren)
+							checkChildren(t, m3kv1, "m3[1]", 2)
+							checkVarRegex(t, m3kv1, 1, "B", `\(*\(*"main\.astruct"\)\(0x[0-9a-f]+\)\)\.B`, "2", "int", noChildren)
 							validateEvaluateName(t, client, m3kv1, 1)
 						}
 					}
 					// key - compound + truncated, value - scalar
-					ref = expectVarExact(t, locals, -1, "m5", "m5", `map[main.C]int [{s: "very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more"}: 1, ]`, "map[main.C]int", hasChildren)
+					ref = checkVarExact(t, locals, -1, "m5", "m5", `map[main.C]int [{s: "very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more"}: 1, ]`, "map[main.C]int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						m5 := client.ExpectVariablesResponse(t)
-						expectChildren(t, m5, "m5", 1)
-						expectVarRegex(t, m5, 0, `main\.C {s: "very long string 0123456789a0123456789b0123456789c01\.\.\. @ 0x[0-9a-f]+`, `m5\[\(\*\(\*"main\.C"\)\(0x[0-9a-f]+\)\)\]`, "1", `int`, hasChildren)
+						checkChildren(t, m5, "m5", 1)
+						checkVarRegex(t, m5, 0, `main\.C {s: "very long string 0123456789a0123456789b0123456789c01\.\.\. @ 0x[0-9a-f]+`, `m5\[\(\*\(\*"main\.C"\)\(0x[0-9a-f]+\)\)\]`, "1", `int`, hasChildren)
 					}
 					// key - compound, value - compound
-					ref = expectVarExact(t, locals, -1, "m4", "m4", "map[main.astruct]main.astruct [{A: 1, B: 1}: {A: 11, B: 11}, {A: 2, B: 2}: {A: 22, B: 22}, ]", "map[main.astruct]main.astruct", hasChildren)
+					ref = checkVarExact(t, locals, -1, "m4", "m4", "map[main.astruct]main.astruct [{A: 1, B: 1}: {A: 11, B: 11}, {A: 2, B: 2}: {A: 22, B: 22}, ]", "map[main.astruct]main.astruct", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						m4 := client.ExpectVariablesResponse(t)
-						expectChildren(t, m4, "m4", 4) // each key and value represented by a child, so double the key-value count
-						expectVarRegex(t, m4, 0, `\[key 0\]`, `\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)`, `main\.astruct {A: 1, B: 1}`, `main\.astruct`, hasChildren)
-						expectVarRegex(t, m4, 1, `\[val 0\]`, `m4\[\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\]`, `main\.astruct {A: 11, B: 11}`, `main\.astruct`, hasChildren)
-						ref = expectVarRegex(t, m4, 2, `\[key 1\]`, `\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)`, `main\.astruct {A: 2, B: 2}`, `main\.astruct`, hasChildren)
+						checkChildren(t, m4, "m4", 4) // each key and value represented by a child, so double the key-value count
+						checkVarRegex(t, m4, 0, `\[key 0\]`, `\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)`, `main\.astruct {A: 1, B: 1}`, `main\.astruct`, hasChildren)
+						checkVarRegex(t, m4, 1, `\[val 0\]`, `m4\[\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\]`, `main\.astruct {A: 11, B: 11}`, `main\.astruct`, hasChildren)
+						ref = checkVarRegex(t, m4, 2, `\[key 1\]`, `\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)`, `main\.astruct {A: 2, B: 2}`, `main\.astruct`, hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							m4Key1 := client.ExpectVariablesResponse(t)
-							expectChildren(t, m4Key1, "m4Key1", 2)
-							expectVarRegex(t, m4Key1, 0, "A", `\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\.A`, "2", "int", noChildren)
-							expectVarRegex(t, m4Key1, 1, "B", `\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\.B`, "2", "int", noChildren)
+							checkChildren(t, m4Key1, "m4Key1", 2)
+							checkVarRegex(t, m4Key1, 0, "A", `\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\.A`, "2", "int", noChildren)
+							checkVarRegex(t, m4Key1, 1, "B", `\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\.B`, "2", "int", noChildren)
 							validateEvaluateName(t, client, m4Key1, 0)
 							validateEvaluateName(t, client, m4Key1, 1)
 						}
-						ref = expectVarRegex(t, m4, 3, `\[val 1\]`, `m4\[\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\]`, `main\.astruct {A: 22, B: 22}`, "main.astruct", hasChildren)
+						ref = checkVarRegex(t, m4, 3, `\[val 1\]`, `m4\[\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\]`, `main\.astruct {A: 22, B: 22}`, "main.astruct", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							m4Val1 := client.ExpectVariablesResponse(t)
-							expectChildren(t, m4Val1, "m4Val1", 2)
-							expectVarRegex(t, m4Val1, 0, "A", `m4\[\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\]\.A`, "22", "int", noChildren)
-							expectVarRegex(t, m4Val1, 1, "B", `m4\[\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\]\.B`, "22", "int", noChildren)
+							checkChildren(t, m4Val1, "m4Val1", 2)
+							checkVarRegex(t, m4Val1, 0, "A", `m4\[\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\]\.A`, "22", "int", noChildren)
+							checkVarRegex(t, m4Val1, 1, "B", `m4\[\(\*\(\*"main\.astruct"\)\(0x[0-9a-f]+\)\)\]\.B`, "22", "int", noChildren)
 							validateEvaluateName(t, client, m4Val1, 0)
 							validateEvaluateName(t, client, m4Val1, 1)
 						}
 					}
-					expectVarExact(t, locals, -1, "emptymap", "emptymap", "map[string]string []", "map[string]string", noChildren)
+					checkVarExact(t, locals, -1, "emptymap", "emptymap", "map[string]string []", "map[string]string", noChildren)
 					// reflect.Kind == Ptr
-					ref = expectVarExact(t, locals, -1, "pp1", "pp1", "**1", "**int", hasChildren)
+					ref = checkVarExact(t, locals, -1, "pp1", "pp1", "**1", "**int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						pp1val := client.ExpectVariablesResponse(t)
-						expectChildren(t, pp1val, "*pp1", 1)
-						ref = expectVarExact(t, pp1val, 0, "", "(*pp1)", "*1", "*int", hasChildren)
+						checkChildren(t, pp1val, "*pp1", 1)
+						ref = checkVarExact(t, pp1val, 0, "", "(*pp1)", "*1", "*int", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							pp1valval := client.ExpectVariablesResponse(t)
-							expectChildren(t, pp1valval, "*(*pp1)", 1)
-							expectVarExact(t, pp1valval, 0, "", "(*(*pp1))", "1", "int", noChildren)
+							checkChildren(t, pp1valval, "*(*pp1)", 1)
+							checkVarExact(t, pp1valval, 0, "", "(*(*pp1))", "1", "int", noChildren)
 							validateEvaluateName(t, client, pp1valval, 0)
 						}
 					}
 					// reflect.Kind == Slice
-					ref = expectVarExact(t, locals, -1, "zsslice", "zsslice", "[]struct {} len: 3, cap: 3, [{},{},{}]", "[]struct {}", hasChildren)
+					ref = checkVarExact(t, locals, -1, "zsslice", "zsslice", "[]struct {} len: 3, cap: 3, [{},{},{}]", "[]struct {}", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						zsslice := client.ExpectVariablesResponse(t)
-						expectChildren(t, zsslice, "zsslice", 3)
-						expectVarExact(t, zsslice, 2, "[2]", "zsslice[2]", "struct {} {}", "struct {}", noChildren)
+						checkChildren(t, zsslice, "zsslice", 3)
+						checkVarExact(t, zsslice, 2, "[2]", "zsslice[2]", "struct {} {}", "struct {}", noChildren)
 						validateEvaluateName(t, client, zsslice, 2)
 					}
-					expectVarExact(t, locals, -1, "emptyslice", "emptyslice", "[]string len: 0, cap: 0, []", "[]string", noChildren)
-					expectVarExact(t, locals, -1, "nilslice", "nilslice", "[]int len: 0, cap: 0, nil", "[]int", noChildren)
+					checkVarExact(t, locals, -1, "emptyslice", "emptyslice", "[]string len: 0, cap: 0, []", "[]string", noChildren)
+					checkVarExact(t, locals, -1, "nilslice", "nilslice", "[]int len: 0, cap: 0, nil", "[]int", noChildren)
 					// reflect.Kind == String
-					expectVarExact(t, locals, -1, "longstr", "longstr", `"very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more"`, "string", noChildren)
+					checkVarExact(t, locals, -1, "longstr", "longstr", `"very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more"`, "string", noChildren)
 					// reflect.Kind == Struct
-					expectVarExact(t, locals, -1, "zsvar", "zsvar", "struct {} {}", "struct {}", noChildren)
+					checkVarExact(t, locals, -1, "zsvar", "zsvar", "struct {} {}", "struct {}", noChildren)
 					// reflect.Kind == UnsafePointer
 					// TODO(polina): how do I test for unsafe.Pointer(nil)?
-					expectVarRegex(t, locals, -1, "upnil", "upnil", `unsafe\.Pointer\(0x0\)`, "int", noChildren)
-					expectVarRegex(t, locals, -1, "up1", "up1", `unsafe\.Pointer\(0x[0-9a-f]+\)`, "int", noChildren)
+					checkVarRegex(t, locals, -1, "upnil", "upnil", `unsafe\.Pointer\(0x0\)`, "int", noChildren)
+					checkVarRegex(t, locals, -1, "up1", "up1", `unsafe\.Pointer\(0x[0-9a-f]+\)`, "int", noChildren)
 
 					// Test unreadable variable
-					ref = expectVarRegex(t, locals, -1, "unread", "unread", `\*\(unreadable .+\)`, "int", hasChildren)
+					ref = checkVarRegex(t, locals, -1, "unread", "unread", `\*\(unreadable .+\)`, "int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						val := client.ExpectVariablesResponse(t)
-						expectChildren(t, val, "*unread", 1)
-						expectVarRegex(t, val, 0, "^$", `\(\*unread\)`, `\(unreadable .+\)`, "int", noChildren)
+						checkChildren(t, val, "*unread", 1)
+						checkVarRegex(t, val, 0, "^$", `\(\*unread\)`, `\(unreadable .+\)`, "int", noChildren)
 						validateEvaluateName(t, client, val, 0)
 					}
 				},
@@ -1419,13 +1415,13 @@ func TestScopesRequestsOptimized(t *testing.T) {
 						startLineno = -1
 					}
 
-					expectStackFrames(t, stack, "main.foobar", startLineno, 1000, 4, 4)
+					checkStackFrames(t, stack, "main.foobar", startLineno, 1000, 4, 4)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
-					expectScope(t, scopes, 0, "Arguments (warning: optimized function)", 1000)
-					expectScope(t, scopes, 1, "Locals (warning: optimized function)", 1001)
-					expectScope(t, scopes, 2, "Globals (package main)", 1002)
+					checkScope(t, scopes, 0, "Arguments (warning: optimized function)", 1000)
+					checkScope(t, scopes, 1, "Locals (warning: optimized function)", 1001)
+					checkScope(t, scopes, 2, "Globals (package main)", 1002)
 				},
 				disconnect: false,
 			}, {
@@ -1434,13 +1430,13 @@ func TestScopesRequestsOptimized(t *testing.T) {
 					// Frame ids get reset at each breakpoint.
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "main.barfoo", 27, 1000, 5, 5)
+					checkStackFrames(t, stack, "main.barfoo", 27, 1000, 5, 5)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
-					expectScope(t, scopes, 0, "Arguments (warning: optimized function)", 1000)
-					expectScope(t, scopes, 1, "Locals (warning: optimized function)", 1001)
-					expectScope(t, scopes, 2, "Globals (package main)", 1002)
+					checkScope(t, scopes, 0, "Arguments (warning: optimized function)", 1000)
+					checkScope(t, scopes, 1, "Locals (warning: optimized function)", 1001)
+					checkScope(t, scopes, 2, "Globals (package main)", 1002)
 				},
 				disconnect: false,
 			}})
@@ -1478,109 +1474,109 @@ func TestVariablesLoading(t *testing.T) {
 					locals := client.ExpectVariablesResponse(t)
 
 					// String partially missing based on LoadConfig.MaxStringLen
-					expectVarExact(t, locals, -1, "longstr", "longstr", "\"very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more\"", "string", noChildren)
+					checkVarExact(t, locals, -1, "longstr", "longstr", "\"very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more\"", "string", noChildren)
 
 					// Array partially missing based on LoadConfig.MaxArrayValues
-					ref := expectVarExact(t, locals, -1, "longarr", "longarr", "(loaded 64/100) [100]int [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,...+36 more]", "[100]int", hasChildren)
+					ref := checkVarExact(t, locals, -1, "longarr", "longarr", "(loaded 64/100) [100]int [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,...+36 more]", "[100]int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						longarr := client.ExpectVariablesResponse(t)
-						expectChildren(t, longarr, "longarr", 64)
+						checkChildren(t, longarr, "longarr", 64)
 					}
 
 					// Slice partially missing based on LoadConfig.MaxArrayValues
-					ref = expectVarExact(t, locals, -1, "longslice", "longslice", "(loaded 64/100) []int len: 100, cap: 100, [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,...+36 more]", "[]int", hasChildren)
+					ref = checkVarExact(t, locals, -1, "longslice", "longslice", "(loaded 64/100) []int len: 100, cap: 100, [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,...+36 more]", "[]int", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						longarr := client.ExpectVariablesResponse(t)
-						expectChildren(t, longarr, "longslice", 64)
+						checkChildren(t, longarr, "longslice", 64)
 					}
 
 					// Map partially missing based on LoadConfig.MaxArrayValues
-					ref = expectVarRegex(t, locals, -1, "m1", "m1", `\(loaded 64/66\) map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
+					ref = checkVarRegex(t, locals, -1, "m1", "m1", `\(loaded 64/66\) map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						m1 := client.ExpectVariablesResponse(t)
-						expectChildren(t, m1, "m1", 64)
+						checkChildren(t, m1, "m1", 64)
 					}
 
 					// Struct partially missing based on LoadConfig.MaxStructFields
-					ref = expectVarExact(t, locals, -1, "sd", "sd", "(loaded 5/6) main.D {u1: 0, u2: 0, u3: 0, u4: 0, u5: 0,...+1 more}", "main.D", hasChildren)
+					ref = checkVarExact(t, locals, -1, "sd", "sd", "(loaded 5/6) main.D {u1: 0, u2: 0, u3: 0, u4: 0, u5: 0,...+1 more}", "main.D", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						sd := client.ExpectVariablesResponse(t)
-						expectChildren(t, sd, "sd", 5)
+						checkChildren(t, sd, "sd", 5)
 					}
 
 					// Fully missing struct auto-loaded when reaching LoadConfig.MaxVariableRecurse (also tests evaluateName corner case)
-					ref = expectVarRegex(t, locals, -1, "c1", "c1", `main\.cstruct {pb: \*main\.bstruct {a: \(\*main\.astruct\)\(0x[0-9a-f]+\)}, sa: []\*main\.astruct len: 3, cap: 3, [\*\(\*main\.astruct\)\(0x[0-9a-f]+\),\*\(\*main\.astruct\)\(0x[0-9a-f]+\),\*\(\*main.astruct\)\(0x[0-9a-f]+\)]}`, `main\.cstruct`, hasChildren)
+					ref = checkVarRegex(t, locals, -1, "c1", "c1", `main\.cstruct {pb: \*main\.bstruct {a: \(\*main\.astruct\)\(0x[0-9a-f]+\)}, sa: []\*main\.astruct len: 3, cap: 3, [\*\(\*main\.astruct\)\(0x[0-9a-f]+\),\*\(\*main\.astruct\)\(0x[0-9a-f]+\),\*\(\*main.astruct\)\(0x[0-9a-f]+\)]}`, `main\.cstruct`, hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						c1 := client.ExpectVariablesResponse(t)
-						expectChildren(t, c1, "c1", 2)
-						ref = expectVarRegex(t, c1, 1, "sa", `c1\.sa`, `\[\]\*main\.astruct len: 3, cap: 3, \[\*\(\*main\.astruct\)\(0x[0-9a-f]+\),\*\(\*main\.astruct\)\(0x[0-9a-f]+\),\*\(\*main\.astruct\)\(0x[0-9a-f]+\)\]`, `\[\]\*main\.astruct`, hasChildren)
+						checkChildren(t, c1, "c1", 2)
+						ref = checkVarRegex(t, c1, 1, "sa", `c1\.sa`, `\[\]\*main\.astruct len: 3, cap: 3, \[\*\(\*main\.astruct\)\(0x[0-9a-f]+\),\*\(\*main\.astruct\)\(0x[0-9a-f]+\),\*\(\*main\.astruct\)\(0x[0-9a-f]+\)\]`, `\[\]\*main\.astruct`, hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							c1sa := client.ExpectVariablesResponse(t)
-							expectChildren(t, c1sa, "c1.sa", 3)
-							ref = expectVarRegex(t, c1sa, 0, `\[0\]`, `c1\.sa\[0\]`, `\*\(\*main\.astruct\)\(0x[0-9a-f]+\)`, `\*main\.astruct`, hasChildren)
+							checkChildren(t, c1sa, "c1.sa", 3)
+							ref = checkVarRegex(t, c1sa, 0, `\[0\]`, `c1\.sa\[0\]`, `\*\(\*main\.astruct\)\(0x[0-9a-f]+\)`, `\*main\.astruct`, hasChildren)
 							if ref > 0 {
 								// Auto-loading of fully missing struc children happens here
 								client.VariablesRequest(ref)
 								c1sa0 := client.ExpectVariablesResponse(t)
-								expectChildren(t, c1sa0, "c1.sa[0]", 1)
+								checkChildren(t, c1sa0, "c1.sa[0]", 1)
 								// TODO(polina): there should be children here once we support auto loading
-								expectVarExact(t, c1sa0, 0, "", "(*c1.sa[0])", "main.astruct {A: 1, B: 2}", "main.astruct", hasChildren)
+								checkVarExact(t, c1sa0, 0, "", "(*c1.sa[0])", "main.astruct {A: 1, B: 2}", "main.astruct", hasChildren)
 							}
 						}
 					}
 
 					// Fully missing struct auto-loaded when hitting LoadConfig.MaxVariableRecurse (also tests evaluteName corner case)
-					ref = expectVarRegex(t, locals, -1, "aas", "aas", `\[\]main\.a len: 1, cap: 1, \[{aas: \[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]}\]`, `\[\]main\.a`, hasChildren)
+					ref = checkVarRegex(t, locals, -1, "aas", "aas", `\[\]main\.a len: 1, cap: 1, \[{aas: \[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]}\]`, `\[\]main\.a`, hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						aas := client.ExpectVariablesResponse(t)
-						expectChildren(t, aas, "aas", 1)
-						ref = expectVarRegex(t, aas, 0, "[0]", `aas\[0\]`, `main\.a {aas: \[\]main.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]}`, `main\.a`, hasChildren)
+						checkChildren(t, aas, "aas", 1)
+						ref = checkVarRegex(t, aas, 0, "[0]", `aas\[0\]`, `main\.a {aas: \[\]main.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]}`, `main\.a`, hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							aas0 := client.ExpectVariablesResponse(t)
-							expectChildren(t, aas0, "aas[0]", 1)
-							ref = expectVarRegex(t, aas0, 0, "aas", `aas\[0\]\.aas`, `\[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]`, `\[\]main\.a`, hasChildren)
+							checkChildren(t, aas0, "aas[0]", 1)
+							ref = checkVarRegex(t, aas0, 0, "aas", `aas\[0\]\.aas`, `\[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]`, `\[\]main\.a`, hasChildren)
 							if ref > 0 {
 								// Auto-loading of fully missing struct children happens here
 								client.VariablesRequest(ref)
 								aas0aas := client.ExpectVariablesResponse(t)
-								expectChildren(t, aas0aas, "aas[0].aas", 1)
+								checkChildren(t, aas0aas, "aas[0].aas", 1)
 								// TODO(polina): there should be a child here once we support auto loading - test for "aas[0].aas[0].aas"
-								ref = expectVarRegex(t, aas0aas, 0, "[0]", `aas\[0\]\.aas\[0\]`, `main\.a {aas: \[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]}`, "main.a", hasChildren)
+								ref = checkVarRegex(t, aas0aas, 0, "[0]", `aas\[0\]\.aas\[0\]`, `main\.a {aas: \[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]}`, "main.a", hasChildren)
 								if ref > 0 {
 									client.VariablesRequest(ref)
 									aas0aas0 := client.ExpectVariablesResponse(t)
-									expectChildren(t, aas0aas, "aas[0].aas[0]", 1)
-									expectVarRegex(t, aas0aas0, 0, "aas", `aas\[0\]\.aas\[0\]\.aas`, `\[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]`, `\[\]main\.a`, hasChildren)
+									checkChildren(t, aas0aas, "aas[0].aas[0]", 1)
+									checkVarRegex(t, aas0aas0, 0, "aas", `aas\[0\]\.aas\[0\]\.aas`, `\[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]`, `\[\]main\.a`, hasChildren)
 								}
 							}
 						}
 					}
 
 					// Fully missing map auto-loaded when hitting LoadConfig.MaxVariableRecurse (also tests evaluateName corner case)
-					ref = expectVarExact(t, locals, -1, "tm", "tm", "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [[...]]}", "main.truncatedMap", hasChildren)
+					ref = checkVarExact(t, locals, -1, "tm", "tm", "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [[...]]}", "main.truncatedMap", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						tm := client.ExpectVariablesResponse(t)
-						expectChildren(t, tm, "tm", 1)
-						ref = expectVarExact(t, tm, 0, "v", "tm.v", "[]map[string]main.astruct len: 1, cap: 1, [[...]]", "[]map[string]main.astruct", hasChildren)
+						checkChildren(t, tm, "tm", 1)
+						ref = checkVarExact(t, tm, 0, "v", "tm.v", "[]map[string]main.astruct len: 1, cap: 1, [[...]]", "[]map[string]main.astruct", hasChildren)
 						if ref > 0 {
 							// Auto-loading of fully missing map chidlren happens here, but they get trancated at MaxArrayValuess
 							client.VariablesRequest(ref)
 							tmV := client.ExpectVariablesResponse(t)
-							expectChildren(t, tmV, "tm.v", 1)
-							ref = expectVarRegex(t, tmV, 0, `\[0\]`, `tm\.v\[0\]`, `map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
+							checkChildren(t, tmV, "tm.v", 1)
+							ref = checkVarRegex(t, tmV, 0, `\[0\]`, `tm\.v\[0\]`, `map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
 							if ref > 0 {
 								client.VariablesRequest(ref)
 								tmV0 := client.ExpectVariablesResponse(t)
-								expectChildren(t, tmV0, "tm.v[0]", 64)
+								checkChildren(t, tmV0, "tm.v[0]", 64)
 							}
 						}
 					}
@@ -1589,28 +1585,28 @@ func TestVariablesLoading(t *testing.T) {
 					protest.MustSupportFunctionCalls(t, testBackend)
 					client.EvaluateRequest("call rettm()", 1000, "repl")
 					got := client.ExpectEvaluateResponse(t)
-					ref = expectEval(t, got, "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [[...]]}", hasChildren)
+					ref = checkEval(t, got, "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [[...]]}", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						rv := client.ExpectVariablesResponse(t)
-						expectChildren(t, rv, "rv", 1)
-						ref = expectVarExact(t, rv, 0, "~r0", "", "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [[...]]}", "main.truncatedMap", hasChildren)
+						checkChildren(t, rv, "rv", 1)
+						ref = checkVarExact(t, rv, 0, "~r0", "", "main.truncatedMap {v: []map[string]main.astruct len: 1, cap: 1, [[...]]}", "main.truncatedMap", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							tm := client.ExpectVariablesResponse(t)
-							expectChildren(t, tm, "tm", 1)
-							ref = expectVarExact(t, tm, 0, "v", "", "[]map[string]main.astruct len: 1, cap: 1, [[...]]", "[]map[string]main.astruct", hasChildren)
+							checkChildren(t, tm, "tm", 1)
+							ref = checkVarExact(t, tm, 0, "v", "", "[]map[string]main.astruct len: 1, cap: 1, [[...]]", "[]map[string]main.astruct", hasChildren)
 							if ref > 0 {
 								// Auto-loading of fully missing map chidlren happens here, but they get trancated at MaxArrayValuess
 								client.VariablesRequest(ref)
 								tmV := client.ExpectVariablesResponse(t)
-								expectChildren(t, tmV, "tm.v", 1)
+								checkChildren(t, tmV, "tm.v", 1)
 								// TODO(polina): this evaluate name is not usable - it should be empty
-								ref = expectVarRegex(t, tmV, 0, `\[0\]`, `\[0\]`, `map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
+								ref = checkVarRegex(t, tmV, 0, `\[0\]`, `\[0\]`, `map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
 								if ref > 0 {
 									client.VariablesRequest(ref)
 									tmV0 := client.ExpectVariablesResponse(t)
-									expectChildren(t, tmV0, "tm.v[0]", 64)
+									checkChildren(t, tmV0, "tm.v[0]", 64)
 								}
 							}
 						}
@@ -1655,43 +1651,43 @@ func TestVariablesLoading(t *testing.T) {
 
 						// Interface auto-loaded when hitting LoadConfig.MaxVariableRecurse=1
 
-						ref := expectVarRegex(t, locals, -1, "ni", "ni", `\[\]interface {} len: 1, cap: 1, \[\[\]interface {} len: 1, cap: 1, \[\*\(\*interface {}\)\(0x[0-9a-f]+\)\]\]`, `\[\]interface {}`, hasChildren)
+						ref := checkVarRegex(t, locals, -1, "ni", "ni", `\[\]interface {} len: 1, cap: 1, \[\[\]interface {} len: 1, cap: 1, \[\*\(\*interface {}\)\(0x[0-9a-f]+\)\]\]`, `\[\]interface {}`, hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							ni := client.ExpectVariablesResponse(t)
-							ref = expectVarRegex(t, ni, 0, `\[0\]`, `ni\[0\]`, `interface \{\}\(\[\]interface \{\}\) \[\*\(\*interface \{\}\)\(0x[0-9a-f]+\)\]`, "interface {}", hasChildren)
+							ref = checkVarRegex(t, ni, 0, `\[0\]`, `ni\[0\]`, `interface \{\}\(\[\]interface \{\}\) \[\*\(\*interface \{\}\)\(0x[0-9a-f]+\)\]`, "interface {}", hasChildren)
 							if ref > 0 {
 								client.VariablesRequest(ref)
 								niI1 := client.ExpectVariablesResponse(t)
-								ref = expectVarRegex(t, niI1, 0, "data", `ni\[0\]\.\(data\)`, `\[\]interface {} len: 1, cap: 1, \[\*\(\*interface {}\)\(0x[0-9a-f]+\)`, `\[\]interface {}`, hasChildren)
+								ref = checkVarRegex(t, niI1, 0, "data", `ni\[0\]\.\(data\)`, `\[\]interface {} len: 1, cap: 1, \[\*\(\*interface {}\)\(0x[0-9a-f]+\)`, `\[\]interface {}`, hasChildren)
 								if ref > 0 {
 									// Auto-loading happens here
 									client.VariablesRequest(ref)
 									niI1Data := client.ExpectVariablesResponse(t)
-									ref = expectVarExact(t, niI1Data, 0, "[0]", "ni[0].(data)[0]", "interface {}(int) 123", "interface {}", hasChildren)
+									ref = checkVarExact(t, niI1Data, 0, "[0]", "ni[0].(data)[0]", "interface {}(int) 123", "interface {}", hasChildren)
 									if ref > 0 {
 										client.VariablesRequest(ref)
 										niI1DataI2 := client.ExpectVariablesResponse(t)
-										expectVarExact(t, niI1DataI2, 0, "data", "ni[0].(data)[0].(data)", "123", "int", noChildren)
+										checkVarExact(t, niI1DataI2, 0, "data", "ni[0].(data)[0].(data)", "123", "int", noChildren)
 									}
 								}
 							}
 						}
 
 						// Pointer values loaded even with LoadConfig.FollowPointers=false
-						expectVarExact(t, locals, -1, "a7", "a7", "*main.FooBar {Baz: 5, Bur: \"strum\"}", "*main.FooBar", hasChildren)
+						checkVarExact(t, locals, -1, "a7", "a7", "*main.FooBar {Baz: 5, Bur: \"strum\"}", "*main.FooBar", hasChildren)
 
 						// Auto-loading works on results of evaluate expressions as well
 						client.EvaluateRequest("a7", frame, "repl")
-						expectEval(t, client.ExpectEvaluateResponse(t), "*main.FooBar {Baz: 5, Bur: \"strum\"}", hasChildren)
+						checkEval(t, client.ExpectEvaluateResponse(t), "*main.FooBar {Baz: 5, Bur: \"strum\"}", hasChildren)
 
 						client.EvaluateRequest("&a7", frame, "repl")
 						pa7 := client.ExpectEvaluateResponse(t)
-						ref = expectEvalRegex(t, pa7, `\*\(\*main\.FooBar\)\(0x[0-9a-f]+\)`, hasChildren)
+						ref = checkEvalRegex(t, pa7, `\*\(\*main\.FooBar\)\(0x[0-9a-f]+\)`, hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							a7 := client.ExpectVariablesResponse(t)
-							expectVarExact(t, a7, 0, "a7", "(*(&a7))", "*main.FooBar {Baz: 5, Bur: \"strum\"}", "*main.FooBar", hasChildren)
+							checkVarExact(t, a7, 0, "a7", "(*(&a7))", "*main.FooBar {Baz: 5, Bur: \"strum\"}", "*main.FooBar", hasChildren)
 						}
 					}
 
@@ -1703,7 +1699,7 @@ func TestVariablesLoading(t *testing.T) {
 					client.ExpectStepInResponse(t)
 					client.ExpectContinuedEvent(t)
 					client.ExpectStoppedEvent(t)
-					handleStop(t, client, 1, "main.barfoo", 24)
+					checkStop(t, client, 1, "main.barfoo", 24)
 					loadvars(1001 /*second frame here is same as topmost above*/)
 				},
 				disconnect: true,
@@ -1731,13 +1727,13 @@ func TestGlobalScopeAndVariables(t *testing.T) {
 				execute: func() {
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "main.main", 36, 1000, 3, 3)
+					checkStackFrames(t, stack, "main.main", 36, 1000, 3, 3)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
-					expectScope(t, scopes, 0, "Arguments", 1000)
-					expectScope(t, scopes, 1, "Locals", 1001)
-					expectScope(t, scopes, 2, "Globals (package main)", 1002)
+					checkScope(t, scopes, 0, "Arguments", 1000)
+					checkScope(t, scopes, 1, "Locals", 1001)
+					checkScope(t, scopes, 2, "Globals (package main)", 1002)
 
 					client.VariablesRequest(1002)
 					client.ExpectVariablesResponse(t)
@@ -1754,25 +1750,25 @@ func TestGlobalScopeAndVariables(t *testing.T) {
 
 					client.StackTraceRequest(1, 0, 20)
 					stack = client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "", 13, 1000, 4, 4)
+					checkStackFrames(t, stack, "", 13, 1000, 4, 4)
 
 					client.ScopesRequest(1000)
 					scopes = client.ExpectScopesResponse(t)
-					expectScope(t, scopes, 0, "Arguments", 1000)
-					expectScope(t, scopes, 1, "Locals", 1001)
-					expectScope(t, scopes, 2, "Globals (package github.com/go-delve/delve/_fixtures/internal/dir0/pkg)", 1002)
+					checkScope(t, scopes, 0, "Arguments", 1000)
+					checkScope(t, scopes, 1, "Locals", 1001)
+					checkScope(t, scopes, 2, "Globals (package github.com/go-delve/delve/_fixtures/internal/dir0/pkg)", 1002)
 
 					client.VariablesRequest(1002)
 					globals := client.ExpectVariablesResponse(t)
-					expectChildren(t, globals, "Globals", 1)
-					ref := expectVarExact(t, globals, 0, "SomeVar", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeVar", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeType {X: 0}", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeType", hasChildren)
+					checkChildren(t, globals, "Globals", 1)
+					ref := checkVarExact(t, globals, 0, "SomeVar", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeVar", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeType {X: 0}", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeType", hasChildren)
 
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						somevar := client.ExpectVariablesResponse(t)
-						expectChildren(t, somevar, "SomeVar", 1)
+						checkChildren(t, somevar, "SomeVar", 1)
 						// TODO(polina): unlike main.p, this prefix won't work
-						expectVarExact(t, somevar, 0, "X", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeVar.X", "0", "float64", noChildren)
+						checkVarExact(t, somevar, 0, "X", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeVar.X", "0", "float64", noChildren)
 					}
 				},
 				disconnect: false,
@@ -1798,19 +1794,19 @@ func TestShadowedVariables(t *testing.T) {
 				execute: func() {
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stack, "main.main", 13, 1000, 3, 3)
+					checkStackFrames(t, stack, "main.main", 13, 1000, 3, 3)
 
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
-					expectScope(t, scopes, 0, "Arguments", 1000)
-					expectScope(t, scopes, 1, "Locals", 1001)
-					expectScope(t, scopes, 2, "Globals (package main)", 1002)
+					checkScope(t, scopes, 0, "Arguments", 1000)
+					checkScope(t, scopes, 1, "Locals", 1001)
+					checkScope(t, scopes, 2, "Globals (package main)", 1002)
 
 					client.VariablesRequest(1001)
 					locals := client.ExpectVariablesResponse(t)
 
-					expectVarExact(t, locals, 0, "(a)", "a", "0", "int", !hasChildren)
-					expectVarExact(t, locals, 1, "a", "a", "1", "int", !hasChildren)
+					checkVarExact(t, locals, 0, "(a)", "a", "0", "int", !hasChildren)
+					checkVarExact(t, locals, 1, "a", "a", "1", "int", !hasChildren)
 
 					// Check that the non-shadowed of "a" is returned from evaluate request.
 					validateEvaluateName(t, client, locals, 1)
@@ -1838,7 +1834,7 @@ func TestLaunchRequestWithStackTraceDepth(t *testing.T) {
 				execute: func() {
 					client.StackTraceRequest(1, 0, 0)
 					stResp = client.ExpectStackTraceResponse(t)
-					expectStackFrames(t, stResp, "main.Increment", 8, 1000, 2 /*returned*/, 2 /*available*/)
+					checkStackFrames(t, stResp, "main.Increment", 8, 1000, 2 /*returned*/, 2 /*available*/)
 				},
 				disconnect: false,
 			}})
@@ -1889,7 +1885,7 @@ func TestSetBreakpoint(t *testing.T) {
 			fixture.Source, []int{16}, // b main.main
 			[]onBreakpoint{{
 				execute: func() {
-					handleStop(t, client, 1, "main.main", 16)
+					checkStop(t, client, 1, "main.main", 16)
 
 					// Set two breakpoints at the next two lines in main
 					client.SetBreakpointsRequest(fixture.Source, []int{17, 18})
@@ -1903,7 +1899,7 @@ func TestSetBreakpoint(t *testing.T) {
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
 					client.ExpectStoppedEvent(t)
-					handleStop(t, client, 1, "main.main", 18)
+					checkStop(t, client, 1, "main.main", 18)
 
 					// Set another breakpoint inside the loop in loop(), twice to trigger error
 					client.SetBreakpointsRequest(fixture.Source, []int{8, 8})
@@ -1913,10 +1909,10 @@ func TestSetBreakpoint(t *testing.T) {
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
 					client.ExpectStoppedEvent(t)
-					handleStop(t, client, 1, "main.loop", 8)
+					checkStop(t, client, 1, "main.loop", 8)
 					client.VariablesRequest(1001) // Locals
 					locals := client.ExpectVariablesResponse(t)
-					expectVarExact(t, locals, 0, "i", "i", "0", "int", noChildren) // i == 0
+					checkVarExact(t, locals, 0, "i", "i", "0", "int", noChildren) // i == 0
 
 					// Edit the breakpoint to add a condition
 					client.SetConditionalBreakpointsRequest(fixture.Source, []int{8}, map[int]string{8: "i == 3"})
@@ -1926,10 +1922,10 @@ func TestSetBreakpoint(t *testing.T) {
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
 					client.ExpectStoppedEvent(t)
-					handleStop(t, client, 1, "main.loop", 8)
+					checkStop(t, client, 1, "main.loop", 8)
 					client.VariablesRequest(1001) // Locals
 					locals = client.ExpectVariablesResponse(t)
-					expectVarExact(t, locals, 0, "i", "i", "3", "int", noChildren) // i == 3
+					checkVarExact(t, locals, 0, "i", "i", "3", "int", noChildren) // i == 3
 
 					// Edit the breakpoint to remove a condition
 					client.SetConditionalBreakpointsRequest(fixture.Source, []int{8}, map[int]string{8: ""})
@@ -1939,10 +1935,10 @@ func TestSetBreakpoint(t *testing.T) {
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
 					client.ExpectStoppedEvent(t)
-					handleStop(t, client, 1, "main.loop", 8)
+					checkStop(t, client, 1, "main.loop", 8)
 					client.VariablesRequest(1001) // Locals
 					locals = client.ExpectVariablesResponse(t)
-					expectVarExact(t, locals, 0, "i", "i", "4", "int", noChildren) // i == 4
+					checkVarExact(t, locals, 0, "i", "i", "4", "int", noChildren) // i == 4
 
 					// Set at a line without a statement
 					client.SetBreakpointsRequest(fixture.Source, []int{1000})
@@ -1966,7 +1962,7 @@ func TestSetFunctionBreakpoints(t *testing.T) {
 			fixture.Source, []int{30}, // b main.main
 			[]onBreakpoint{{
 				execute: func() {
-					handleStop(t, client, 1, "main.main", 30)
+					checkStop(t, client, 1, "main.main", 30)
 
 					type Breakpoint struct {
 						line       int
@@ -2151,7 +2147,7 @@ func TestSetFunctionBreakpoints(t *testing.T) {
 					if se := client.ExpectStoppedEvent(t); se.Body.Reason != "function breakpoint" || se.Body.ThreadId != 1 {
 						t.Errorf("got %#v, want Reason=\"function breakpoint\", ThreadId=1", se)
 					}
-					handleStop(t, client, 1, "main.(*SomeType).SomeFunction", 22)
+					checkStop(t, client, 1, "main.(*SomeType).SomeFunction", 22)
 
 					// Set a breakpoint at the next line in the program.
 					client.SetBreakpointsRequest(fixture.Source, []int{23})
@@ -2178,7 +2174,7 @@ func TestSetFunctionBreakpoints(t *testing.T) {
 					if se := client.ExpectStoppedEvent(t); se.Body.Reason != "breakpoint" || se.Body.ThreadId != 1 {
 						t.Errorf("got %#v, want Reason=\"breakpoint\", ThreadId=1", se)
 					}
-					handleStop(t, client, 1, "main.(*SomeType).SomeFunction", 23)
+					checkStop(t, client, 1, "main.(*SomeType).SomeFunction", 23)
 
 					// Set a breakpoint, this should not clear the breakpoint that was set in the previous setFunctionBreakpoints request.
 					client.SetBreakpointsRequest(fixture.Source, []int{37})
@@ -2199,7 +2195,7 @@ func TestSetFunctionBreakpoints(t *testing.T) {
 					if se := client.ExpectStoppedEvent(t); se.Body.Reason != "function breakpoint" || se.Body.ThreadId != 1 {
 						t.Errorf("got %#v, want Reason=\"function breakpoint\", ThreadId=1", se)
 					}
-					handleStop(t, client, 1, "main.anotherFunction", 26)
+					checkStop(t, client, 1, "main.anotherFunction", 26)
 
 				},
 				disconnect: true,
@@ -2253,7 +2249,7 @@ func TestSetBreakpointWhileRunning(t *testing.T) {
 			[]onBreakpoint{{
 				execute: func() {
 					// The program loops 3 times over lines 14-15-8-9-10-16
-					handleStop(t, client, 1, "main.main", 16) // Line that sleeps for 1 second
+					checkStop(t, client, 1, "main.main", 16) // Line that sleeps for 1 second
 
 					// We can set breakpoints while nexting
 					client.NextRequest(1)
@@ -2272,7 +2268,7 @@ func TestSetBreakpointWhileRunning(t *testing.T) {
 					if se.Body.Reason != "breakpoint" || !se.Body.AllThreadsStopped || se.Body.ThreadId != 1 {
 						t.Errorf("\ngot  %#v\nwant Reason='breakpoint' AllThreadsStopped=true ThreadId=1", se)
 					}
-					handleStop(t, client, 1, "main.main", 15)
+					checkStop(t, client, 1, "main.main", 15)
 
 					// We can set breakpoints while continuing
 					client.ContinueRequest(1)
@@ -2289,7 +2285,7 @@ func TestSetBreakpointWhileRunning(t *testing.T) {
 					if se.Body.Reason != "breakpoint" || !se.Body.AllThreadsStopped || se.Body.ThreadId != 1 {
 						t.Errorf("\ngot  %#v\nwant Reason='breakpoint' AllThreadsStopped=true ThreadId=1", se)
 					}
-					handleStop(t, client, 1, "main.sayhi", 9)
+					checkStop(t, client, 1, "main.sayhi", 9)
 
 				},
 				disconnect: true,
@@ -2309,7 +2305,7 @@ func TestSetFunctionBreakpointWhileRunning(t *testing.T) {
 			[]onBreakpoint{{
 				execute: func() {
 					// The program loops 3 times over lines 14-15-8-9-10-16
-					handleStop(t, client, 1, "main.main", 16) // Line that sleeps for 1 second
+					checkStop(t, client, 1, "main.main", 16) // Line that sleeps for 1 second
 
 					// We can set breakpoints while nexting
 					client.NextRequest(1)
@@ -2332,7 +2328,7 @@ func TestSetFunctionBreakpointWhileRunning(t *testing.T) {
 					if se.Body.Reason != "function breakpoint" || !se.Body.AllThreadsStopped || se.Body.ThreadId != 1 {
 						t.Errorf("\ngot  %#v\nwant Reason='breakpoint' AllThreadsStopped=true ThreadId=1", se)
 					}
-					handleStop(t, client, 1, "main.sayhi", 8)
+					checkStop(t, client, 1, "main.sayhi", 8)
 
 					// We can set breakpoints while continuing
 					client.ContinueRequest(1)
@@ -2357,7 +2353,7 @@ func TestSetFunctionBreakpointWhileRunning(t *testing.T) {
 					if se.Body.Reason != "breakpoint" || !se.Body.AllThreadsStopped || se.Body.ThreadId != 1 {
 						t.Errorf("\ngot  %#v\nwant Reason='breakpoint' AllThreadsStopped=true ThreadId=1", se)
 					}
-					handleStop(t, client, 1, "main.main", 16)
+					checkStop(t, client, 1, "main.main", 16)
 
 				},
 				disconnect: true,
@@ -2434,7 +2430,7 @@ func substitutePathTestHelper(t *testing.T, fixture protest.Fixture, client *dap
 		[]onBreakpoint{{
 
 			execute: func() {
-				handleStop(t, client, 1, "main.loop", 8)
+				checkStop(t, client, 1, "main.loop", 8)
 			},
 			disconnect: true,
 		}})
@@ -2477,12 +2473,12 @@ func TestWorkingDir(t *testing.T) {
 			fixture.Source, []int{10}, // b main.main
 			[]onBreakpoint{{
 				execute: func() {
-					handleStop(t, client, 1, "main.main", 10)
+					checkStop(t, client, 1, "main.main", 10)
 					client.VariablesRequest(1001) // Locals
 					locals := client.ExpectVariablesResponse(t)
-					expectChildren(t, locals, "Locals", 2)
-					expectVarExact(t, locals, 0, "pwd", "pwd", fmt.Sprintf("%q", wd), "string", noChildren)
-					expectVarExact(t, locals, 1, "err", "err", "error nil", "error", noChildren)
+					checkChildren(t, locals, "Locals", 2)
+					checkVarExact(t, locals, 0, "pwd", "pwd", fmt.Sprintf("%q", wd), "string", noChildren)
+					checkVarExact(t, locals, 1, "err", "err", "error nil", "error", noChildren)
 
 				},
 				disconnect: false,
@@ -2490,11 +2486,11 @@ func TestWorkingDir(t *testing.T) {
 	})
 }
 
-// expectEval is a helper for verifying the values within an EvaluateResponse.
+// checkEval is a helper for verifying the values within an EvaluateResponse.
 //     value - the value of the evaluated expression
 //     hasRef - true if the evaluated expression should have children and therefore a non-0 variable reference
 //     ref - reference to retrieve children of this evaluated expression (0 if none)
-func expectEval(t *testing.T, got *dap.EvaluateResponse, value string, hasRef bool) (ref int) {
+func checkEval(t *testing.T, got *dap.EvaluateResponse, value string, hasRef bool) (ref int) {
 	t.Helper()
 	if got.Body.Result != value || (got.Body.VariablesReference > 0) != hasRef {
 		t.Errorf("\ngot  %#v\nwant Result=%q hasRef=%t", got, value, hasRef)
@@ -2502,7 +2498,7 @@ func expectEval(t *testing.T, got *dap.EvaluateResponse, value string, hasRef bo
 	return got.Body.VariablesReference
 }
 
-func expectEvalRegex(t *testing.T, got *dap.EvaluateResponse, valueRegex string, hasRef bool) (ref int) {
+func checkEvalRegex(t *testing.T, got *dap.EvaluateResponse, valueRegex string, hasRef bool) (ref int) {
 	t.Helper()
 	matched, _ := regexp.MatchString(valueRegex, got.Body.Result)
 	if !matched || (got.Body.VariablesReference > 0) != hasRef {
@@ -2521,22 +2517,22 @@ func TestEvaluateRequest(t *testing.T) {
 			fixture.Source, []int{}, // Breakpoint set in the program
 			[]onBreakpoint{{ // Stop at first breakpoint
 				execute: func() {
-					handleStop(t, client, 1, "main.foobar", 66)
+					checkStop(t, client, 1, "main.foobar", 66)
 
 					// Variable lookup
 					client.EvaluateRequest("a2", 1000, "this context will be ignored")
 					got := client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "6", noChildren)
+					checkEval(t, got, "6", noChildren)
 
 					client.EvaluateRequest("a5", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					ref := expectEval(t, got, "[]int len: 5, cap: 5, [1,2,3,4,5]", hasChildren)
+					ref := checkEval(t, got, "[]int len: 5, cap: 5, [1,2,3,4,5]", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						a5 := client.ExpectVariablesResponse(t)
-						expectChildren(t, a5, "a5", 5)
-						expectVarExact(t, a5, 0, "[0]", "(a5)[0]", "1", "int", noChildren)
-						expectVarExact(t, a5, 4, "[4]", "(a5)[4]", "5", "int", noChildren)
+						checkChildren(t, a5, "a5", 5)
+						checkVarExact(t, a5, 0, "[0]", "(a5)[0]", "1", "int", noChildren)
+						checkVarExact(t, a5, 4, "[4]", "(a5)[4]", "5", "int", noChildren)
 						validateEvaluateName(t, client, a5, 0)
 						validateEvaluateName(t, client, a5, 4)
 					}
@@ -2544,101 +2540,101 @@ func TestEvaluateRequest(t *testing.T) {
 					// Variable lookup that's not fully loaded
 					client.EvaluateRequest("ba", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "(loaded 64/200) []int len: 200, cap: 200, [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,...+136 more]", hasChildren)
+					checkEval(t, got, "(loaded 64/200) []int len: 200, cap: 200, [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,...+136 more]", hasChildren)
 
 					// All (binary and unary) on basic types except <-, ++ and --
 					client.EvaluateRequest("1+1", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "2", noChildren)
+					checkEval(t, got, "2", noChildren)
 
 					// Comparison operators on any type
 					client.EvaluateRequest("1<2", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "true", noChildren)
+					checkEval(t, got, "true", noChildren)
 
 					// Type casts between numeric types
 					client.EvaluateRequest("int(2.3)", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "2", noChildren)
+					checkEval(t, got, "2", noChildren)
 
 					// Type casts of integer constants into any pointer type and vice versa
 					client.EvaluateRequest("(*int)(2)", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					ref = expectEvalRegex(t, got, `\*\(unreadable .+\)`, hasChildren)
+					ref = checkEvalRegex(t, got, `\*\(unreadable .+\)`, hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						val := client.ExpectVariablesResponse(t)
-						expectChildren(t, val, "*(*int)(2)", 1)
-						expectVarRegex(t, val, 0, "^$", `\(\*\(\(\*int\)\(2\)\)\)`, `\(unreadable .+\)`, "int", noChildren)
+						checkChildren(t, val, "*(*int)(2)", 1)
+						checkVarRegex(t, val, 0, "^$", `\(\*\(\(\*int\)\(2\)\)\)`, `\(unreadable .+\)`, "int", noChildren)
 						validateEvaluateName(t, client, val, 0)
 					}
 
 					// Type casts between string, []byte and []rune
 					client.EvaluateRequest("[]byte(\"ABC€\")", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "[]uint8 len: 6, cap: 6, [65,66,67,226,130,172]", noChildren)
+					checkEval(t, got, "[]uint8 len: 6, cap: 6, [65,66,67,226,130,172]", noChildren)
 
 					// Struct member access (i.e. somevar.memberfield)
 					client.EvaluateRequest("ms.Nest.Level", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "1", noChildren)
+					checkEval(t, got, "1", noChildren)
 
 					// Slicing and indexing operators on arrays, slices and strings
 					client.EvaluateRequest("a5[4]", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "5", noChildren)
+					checkEval(t, got, "5", noChildren)
 
 					// Map access
 					client.EvaluateRequest("mp[1]", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					ref = expectEval(t, got, "interface {}(int) 42", hasChildren)
+					ref = checkEval(t, got, "interface {}(int) 42", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						expr := client.ExpectVariablesResponse(t)
-						expectChildren(t, expr, "mp[1]", 1)
-						expectVarExact(t, expr, 0, "data", "(mp[1]).(data)", "42", "int", noChildren)
+						checkChildren(t, expr, "mp[1]", 1)
+						checkVarExact(t, expr, 0, "data", "(mp[1]).(data)", "42", "int", noChildren)
 						validateEvaluateName(t, client, expr, 0)
 					}
 
 					// Pointer dereference
 					client.EvaluateRequest("*ms.Nest", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					ref = expectEvalRegex(t, got, `main\.Nest {Level: 1, Nest: \*main.Nest {Level: 2, Nest: \*\(\*main\.Nest\)\(0x[0-9a-f]+\)}}`, hasChildren)
+					ref = checkEvalRegex(t, got, `main\.Nest {Level: 1, Nest: \*main.Nest {Level: 2, Nest: \*\(\*main\.Nest\)\(0x[0-9a-f]+\)}}`, hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						expr := client.ExpectVariablesResponse(t)
-						expectChildren(t, expr, "*ms.Nest", 2)
-						expectVarExact(t, expr, 0, "Level", "(*ms.Nest).Level", "1", "int", noChildren)
+						checkChildren(t, expr, "*ms.Nest", 2)
+						checkVarExact(t, expr, 0, "Level", "(*ms.Nest).Level", "1", "int", noChildren)
 						validateEvaluateName(t, client, expr, 0)
 					}
 
 					// Calls to builtin functions: cap, len, complex, imag and real
 					client.EvaluateRequest("len(a5)", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "5", noChildren)
+					checkEval(t, got, "5", noChildren)
 
 					// Type assertion on interface variables (i.e. somevar.(concretetype))
 					client.EvaluateRequest("mp[1].(int)", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "42", noChildren)
+					checkEval(t, got, "42", noChildren)
 				},
 				disconnect: false,
 			}, { // Stop at second breakpoint
 				execute: func() {
-					handleStop(t, client, 1, "main.barfoo", 27)
+					checkStop(t, client, 1, "main.barfoo", 27)
 
 					// Top-most frame
 					client.EvaluateRequest("a1", 1000, "this context will be ignored")
 					got := client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "\"bur\"", noChildren)
+					checkEval(t, got, "\"bur\"", noChildren)
 					// No frame defaults to top-most frame
 					client.EvaluateRequest("a1", 0, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "\"bur\"", noChildren)
+					checkEval(t, got, "\"bur\"", noChildren)
 					// Next frame
 					client.EvaluateRequest("a1", 1001, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "\"foofoofoofoofoofoo\"", noChildren)
+					checkEval(t, got, "\"foofoofoofoofoofoo\"", noChildren)
 					// Next frame
 					client.EvaluateRequest("a1", 1002, "any context but watch")
 					erres := client.ExpectVisibleErrorResponse(t)
@@ -2681,7 +2677,7 @@ func TestEvaluateRequestLongStr(t *testing.T) {
 					longstr := `"very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"`
 					longstrTruncated := `"very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more"`
 
-					handleStop(t, client, 1, "main.main", -1)
+					checkStop(t, client, 1, "main.main", -1)
 
 					client.VariablesRequest(1001) // Locals
 					locals := client.ExpectVariablesResponse(t)
@@ -2696,16 +2692,16 @@ func TestEvaluateRequestLongStr(t *testing.T) {
 							if evalContext == "repl" || evalContext == "variables" {
 								want = longstr
 							}
-							expectEval(t, got, want, false)
+							checkEval(t, got, want, false)
 
 							// long string as a struct field
 							client.EvaluateRequest("(m6).s", 0, evalContext)
 							got2 := client.ExpectEvaluateResponse(t)
-							expectEval(t, got2, want, false)
+							checkEval(t, got2, want, false)
 
 							// variables are not affected.
-							expectVarExact(t, locals, -1, "longstr", "longstr", longstrTruncated, "string", noChildren)
-							expectVarExact(t, locals, -1, "m6", "m6", `main.C {s: `+longstrTruncated+`}`, "main.C", hasChildren)
+							checkVarExact(t, locals, -1, "longstr", "longstr", longstrTruncated, "string", noChildren)
+							checkVarExact(t, locals, -1, "m6", "m6", `main.C {s: `+longstrTruncated+`}`, "main.C", hasChildren)
 						})
 					}
 
@@ -2726,7 +2722,7 @@ func TestEvaluateCallRequest(t *testing.T) {
 			fixture.Source, []int{88},
 			[]onBreakpoint{{ // Stop in makeclos()
 				execute: func() {
-					handleStop(t, client, 1, "main.makeclos", 88)
+					checkStop(t, client, 1, "main.makeclos", 88)
 
 					// Topmost frame: both types of expressions should work
 					client.EvaluateRequest("callstacktrace", 1000, "this context will be ignored")
@@ -2765,7 +2761,7 @@ func TestEvaluateCallRequest(t *testing.T) {
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
 					client.ExpectStoppedEvent(t)
-					handleStop(t, client, 1, "main.makeclos", 88)
+					checkStop(t, client, 1, "main.makeclos", 88)
 
 					// Inject a call for the same function that is stopped at breakpoint:
 					// it might stop at the exact same breakpoint on the same goroutine,
@@ -2778,80 +2774,80 @@ func TestEvaluateCallRequest(t *testing.T) {
 					if erres.Body.Error.Format != "Unable to evaluate expression: call stopped" {
 						t.Errorf("\ngot %#v\nwant Format=\"Unable to evaluate expression: call stopped\"", erres)
 					}
-					handleStop(t, client, stopped.Body.ThreadId, "main.makeclos", 88)
+					checkStop(t, client, stopped.Body.ThreadId, "main.makeclos", 88)
 
 					// Complete the call and get back to original breakpoint in makeclos()
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
 					client.ExpectStoppedEvent(t)
-					handleStop(t, client, 1, "main.makeclos", 88)
+					checkStop(t, client, 1, "main.makeclos", 88)
 				},
 				disconnect: false,
 			}, { // Stop at runtime breakpoint
 				execute: func() {
-					handleStop(t, client, 1, "main.main", 197)
+					checkStop(t, client, 1, "main.main", 197)
 
 					// No return values
 					client.EvaluateRequest("call call0(1, 2)", 1000, "this context will be ignored")
 					got := client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "", noChildren)
+					checkEval(t, got, "", noChildren)
 					// One unnamed return value
 					client.EvaluateRequest("call call1(one, two)", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					ref := expectEval(t, got, "3", hasChildren)
+					ref := checkEval(t, got, "3", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						rv := client.ExpectVariablesResponse(t)
-						expectChildren(t, rv, "rv", 1)
-						expectVarExact(t, rv, 0, "~r2", "", "3", "int", noChildren)
+						checkChildren(t, rv, "rv", 1)
+						checkVarExact(t, rv, 0, "~r2", "", "3", "int", noChildren)
 					}
 					// One named return value
 					// Panic doesn't panic, but instead returns the error as a named return variable
 					client.EvaluateRequest("call callpanic()", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					ref = expectEval(t, got, `interface {}(string) "callpanic panicked"`, hasChildren)
+					ref = checkEval(t, got, `interface {}(string) "callpanic panicked"`, hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						rv := client.ExpectVariablesResponse(t)
-						expectChildren(t, rv, "rv", 1)
-						ref = expectVarExact(t, rv, 0, "~panic", "", `interface {}(string) "callpanic panicked"`, "interface {}", hasChildren)
+						checkChildren(t, rv, "rv", 1)
+						ref = checkVarExact(t, rv, 0, "~panic", "", `interface {}(string) "callpanic panicked"`, "interface {}", hasChildren)
 						if ref > 0 {
 							client.VariablesRequest(ref)
 							p := client.ExpectVariablesResponse(t)
-							expectChildren(t, p, "~panic", 1)
-							expectVarExact(t, p, 0, "data", "", "\"callpanic panicked\"", "string", noChildren)
+							checkChildren(t, p, "~panic", 1)
+							checkVarExact(t, p, 0, "data", "", "\"callpanic panicked\"", "string", noChildren)
 						}
 					}
 					// Multiple return values
 					client.EvaluateRequest("call call2(one, two)", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					ref = expectEval(t, got, "1, 2", hasChildren)
+					ref = checkEval(t, got, "1, 2", hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						rvs := client.ExpectVariablesResponse(t)
-						expectChildren(t, rvs, "rvs", 2)
-						expectVarExact(t, rvs, 0, "~r2", "", "1", "int", noChildren)
-						expectVarExact(t, rvs, 1, "~r3", "", "2", "int", noChildren)
+						checkChildren(t, rvs, "rvs", 2)
+						checkVarExact(t, rvs, 0, "~r2", "", "1", "int", noChildren)
+						checkVarExact(t, rvs, 1, "~r3", "", "2", "int", noChildren)
 					}
 					// No frame defaults to top-most frame
 					client.EvaluateRequest("call call1(one, two)", 0, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "3", hasChildren)
+					checkEval(t, got, "3", hasChildren)
 					// Extra spaces don't matter
 					client.EvaluateRequest(" call  call1(one, one) ", 0, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "2", hasChildren)
+					checkEval(t, got, "2", hasChildren)
 					// Just 'call', even with extra space, is treated as {expression}
 					client.EvaluateRequest("call ", 1000, "watch")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "\"this is a variable named `call`\"", noChildren)
+					checkEval(t, got, "\"this is a variable named `call`\"", noChildren)
 					// Long string as a return value
 					client.EvaluateRequest(`call stringsJoin(longstrs, ",")`, 1000, "variables") // full string
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, `"very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"`, hasChildren)
+					checkEval(t, got, `"very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"`, hasChildren)
 					client.EvaluateRequest(`call stringsJoin(longstrs, ",")`, 1000, "watch") // full string
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, `"very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"`, hasChildren)
+					checkEval(t, got, `"very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"`, hasChildren)
 
 					// Call error
 					client.EvaluateRequest("call call1(one)", 1000, "watch")
@@ -2863,11 +2859,11 @@ func TestEvaluateCallRequest(t *testing.T) {
 					// Assignment - expect no error, but no return value.
 					client.EvaluateRequest("call one = two", 1000, "this context will be ignored")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "", noChildren)
+					checkEval(t, got, "", noChildren)
 					// Check one=two was applied.
 					client.EvaluateRequest("one", 1000, "repl")
 					got = client.ExpectEvaluateResponse(t)
-					expectEval(t, got, "2", noChildren)
+					checkEval(t, got, "2", noChildren)
 
 					// Call can exit.
 					client.EvaluateRequest("call callexit()", 1000, "this context will be ignored")
@@ -2893,7 +2889,7 @@ func TestNextAndStep(t *testing.T) {
 			fixture.Source, []int{11},
 			[]onBreakpoint{{ // Stop at line 11
 				execute: func() {
-					handleStop(t, client, 1, "main.initialize", 11)
+					checkStop(t, client, 1, "main.initialize", 11)
 
 					expectStop := func(fun string, line int) {
 						t.Helper()
@@ -2901,7 +2897,7 @@ func TestNextAndStep(t *testing.T) {
 						if se.Body.Reason != "step" || se.Body.ThreadId != 1 || !se.Body.AllThreadsStopped {
 							t.Errorf("got %#v, want Reason=\"step\", ThreadId=1, AllThreadsStopped=true", se)
 						}
-						handleStop(t, client, 1, fun, line)
+						checkStop(t, client, 1, fun, line)
 					}
 
 					client.StepOutRequest(1)
@@ -2925,7 +2921,7 @@ func TestNextAndStep(t *testing.T) {
 					if se := client.ExpectStoppedEvent(t); se.Body.Reason != "error" || se.Body.Text != "unknown goroutine -1000" {
 						t.Errorf("got %#v, want Reason=\"error\", Text=\"unknown goroutine -1000\"", se)
 					}
-					handleStop(t, client, 1, "main.inlineThis", 5)
+					checkStop(t, client, 1, "main.inlineThis", 5)
 				},
 				disconnect: false,
 			}})
@@ -3132,7 +3128,7 @@ func TestBadAccess(t *testing.T) {
 			fixture.Source, []int{4},
 			[]onBreakpoint{{ // Stop at line 4
 				execute: func() {
-					handleStop(t, client, 1, "main.main", 4)
+					checkStop(t, client, 1, "main.main", 4)
 
 					expectStoppedOnError := func(errorPrefix string) {
 						t.Helper()
@@ -3188,7 +3184,7 @@ func TestPanicBreakpointOnContinue(t *testing.T) {
 			fixture.Source, []int{5},
 			[]onBreakpoint{{
 				execute: func() {
-					handleStop(t, client, 1, "main.main", 5)
+					checkStop(t, client, 1, "main.main", 5)
 
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
@@ -3226,7 +3222,7 @@ func TestPanicBreakpointOnNext(t *testing.T) {
 			fixture.Source, []int{5},
 			[]onBreakpoint{{
 				execute: func() {
-					handleStop(t, client, 1, "main.main", 5)
+					checkStop(t, client, 1, "main.main", 5)
 
 					client.NextRequest(1)
 					client.ExpectNextResponse(t)
@@ -3259,7 +3255,7 @@ func TestFatalThrowBreakpoint(t *testing.T) {
 			fixture.Source, []int{3},
 			[]onBreakpoint{{
 				execute: func() {
-					handleStop(t, client, 1, "main.main", 3)
+					checkStop(t, client, 1, "main.main", 3)
 
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
@@ -3291,12 +3287,12 @@ func verifyStopLocation(t *testing.T, client *daptest.Client, thread int, name s
 	}
 }
 
-// handleStop covers the standard sequence of requests issued by
+// checkStop covers the standard sequence of requests issued by
 // a client at a breakpoint or another non-terminal stop event.
 // The details have been tested by other tests,
 // so this is just a sanity check.
 // Skips line check if line is -1.
-func handleStop(t *testing.T, client *daptest.Client, thread int, name string, line int) {
+func checkStop(t *testing.T, client *daptest.Client, thread int, name string, line int) {
 	t.Helper()
 	client.ThreadsRequest()
 	client.ExpectThreadsResponse(t)
@@ -3585,11 +3581,11 @@ func TestAttachRequest(t *testing.T) {
 			[]onBreakpoint{{
 				// Stop at line 8
 				execute: func() {
-					handleStop(t, client, 1, "main.loop", 8)
+					checkStop(t, client, 1, "main.loop", 8)
 					client.VariablesRequest(1001) // Locals
 					locals := client.ExpectVariablesResponse(t)
-					expectChildren(t, locals, "Locals", 1)
-					expectVarRegex(t, locals, 0, "i", "i", "[0-9]+", "int", noChildren)
+					checkChildren(t, locals, "Locals", 1)
+					checkVarRegex(t, locals, 0, "i", "i", "[0-9]+", "int", noChildren)
 				},
 				disconnect: true,
 			}})
@@ -3717,14 +3713,14 @@ func (h *helperForSetVariable) evaluate(expr, want string, hasRef bool) {
 	h.t.Helper()
 	h.c.EvaluateRequest(expr, 1000, "whatever")
 	got := h.c.ExpectEvaluateResponse(h.t)
-	expectEval(h.t, got, want, hasRef)
+	checkEval(h.t, got, want, hasRef)
 }
 
 func (h *helperForSetVariable) evaluateRegex(expr, want string, hasRef bool) {
 	h.t.Helper()
 	h.c.EvaluateRequest(expr, 1000, "whatever")
 	got := h.c.ExpectEvaluateResponse(h.t)
-	expectEvalRegex(h.t, got, want, hasRef)
+	checkEvalRegex(h.t, got, want, hasRef)
 }
 
 func (h *helperForSetVariable) expectSetVariable0(ref int, name, value string, wantStop bool) {
@@ -3780,16 +3776,16 @@ func TestSetVariable(t *testing.T) {
 						startLineno = -1
 					}
 
-					handleStop(t, client, 1, "main.foobar", startLineno)
+					checkStop(t, client, 1, "main.foobar", startLineno)
 
 					// Args of foobar(baz string, bar FooBar)
 					args := tester.variables(1000)
 
-					expectVarExact(t, args, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
+					checkVarExact(t, args, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
 					tester.failSetVariable(1000, "bar", `main.FooBar {Baz: 42, Bur: "ipsum"}`, "*ast.CompositeLit not implemented")
 
 					// Nested field.
-					barRef := expectVarExact(t, args, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
+					barRef := checkVarExact(t, args, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
 					tester.expectSetVariable(barRef, "Baz", "42")
 					tester.evaluate("bar", `main.FooBar {Baz: 42, Bur: "lorem"}`, hasChildren)
 
@@ -3799,47 +3795,47 @@ func TestSetVariable(t *testing.T) {
 					locals := tester.variables(1001)
 
 					// int
-					expectVarExact(t, locals, -1, "a2", "a2", "6", "int", noChildren)
+					checkVarExact(t, locals, -1, "a2", "a2", "6", "int", noChildren)
 					tester.expectSetVariable(1001, "a2", "42")
 					tester.evaluate("a2", "42", noChildren)
 
 					tester.failSetVariable(1001, "a2", "false", "can not convert")
 
 					// float
-					expectVarExact(t, locals, -1, "a3", "a3", "7.23", "float64", noChildren)
+					checkVarExact(t, locals, -1, "a3", "a3", "7.23", "float64", noChildren)
 					tester.expectSetVariable(1001, "a3", "-0.1")
 					tester.evaluate("a3", "-0.1", noChildren)
 
 					// array of int
-					a4Ref := expectVarExact(t, locals, -1, "a4", "a4", "[2]int [1,2]", "[2]int", hasChildren)
+					a4Ref := checkVarExact(t, locals, -1, "a4", "a4", "[2]int [1,2]", "[2]int", hasChildren)
 					tester.expectSetVariable(a4Ref, "[1]", "-7")
 					tester.evaluate("a4", "[2]int [1,-7]", hasChildren)
 
 					tester.failSetVariable(1001, "a4", "[2]int{3, 4}", "not implemented")
 
 					// slice of int
-					a5Ref := expectVarExact(t, locals, -1, "a5", "a5", "[]int len: 5, cap: 5, [1,2,3,4,5]", "[]int", hasChildren)
+					a5Ref := checkVarExact(t, locals, -1, "a5", "a5", "[]int len: 5, cap: 5, [1,2,3,4,5]", "[]int", hasChildren)
 					tester.expectSetVariable(a5Ref, "[3]", "100")
 					tester.evaluate("a5", "[]int len: 5, cap: 5, [1,2,3,100,5]", hasChildren)
 
 					// composite literal and its nested fields.
-					a7Ref := expectVarExact(t, locals, -1, "a7", "a7", `*main.FooBar {Baz: 5, Bur: "strum"}`, "*main.FooBar", hasChildren)
+					a7Ref := checkVarExact(t, locals, -1, "a7", "a7", `*main.FooBar {Baz: 5, Bur: "strum"}`, "*main.FooBar", hasChildren)
 					a7Val := tester.variables(a7Ref)
-					a7ValRef := expectVarExact(t, a7Val, -1, "", "(*a7)", `main.FooBar {Baz: 5, Bur: "strum"}`, "main.FooBar", hasChildren)
+					a7ValRef := checkVarExact(t, a7Val, -1, "", "(*a7)", `main.FooBar {Baz: 5, Bur: "strum"}`, "main.FooBar", hasChildren)
 					tester.expectSetVariable(a7ValRef, "Baz", "7")
 					tester.evaluate("(*a7)", `main.FooBar {Baz: 7, Bur: "strum"}`, hasChildren)
 
 					// pointer
-					expectVarExact(t, locals, -1, "a9", "a9", `*main.FooBar nil`, "*main.FooBar", noChildren)
+					checkVarExact(t, locals, -1, "a9", "a9", `*main.FooBar nil`, "*main.FooBar", noChildren)
 					tester.expectSetVariable(1001, "a9", "&a6")
 					tester.evaluate("a9", `*main.FooBar {Baz: 8, Bur: "word"}`, hasChildren)
 
 					// slice of pointers
-					a13Ref := expectVarExact(t, locals, -1, "a13", "a13", `[]*main.FooBar len: 3, cap: 3, [*{Baz: 6, Bur: "f"},*{Baz: 7, Bur: "g"},*{Baz: 8, Bur: "h"}]`, "[]*main.FooBar", hasChildren)
+					a13Ref := checkVarExact(t, locals, -1, "a13", "a13", `[]*main.FooBar len: 3, cap: 3, [*{Baz: 6, Bur: "f"},*{Baz: 7, Bur: "g"},*{Baz: 8, Bur: "h"}]`, "[]*main.FooBar", hasChildren)
 					a13 := tester.variables(a13Ref)
-					a13c0Ref := expectVarExact(t, a13, -1, "[0]", "a13[0]", `*main.FooBar {Baz: 6, Bur: "f"}`, "*main.FooBar", hasChildren)
+					a13c0Ref := checkVarExact(t, a13, -1, "[0]", "a13[0]", `*main.FooBar {Baz: 6, Bur: "f"}`, "*main.FooBar", hasChildren)
 					a13c0 := tester.variables(a13c0Ref)
-					a13c0valRef := expectVarExact(t, a13c0, -1, "", "(*a13[0])", `main.FooBar {Baz: 6, Bur: "f"}`, "main.FooBar", hasChildren)
+					a13c0valRef := checkVarExact(t, a13c0, -1, "", "(*a13[0])", `main.FooBar {Baz: 6, Bur: "f"}`, "main.FooBar", hasChildren)
 					tester.expectSetVariable(a13c0valRef, "Baz", "777")
 					tester.evaluate("a13[0]", `*main.FooBar {Baz: 777, Bur: "f"}`, hasChildren)
 
@@ -3855,7 +3851,7 @@ func TestSetVariable(t *testing.T) {
 					client.VariablesRequest(1002)
 					globals := client.ExpectVariablesResponse(t)
 
-					expectVarExact(t, globals, -1, "p1", "main.p1", "10", "int", noChildren)
+					checkVarExact(t, globals, -1, "p1", "main.p1", "10", "int", noChildren)
 					tester.expectSetVariable(1002, "p1", "-10")
 					tester.evaluate("p1", "-10", noChildren)
 					tester.failSetVariable(1002, "p1", "0.1", "can not convert")
@@ -3881,7 +3877,7 @@ func TestSetVariable(t *testing.T) {
 						startLineno = -1
 					}
 
-					handleStop(t, client, 1, "main.main", startLineno)
+					checkStop(t, client, 1, "main.main", startLineno)
 					locals := tester.variables(1001)
 
 					// channel
@@ -3900,17 +3896,17 @@ func TestSetVariable(t *testing.T) {
 					tester.evaluate("ifacenil", "interface {}(*main.astruct) *{A: 1, B: 2}", hasChildren)
 
 					// interface.(data)
-					iface1Ref := expectVarExact(t, locals, -1, "iface1", "iface1", "interface {}(*main.astruct) *{A: 1, B: 2}", "interface {}", hasChildren)
+					iface1Ref := checkVarExact(t, locals, -1, "iface1", "iface1", "interface {}(*main.astruct) *{A: 1, B: 2}", "interface {}", hasChildren)
 					iface1 := tester.variables(iface1Ref)
-					iface1DataRef := expectVarExact(t, iface1, -1, "data", "iface1.(data)", "*main.astruct {A: 1, B: 2}", "*main.astruct", hasChildren)
+					iface1DataRef := checkVarExact(t, iface1, -1, "data", "iface1.(data)", "*main.astruct {A: 1, B: 2}", "*main.astruct", hasChildren)
 					iface1Data := tester.variables(iface1DataRef)
-					iface1DataValueRef := expectVarExact(t, iface1Data, -1, "", "(*iface1.(data))", "main.astruct {A: 1, B: 2}", "main.astruct", hasChildren)
+					iface1DataValueRef := checkVarExact(t, iface1Data, -1, "", "(*iface1.(data))", "main.astruct {A: 1, B: 2}", "main.astruct", hasChildren)
 					tester.expectSetVariable(iface1DataValueRef, "A", "2021")
 					tester.evaluate("iface1", "interface {}(*main.astruct) *{A: 2021, B: 2}", hasChildren)
 
 					// map: string -> struct
 					tester.evaluate(`m1["Malone"]`, "main.astruct {A: 2, B: 3}", hasChildren)
-					m1Ref := expectVarRegex(t, locals, -1, "m1", "m1", `.*map\[string\]main\.astruct.*`, `map\[string\]main\.astruct`, hasChildren)
+					m1Ref := checkVarRegex(t, locals, -1, "m1", "m1", `.*map\[string\]main\.astruct.*`, `map\[string\]main\.astruct`, hasChildren)
 					m1 := tester.variables(m1Ref)
 					elem1 := m1.Body.Variables[0]
 					tester.expectSetVariable(elem1.VariablesReference, "A", "-9999")
@@ -3918,25 +3914,25 @@ func TestSetVariable(t *testing.T) {
 					tester.evaluate(elem1.EvaluateName, "main.astruct {A: -9999, B: 10000}", hasChildren)
 
 					// map: struct -> int
-					m3Ref := expectVarExact(t, locals, -1, "m3", "m3", "map[main.astruct]int [{A: 1, B: 1}: 42, {A: 2, B: 2}: 43, ]", "map[main.astruct]int", hasChildren)
+					m3Ref := checkVarExact(t, locals, -1, "m3", "m3", "map[main.astruct]int [{A: 1, B: 1}: 42, {A: 2, B: 2}: 43, ]", "map[main.astruct]int", hasChildren)
 					tester.expectSetVariable(m3Ref, "main.astruct {A: 1, B: 1}", "8888")
 					// note: updating keys is possible, but let's not promise anything.
 					tester.evaluateRegex("m3", `.*\[\{A: 1, B: 1\}: 8888,.*`, hasChildren)
 
 					// map: struct -> struct
-					m4Ref := expectVarRegex(t, locals, -1, "m4", "m4", `map\[main\.astruct]main\.astruct.*\[\{A: 1, B: 1\}: \{A: 11, B: 11\}.*`, `map\[main\.astruct\]main\.astruct`, hasChildren)
+					m4Ref := checkVarRegex(t, locals, -1, "m4", "m4", `map\[main\.astruct]main\.astruct.*\[\{A: 1, B: 1\}: \{A: 11, B: 11\}.*`, `map\[main\.astruct\]main\.astruct`, hasChildren)
 					m4 := tester.variables(m4Ref)
-					m4Val1Ref := expectVarRegex(t, m4, -1, "[val 0]", `.*0x[0-9a-f]+.*`, `main.astruct.*`, `main\.astruct`, hasChildren)
+					m4Val1Ref := checkVarRegex(t, m4, -1, "[val 0]", `.*0x[0-9a-f]+.*`, `main.astruct.*`, `main\.astruct`, hasChildren)
 					tester.expectSetVariable(m4Val1Ref, "A", "-9999")
 					tester.evaluateRegex("m4", `.*A: -9999,.*`, hasChildren)
 
 					// unsigned pointer
-					expectVarRegex(t, locals, -1, "up1", "up1", `unsafe\.Pointer\(0x[0-9a-f]+\)`, "unsafe.Pointer", noChildren)
+					checkVarRegex(t, locals, -1, "up1", "up1", `unsafe\.Pointer\(0x[0-9a-f]+\)`, "unsafe.Pointer", noChildren)
 					tester.expectSetVariable(1001, "up1", "unsafe.Pointer(0x0)")
 					tester.evaluate("up1", "unsafe.Pointer(0x0)", noChildren)
 
 					// val := A{val: 1}
-					valRef := expectVarExact(t, locals, -1, "val", "val", `main.A {val: 1}`, "main.A", hasChildren)
+					valRef := checkVarExact(t, locals, -1, "val", "val", `main.A {val: 1}`, "main.A", hasChildren)
 					tester.expectSetVariable(valRef, "val", "3")
 					tester.evaluate("val", `main.A {val: 3}`, hasChildren)
 				},
@@ -3969,28 +3965,28 @@ func TestSetVariableWithCall(t *testing.T) {
 						startLineno = -1
 					}
 
-					handleStop(t, client, 1, "main.foobar", startLineno)
+					checkStop(t, client, 1, "main.foobar", startLineno)
 
 					// Args of foobar(baz string, bar FooBar)
 					args := tester.variables(1000)
 
-					expectVarExact(t, args, 0, "baz", "baz", `"bazburzum"`, "string", noChildren)
+					checkVarExact(t, args, 0, "baz", "baz", `"bazburzum"`, "string", noChildren)
 					tester.expectSetVariable(1000, "baz", `"BazBurZum"`)
 					tester.evaluate("baz", `"BazBurZum"`, noChildren)
 
 					args = tester.variables(1000)
-					barRef := expectVarExact(t, args, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
+					barRef := checkVarExact(t, args, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
 					tester.expectSetVariable(barRef, "Bur", `"ipsum"`)
 					tester.evaluate("bar", `main.FooBar {Baz: 10, Bur: "ipsum"}`, hasChildren)
 
 					// Local variables
 					locals := tester.variables(1001)
 
-					expectVarExact(t, locals, -1, "a1", "a1", `"foofoofoofoofoofoo"`, "string", noChildren)
+					checkVarExact(t, locals, -1, "a1", "a1", `"foofoofoofoofoofoo"`, "string", noChildren)
 					tester.expectSetVariable(1001, "a1", `"barbarbar"`)
 					tester.evaluate("a1", `"barbarbar"`, noChildren)
 
-					a6Ref := expectVarExact(t, locals, -1, "a6", "a6", `main.FooBar {Baz: 8, Bur: "word"}`, "main.FooBar", hasChildren)
+					a6Ref := checkVarExact(t, locals, -1, "a6", "a6", `main.FooBar {Baz: 8, Bur: "word"}`, "main.FooBar", hasChildren)
 					tester.failSetVariable(a6Ref, "Bur", "false", "can not convert")
 
 					tester.expectSetVariable(a6Ref, "Bur", `"sentence"`)
@@ -4001,11 +3997,11 @@ func TestSetVariableWithCall(t *testing.T) {
 				execute: func() {
 					tester := &helperForSetVariable{t, client}
 
-					handleStop(t, client, 1, "main.barfoo", -1)
+					checkStop(t, client, 1, "main.barfoo", -1)
 					// Test: set string 'a1' in main.barfoo.
 					// This shouldn't affect 'a1' in main.foobar - we will check that in the next breakpoint.
 					locals := tester.variables(1001)
-					expectVarExact(t, locals, -1, "a1", "a1", `"bur"`, "string", noChildren)
+					checkVarExact(t, locals, -1, "a1", "a1", `"bur"`, "string", noChildren)
 					tester.expectSetVariable(1001, "a1", `"fur"`)
 					tester.evaluate("a1", `"fur"`, noChildren)
 					// We will check a1 in main.foobar isn't affected from the next breakpoint.
@@ -4018,7 +4014,7 @@ func TestSetVariableWithCall(t *testing.T) {
 					outerFrame := res.Body.StackFrames[0].Id
 					client.EvaluateRequest("a1", outerFrame, "whatever_context")
 					evalRes := client.ExpectEvaluateResponse(t)
-					expectEval(t, evalRes, `"barbarbar"`, noChildren)
+					checkEval(t, evalRes, `"barbarbar"`, noChildren)
 				},
 				disconnect: true,
 			}})
@@ -4037,7 +4033,7 @@ func TestSetVariableWithCall(t *testing.T) {
 				execute: func() {
 					tester := &helperForSetVariable{t, client}
 
-					handleStop(t, client, 1, "main.main", 197)
+					checkStop(t, client, 1, "main.main", 197)
 
 					_ = tester.variables(1001)
 
@@ -4046,7 +4042,7 @@ func TestSetVariableWithCall(t *testing.T) {
 					tester.evaluateRegex("str", `.*in main.callstacktrace at.*`, noChildren)
 
 					tester.failSetVariableAndStop(1001, "str", `callpanic()`, `callpanic panicked`)
-					handleStop(t, client, 1, "main.main", 197)
+					checkStop(t, client, 1, "main.main", 197)
 
 					// breakpoint during a function call.
 					tester.failSetVariableAndStop(1001, "str", `callbreak()`, "call stopped")
@@ -4106,7 +4102,7 @@ func TestOptionalNotYetImplementedResponses(t *testing.T) {
 func TestBadLaunchRequests(t *testing.T) {
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
 		seqCnt := 1
-		expectFailedToLaunch := func(response *dap.ErrorResponse) {
+		checkFailedToLaunch := func(response *dap.ErrorResponse) {
 			t.Helper()
 			if response.RequestSeq != seqCnt {
 				t.Errorf("RequestSeq got %d, want %d", seqCnt, response.RequestSeq)
@@ -4123,9 +4119,9 @@ func TestBadLaunchRequests(t *testing.T) {
 			seqCnt++
 		}
 
-		expectFailedToLaunchWithMessage := func(response *dap.ErrorResponse, errmsg string) {
+		checkFailedToLaunchWithMessage := func(response *dap.ErrorResponse, errmsg string) {
 			t.Helper()
-			expectFailedToLaunch(response)
+			checkFailedToLaunch(response)
 			if response.Body.Error.Format != errmsg {
 				t.Errorf("\ngot  %q\nwant %q", response.Body.Error.Format, errmsg)
 			}
@@ -4133,119 +4129,119 @@ func TestBadLaunchRequests(t *testing.T) {
 
 		// Test for the DAP-specific detailed error message.
 		client.LaunchRequest("exec", "", stopOnEntry)
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: The program attribute is missing in debug configuration.")
 
 		// Bad "program"
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": 12345})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: The program attribute is missing in debug configuration.")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": nil})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: The program attribute is missing in debug configuration.")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug"})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: The program attribute is missing in debug configuration.")
 
 		// Bad "mode"
 		client.LaunchRequest("remote", fixture.Path, stopOnEntry)
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: Unsupported 'mode' value \"remote\" in debug configuration.")
 
 		client.LaunchRequest("notamode", fixture.Path, stopOnEntry)
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: Unsupported 'mode' value \"notamode\" in debug configuration.")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": 12345, "program": fixture.Path})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: Unsupported 'mode' value %!q(float64=12345) in debug configuration.")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": ""}) // empty mode defaults to "debug" (not an error)
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: The program attribute is missing in debug configuration.")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{}) // missing mode defaults to "debug" (not an error)
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: The program attribute is missing in debug configuration.")
 
 		// Bad "args"
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "exec", "program": fixture.Path, "args": nil})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: 'args' attribute '<nil>' in debug configuration is not an array.")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "exec", "program": fixture.Path, "args": 12345})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: 'args' attribute '12345' in debug configuration is not an array.")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "exec", "program": fixture.Path, "args": []int{1, 2}})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: value '1' in 'args' attribute in debug configuration is not a string.")
 
 		// Bad "buildFlags"
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "buildFlags": 123})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: 'buildFlags' attribute '123' in debug configuration is not a string.")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "substitutePath": 123})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: 'substitutePath' attribute '123' in debug configuration is not a []{'from': string, 'to': string}")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "substitutePath": []interface{}{123}})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: 'substitutePath' attribute '[123]' in debug configuration is not a []{'from': string, 'to': string}")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "substitutePath": []interface{}{map[string]interface{}{"to": "path2"}}})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: 'substitutePath' attribute '[map[to:path2]]' in debug configuration is not a []{'from': string, 'to': string}")
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "substitutePath": []interface{}{map[string]interface{}{"from": "path1", "to": 123}}})
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to launch: 'substitutePath' attribute '[map[from:path1 to:123]]' in debug configuration is not a []{'from': string, 'to': string}")
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "cwd": 123})
-		expectFailedToLaunchWithMessage(client.ExpectErrorResponse(t),
+		checkFailedToLaunchWithMessage(client.ExpectErrorResponse(t),
 			"Failed to launch: 'cwd' attribute '123' in debug configuration is not a string.")
 
 		// Skip detailed message checks for potentially different OS-specific errors.
 		client.LaunchRequest("exec", fixture.Path+"_does_not_exist", stopOnEntry)
-		expectFailedToLaunch(client.ExpectInvisibleErrorResponse(t)) // No such file or directory
+		checkFailedToLaunch(client.ExpectInvisibleErrorResponse(t)) // No such file or directory
 
 		client.LaunchRequest("debug", fixture.Path+"_does_not_exist", stopOnEntry)
 		oe := client.ExpectOutputEvent(t)
 		if !strings.HasPrefix(oe.Body.Output, "Build Error: ") || oe.Body.Category != "stderr" {
 			t.Errorf("got %#v, want Category=\"stderr\" Output=\"Build Error: ...\"", oe)
 		}
-		expectFailedToLaunch(client.ExpectInvisibleErrorResponse(t))
+		checkFailedToLaunch(client.ExpectInvisibleErrorResponse(t))
 
 		client.LaunchRequest("" /*debug by default*/, fixture.Path+"_does_not_exist", stopOnEntry)
 		oe = client.ExpectOutputEvent(t)
 		if !strings.HasPrefix(oe.Body.Output, "Build Error: ") || oe.Body.Category != "stderr" {
 			t.Errorf("got %#v, want Category=\"stderr\" Output=\"Build Error: ...\"", oe)
 		}
-		expectFailedToLaunch(client.ExpectInvisibleErrorResponse(t))
+		checkFailedToLaunch(client.ExpectInvisibleErrorResponse(t))
 
 		client.LaunchRequest("exec", fixture.Source, stopOnEntry)
-		expectFailedToLaunch(client.ExpectInvisibleErrorResponse(t)) // Not an executable
+		checkFailedToLaunch(client.ExpectInvisibleErrorResponse(t)) // Not an executable
 
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "buildFlags": "-bad -flags"})
 		oe = client.ExpectOutputEvent(t)
 		if !strings.HasPrefix(oe.Body.Output, "Build Error: ") || oe.Body.Category != "stderr" {
 			t.Errorf("got %#v, want Category=\"stderr\" Output=\"Build Error: ...\"", oe)
 		}
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t), "Failed to launch: Build error: Check the debug console for details.")
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t), "Failed to launch: Build error: Check the debug console for details.")
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": true, "buildFlags": "-bad -flags"})
 		oe = client.ExpectOutputEvent(t)
 		if !strings.HasPrefix(oe.Body.Output, "Build Error: ") || oe.Body.Category != "stderr" {
 			t.Errorf("got %#v, want Category=\"stderr\" Output=\"Build Error: ...\"", oe)
 		}
-		expectFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t), "Failed to launch: Build error: Check the debug console for details.")
+		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t), "Failed to launch: Build error: Check the debug console for details.")
 
 		// Bad "wd".
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": false, "cwd": "dir/invalid"})
-		expectFailedToLaunch(client.ExpectErrorResponse(t)) // invalid directory, the error message is system-dependent.
+		checkFailedToLaunch(client.ExpectErrorResponse(t)) // invalid directory, the error message is system-dependent.
 		client.LaunchRequestWithArgs(map[string]interface{}{"mode": "debug", "program": fixture.Source, "noDebug": true, "cwd": "dir/invalid"})
-		expectFailedToLaunch(client.ExpectErrorResponse(t)) // invalid directory, the error message is system-dependent.
+		checkFailedToLaunch(client.ExpectErrorResponse(t)) // invalid directory, the error message is system-dependent.
 
 		// We failed to launch the program. Make sure shutdown still works.
 		client.DisconnectRequest()
@@ -4259,7 +4255,7 @@ func TestBadLaunchRequests(t *testing.T) {
 func TestBadAttachRequest(t *testing.T) {
 	runTest(t, "loopprog", func(client *daptest.Client, fixture protest.Fixture) {
 		seqCnt := 1
-		expectFailedToAttach := func(response *dap.ErrorResponse) {
+		checkFailedToAttach := func(response *dap.ErrorResponse) {
 			t.Helper()
 			if response.RequestSeq != seqCnt {
 				t.Errorf("RequestSeq got %d, want %d", seqCnt, response.RequestSeq)
@@ -4276,9 +4272,9 @@ func TestBadAttachRequest(t *testing.T) {
 			seqCnt++
 		}
 
-		expectFailedToAttachWithMessage := func(response *dap.ErrorResponse, errmsg string) {
+		checkFailedToAttachWithMessage := func(response *dap.ErrorResponse, errmsg string) {
 			t.Helper()
-			expectFailedToAttach(response)
+			checkFailedToAttach(response)
 			if response.Body.Error.Format != errmsg {
 				t.Errorf("\ngot  %q\nwant %q", response.Body.Error.Format, errmsg)
 			}
@@ -4286,45 +4282,45 @@ func TestBadAttachRequest(t *testing.T) {
 
 		// Bad "mode"
 		client.AttachRequest(map[string]interface{}{"mode": "remote"})
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: Unsupported 'mode' value \"remote\" in debug configuration")
 
 		client.AttachRequest(map[string]interface{}{"mode": "blah blah blah"})
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: Unsupported 'mode' value \"blah blah blah\" in debug configuration")
 
 		client.AttachRequest(map[string]interface{}{"mode": 123})
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: Unsupported 'mode' value %!q(float64=123) in debug configuration")
 
 		client.AttachRequest(map[string]interface{}{"mode": ""}) // empty mode defaults to "local" (not an error)
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: The 'processId' attribute is missing in debug configuration")
 
 		client.AttachRequest(map[string]interface{}{}) // no mode defaults to "local" (not an error)
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: The 'processId' attribute is missing in debug configuration")
 
 		// Bad "processId"
 		client.AttachRequest(map[string]interface{}{"mode": "local"})
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: The 'processId' attribute is missing in debug configuration")
 
 		client.AttachRequest(map[string]interface{}{"mode": "local", "processId": nil})
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: The 'processId' attribute is missing in debug configuration")
 
 		client.AttachRequest(map[string]interface{}{"mode": "local", "processId": 0})
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: The 'processId' attribute is missing in debug configuration")
 
 		client.AttachRequest(map[string]interface{}{"mode": "local", "processId": "1"})
-		expectFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
+		checkFailedToAttachWithMessage(client.ExpectInvisibleErrorResponse(t),
 			"Failed to attach: The 'processId' attribute is missing in debug configuration")
 
 		client.AttachRequest(map[string]interface{}{"mode": "local", "processId": 1})
 		// The exact message varies on different systems, so skip that check
-		expectFailedToAttach(client.ExpectInvisibleErrorResponse(t)) // could not attach to pid 1
+		checkFailedToAttach(client.ExpectInvisibleErrorResponse(t)) // could not attach to pid 1
 
 		// This will make debugger.(*Debugger) panic, which we will catch as an internal error.
 		client.AttachRequest(map[string]interface{}{"mode": "local", "processId": -1})


### PR DESCRIPTION
Separates checking already read messages into separate helpers. Renames all helpers to follow the same convention:
- Expect = read + verify
- Check = only verify