### PR TITLE
sameuser: log the uid/remoteUID when they are not matching

### DIFF
--- a/service/internal/sameuser/sameuser_linux.go
+++ b/service/internal/sameuser/sameuser_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package sameuser
 
@@ -56,7 +57,11 @@ func sameUserForHexLocalAddr(filename, hexaddr string) (bool, error) {
 		if localAddr != hexaddr {
 			continue
 		}
-		return uid == int(remoteUID), nil
+		same := uid == int(remoteUID)
+		if !same && logflags.Any() {
+			log.Printf("connection from different user (remote: %d, local: %d) detected: %v", remoteUID, uid, line)
+		}
+		return same, nil
 	}
 	return false, &errConnectionNotFound{filename}
 }


### PR DESCRIPTION
Sometimes we observe failure in the same user check (not a file read/parse error).
Log uid/remoteUID, and the info from /proc/net/tcp{6} file.

Updates golang/vscode-go#1555
