### PR TITLE
proc/core/minidump,proc/gdbserial: update broken ext links

### DIFF
--- a/pkg/proc/core/minidump/minidump.go
+++ b/pkg/proc/core/minidump/minidump.go
@@ -7,7 +7,7 @@ package minidump
 // ProcDump utility.
 //
 // The file format is described on MSDN starting at:
-//  https://docs.microsoft.com/en-us/windows/desktop/api/minidumpapiset/ns-minidumpapiset-_minidump_header
+//  https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_header
 // which is the structure found at offset 0 on a minidump file.
 //
 // Further information on the format can be found reading
@@ -120,7 +120,7 @@ type Minidump struct {
 }
 
 // Stream represents one (uninterpreted) stream in a minidump file.
-// See: https://docs.microsoft.com/en-us/windows/desktop/api/minidumpapiset/ns-minidumpapiset-_minidump_directory
+// See: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_directory
 type Stream struct {
 	Type    StreamType
 	Offset  int
@@ -128,7 +128,7 @@ type Stream struct {
 }
 
 // Thread represents an entry in the ThreadList stream.
-// See: https://docs.microsoft.com/en-us/windows/desktop/api/minidumpapiset/ns-minidumpapiset-_minidump_thread
+// See: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_thread
 type Thread struct {
 	ID            uint32
 	SuspendCount  uint32
@@ -139,7 +139,7 @@ type Thread struct {
 }
 
 // Module represents an entry in the ModuleList stream.
-// See: https://docs.microsoft.com/en-us/windows/desktop/api/minidumpapiset/ns-minidumpapiset-_minidump_module
+// See: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_module
 type Module struct {
 	BaseOfImage   uint64
 	SizeOfImage   uint32
@@ -156,7 +156,7 @@ type Module struct {
 }
 
 // VSFixedFileInfo: Visual Studio Fixed File Info.
-// See: https://docs.microsoft.com/en-us/windows/desktop/api/verrsrc/ns-verrsrc-tagvs_fixedfileinfo
+// See: https://docs.microsoft.com/en-us/windows/win32/api/verrsrc/ns-verrsrc-vs_fixedfileinfo
 type VSFixedFileInfo struct {
 	Signature        uint32
 	StructVersion    uint32
@@ -194,7 +194,7 @@ func (m *MemoryRange) ReadMemory(buf []byte, addr uint64) (int, error) {
 }
 
 // MemoryInfo reprents an entry in the MemoryInfoList stream.
-// See: https://docs.microsoft.com/en-us/windows/desktop/api/minidumpapiset/ns-minidumpapiset-_minidump_memory_info
+// See: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_info_list
 type MemoryInfo struct {
 	Addr       uint64
 	Size       uint64
@@ -596,8 +596,8 @@ func readModuleList(mdmp *Minidump, buf *minidumpBuf) {
 
 // readMemory64List reads a _MINIDUMP_MEMORY64_LIST structure, containing
 // the description of the process memory.
-// See: https://docs.microsoft.com/en-us/windows/desktop/api/minidumpapiset/ns-minidumpapiset-_minidump_memory64_list
-// And: https://docs.microsoft.com/en-us/windows/desktop/api/minidumpapiset/ns-minidumpapiset-_minidump_memory_descriptor
+// See: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory64_list
+// And: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_descriptor
 func readMemory64List(mdmp *Minidump, buf *minidumpBuf, logfn func(fmt string, args ...interface{})) {
 	rangesNum := buf.u64()
 	baseOff := int(buf.u64())

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -11,7 +11,7 @@
 // The protocol is specified at:
 //   https://sourceware.org/gdb/onlinedocs/gdb/Remote-Protocol.html
 // with additional documentation for lldb specific extensions described at:
-//   https://github.com/llvm-mirror/lldb/blob/master/docs/lldb-gdb-remote.txt
+//   https://github.com/llvm/llvm-project/blob/main/lldb/docs/lldb-gdb-remote.txt
 //
 // Terminology:
 //  * inferior: the program we are trying to debug


### PR DESCRIPTION
The LLVM project archived their repository and moved it elsewhere,
Microsoft broke their minidump documentation URLs.
