### PR TITLE
proc: when converting registers to slices set Base address

### DIFF
--- a/_fixtures/fputest/fputest_amd64.s
+++ b/_fixtures/fputest/fputest_amd64.s
@@ -56,6 +56,8 @@ TEXT ·fputestsetup(SB),$0-50
 	MOVAPS X1, X9
 	MOVAPS X2, X10
 	
+	MOVQ $42, AX
+	
 	CMPB avx2+48(FP), $0x0
 	JE done
 	//copy XMM1 to both halves of YMM11

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -2318,6 +2318,7 @@ func (v *Variable) registerVariableTypeConv(newtyp string) (*Variable, error) {
 	v.loaded = true
 	v.Kind = reflect.Array
 	v.Len = int64(len(v.Children))
+	v.Base = fakeAddress
 	v.DwarfType = fakeArrayType(uint64(len(v.Children)), &godwarf.VoidType{CommonType: godwarf.CommonType{ByteSize: int64(n)}})
 	v.RealType = v.DwarfType
 	return v, nil

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1598,6 +1598,7 @@ func TestClientServer_FpRegisters(t *testing.T) {
 			{"XMM1.uint16[0]", `52429`},
 			{"XMM1.float32[0]", `-107374184`},
 			{"XMM1.float64[0]", `1.3`},
+			{"RAX.uint8[0]", "42"},
 		} {
 			v, err := c.EvalVariable(scope, tc.expr, normalLoadConfig)
 			if err != nil {


### PR DESCRIPTION
If the base address isn't set then indexing and slicing will not work.

Large floating point registers already had the base set but small
general purpose registers did not.
