### PR TITLE
terminal: add prompt when breakpoint is hit during next/step/stepout

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1436,15 +1436,15 @@ func continueUntilCompleteNext(t *Term, state *api.DebuggerState, op string, sho
 		}
 		return nil
 	}
-	autoContinue := false
+	skipBreakpoints := false
 	for {
 		fmt.Printf("\tbreakpoint hit during %s", op)
-		if !autoContinue {
+		if !skipBreakpoints {
 			fmt.Printf("\n")
 			answer, err := promptAutoContinue(t, op)
 			switch answer {
 			case "f": // finish next
-				autoContinue = true
+				skipBreakpoints = true
 				fallthrough
 			case "c": // continue once
 				fmt.Printf("continuing...\n")
@@ -1476,7 +1476,7 @@ func continueUntilCompleteNext(t *Term, state *api.DebuggerState, op string, sho
 
 func promptAutoContinue(t *Term, op string) (string, error) {
 	for {
-		answer, err := t.line.Prompt(fmt.Sprintf("[c] continue [s] stop her and cancel %s, [f] finish %s skipping all breakpoints? ", op, op))
+		answer, err := t.line.Prompt(fmt.Sprintf("[c] continue [s] stop here and cancel %s, [f] finish %s skipping all breakpoints? ", op, op))
 		if err != nil {
 			return "", err
 		}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -581,47 +581,6 @@ func countOccurrences(s, needle string) int {
 	return count
 }
 
-func TestIssue387(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
-	}
-	// a breakpoint triggering during a 'next' operation will interrupt it
-	test.AllowRecording(t)
-	withTestTerminal("issue387", t, func(term *FakeTerminal) {
-		breakpointHitCount := 0
-		term.MustExec("break dostuff")
-		for {
-			outstr, err := term.Exec("continue")
-			breakpointHitCount += countOccurrences(outstr, "issue387.go:8")
-			t.Log(outstr)
-			if err != nil {
-				if !strings.Contains(err.Error(), "exited") {
-					t.Fatalf("Unexpected error executing 'continue': %v", err)
-				}
-				break
-			}
-
-			pos := 9
-
-			for {
-				outstr = term.MustExec("next")
-				breakpointHitCount += countOccurrences(outstr, "issue387.go:8")
-				t.Log(outstr)
-				if countOccurrences(outstr, fmt.Sprintf("issue387.go:%d", pos)) == 0 {
-					t.Fatalf("did not continue to expected position %d", pos)
-				}
-				pos++
-				if pos >= 11 {
-					break
-				}
-			}
-		}
-		if breakpointHitCount != 10 {
-			t.Fatalf("Breakpoint hit wrong number of times, expected 10 got %d", breakpointHitCount)
-		}
-	})
-}
-
 func listIsAt(t *testing.T, term *FakeTerminal, listcmd string, cur, start, end int) {
 	t.Helper()
 	outstr := term.MustExec(listcmd)


### PR DESCRIPTION
Adds a prompt asking the user what to do when a breakpoint is hit on a
different goroutine while next/step/stepout is being executed.

Gives the user the opportunity to cancel next/step/stepout, continue
once skipping the breakpoint or automatically skipping all other
concurrent breakpoints until next/step/stepout is finished.

Fixes #2317
