### PR TITLE
debugserver: fix typo in checking whether debugserver support unmask_…

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -395,7 +395,7 @@ func getDebugServerAbsolutePath() string {
 
 func canUnmaskSignals(debugServerExecutable string) bool {
 	checkCanUnmaskSignalsOnce.Do(func() {
-		buf, _ := exec.Command(debugServerExecutable, "--unmask-singals").CombinedOutput()
+		buf, _ := exec.Command(debugServerExecutable, "--unmask-signals").CombinedOutput()
 		canUnmaskSignalsCached = !strings.Contains(string(buf), "unrecognized option")
 	})
 	return canUnmaskSignalsCached

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -896,7 +896,7 @@ func (p *gdbProcess) findThreadByStrID(threadID string) *gdbThread {
 // and returns true if we should stop execution in response to one of the
 // signals and return control to the user.
 // Adjusts trapthread to a thread that we actually want to stop at.
-func (p *gdbProcess) handleThreadSignals(trapthread *gdbThread) (trapthreadOut *gdbThread, atstart bool, shouldStop bool) {
+func (p *gdbProcess) handleThreadSignals(trapthread *gdbThread) (trapthreadOut *gdbThread, atstart, shouldStop bool) {
 	var trapthreadCandidate *gdbThread
 
 	for _, th := range p.threads {
@@ -1574,8 +1574,7 @@ func (t *gdbThread) reloadRegisters() error {
 		}
 	}
 
-	switch t.p.bi.GOOS {
-	case "linux":
+	if t.p.bi.GOOS == "linux" {
 		if reg, hasFsBase := t.regs.regs[t.p.regnames.FsBase]; hasFsBase {
 			t.regs.gaddr = 0
 			t.regs.tls = binary.LittleEndian.Uint64(reg.value)


### PR DESCRIPTION
debugserver: fix typo in checking whether debugserver support unmask_signals. 
Related commit is  https://github.com/llvm/llvm-project/commit/27012c0f75c2e4891277d0d14f9f97a9f564d596. 
Correct parameter for debugserver in [debugserver.cpp:901](https://github.com/llvm/llvm-project/blob/ac8cedead8859b2e86155e8cc1f0c3cfd822049c/lldb/tools/debugserver/source/debugserver.cpp#L901) is `unmask-signals`. 