### PR TITLE
proc/native,proc/gdbserial: detect and complain about Rosetta

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -82,6 +82,7 @@ import (
 	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/go-delve/delve/pkg/proc"
 	"github.com/go-delve/delve/pkg/proc/linutil"
+	"github.com/go-delve/delve/pkg/proc/macutil"
 	isatty "github.com/mattn/go-isatty"
 )
 
@@ -431,6 +432,9 @@ func LLDBLaunch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs [
 	if runtime.GOOS == "windows" {
 		return nil, ErrUnsupportedOS
 	}
+	if err := macutil.CheckRosetta(); err != nil {
+		return nil, err
+	}
 
 	foreground := flags&proc.LaunchForeground != 0
 
@@ -547,6 +551,9 @@ func LLDBLaunch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs [
 func LLDBAttach(pid int, path string, debugInfoDirs []string) (*proc.Target, error) {
 	if runtime.GOOS == "windows" {
 		return nil, ErrUnsupportedOS
+	}
+	if err := macutil.CheckRosetta(); err != nil {
+		return nil, err
 	}
 
 	var (

--- a/pkg/proc/macutil/rosetta_darwin.go
+++ b/pkg/proc/macutil/rosetta_darwin.go
@@ -1,0 +1,19 @@
+package macutil
+
+import (
+	"errors"
+	"syscall"
+)
+
+// CheckRosetta returns an error if the calling process is being translated
+// by Apple Rosetta.
+func CheckRosetta() error {
+	pt, err := syscall.Sysctl("sysctl.proc_translated")
+	if err != nil {
+		return nil
+	}
+	if len(pt) > 0 && pt[0] == 1 {
+		return errors.New("can not run under Rosetta, check that the installed build of Go is right for your CPU architecture")
+	}
+	return nil
+}

--- a/pkg/proc/macutil/rosetta_other.go
+++ b/pkg/proc/macutil/rosetta_other.go
@@ -1,0 +1,9 @@
+// +build !darwin
+
+package macutil
+
+// CheckRosetta returns an error if the calling process is being translated
+// by Apple Rosetta.
+func CheckRosetta() error {
+	return nil
+}

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -18,6 +18,7 @@ import (
 	sys "golang.org/x/sys/unix"
 
 	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc/macutil"
 )
 
 // osProcessDetails holds Darwin specific information.
@@ -49,6 +50,9 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ strin
 		}
 	}
 	if _, err := os.Stat(argv0Go); err != nil {
+		return nil, err
+	}
+	if err := macutil.CheckRosetta(); err != nil {
 		return nil, err
 	}
 
@@ -130,6 +134,9 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ strin
 
 // Attach to an existing process with the given PID.
 func Attach(pid int, _ []string) (*proc.Target, error) {
+	if err := macutil.CheckRosetta(); err != nil {
+		return nil, err
+	}
 	dbp := newProcess(pid)
 
 	kret := C.acquire_mach_task(C.int(pid),


### PR DESCRIPTION
Delve does not run under Rosetta. Detect this condition and point
confused users towards the solution.
