### PR TITLE
service/dap: fix nil pointer dereference bug

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1552,8 +1552,8 @@ func (s *Server) onStackTraceRequest(request *dap.StackTraceRequest) {
 	// Determine if the goroutine is a system goroutine.
 	// TODO(suzmue): Use the System() method defined in: https://github.com/go-delve/delve/pull/2504
 	g, err := s.debugger.FindGoroutine(goroutineID)
-	var isSystemGoroutine bool
-	if err == nil {
+	isSystemGoroutine := true
+	if err == nil && g != nil {
 		userLoc := g.UserCurrent()
 		isSystemGoroutine = fnPackageName(&userLoc) == "runtime"
 	}


### PR DESCRIPTION
Make sure that g is nonnil before dereferencing it. If there is no user current function then we should assume that it is a system thread.