### PR TITLE
service/dap: add throw reason to exception info

### DIFF
--- a/_fixtures/fatalerror.go
+++ b/_fixtures/fatalerror.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	var f func()
+	go f()
+}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2366,7 +2366,9 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 			// Attempt to get the value of the throw reason.
 			// This is not currently working for Go 1.16 or 1.17: https://github.com/golang/go/issues/46425.
 			handleError := func(err error) {
-				body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())
+				if err != nil {
+					body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())
+				}
 				if goversion.VersionAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
 					body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
 				}
@@ -2376,7 +2378,7 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 			if err == nil {
 				if exprVar.Value != nil {
 					body.Description = exprVar.Value.String()
-				} else if exprVar.Unreadable != nil {
+				} else {
 					handleError(exprVar.Unreadable)
 				}
 			} else {

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2368,7 +2368,7 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 			exprVar, err := s.debugger.EvalVariableInScope(goroutineID, 1, 0, "s", DefaultLoadConfig)
 			if err == nil {
 				body.Description = exprVar.Value.String()
-			} else if goversion.VersionAfterOrEqual(runtime.Version(), 1, 16) {
+			} else if goversion.VersionAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
 				body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
 			} else {
 				body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 
 	"github.com/go-delve/delve/pkg/gobuild"
+	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/go-delve/delve/pkg/locspec"
 	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/go-delve/delve/pkg/proc"
@@ -2361,14 +2362,25 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 	if bpState != nil && bpState.Breakpoint != nil && (bpState.Breakpoint.Name == proc.FatalThrow || bpState.Breakpoint.Name == proc.UnrecoveredPanic) {
 		switch bpState.Breakpoint.Name {
 		case proc.FatalThrow:
-			// TODO(suzmue): add the fatal throw reason to body.Description.
 			body.ExceptionId = "fatal error"
+			// Attempt to get the value of the throw reason.
+			// This is not currently working for Go 1.16 or 1.17: https://github.com/golang/go/issues/46425.
+			exprVar, err := s.debugger.EvalVariableInScope(goroutineID, 1, 0, "s", DefaultLoadConfig)
+			if err == nil {
+				body.Description = exprVar.Value.String()
+			} else if goversion.VersionAfterOrEqual(runtime.Version(), 1, 16) {
+				body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
+			} else {
+				body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())
+			}
 		case proc.UnrecoveredPanic:
 			body.ExceptionId = "panic"
 			// Attempt to get the value of the panic message.
 			exprVar, err := s.debugger.EvalVariableInScope(goroutineID, 0, 0, "(*msgs).arg.(data)", DefaultLoadConfig)
 			if err == nil {
 				body.Description = exprVar.Value.String()
+			} else {
+				body.Description = fmt.Sprintf("Error getting panic message: %s", err.Error())
 			}
 		}
 	} else {
@@ -2397,7 +2409,7 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 	}
 
 	frames, err := s.debugger.Stacktrace(goroutineID, s.args.stackTraceDepth, 0)
-	if err == nil && len(frames) > 0 {
+	if err == nil {
 		apiFrames, err := s.debugger.ConvertStacktrace(frames, nil)
 		if err == nil {
 			var buf bytes.Buffer
@@ -2405,6 +2417,8 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 			terminal.PrintStack(s.toClientPath, &buf, apiFrames, "\t", false)
 			body.Details.StackTrace = buf.String()
 		}
+	} else {
+		body.Details.StackTrace = fmt.Sprintf("Error getting stack trace: %s", err.Error())
 	}
 	response := &dap.ExceptionInfoResponse{
 		Response: *newResponse(request.Request),

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2369,11 +2369,12 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 			if err == nil {
 				if exprVar.Value != nil {
 					body.Description = exprVar.Value.String()
-				} else if goversion.VersionAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
-					body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
 				}
 			} else {
 				body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())
+				if goversion.VersionAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
+					body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
+				}
 			}
 		case proc.UnrecoveredPanic:
 			body.ExceptionId = "panic"

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2367,9 +2367,11 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 			// This is not currently working for Go 1.16 or 1.17: https://github.com/golang/go/issues/46425.
 			exprVar, err := s.debugger.EvalVariableInScope(goroutineID, 1, 0, "s", DefaultLoadConfig)
 			if err == nil {
-				body.Description = exprVar.Value.String()
-			} else if goversion.VersionAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
-				body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
+				if exprVar.Value != nil {
+					body.Description = exprVar.Value.String()
+				} else if goversion.VersionAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
+					body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
+				}
 			} else {
 				body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())
 			}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2369,7 +2369,7 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 				if err != nil {
 					body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())
 				}
-				if goversion.VersionAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
+				if goversion.ProducerAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
 					body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
 				}
 			}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3339,6 +3339,9 @@ func TestFatalThrowBreakpoint(t *testing.T) {
 					if se.Body.Reason != "exception" || se.Body.Description != "fatal error" {
 						t.Errorf("\ngot  %#v\nwant Reason=\"exception\" Description=\"fatal error\"", se)
 					}
+
+					// TODO(suzmue): Get the exception info for the thread and check the description
+					// includes "all goroutines are asleep - deadlock!".
 				},
 				disconnect: true,
 			}})

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3340,19 +3340,20 @@ func TestFatalThrowBreakpoint(t *testing.T) {
 					}
 
 					// TODO(suzmue): Enable this test for 1.17 when https://github.com/golang/go/issues/46425 is fixed.
-					if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 16) {
-						errorPrefix := "\"go of nil func value\""
-						client.ExceptionInfoRequest(1)
-						eInfo := client.ExpectExceptionInfoResponse(t)
-						if eInfo.Body.ExceptionId != "runtime error" || !strings.HasPrefix(eInfo.Body.Description, errorPrefix) {
-							t.Errorf("\ngot  %#v\nwant ExceptionId=\"runtime error\" Text=\"%s\"", eInfo, errorPrefix)
-						}
+					errorPrefix := "\"go of nil func value\""
+					if goversion.VersionAfterOrEqual(runtime.Version(), 1, 16) {
+						errorPrefix = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
 					}
+					client.ExceptionInfoRequest(1)
+					eInfo := client.ExpectExceptionInfoResponse(t)
+					if eInfo.Body.ExceptionId != "fatal error" || !strings.HasPrefix(eInfo.Body.Description, errorPrefix) {
+						t.Errorf("\ngot  %#v\nwant ExceptionId=\"runtime error\" Text=%s", eInfo, errorPrefix)
+					}
+
 				},
 				disconnect: true,
 			}})
 	})
-
 	runTest(t, "testdeadlock", func(client *daptest.Client, fixture protest.Fixture) {
 		runDebugSessionWithBPs(t, client, "launch",
 			// Launch

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -237,6 +237,12 @@ func (d *Debugger) checkGoVersion() error {
 	return goversion.Compatible(producer)
 }
 
+func (d *Debugger) TargetGoVersion() string {
+	d.targetMutex.Lock()
+	defer d.targetMutex.Unlock()
+	return d.target.BinInfo().Producer()
+}
+
 // Launch will start a process with the given args and working directory.
 func (d *Debugger) Launch(processArgs []string, wd string) (*proc.Target, error) {
 	if err := verifyBinaryFormat(processArgs[0]); err != nil {


### PR DESCRIPTION
We can get the throw reason by looking at the argument "s" in runtime.throw. This is not currently working in Go 1.16 or Go 1.17 (see golang/go#46425), but does work in Go 1.15 and Go 1.14
