### PR TITLE
cmd: treat SIGTERM as a server disconnect signal

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -685,14 +685,14 @@ func connectCmd(cmd *cobra.Command, args []string) {
 }
 
 // waitForDisconnectSignal is a blocking function that waits for either
-// a SIGINT (Ctrl-C) signal from the OS or for disconnectChan to be closed
-// by the server when the client disconnects.
+// a SIGINT (Ctrl-C) or SIGTERM (kill -15) OS signal or for disconnectChan
+// to be closed by the server when the client disconnects.
 // Note that in headless mode, the debugged process is foregrounded
 // (to have control of the tty for debugging interactive programs),
 // so SIGINT gets sent to the debuggee and not to delve.
 func waitForDisconnectSignal(disconnectChan chan struct{}) {
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGINT)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	if runtime.GOOS == "windows" {
 		// On windows Ctrl-C sent to inferior process is delivered
 		// as SIGINT to delve. Ignore it instead of stopping the server


### PR DESCRIPTION
SIGINT might get forwarded to the target process, so we need another way to request clean shutdown.

**Before**
```
DAP server listening at: [::]:54321
2021-07-12T03:00:21-07:00 debug layer=dap DAP server pid = 19852
Terminated: 15
```
```
API server listening at: [::]:54321
2021-07-12T03:03:23-07:00 debug layer=rpc API server pid = 20146
2021-07-12T03:03:23-07:00 info layer=debugger launching process with args: [/Users/polina/delve/__debug_bin]
debugserver-@(#)PROGRAM:LLDB  PROJECT:lldb-1205.0.27
 for x86_64.
Got a connection, launched process /Users/polina/delve/__debug_bin (pid = 20161).
Terminated: 15
Exiting.
```
**After**
```
DAP server listening at: [::]:54321
2021-07-12T03:00:53-07:00 debug layer=dap DAP server pid = 19889
2021-07-12T03:01:04-07:00 debug layer=dap DAP server stopping...
2021-07-12T03:01:04-07:00 debug layer=dap DAP server stopped
```
```
API server listening at: [::]:54321
2021-07-12T03:02:19-07:00 debug layer=rpc API server pid = 20013
2021-07-12T03:02:19-07:00 info layer=debugger launching process with args: [/Users/polina/delve/__debug_bin]
debugserver-@(#)PROGRAM:LLDB  PROJECT:lldb-1205.0.27
 for x86_64.
Got a connection, launched process /Users/polina/delve/__debug_bin (pid = 20028).
2021-07-12T03:02:46-07:00 debug layer=debugger detaching
```