### PR TITLE
proc,terminal,service: support stack watchpoints

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -1,31 +1,31 @@
 Tests skipped by each supported backend:
 
-* 386 skipped = 6
+* 386 skipped = 7
 	* 1 broken
 	* 3 broken - cgo stacktraces
-	* 2 not implemented
-* arm64 skipped = 4
+	* 3 not implemented
+* arm64 skipped = 5
 	* 1 broken
 	* 1 broken - global variable symbolication
-	* 2 not implemented
-* darwin skipped = 2
-	* 2 not implemented
+	* 3 not implemented
+* darwin skipped = 3
+	* 3 not implemented
 * darwin/arm64 skipped = 1
 	* 1 broken - cgo stacktraces
 * darwin/lldb skipped = 1
 	* 1 upstream issue
-* freebsd skipped = 14
+* freebsd skipped = 15
 	* 11 broken
-	* 3 not implemented
+	* 4 not implemented
 * linux/386/pie skipped = 1
 	* 1 broken
 * linux/arm64 skipped = 1
 	* 1 broken - cgo stacktraces
 * pie skipped = 2
 	* 2 upstream issue - https://github.com/golang/go/issues/29322
-* rr skipped = 2
-	* 2 not implemented
-* windows skipped = 4
+* rr skipped = 3
+	* 3 not implemented
+* windows skipped = 5
 	* 1 broken
-	* 2 not implemented
+	* 3 not implemented
 	* 1 upstream issue

--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -114,6 +114,10 @@ Aliases: b
 
 ## breakpoints
 Print out info for active breakpoints.
+	
+	breakpoints [-a]
+
+Specifying -a prints all physical breakpoint, including internal breakpoints.
 
 Aliases: bp
 

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -40,7 +40,7 @@ get_breakpoint(Id, Name) | Equivalent to API call [GetBreakpoint](https://godoc.
 get_thread(Id) | Equivalent to API call [GetThread](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.GetThread)
 is_multiclient() | Equivalent to API call [IsMulticlient](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.IsMulticlient)
 last_modified() | Equivalent to API call [LastModified](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.LastModified)
-breakpoints() | Equivalent to API call [ListBreakpoints](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListBreakpoints)
+breakpoints(All) | Equivalent to API call [ListBreakpoints](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListBreakpoints)
 checkpoints() | Equivalent to API call [ListCheckpoints](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListCheckpoints)
 dynamic_libraries() | Equivalent to API call [ListDynamicLibraries](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListDynamicLibraries)
 function_args(Scope, Cfg) | Equivalent to API call [ListFunctionArgs](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListFunctionArgs)

--- a/_fixtures/databpstack.go
+++ b/_fixtures/databpstack.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func f() {
+	w := 0
+	runtime.Breakpoint()
+	g(1000, &w) // Position 0
+}
+
+func g(cnt int, p *int) {
+	if cnt == 0 {
+		*p = 10
+		return // Position 1
+	}
+	g(cnt-1, p)
+}
+
+func main() {
+	f()
+	fmt.Printf("done\n") // Position 2
+}

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -147,6 +147,34 @@ func (bp *Breakpoint) String() string {
 	return fmt.Sprintf("Breakpoint %d at %#v %s:%d", bp.LogicalID, bp.Addr, bp.File, bp.Line)
 }
 
+// VerboseDescr returns a string describing parts of the breakpoint struct
+// that aren't otherwise user visible, for debugging purposes.
+func (bp *Breakpoint) VerboseDescr() []string {
+	r := []string{}
+
+	r = append(r, fmt.Sprintf("OriginalData=%#x", bp.OriginalData))
+
+	if bp.WatchType != 0 {
+		r = append(r, fmt.Sprintf("HWBreakIndex=%#x", bp.HWBreakIndex))
+	}
+
+	for _, breaklet := range bp.Breaklets {
+		switch breaklet.Kind {
+		case UserBreakpoint:
+			r = append(r, fmt.Sprintf("User Cond=%q HitCond=%v", exprToString(breaklet.Cond), breaklet.HitCond))
+		case NextBreakpoint:
+			r = append(r, fmt.Sprintf("Next Cond=%q", exprToString(breaklet.Cond)))
+		case NextDeferBreakpoint:
+			r = append(r, fmt.Sprintf("NextDefer Cond=%q DeferReturns=%#x", exprToString(breaklet.Cond), breaklet.DeferReturns))
+		case StepBreakpoint:
+			r = append(r, fmt.Sprintf("Step Cond=%q", exprToString(breaklet.Cond)))
+		default:
+			r = append(r, fmt.Sprintf("Unknown %d", breaklet.Kind))
+		}
+	}
+	return r
+}
+
 // BreakpointExistsError is returned when trying to set a breakpoint at
 // an address that already has a breakpoint set for it.
 type BreakpointExistsError struct {

--- a/pkg/proc/stackwatch.go
+++ b/pkg/proc/stackwatch.go
@@ -1,0 +1,170 @@
+package proc
+
+import (
+	"errors"
+
+	"github.com/go-delve/delve/pkg/astutil"
+	"github.com/go-delve/delve/pkg/logflags"
+)
+
+// This file implements most of the details needed to support stack
+// watchpoints. Some of the remaining details are in breakpoints, along with
+// the code to support non-stack allocated watchpoints.
+//
+// In Go goroutine stacks start small and are frequently resized by the
+// runtime according to the needs of the goroutine.
+// To support this behavior we create a StackResizeBreakpoint, deep inside
+// the Go runtime, when this breakpoint is hit all the stack watchpoints on
+// the goroutine being resized are adjusted for the new stack.
+// Furthermore, we need to detect when a goroutine leaves the stack frame
+// where the variable we are watching was declared, so that we can notify
+// the user that the variable went out of scope and clear the watchpoint.
+//
+// These breakpoints are created by setStackWatchBreakpoints and cleared by
+// clearStackWatchBreakpoints.
+
+// setStackWatchBreakpoints sets the out of scope sentinel breakpoints for
+// watchpoint and a stack resize breakpoint.
+func (t *Target) setStackWatchBreakpoints(scope *EvalScope, watchpoint *Breakpoint) error {
+	// Watchpoint Out-of-scope Sentinel
+
+	woos := func(_ Thread) bool {
+		watchpointOutOfScope(t, watchpoint)
+		return true
+	}
+
+	topframe, retframe, err := topframe(scope.g, nil)
+	if err != nil {
+		return err
+	}
+
+	sameGCond := sameGoroutineCondition(scope.g)
+	retFrameCond := astutil.And(sameGCond, frameoffCondition(&retframe))
+
+	var deferpc uint64
+	if topframe.TopmostDefer != nil {
+		_, _, deferfn := topframe.TopmostDefer.DeferredFunc(t)
+		if deferfn != nil {
+			var err error
+			deferpc, err = FirstPCAfterPrologue(t, deferfn, false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if deferpc != 0 && deferpc != topframe.Current.PC {
+		deferbp, err := t.SetBreakpoint(deferpc, WatchOutOfScopeBreakpoint, sameGCond)
+		if err != nil {
+			return err
+		}
+		deferbreaklet := deferbp.Breaklets[len(deferbp.Breaklets)-1]
+		deferbreaklet.checkPanicCall = true
+		deferbreaklet.watchpoint = watchpoint
+		deferbreaklet.callback = woos
+	}
+
+	retbp, err := t.SetBreakpoint(retframe.Current.PC, WatchOutOfScopeBreakpoint, retFrameCond)
+	if err != nil {
+		return err
+	}
+
+	retbreaklet := retbp.Breaklets[len(retbp.Breaklets)-1]
+	retbreaklet.watchpoint = watchpoint
+	retbreaklet.callback = woos
+
+	// Stack Resize Sentinel
+
+	fn := t.BinInfo().LookupFunc["runtime.copystack"]
+	if fn == nil {
+		return errors.New("could not find runtime.copystack")
+	}
+	text, err := Disassemble(t.Memory(), nil, t.Breakpoints(), t.BinInfo(), fn.Entry, fn.End)
+	if err != nil {
+		return err
+	}
+	var retpc uint64
+	for _, instr := range text {
+		if instr.IsRet() {
+			if retpc != 0 {
+				return errors.New("runtime.copystack has too many return instructions")
+			}
+			retpc = instr.Loc.PC
+		}
+	}
+	if retpc == 0 {
+		return errors.New("could not find return instruction in runtime.copystack")
+	}
+	rszbp, err := t.SetBreakpoint(retpc, StackResizeBreakpoint, sameGCond)
+	if err != nil {
+		return err
+	}
+
+	rszbreaklet := rszbp.Breaklets[len(rszbp.Breaklets)-1]
+	rszbreaklet.watchpoint = watchpoint
+	rszbreaklet.callback = func(th Thread) bool {
+		adjustStackWatchpoint(t, th, watchpoint)
+		return false // we never want this breakpoint to be shown to the user
+	}
+
+	return nil
+}
+
+// clearStackWatchBreakpoints clears all accessory breakpoints for
+// watchpoint.
+func (t *Target) clearStackWatchBreakpoints(watchpoint *Breakpoint) error {
+	bpmap := t.Breakpoints()
+	for _, bp := range bpmap.M {
+		changed := false
+		for i, breaklet := range bp.Breaklets {
+			if breaklet.watchpoint == watchpoint {
+				bp.Breaklets[i] = nil
+				changed = true
+			}
+		}
+		if changed {
+			_, err := t.finishClearBreakpoint(bp)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// watchpointOutOfScope is called when the watchpoint goes out of scope. It
+// is used as a breaklet callback function.
+// Its responsibility is to delete the watchpoint and make sure that the
+// user is notified of the watchpoint going out of scope.
+func watchpointOutOfScope(t *Target, watchpoint *Breakpoint) {
+	t.Breakpoints().WatchOutOfScope = append(t.Breakpoints().WatchOutOfScope, watchpoint)
+	_, err := t.ClearBreakpoint(watchpoint.Addr)
+	if err != nil {
+		log := logflags.DebuggerLogger()
+		log.Errorf("could not clear out-of-scope watchpoint: %v", err)
+	}
+}
+
+// adjustStackWatchpoint is called when the goroutine of watchpoint resizes
+// its stack. It is used as a breaklet callback function.
+// Its responsibility is to move the watchpoint to a its new address.
+func adjustStackWatchpoint(t *Target, th Thread, watchpoint *Breakpoint) {
+	g, _ := GetG(th)
+	if g == nil {
+		return
+	}
+	err := t.proc.EraseBreakpoint(watchpoint)
+	if err != nil {
+		log := logflags.DebuggerLogger()
+		log.Errorf("could not adjust watchpoint at %#x: %v", watchpoint.Addr, err)
+		return
+	}
+	delete(t.Breakpoints().M, watchpoint.Addr)
+	watchpoint.Addr = uint64(int64(g.stack.hi) + watchpoint.watchStackOff)
+	err = t.proc.WriteBreakpoint(watchpoint)
+	if err != nil {
+		log := logflags.DebuggerLogger()
+		log.Errorf("could not adjust watchpoint at %#x: %v", watchpoint.Addr, err)
+		return
+	}
+	t.Breakpoints().M[watchpoint.Addr] = watchpoint
+}

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -54,6 +54,7 @@ func (dbp *Target) Continue() error {
 		thread.Common().CallReturn = false
 		thread.Common().returnValues = nil
 	}
+	dbp.Breakpoints().WatchOutOfScope = nil
 	dbp.CheckAndClearManualStopRequest()
 	defer func() {
 		// Make sure we clear internal breakpoints if we simultaneously receive a
@@ -910,10 +911,12 @@ func setDeferBreakpoint(p *Target, text []AsmInstruction, topframe Stackframe, s
 	var deferpc uint64
 	if topframe.TopmostDefer != nil && topframe.TopmostDefer.DwrapPC != 0 {
 		_, _, deferfn := topframe.TopmostDefer.DeferredFunc(p)
-		var err error
-		deferpc, err = FirstPCAfterPrologue(p, deferfn, false)
-		if err != nil {
-			return 0, err
+		if deferfn != nil {
+			var err error
+			deferpc, err = FirstPCAfterPrologue(p, deferfn, false)
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 	if deferpc != 0 && deferpc != topframe.Current.PC {

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1750,7 +1750,11 @@ func breakpoints(t *Term, ctx callContext, args string) error {
 	}
 	sort.Sort(byID(breakPoints))
 	for _, bp := range breakPoints {
-		fmt.Printf("%s at %v (%d)\n", formatBreakpointName(bp, true), t.formatBreakpointLocation(bp), bp.TotalHitCount)
+		enabled := "(enabled)"
+		if bp.Disabled {
+			enabled = "(disabled)"
+		}
+		fmt.Printf("%s %s at %v (%d)\n", formatBreakpointName(bp, true), enabled, t.formatBreakpointLocation(bp), bp.TotalHitCount)
 
 		attrs := formatBreakpointAttrs("\t", bp, false)
 
@@ -2609,6 +2613,10 @@ func printcontext(t *Term, state *api.DebuggerState) {
 	if state.When != "" {
 		fmt.Println(state.When)
 	}
+
+	for _, watchpoint := range state.WatchOutOfScope {
+		fmt.Printf("%s went out of scope and was cleared\n", formatBreakpointName(watchpoint, true))
+	}
 }
 
 func printcontextLocation(t *Term, loc api.Location) {
@@ -3120,11 +3128,7 @@ func formatBreakpointName(bp *api.Breakpoint, upcase bool) string {
 	if bp.WatchExpr != "" && bp.WatchExpr != bp.Name {
 		return fmt.Sprintf("%s %s on [%s]", thing, id, bp.WatchExpr)
 	}
-	state := "(enabled)"
-	if bp.Disabled {
-		state = "(disabled)"
-	}
-	return fmt.Sprintf("%s %s %s", thing, id, state)
+	return fmt.Sprintf("%s %s", thing, id)
 }
 
 func (t *Term) formatBreakpointLocation(bp *api.Breakpoint) string {

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -286,7 +286,11 @@ Groups goroutines by the value of the label with the specified key.
 Called without arguments it will show information about the current goroutine.
 Called with a single argument it will switch to the specified goroutine.
 Called with more arguments it will execute a command on the specified goroutine.`},
-		{aliases: []string{"breakpoints", "bp"}, group: breakCmds, cmdFn: breakpoints, helpMsg: "Print out info for active breakpoints."},
+		{aliases: []string{"breakpoints", "bp"}, group: breakCmds, cmdFn: breakpoints, helpMsg: `Print out info for active breakpoints.
+	
+	breakpoints [-a]
+
+Specifying -a prints all physical breakpoint, including internal breakpoints.`},
 		{aliases: []string{"print", "p"}, group: dataCmds, allowedPrefixes: onPrefix | deferredPrefix, cmdFn: printVar, helpMsg: `Evaluate an expression.
 
 	[goroutine <n>] [frame <m>] print [%format] <expression>
@@ -1674,7 +1678,7 @@ func clear(t *Term, ctx callContext, args string) error {
 }
 
 func clearAll(t *Term, ctx callContext, args string) error {
-	breakPoints, err := t.client.ListBreakpoints()
+	breakPoints, err := t.client.ListBreakpoints(false)
 	if err != nil {
 		return err
 	}
@@ -1740,7 +1744,7 @@ func (a byID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byID) Less(i, j int) bool { return a[i].ID < a[j].ID }
 
 func breakpoints(t *Term, ctx callContext, args string) error {
-	breakPoints, err := t.client.ListBreakpoints()
+	breakPoints, err := t.client.ListBreakpoints(args == "-a")
 	if err != nil {
 		return err
 	}
@@ -1790,6 +1794,9 @@ func formatBreakpointAttrs(prefix string, bp *api.Breakpoint, includeTrace bool)
 	}
 	if includeTrace && bp.Tracepoint {
 		attrs = append(attrs, fmt.Sprintf("%strace", prefix))
+	}
+	for i := range bp.VerboseDescr {
+		attrs = append(attrs, fmt.Sprintf("%s%s", prefix, bp.VerboseDescr[i]))
 	}
 	return attrs
 }

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -792,6 +792,24 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 		}
 		var rpcArgs rpc2.ListBreakpointsIn
 		var rpcRet rpc2.ListBreakpointsOut
+		if len(args) > 0 && args[0] != starlark.None {
+			err := unmarshalStarlarkValue(args[0], &rpcArgs.All, "All")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
+		for _, kv := range kwargs {
+			var err error
+			switch kv[0].(starlark.String) {
+			case "All":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.All, "All")
+			default:
+				err = fmt.Errorf("unknown argument %q", kv[0])
+			}
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
 		err := env.ctx.Client().CallAPI("ListBreakpoints", &rpcArgs, &rpcRet)
 		if err != nil {
 			return starlark.None, err

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -93,6 +93,8 @@ type Breakpoint struct {
 	WatchExpr string
 	WatchType WatchType
 
+	VerboseDescr []string `json:"VerboseDescr,omitempty"`
+
 	// number of times a breakpoint has been reached in a certain goroutine
 	HitCount map[string]uint64 `json:"hitCount"`
 	// number of times a breakpoint has been reached

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -39,6 +39,9 @@ type DebuggerState struct {
 	// While NextInProgress is set further requests for next or step may be rejected.
 	// Either execute continue until NextInProgress is false or call CancelNext
 	NextInProgress bool
+	// WatchOutOfScope contains the list of watchpoints that went out of scope
+	// during the last continue.
+	WatchOutOfScope []*Breakpoint
 	// Exited indicates whether the debugged process has exited.
 	Exited     bool `json:"exited"`
 	ExitStatus int  `json:"exitStatus"`

--- a/service/client.go
+++ b/service/client.go
@@ -69,7 +69,7 @@ type Client interface {
 	// CreateWatchpoint creates a new watchpoint.
 	CreateWatchpoint(api.EvalScope, string, api.WatchType) (*api.Breakpoint, error)
 	// ListBreakpoints gets all breakpoints.
-	ListBreakpoints() ([]*api.Breakpoint, error)
+	ListBreakpoints(bool) ([]*api.Breakpoint, error)
 	// ClearBreakpoint deletes a breakpoint by ID.
 	ClearBreakpoint(id int) (*api.Breakpoint, error)
 	// ClearBreakpointByName deletes a breakpoint by name

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1365,7 +1365,7 @@ func (s *Server) clearBreakpoints(existingBps map[string]*api.Breakpoint, bpAdde
 }
 
 func (s *Server) getMatchingBreakpoints(prefix string) map[string]*api.Breakpoint {
-	existing := s.debugger.Breakpoints()
+	existing := s.debugger.Breakpoints(false)
 	matchingBps := make(map[string]*api.Breakpoint, len(existing))
 	for _, bp := range existing {
 		// Skip special breakpoints such as for panic.

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -939,11 +939,21 @@ func (d *Debugger) clearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint
 }
 
 // Breakpoints returns the list of current breakpoints.
-func (d *Debugger) Breakpoints() []*api.Breakpoint {
+func (d *Debugger) Breakpoints(all bool) []*api.Breakpoint {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 
-	bps := api.ConvertBreakpoints(d.breakpoints())
+	var bps []*api.Breakpoint
+
+	if !all {
+		bps = api.ConvertBreakpoints(d.breakpoints())
+	} else {
+		for _, bp := range d.target.Breakpoints().M {
+			abp := api.ConvertBreakpoint(bp)
+			abp.VerboseDescr = bp.VerboseDescr()
+			bps = append(bps, abp)
+		}
+	}
 
 	for _, bp := range d.disabledBreakpoints {
 		bps = append(bps, bp)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -623,6 +623,11 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 		state.When, _ = d.target.When()
 	}
 
+	state.WatchOutOfScope = make([]*api.Breakpoint, 0, len(d.target.Breakpoints().WatchOutOfScope))
+	for _, bp := range d.target.Breakpoints().WatchOutOfScope {
+		state.WatchOutOfScope = append(state.WatchOutOfScope, api.ConvertBreakpoint(bp))
+	}
+
 	return state, nil
 }
 

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -98,7 +98,7 @@ func (s *RPCServer) StacktraceGoroutine(args *StacktraceGoroutineArgs, locations
 }
 
 func (s *RPCServer) ListBreakpoints(arg interface{}, breakpoints *[]*api.Breakpoint) error {
-	*breakpoints = s.debugger.Breakpoints()
+	*breakpoints = s.debugger.Breakpoints(false)
 	return nil
 }
 

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -242,9 +242,9 @@ func (c *RPCClient) CreateWatchpoint(scope api.EvalScope, expr string, wtype api
 	return out.Breakpoint, err
 }
 
-func (c *RPCClient) ListBreakpoints() ([]*api.Breakpoint, error) {
+func (c *RPCClient) ListBreakpoints(all bool) ([]*api.Breakpoint, error) {
 	var out ListBreakpointsOut
-	err := c.call("ListBreakpoints", ListBreakpointsIn{}, &out)
+	err := c.call("ListBreakpoints", ListBreakpointsIn{all}, &out)
 	return out.Breakpoints, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -215,6 +215,7 @@ func (s *RPCServer) Ancestors(arg AncestorsIn, out *AncestorsOut) error {
 }
 
 type ListBreakpointsIn struct {
+	All bool
 }
 
 type ListBreakpointsOut struct {
@@ -223,7 +224,7 @@ type ListBreakpointsOut struct {
 
 // ListBreakpoints gets all breakpoints.
 func (s *RPCServer) ListBreakpoints(arg ListBreakpointsIn, out *ListBreakpointsOut) error {
-	out.Breakpoints = s.debugger.Breakpoints()
+	out.Breakpoints = s.debugger.Breakpoints(arg.All)
 	return nil
 }
 

--- a/service/test/common_test.go
+++ b/service/test/common_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/go-delve/delve/service/api"
+	"github.com/go-delve/delve/service/rpc1"
+	"github.com/go-delve/delve/service/rpc2"
 )
 
 func assertNoError(err error, t *testing.T, s string) {
@@ -63,8 +65,15 @@ type BreakpointLister interface {
 	ListBreakpoints() ([]*api.Breakpoint, error)
 }
 
-func countBreakpoints(t *testing.T, c BreakpointLister) int {
-	bps, err := c.ListBreakpoints()
+func countBreakpoints(t *testing.T, c interface{}) int {
+	var bps []*api.Breakpoint
+	var err error
+	switch c := c.(type) {
+	case *rpc2.RPCClient:
+		bps, err = c.ListBreakpoints(false)
+	case *rpc1.RPCClient:
+		bps, err = c.ListBreakpoints()
+	}
 	assertNoError(err, t, "ListBreakpoints()")
 	bpcount := 0
 	for _, bp := range bps {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -196,7 +196,7 @@ func TestRestart_duringStop(t *testing.T) {
 		if c.ProcessPid() == origPid {
 			t.Fatal("did not spawn new process, has same PID")
 		}
-		bps, err := c.ListBreakpoints()
+		bps, err := c.ListBreakpoints(false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1631,7 +1631,7 @@ func TestClientServer_RestartBreakpointPosition(t *testing.T) {
 		assertNoError(err, t, "Halt")
 		_, err = c.Restart(false)
 		assertNoError(err, t, "Restart")
-		bps, err := c.ListBreakpoints()
+		bps, err := c.ListBreakpoints(false)
 		assertNoError(err, t, "ListBreakpoints")
 		for _, bp := range bps {
 			if bp.Name == bpBefore.Name {
@@ -2138,7 +2138,7 @@ func TestDoubleCreateBreakpoint(t *testing.T) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1, Name: "firstbreakpoint", Tracepoint: true})
 		assertNoError(err, t, "CreateBreakpoint 1")
 
-		bps, err := c.ListBreakpoints()
+		bps, err := c.ListBreakpoints(false)
 		assertNoError(err, t, "ListBreakpoints 1")
 
 		t.Logf("breakpoints before second call:")
@@ -2151,7 +2151,7 @@ func TestDoubleCreateBreakpoint(t *testing.T) {
 		_, err = c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1, Name: "secondbreakpoint", Tracepoint: true})
 		assertError(err, t, "CreateBreakpoint 2") // breakpoint exists
 
-		bps, err = c.ListBreakpoints()
+		bps, err = c.ListBreakpoints(false)
 		assertNoError(err, t, "ListBreakpoints 2")
 
 		t.Logf("breakpoints after second call:")
@@ -2201,7 +2201,7 @@ func TestClearLogicalBreakpoint(t *testing.T) {
 		}
 		_, err = c.ClearBreakpoint(bp.ID)
 		assertNoError(err, t, "ClearBreakpoint()")
-		bps, err := c.ListBreakpoints()
+		bps, err := c.ListBreakpoints(false)
 		assertNoError(err, t, "ListBreakpoints()")
 		for _, curbp := range bps {
 			if curbp.ID == bp.ID {
@@ -2322,7 +2322,7 @@ func TestDetachLeaveRunning(t *testing.T) {
 
 func assertNoDuplicateBreakpoints(t *testing.T, c service.Client) {
 	t.Helper()
-	bps, _ := c.ListBreakpoints()
+	bps, _ := c.ListBreakpoints(false)
 	seen := make(map[int]bool)
 	for _, bp := range bps {
 		t.Logf("%#v\n", bp)


### PR DESCRIPTION
### proc,terminal,service: support stack watchpoints

Adds support for watchpoints on stack allocated variables.

When a stack variable is watched, in addition to the normal watchpoint
some support breakpoints are created:

* one breakpoint inside runtime.copystack, used to adjust the address
of the watchpoint when the stack is resized
* one or more breakpoints used to detect when the stack variable goes
out of scope, those are similar to the breakpoints set by StepOut.

Implements #279

### terminal,service: add way to see internal breakpoints

Now that Delve has internal breakpoints that survive for long periods
of time it will be useful to have an option to display them.

### proc: allow multiple overlapping internal breakpoints

Changes Breakpoint to allow multiple overlapping internal breakpoints
on the same instruction address.

This is done by changing the Breakpoint structure to contain a list of
"breaklets", each breaklet has a BreakpointKind and a condition
expression, independent of the other.

A breakpoint is considered active if any of its breaklets are active.

A breakpoint is removed when all its breaklets are removed.

We also change the terminology "internal breakpoint" to "stepping
breakpoint":

HasInternalBreakpoints -> HasSteppingBreakpoints
IsInternal -> IsStepping
etc...

The motivation for this change is implementing watchpoints on stack
variables.

Watching a stack variable requires also setting a special breakpoint to
find out when the variable goes out of scope. These breakpoints can not
be UserBreakpoints because only one user breakpoint is allowed on the
same instruction and they can not be internal breakpoints because they
should not be cleared when a next operation is completed (they should
be cleared when the variable watch is cleared).

Updates #279
