### PR TITLE
dap: add 'clipboard' support, and truncate a long value

### DIFF
--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -104,6 +104,7 @@ func (c *Client) ExpectInitializeResponseAndCapabilities(t *testing.T) *dap.Init
 		SupportsSetVariable:              true,
 		SupportsFunctionBreakpoints:      true,
 		SupportsEvaluateForHovers:        true,
+		SupportsClipboardContext:         true,
 	}
 	if !reflect.DeepEqual(initResp.Body, wantCapabilities) {
 		t.Errorf("capabilities in initializeResponse: got %+v, want %v", pretty(initResp.Body), pretty(wantCapabilities))

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2041,15 +2041,18 @@ func (s *Server) onEvaluateRequest(request *dap.EvaluateRequest) {
 		}
 
 		ctxt := request.Arguments.Context
-		if exprVar.Kind == reflect.String && (ctxt == "repl" || ctxt == "variables" || ctxt == "hover" || ctxt == "clipboard") {
-			if strVal := constant.StringVal(exprVar.Value); exprVar.Len > int64(len(strVal)) {
-				// reload string value with a bigger limit.
-				loadCfg := DefaultLoadConfig
-				loadCfg.MaxStringLen = 4 << 10
-				if v, err := s.debugger.EvalVariableInScope(goid, frame, 0, request.Arguments.Expression, loadCfg); err != nil {
-					s.log.Debugf("Failed to load more for %v: %v", request.Arguments.Expression, err)
-				} else {
-					exprVar = v
+		switch ctxt {
+		case "repl", "variables", "hover", "clipboard":
+			if exprVar.Kind == reflect.String {
+				if strVal := constant.StringVal(exprVar.Value); exprVar.Len > int64(len(strVal)) {
+					// reload string value with a bigger limit.
+					loadCfg := DefaultLoadConfig
+					loadCfg.MaxStringLen = 4 << 10
+					if v, err := s.debugger.EvalVariableInScope(goid, frame, 0, request.Arguments.Expression, loadCfg); err != nil {
+						s.log.Debugf("Failed to load more for %v: %v", request.Arguments.Expression, err)
+					} else {
+						exprVar = v
+					}
 				}
 			}
 		}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1828,8 +1828,10 @@ func (s *Server) convertVariableToString(v *proc.Variable) string {
 const defaultMaxValueLen = 1 << 8 // 256
 
 // Flags for convertVariableWithOpts option.
+type convertVariableFlags uint8
+
 const (
-	skipRef = 1 << iota
+	skipRef convertVariableFlags = 1 << iota
 	showFullValue
 )
 
@@ -1837,7 +1839,7 @@ const (
 // a string representation of the variable. When the variable is a compound or reference
 // type variable and its full string representation can be larger than defaultMaxValueLen,
 // this returns a truncated value unless showFull option flag is set.
-func (s *Server) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr string, opts int) (value string, variablesReference int) {
+func (s *Server) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr string, opts convertVariableFlags) (value string, variablesReference int) {
 	canHaveRef := false
 	maybeCreateVariableHandle := func(v *proc.Variable) int {
 		canHaveRef = true
@@ -2051,7 +2053,7 @@ func (s *Server) onEvaluateRequest(request *dap.EvaluateRequest) {
 				}
 			}
 		}
-		opts := 0
+		var opts convertVariableFlags
 		if ctxt == "variables" || ctxt == "hover" || ctxt == "clipboard" {
 			opts |= showFullValue
 		}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1493,7 +1493,7 @@ func TestVariablesLoading(t *testing.T) {
 					}
 
 					// Map partially missing based on LoadConfig.MaxArrayValues
-					ref = checkVarRegex(t, locals, -1, "m1", "m1", `\(loaded 64/66\) map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
+					ref = checkVarRegex(t, locals, -1, "m1", "m1", `\(loaded 64/66\) map\[string\]main\.astruct \[.+\.\.\.`, `map\[string\]main\.astruct`, hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						m1 := client.ExpectVariablesResponse(t)
@@ -1572,7 +1572,7 @@ func TestVariablesLoading(t *testing.T) {
 							client.VariablesRequest(ref)
 							tmV := client.ExpectVariablesResponse(t)
 							checkChildren(t, tmV, "tm.v", 1)
-							ref = checkVarRegex(t, tmV, 0, `\[0\]`, `tm\.v\[0\]`, `map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
+							ref = checkVarRegex(t, tmV, 0, `\[0\]`, `tm\.v\[0\]`, `map\[string\]main\.astruct \[.+\.\.\.`, `map\[string\]main\.astruct`, hasChildren)
 							if ref > 0 {
 								client.VariablesRequest(ref)
 								tmV0 := client.ExpectVariablesResponse(t)
@@ -1602,7 +1602,7 @@ func TestVariablesLoading(t *testing.T) {
 								tmV := client.ExpectVariablesResponse(t)
 								checkChildren(t, tmV, "tm.v", 1)
 								// TODO(polina): this evaluate name is not usable - it should be empty
-								ref = checkVarRegex(t, tmV, 0, `\[0\]`, `\[0\]`, `map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`, `map\[string\]main\.astruct`, hasChildren)
+								ref = checkVarRegex(t, tmV, 0, `\[0\]`, `\[0\]`, `map\[string\]main\.astruct \[.+\.\.\.`, `map\[string\]main\.astruct`, hasChildren)
 								if ref > 0 {
 									client.VariablesRequest(ref)
 									tmV0 := client.ExpectVariablesResponse(t)
@@ -2656,13 +2656,18 @@ func TestEvaluateRequest(t *testing.T) {
 					if erres.Body.Error.Format != "Unable to evaluate expression: could not find symbol value for a1" {
 						t.Errorf("\ngot %#v\nwant Format=\"Unable to evaluate expression: could not find symbol value for a1\"", erres)
 					}
+					client.EvaluateRequest("a1", 1002, "clipboard")
+					erres = client.ExpectVisibleErrorResponse(t)
+					if erres.Body.Error.Format != "Unable to evaluate expression: could not find symbol value for a1" {
+						t.Errorf("\ngot %#v\nwant Format=\"Unable to evaluate expression: could not find symbol value for a1\"", erres)
+					}
 				},
 				disconnect: false,
 			}})
 	})
 }
 
-func TestEvaluateRequestLongStr(t *testing.T) {
+func TestEvaluateRequestLongStrLargeValue(t *testing.T) {
 	runTest(t, "testvariables2", func(client *daptest.Client, fixture protest.Fixture) {
 		runDebugSessionWithBPs(t, client, "launch",
 			// Launch
@@ -2674,22 +2679,24 @@ func TestEvaluateRequestLongStr(t *testing.T) {
 			[]onBreakpoint{{
 				execute: func() {
 
-					longstr := `"very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"`
-					longstrTruncated := `"very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more"`
-
 					checkStop(t, client, 1, "main.main", -1)
 
 					client.VariablesRequest(1001) // Locals
 					locals := client.ExpectVariablesResponse(t)
 
 					// reflect.Kind == String, load with longer load limit if evaluated in repl/variables context.
-					for _, evalContext := range []string{"", "watch", "repl", "variables", "somethingelse"} {
+					for _, evalContext := range []string{"", "watch", "repl", "variables", "hover", "clipboard", "somethingelse"} {
 						t.Run(evalContext, func(t *testing.T) {
 							// long string
+
+							longstr := `"very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"`
+							longstrTruncated := `"very long string 0123456789a0123456789b0123456789c0123456789d012...+73 more"`
+
 							client.EvaluateRequest("longstr", 0, evalContext)
 							got := client.ExpectEvaluateResponse(t)
 							want := longstrTruncated
-							if evalContext == "repl" || evalContext == "variables" {
+							switch evalContext {
+							case "repl", "variables", "hover", "clipboard":
 								want = longstr
 							}
 							checkEval(t, got, want, false)
@@ -2702,9 +2709,22 @@ func TestEvaluateRequestLongStr(t *testing.T) {
 							// variables are not affected.
 							checkVarExact(t, locals, -1, "longstr", "longstr", longstrTruncated, "string", noChildren)
 							checkVarExact(t, locals, -1, "m6", "m6", `main.C {s: `+longstrTruncated+`}`, "main.C", hasChildren)
+
+							// large array
+							m1 := `\(loaded 64/66\) map\[string\]main\.astruct \[.+\.\.\.\+2 more\]`
+							m1Truncated := `\(loaded 64/66\) map\[string\]main\.astruct \[.+\.\.\.`
+
+							client.EvaluateRequest("m1", 0, evalContext)
+							got3 := client.ExpectEvaluateResponse(t)
+							want3 := m1Truncated
+							switch evalContext {
+							case "variables", "hover", "clipboard":
+								want3 = m1
+							}
+							checkEvalRegex(t, got3, want3, true)
+							checkVarRegex(t, locals, -1, "m1", "m1", m1Truncated, `map\[string\]main\.astruct`, true)
 						})
 					}
-
 				},
 				disconnect: true,
 			}})


### PR DESCRIPTION
* add 'clipboard' capability
* apply a larger string limit for 'hover' and 'clipboard' context
* truncate the string representation of a compound type (or pointer of a compound type) variable if the length of the value is larger than 256. But when a variable is returned as a result of Evaluate Request for hover or copy value feature (clipboard or variables context), do not truncate the value.

Updates golang/vscode-go#1318
Fixes golang/vscode-go#1435