### PR TITLE
[Draft] Support env from dap request

### DIFF
--- a/_fixtures/testenv.go
+++ b/_fixtures/testenv.go
@@ -7,7 +7,14 @@ import (
 )
 
 func main() {
-	x := os.Getenv("SOMEVAR")
+	x := os.Getenv("VAR1")
 	runtime.Breakpoint()
-	fmt.Printf("SOMEVAR=%s\n", x)
+	fmt.Printf("VAR1=%s\n", x)
+
+	ok := false
+	x, ok = os.LookupEnv("VAR2")
+	if ok {
+		runtime.Breakpoint()
+		fmt.Printf("VAR2=%s\n", x)
+	}
 }

--- a/_fixtures/testenv_from_dap.go
+++ b/_fixtures/testenv_from_dap.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	// this test expects two ENV: VAR1=foo VAR2=bar.
+	if os.Getenv("VAR1") != "foo" {
+		panic("VAR1 is not foo!")
+	}
+	if os.Getenv("VAR2") != "bar" {
+		panic("VAR2 is not bar!")
+	}
+}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -428,7 +428,7 @@ func getLdEnvVars() []string {
 // LLDBLaunch starts an instance of lldb-server and connects to it, asking
 // it to launch the specified target program with the specified arguments
 // (cmd) on the specified directory wd.
-func LLDBLaunch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs []string, tty string, redirects [3]string) (*proc.Target, error) {
+func LLDBLaunch(cmd, environ []string, wd string, flags proc.LaunchFlags, debugInfoDirs []string, tty string, redirects [3]string) (*proc.Target, error) {
 	if runtime.GOOS == "windows" {
 		return nil, ErrUnsupportedOS
 	}
@@ -523,9 +523,7 @@ func LLDBLaunch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs [
 		process.SysProcAttr = sysProcAttr(foreground)
 	}
 
-	if runtime.GOOS == "darwin" {
-		process.Env = proc.DisableAsyncPreemptEnv()
-	}
+	process.Env = proc.MergeInheritedEnviron(environ)
 
 	if err = process.Start(); err != nil {
 		return nil, err

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -30,7 +30,7 @@ func withTestRecording(name string, t testing.TB, fn func(t *proc.Target, fixtur
 		t.Skip("test skipped, rr not found")
 	}
 	t.Log("recording")
-	p, tracedir, err := gdbserial.RecordAndReplay([]string{fixture.Path}, ".", true, []string{}, [3]string{})
+	p, tracedir, err := gdbserial.RecordAndReplay([]string{fixture.Path}, nil, ".", true, []string{}, [3]string{})
 	if err != nil {
 		t.Fatal("Launch():", err)
 	}

--- a/pkg/proc/native/exec_darwin.c
+++ b/pkg/proc/native/exec_darwin.c
@@ -3,8 +3,6 @@
 #include "exec_darwin.h"
 #include "stdio.h"
 
-extern char** environ;
-
 int
 close_exec_pipe(int fd[2]) {
 	if (pipe(fd) < 0) return -1;
@@ -14,7 +12,7 @@ close_exec_pipe(int fd[2]) {
 }
 
 int
-fork_exec(char *argv0, char **argv, int size,
+fork_exec(char *argv0, char **argv, char **environ, int size,
 		char *wd,
 		task_t *task,
 		mach_port_t *port_set,

--- a/pkg/proc/native/exec_darwin.h
+++ b/pkg/proc/native/exec_darwin.h
@@ -9,4 +9,4 @@
 #include <fcntl.h>
 
 int
-fork_exec(char *, char **, int, char *, task_t*, mach_port_t*, mach_port_t*, mach_port_t*);
+fork_exec(char *, char **, char **, int, char *, task_t*, mach_port_t*, mach_port_t*, mach_port_t*);

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -13,7 +13,7 @@ import (
 var ErrNativeBackendDisabled = errors.New("native backend disabled during compilation")
 
 // Launch returns ErrNativeBackendDisabled.
-func Launch(_ []string, _ string, _ proc.LaunchFlags, _ []string, _ string, _ [3]string) (*proc.Target, error) {
+func Launch(_, _ []string, _ string, _ proc.LaunchFlags, _ []string, _ string, _ [3]string) (*proc.Target, error) {
 	return nil, ErrNativeBackendDisabled
 }
 

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -42,7 +42,7 @@ type osProcessDetails struct {
 // to be supplied to that process. `wd` is working directory of the program.
 // If the DWARF information cannot be found in the binary, Delve will look
 // for external debug files in the directories passed in.
-func Launch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs []string, tty string, redirects [3]string) (*proc.Target, error) {
+func Launch(cmd, environ []string, wd string, flags proc.LaunchFlags, debugInfoDirs []string, tty string, redirects [3]string) (*proc.Target, error) {
 	var (
 		process *exec.Cmd
 		err     error
@@ -70,11 +70,11 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs []str
 	dbp.execPtraceFunc(func() {
 		process = exec.Command(cmd[0])
 		process.Args = cmd
+		process.Env = proc.MergeInheritedEnviron(environ)
 		process.Stdin = stdin
 		process.Stdout = stdout
 		process.Stderr = stderr
 		process.SysProcAttr = &syscall.SysProcAttr{Ptrace: true, Setpgid: true, Foreground: foreground}
-		process.Env = proc.DisableAsyncPreemptEnv()
 		if foreground {
 			signal.Ignore(syscall.SIGTTOU, syscall.SIGTTIN)
 		}

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -52,7 +52,7 @@ type osProcessDetails struct {
 // to be supplied to that process. `wd` is working directory of the program.
 // If the DWARF information cannot be found in the binary, Delve will look
 // for external debug files in the directories passed in.
-func Launch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs []string, tty string, redirects [3]string) (*proc.Target, error) {
+func Launch(cmd, environ []string, wd string, flags proc.LaunchFlags, debugInfoDirs []string, tty string, redirects [3]string) (*proc.Target, error) {
 	var (
 		process *exec.Cmd
 		err     error
@@ -89,6 +89,7 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs []str
 
 		process = exec.Command(cmd[0])
 		process.Args = cmd
+		process.Env = proc.MergeInheritedEnviron(environ)
 		process.Stdin = stdin
 		process.Stdout = stdout
 		process.Stderr = stderr

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -21,13 +21,11 @@ type osProcessDetails struct {
 }
 
 // Launch creates and begins debugging a new process.
-func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ string, redirects [3]string) (*proc.Target, error) {
+func Launch(cmd, environ []string, wd string, flags proc.LaunchFlags, _ []string, _ string, redirects [3]string) (*proc.Target, error) {
 	argv0Go, err := filepath.Abs(cmd[0])
 	if err != nil {
 		return nil, err
 	}
-
-	env := proc.DisableAsyncPreemptEnv()
 
 	stdin, stdout, stderr, closefn, err := openRedirects(redirects, true)
 	if err != nil {
@@ -43,7 +41,7 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ strin
 			Sys: &syscall.SysProcAttr{
 				CreationFlags: _DEBUG_ONLY_THIS_PROCESS,
 			},
-			Env: env,
+			Env: proc.MergeInheritedEnviron(environ),
 		}
 		p, err = os.StartProcess(argv0Go, cmd, attr)
 	})

--- a/pkg/proc/proc_linux_test.go
+++ b/pkg/proc/proc_linux_test.go
@@ -14,7 +14,7 @@ func TestLoadingExternalDebugInfo(t *testing.T) {
 	fixture := protest.BuildFixture("locationsprog", 0)
 	defer os.Remove(fixture.Path)
 	stripAndCopyDebugInfo(fixture, t)
-	p, err := native.Launch(append([]string{fixture.Path}, ""), "", 0, []string{filepath.Dir(fixture.Path)}, "", [3]string{})
+	p, err := native.Launch(append([]string{fixture.Path}, ""), nil, "", 0, []string{filepath.Dir(fixture.Path)}, "", [3]string{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -101,13 +101,13 @@ func withTestProcessArgs(name string, t testing.TB, wd string, args []string, bu
 
 	switch testBackend {
 	case "native":
-		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, 0, []string{}, "", [3]string{})
+		p, err = native.Launch(append([]string{fixture.Path}, args...), nil, wd, 0, []string{}, "", [3]string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, 0, []string{}, "", [3]string{})
+		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), nil, wd, 0, []string{}, "", [3]string{})
 	case "rr":
 		protest.MustHaveRecordingAllowed(t)
 		t.Log("recording")
-		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), wd, true, []string{}, [3]string{})
+		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), nil, wd, true, []string{}, [3]string{})
 		t.Logf("replaying %q", tracedir)
 	default:
 		t.Fatal("unknown backend")
@@ -2162,9 +2162,9 @@ func TestUnsupportedArch(t *testing.T) {
 
 	switch testBackend {
 	case "native":
-		p, err = native.Launch([]string{outfile}, ".", 0, []string{}, "", [3]string{})
+		p, err = native.Launch([]string{outfile}, nil, ".", 0, []string{}, "", [3]string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch([]string{outfile}, ".", 0, []string{}, "", [3]string{})
+		p, err = gdbserial.LLDBLaunch([]string{outfile}, nil, ".", 0, []string{}, "", [3]string{})
 	default:
 		t.Skip("test not valid for this backend")
 	}

--- a/service/config.go
+++ b/service/config.go
@@ -23,6 +23,10 @@ type Config struct {
 	// ProcessArgs are the arguments to launch a new process.
 	ProcessArgs []string
 
+	// Environ are additional environment variables for the new process,
+	// in the form "key=value".
+	Environ []string
+
 	// AcceptMulti configures the server to accept multiple connection.
 	// Note that the server API is not reentrant and clients will have to coordinate.
 	AcceptMulti bool

--- a/service/debugger/debugger_test.go
+++ b/service/debugger/debugger_test.go
@@ -23,7 +23,7 @@ func TestDebugger_LaunchNoMain(t *testing.T) {
 	}
 
 	d := new(Debugger)
-	_, err := d.Launch([]string{exepath}, ".")
+	_, err := d.Launch([]string{exepath}, nil, ".")
 	if err == nil {
 		t.Fatalf("expected error but none was generated")
 	}
@@ -60,7 +60,7 @@ func TestDebugger_LaunchInvalidFormat(t *testing.T) {
 	defer os.Remove(exepath)
 
 	d := new(Debugger)
-	_, err := d.Launch([]string{exepath}, ".")
+	_, err := d.Launch([]string{exepath}, nil, ".")
 	if err == nil {
 		t.Fatalf("expected error but none was generated")
 	}

--- a/service/debugger/debugger_unix_test.go
+++ b/service/debugger/debugger_unix_test.go
@@ -44,7 +44,7 @@ func TestDebugger_LaunchNoExecutablePerm(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := new(Debugger)
-	_, err := d.Launch([]string{exepath}, ".")
+	_, err := d.Launch([]string{exepath}, nil, ".")
 	if err == nil {
 		t.Fatalf("expected error but none was generated")
 	}
@@ -82,7 +82,7 @@ func TestDebugger_LaunchWithTTY(t *testing.T) {
 	protest.DefaultTestBackend(&backend)
 	conf := &Config{TTY: tty.Name(), Backend: backend}
 	pArgs := []string{exepath}
-	d, err := New(conf, pArgs)
+	d, err := New(conf, pArgs, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -113,7 +113,7 @@ func (s *ServerImpl) Run() error {
 
 	// Create and start the debugger
 	config := s.config.Debugger
-	if s.debugger, err = debugger.New(&config, s.config.ProcessArgs); err != nil {
+	if s.debugger, err = debugger.New(&config, s.config.ProcessArgs, s.config.Environ); err != nil {
 		return err
 	}
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -132,13 +132,13 @@ func withTestProcessArgs(name string, t *testing.T, wd string, args []string, bu
 	var tracedir string
 	switch testBackend {
 	case "native":
-		p, err = native.Launch(append([]string{fixture.Path}, args...), wd, 0, []string{}, "", [3]string{})
+		p, err = native.Launch(append([]string{fixture.Path}, args...), nil, wd, 0, []string{}, "", [3]string{})
 	case "lldb":
-		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), wd, 0, []string{}, "", [3]string{})
+		p, err = gdbserial.LLDBLaunch(append([]string{fixture.Path}, args...), nil, wd, 0, []string{}, "", [3]string{})
 	case "rr":
 		protest.MustHaveRecordingAllowed(t)
 		t.Log("recording")
-		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), wd, true, []string{}, [3]string{})
+		p, tracedir, err = gdbserial.RecordAndReplay(append([]string{fixture.Path}, args...), nil, wd, true, []string{}, [3]string{})
 		t.Logf("replaying %q", tracedir)
 	default:
 		t.Fatalf("unknown backend %q", testBackend)


### PR DESCRIPTION
This PR adds `env` arguments support from DAP requests, which is quite handy for some IDE/Editor's configuration files, such like VSCode's launch.json.

If this feature is acceptable, I'll drive it to finish. Thanks.