### PR TITLE
dap: clean output executable name for windows

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -745,8 +745,9 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 	if mode == "debug" || mode == "test" {
 		output, ok := request.Arguments["output"].(string)
 		if !ok || output == "" {
-			output = cleanExeName(defaultDebugBinary)
+			output = defaultDebugBinary
 		}
+		output = cleanExeName(output)
 		debugbinary, err := filepath.Abs(output)
 		if err != nil {
 			s.sendInternalErrorResponse(request.Seq, err.Error())

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3482,7 +3482,7 @@ func TestLaunchRequestNoDebug_GoodStatus(t *testing.T) {
 				"noDebug": true,
 				"mode":    "debug",
 				"program": fixture.Source,
-				"output":  cleanExeName("__mybin")})
+				"output":  "__mybin"})
 		}, fixture.Source, []int{8}, 0)
 	})
 }
@@ -3494,7 +3494,7 @@ func TestLaunchRequestNoDebug_BadStatus(t *testing.T) {
 				"noDebug": true,
 				"mode":    "debug",
 				"program": fixture.Source,
-				"output":  cleanExeName("__mybin")})
+				"output":  "__mybin"})
 		}, fixture.Source, []int{8}, 2)
 	})
 }


### PR DESCRIPTION
If the output binary name does not end with .exe, it can't run on Windows
in noDebug mode. If user-provided output name doesn't have file extension
name (.exe), append it.

Fixes golang/vscode-go#1473