### PR TITLE
service/dap: variables response must not have null variables array

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1716,7 +1716,7 @@ func (s *Server) onVariablesRequest(request *dap.VariablesRequest) {
 		}
 	}
 
-	var children []dap.Variable
+	children := []dap.Variable{} // must return empty array, not null, if no children
 	if request.Arguments.Filter == "named" || request.Arguments.Filter == "" {
 		named, err := s.metadataToDAPVariables(v)
 		if err != nil {
@@ -1769,7 +1769,7 @@ func (s *Server) childrenToDAPVariables(v *fullyQualifiedVariable) ([]dap.Variab
 	// TODO(polina): consider convertVariableToString instead of convertVariable
 	// and avoid unnecessary creation of variable handles when this is called to
 	// compute evaluate names when this is called from onSetVariableRequest.
-	var children []dap.Variable
+	children := []dap.Variable{} // must return empty array, not null, if no children
 
 	switch v.Kind {
 	case reflect.Map:
@@ -1917,7 +1917,7 @@ func getNamedVariableCount(v *proc.Variable) int {
 // metadataToDAPVariables returns the DAP presentation of the referenced variable's metadata.
 // These are included as named variables
 func (s *Server) metadataToDAPVariables(v *fullyQualifiedVariable) ([]dap.Variable, error) {
-	var children []dap.Variable
+	children := []dap.Variable{} // must return empty array, not null, if no children
 
 	if isListOfBytesOrRunes(v.Variable) {
 		// Return the string value of []byte or []rune.

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -658,6 +658,9 @@ func checkScope(t *testing.T, got *dap.ScopesResponse, i int, name string, varRe
 //      numChildren - number of variables/fields/elements of this variable
 func checkChildren(t *testing.T, got *dap.VariablesResponse, parentName string, numChildren int) {
 	t.Helper()
+	if got.Body.Variables == nil {
+		t.Errorf("\ngot  %s children=%#v want []", parentName, got.Body.Variables)
+	}
 	if len(got.Body.Variables) != numChildren {
 		t.Errorf("\ngot  len(%s)=%d (children=%#v)\nwant len=%d", parentName, len(got.Body.Variables), got.Body.Variables, numChildren)
 	}


### PR DESCRIPTION
Fixes #2590

The above issue breaks clients that don't expect null as per spec.

From [dap spec](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Variables) ([json](https://microsoft.github.io/debug-adapter-protocol/debugAdapterProtocol.json)), 
```
variables: Variable[];
```
```
"variables": {
        "type": "array",  <========== no "null" option
```

Technically, only top-level scope variables (Arguments, Locals, etc) would result variables requests and could trigger this issue. The rest of childless variables are mapped to a reference of 0 and therefore do not offer an option for further expansion to view the children that result in a variable request/response. But just in case I am updating children initialization for all types and cases.