### PR TITLE
service/dap: truncate value for expandable types in hover

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1832,10 +1832,7 @@ type convertVariableFlags uint8
 
 const (
 	skipRef convertVariableFlags = 1 << iota
-	// A variable is considered basic if it cannot be expanded to get additional
-	// values.
-	showFullValueBasic
-	showFullValueAll
+	showFullValue
 )
 
 // convertVariableWithOpts allows to skip reference generation in case all we need is
@@ -1982,7 +1979,10 @@ func (s *Server) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr s
 			variablesReference = maybeCreateVariableHandle(v)
 		}
 	}
-	canTruncateValue := showFullValueAll&opts == 0 && (showFullValueBasic&opts == 0 || variablesReference != 0)
+
+	// By default, only values of variables that have children can be truncated.
+	// If showFullValue is set, then all value strings are not truncated.
+	canTruncateValue := showFullValue&opts == 0
 	if len(value) > defaultMaxValueLen && canTruncateValue && canHaveRef {
 		value = value[:defaultMaxValueLen] + "..."
 	}
@@ -2061,10 +2061,7 @@ func (s *Server) onEvaluateRequest(request *dap.EvaluateRequest) {
 		}
 		var opts convertVariableFlags
 		if ctxt == "clipboard" || ctxt == "variables" {
-			opts |= showFullValueAll
-		}
-		if ctxt == "hover" {
-			opts |= showFullValueBasic
+			opts |= showFullValue
 		}
 		exprVal, exprRef := s.convertVariableWithOpts(exprVar, fmt.Sprintf("(%s)", request.Arguments.Expression), opts)
 		response.Body = dap.EvaluateResponseBody{Result: exprVal, VariablesReference: exprRef}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2126,6 +2126,8 @@ func (s *Server) onEvaluateRequest(request *dap.EvaluateRequest) {
 			}
 		}
 		var opts convertVariableFlags
+		// Send the full value when the context is "clipboard" or "variables" since
+		// these contexts are used to copy the value.
 		if ctxt == "clipboard" || ctxt == "variables" {
 			opts |= showFullValue
 		}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2785,7 +2785,7 @@ func TestEvaluateRequestLongStrLargeValue(t *testing.T) {
 							got3 := client.ExpectEvaluateResponse(t)
 							want3 := m1Truncated
 							switch evalContext {
-							case "variables", "hover", "clipboard":
+							case "variables", "clipboard":
 								want3 = m1
 							}
 							checkEvalRegex(t, got3, want3, true)


### PR DESCRIPTION
On hovers, including the full value for complex types is unnecessary, since the user will likely need to expand the children to inspect the values. Additionally, this can really slow down getting the hover values. This change will allow truncating the value
in hover if the variable has a variables reference.

Updates golang/vscode-go#1435