### PR TITLE
terminal: support setting hitcount conditions on breakpoints

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -174,8 +174,21 @@ If called with the linespec argument it will delete all the breakpoints matching
 Set breakpoint condition.
 
 	condition <breakpoint name or id> <boolean expression>.
+	condition -hitcount <breakpoint name or id> <operator> <argument>
 
-Specifies that the breakpoint or tracepoint should break only if the boolean expression is true.
+Specifies that the breakpoint, tracepoint or watchpoint should break only if the boolean expression is true.
+
+With the -hitcount option a condition on the breakpoint hit count can be set, the following operators are supported
+
+	condition -hitcount bp > n
+	condition -hitcount bp >= n
+	condition -hitcount bp < n
+	condition -hitcount bp <= n
+	condition -hitcount bp == n
+	condition -hitcount bp != n
+	condition -hitcount bp % n
+	
+The '% n' form means we should stop at the breakpoint when the hitcount is a multiple of n.
 
 Aliases: cond
 

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1178,3 +1178,16 @@ func TestPrintFormat(t *testing.T) {
 		}
 	})
 }
+
+func TestHitCondBreakpoint(t *testing.T) {
+	withTestTerminal("break", t, func(term *FakeTerminal) {
+		term.MustExec("break bp1 main.main:4")
+		term.MustExec("condition -hitcount bp1 > 2")
+		listIsAt(t, term, "continue", 7, -1, -1)
+		out := term.MustExec("print i")
+		t.Logf("%q", out)
+		if !strings.Contains(out, "3\n") {
+			t.Fatalf("wrong value of i")
+		}
+	})
+}


### PR DESCRIPTION
Adds a -hitcount argument to condition that sets a hitcount condition
on breakpoints.
