### PR TITLE
test: disable avx512 test when backend is 'rr'

### DIFF
--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1565,7 +1565,7 @@ func TestClientServer_FpRegisters(t *testing.T) {
 			if regtest.name == "XMM11" && !avx2 {
 				continue
 			}
-			if regtest.name == "XMM12" && !avx512 {
+			if regtest.name == "XMM12" && (!avx512 || testBackend == "rr") {
 				continue
 			}
 			found := false


### PR DESCRIPTION
The rr backend does not report avx512 registers back to us.
