### PR TITLE
service/debugger: improve CreateBreakpoint docs

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -622,7 +622,15 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 
 // CreateBreakpoint creates a breakpoint using information from the provided `requestedBp`.
 // This function accepts several different ways of specifying where and how to create the
-// breakpoint that has been requested.
+// breakpoint that has been requested. Any error encountered during the attempt to set the
+// breakpoint will be returned to the caller.
+//
+// The ways of specifying a breakpoint are listed below in the order they are considered by
+// this function:
+//
+// - If requestedBp.TraceReturn is true then it is expected that
+// requestedBp.Addrs will contain the list of return addresses
+// supplied by the caller.
 //
 // - If requestedBp.File is not an empty string the breakpoint
 // will be created on the specified file:line location
@@ -634,11 +642,11 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 // - If requestedBp.Addrs is filled it will create a logical breakpoint
 // corresponding to all specified addresses.
 //
-// - If requestedBp.TraceReturn is true then it is expected that
-// requestedBp.Addrs will contain the list of return addresses
-// supplied by the caller.
-//
 // - Otherwise the value specified by arg.Breakpoint.Addr will be used.
+//
+// Note that this method will use the first successful method in order to
+// create a breakpoint, so mixing different fields will not result is multiple
+// breakpoints being set.
 func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -620,7 +620,17 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 	return state, nil
 }
 
-// CreateBreakpoint creates a breakpoint.
+// CreateBreakpoint creates a breakpoint using information from the provided `requestedBp`.
+// This function accepts several different ways of specifying where and how to create the
+// breakpoint that has been requested.
+//
+// 1. You may provide a file:line combination and the debugger will take care of associating that with
+// the correct address in which to place the breakpoint in the running program.
+// 2. You may provide the name of a function. In this case the debugger will resolve the function name
+// to the correct address and place a breakpoint at the entry point of the function after the function prologue.
+// 3. You may provide a memory address (or addresses) directly and the debugger will set a breakpoint directly
+// on the addresses provided. Note that if you are setting a breakpoint of type `TraceReturn` it is expected that
+// the `requestedBp` contains the list of addresses representing each location that a function may return.
 func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -624,13 +624,21 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 // This function accepts several different ways of specifying where and how to create the
 // breakpoint that has been requested.
 //
-// 1. You may provide a file:line combination and the debugger will take care of associating that with
-// the correct address in which to place the breakpoint in the running program.
-// 2. You may provide the name of a function. In this case the debugger will resolve the function name
-// to the correct address and place a breakpoint at the entry point of the function after the function prologue.
-// 3. You may provide a memory address (or addresses) directly and the debugger will set a breakpoint directly
-// on the addresses provided. Note that if you are setting a breakpoint of type `TraceReturn` it is expected that
-// the `requestedBp` contains the list of addresses representing each location that a function may return.
+// - If requestedBp.File is not an empty string the breakpoint
+// will be created on the specified file:line location
+//
+// - If requestedBp.FunctionName is not an empty string
+// the breakpoint will be created on the specified function:line
+// location.
+//
+// - If requestedBp.Addrs is filled it will create a logical breakpoint
+// corresponding to all specified addresses.
+//
+// - If requestedBp.TraceReturn is true then it is expected that
+// requestedBp.Addrs will contain the list of return addresses
+// supplied by the caller.
+//
+// - Otherwise the value specified by arg.Breakpoint.Addr will be used.
 func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -226,6 +226,9 @@ func (c *RPCClient) GetBreakpointByName(name string) (*api.Breakpoint, error) {
 	return &out.Breakpoint, err
 }
 
+// CreateBreakpoint will request that the debugger set a breakpoint in the target process.
+// Please refer to the documentation for `Debugger.CreateBreakpoint` for a description of how
+// the requested breakpoint parameters are interpreted and used.
 func (c *RPCClient) CreateBreakpoint(breakPoint *api.Breakpoint) (*api.Breakpoint, error) {
 	var out CreateBreakpointOut
 	err := c.call("CreateBreakpoint", CreateBreakpointIn{*breakPoint}, &out)

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -226,9 +226,10 @@ func (c *RPCClient) GetBreakpointByName(name string) (*api.Breakpoint, error) {
 	return &out.Breakpoint, err
 }
 
-// CreateBreakpoint will request that the debugger set a breakpoint in the target process.
+// CreateBreakpoint will send a request to the RPC server to create a breakpoint.
 // Please refer to the documentation for `Debugger.CreateBreakpoint` for a description of how
-// the requested breakpoint parameters are interpreted and used.
+// the requested breakpoint parameters are interpreted and used:
+// https://pkg.go.dev/github.com/go-delve/delve/service/debugger#Debugger.CreateBreakpoint
 func (c *RPCClient) CreateBreakpoint(breakPoint *api.Breakpoint) (*api.Breakpoint, error) {
 	var out CreateBreakpointOut
 	err := c.call("CreateBreakpoint", CreateBreakpointIn{*breakPoint}, &out)

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -235,19 +235,10 @@ type CreateBreakpointOut struct {
 	Breakpoint api.Breakpoint
 }
 
-// CreateBreakpoint creates a new breakpoint.
-//
-// - If arg.Breakpoint.File is not an empty string the breakpoint
-// will be created on the specified file:line location
-//
-// - If arg.Breakpoint.FunctionName is not an empty string
-// the breakpoint will be created on the specified function:line
-// location.
-//
-// - If arg.Breakpoint.Addrs is filled it will create a logical breakpoint
-// corresponding to all specified addresses.
-//
-// - Otherwise the value specified by arg.Breakpoint.Addr will be used.
+// CreateBreakpoint creates a new breakpoint. The client is expected to populate `CreateBreakpointIn`
+// with an `api.Breakpoint` struct describing where to set the breakpoing. For more information on
+// how to properly request a breakpoint via the `api.Breakpoint` struct see the documentation for
+// `debugger.CreateBreakpoint` here: https://pkg.go.dev/github.com/go-delve/delve/service/debugger#Debugger.CreateBreakpoint.
 func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpointOut) error {
 	if err := api.ValidBreakpointName(arg.Breakpoint.Name); err != nil {
 		return err


### PR DESCRIPTION
The existing documentation was a little light on details. This patch
gives more insight into how the argument to this function is used and
interpreted.