### PR TITLE
Update README.md

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -328,7 +328,7 @@ Set the current frame, or execute command on a different frame.
 The first form sets frame used by subsequent commands such as "print" or "set".
 The second form runs the command on the given frame.
 
-Note: `next/step/stepout` don't work if you are not on the topmost frame i.e., frame 0. Frames are numbered in the reverse order. The frame you started your debugging from would be your bottom most frame. Check [this](https://github.com/go-delve/delve/pull/1242) for more info.
+Note: `next/step/stepout` don't work if you are not on the topmost frame i.e., frame 0. Frames are numbered in the reverse order. The frame you started your debugging from would be your bottom most frame and your deepest frame would be your topmost frame. Check [this](https://github.com/go-delve/delve/pull/1242) for more info.
 
 
 ## funcs

--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -328,6 +328,8 @@ Set the current frame, or execute command on a different frame.
 The first form sets frame used by subsequent commands such as "print" or "set".
 The second form runs the command on the given frame.
 
+Note: `next/step/stepout` don't work if you are not on the topmost frame i.e., frame 0. Frames are numbered in the reverse order. The frame you started your debugging from would be your bottom most frame. Check [this](https://github.com/go-delve/delve/pull/1242) for more info.
+
 
 ## funcs
 Print list of functions.


### PR DESCRIPTION
- add info about frame error

Added a note in README around frames because I couldn't find much information around why I couldn't execute `next/step/stepout` commands in frames other than my deepest frame. 

[Slack thread](https://gophers.slack.com/archives/C07EXM5E0/p1625163851093300?thread_ts=1625153812.092900&cid=C07EXM5E0)