### PR TITLE
service/dap: send dap error response on dap error

### DIFF
--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -511,6 +511,15 @@ func (c *Client) UnknownEvent() {
 	c.send(event)
 }
 
+// BadRequest triggers an unmarshal error.
+func (c *Client) BadRequest() {
+	content := []byte("{malformedString}")
+	contentLengthHeaderFmt := "Content-Length: %d\r\n\r\n"
+	header := fmt.Sprintf(contentLengthHeaderFmt, len(content))
+	c.conn.Write([]byte(header))
+	c.conn.Write(content)
+}
+
 // KnownEvent passes decode checks, but delve has no 'case' to
 // handle it. This behaves the same way a new request type
 // added to go-dap, but not to delve.

--- a/service/dap/error_ids.go
+++ b/service/dap/error_ids.go
@@ -7,7 +7,6 @@ const (
 	UnsupportedCommand int = 9999
 	InternalError      int = 8888
 	NotYetImplemented  int = 7777
-	DapError           int = 6666
 
 	// Where applicable and for consistency only,
 	// values below are inspired the original vscode-go debug adaptor.

--- a/service/dap/error_ids.go
+++ b/service/dap/error_ids.go
@@ -7,6 +7,7 @@ const (
 	UnsupportedCommand int = 9999
 	InternalError      int = 8888
 	NotYetImplemented  int = 7777
+	DapError           int = 6666
 
 	// Where applicable and for consistency only,
 	// values below are inspired the original vscode-go debug adaptor.

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -372,7 +372,7 @@ func (s *Server) serveDAPCodec() {
 				if err != io.EOF {
 					if decodeErr, ok := err.(*dap.DecodeProtocolMessageFieldError); ok {
 						// Send an error response to the users if we were unable to process the message.
-						s.sendDapErrorResponse(decodeErr.Seq, err.Error())
+						s.sendInternalErrorResponse(decodeErr.Seq, err.Error())
 						continue
 					}
 					s.log.Error("DAP error: ", err)
@@ -2629,18 +2629,6 @@ func (s *Server) sendInternalErrorResponse(seq int, details string) {
 	er.Success = false
 	er.Message = "Internal Error"
 	er.Body.Error.Id = InternalError
-	er.Body.Error.Format = fmt.Sprintf("%s: %s", er.Message, details)
-	s.log.Debug(er.Body.Error.Format)
-	s.send(er)
-}
-
-func (s *Server) sendDapErrorResponse(seq int, details string) {
-	er := &dap.ErrorResponse{}
-	er.Type = "response"
-	er.Seq = seq
-	er.Success = false
-	er.Message = "DAP Error"
-	er.Body.Error.Id = DapError
 	er.Body.Error.Format = fmt.Sprintf("%s: %s", er.Message, details)
 	s.log.Debug(er.Body.Error.Format)
 	s.send(er)

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -357,10 +357,14 @@ func (s *Server) serveDAPCodec() {
 	s.reader = bufio.NewReader(s.conn)
 	for {
 		request, err := dap.ReadProtocolMessage(s.reader)
-		// Handle unknown command errors gracefully by responding with an ErrorResponse.
+		// Handle dap.DecodeProtocolMessageFieldError errors gracefully by responding with an ErrorResponse.
+		// For example:
 		// -- "Request command 'foo' is not supported" means we
 		// potentially got some new DAP request that we do not yet have
 		// decoding support for, so we can respond with an ErrorResponse.
+		//
+		// Other errors, such as unmarshalling errors, will log the error and cause the server to trigger
+		// a stop.
 		if err != nil {
 			select {
 			case <-s.stopTriggered:

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -357,13 +357,10 @@ func (s *Server) serveDAPCodec() {
 	s.reader = bufio.NewReader(s.conn)
 	for {
 		request, err := dap.ReadProtocolMessage(s.reader)
-		// TODO(polina): Differentiate between errors and handle them
-		// gracefully. For example,
+		// Handle errors gracefully by responding with an ErrorResponse.
 		// -- "Request command 'foo' is not supported" means we
 		// potentially got some new DAP request that we do not yet have
 		// decoding support for, so we can respond with an ErrorResponse.
-		// TODO(polina): to support this add Seq to
-		// dap.DecodeProtocolMessageFieldError.
 		if err != nil {
 			select {
 			case <-s.stopTriggered:

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4811,5 +4811,9 @@ func TestBadlyFormattedMessageToServer(t *testing.T) {
 		if err.Body.Error.Format != "DAP Error: Request command 'unknown' is not supported (seq: 1)" || err.Seq != 1 {
 			t.Errorf("got %v, want  Seq=1 Error=\"DAP Error: Request command 'unknown' is not supported (seq: 1)\"", err)
 		}
+
+		// Make sure that the unknown request did not kill the server.
+		client.InitializeRequest()
+		client.ExpectInitializeResponse(t)
 	})
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -4805,15 +4804,12 @@ func TestBadInitializeRequest(t *testing.T) {
 
 func TestBadlyFormattedMessageToServer(t *testing.T) {
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
-		// Send a badly formatted message to the server, and expect it to close the
-		// connection.
+		// Send an unknown request message to the server, and expect it to send
+		// an error response.
 		client.UnknownRequest()
-		time.Sleep(100 * time.Millisecond)
-
-		_, err := client.ReadMessage()
-
-		if err != io.EOF {
-			t.Errorf("got err=%v, want io.EOF", err)
+		err := client.ExpectErrorResponse(t)
+		if err.Body.Error.Format != "DAP Error: Request command 'unknown' is not supported (seq: 1)" || err.Seq != 1 {
+			t.Errorf("got %v, want  Seq=1 Error=\"DAP Error: Request command 'unknown' is not supported (seq: 1)\"", err)
 		}
 	})
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4821,8 +4821,8 @@ func TestBadlyFormattedMessageToServer(t *testing.T) {
 		// an error response.
 		client.UnknownRequest()
 		err := client.ExpectErrorResponse(t)
-		if err.Body.Error.Format != "DAP Error: Request command 'unknown' is not supported (seq: 1)" || err.Seq != 1 {
-			t.Errorf("got %v, want  Seq=1 Error=\"DAP Error: Request command 'unknown' is not supported (seq: 1)\"", err)
+		if err.Body.Error.Format != "Internal Error: Request command 'unknown' is not supported (seq: 1)" || err.RequestSeq != 1 {
+			t.Errorf("got %v, want  RequestSeq=1 Error=\"Internal Error: Request command 'unknown' is not supported (seq: 1)\"", err)
 		}
 
 		// Make sure that the unknown request did not kill the server.

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -4803,6 +4804,18 @@ func TestBadInitializeRequest(t *testing.T) {
 }
 
 func TestBadlyFormattedMessageToServer(t *testing.T) {
+	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
+		// Send a badly formatted message to the server, and expect it to close the
+		// connection.
+		client.BadRequest()
+		time.Sleep(100 * time.Millisecond)
+
+		_, err := client.ReadMessage()
+
+		if err != io.EOF {
+			t.Errorf("got err=%v, want io.EOF", err)
+		}
+	})
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
 		// Send an unknown request message to the server, and expect it to send
 		// an error response.


### PR DESCRIPTION
The code previously expected the server to close when receiving
a message that it could not decode. However, there may be changes to
the spec that make new requests that we have not handled yet. In
that case, it would be preferable to return an error.