### PR TITLE
service/dap: limit the number of goroutines returned from threads req

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -189,6 +189,8 @@ const (
 	// what is presented. A common use case of a call injection is to
 	// stringify complex data conveniently.
 	maxStringLenInCallRetVars = 1 << 10 // 1024
+	// Max number of goroutines that we will return.
+	maxGoroutines = 1 << 10
 )
 
 // NewServer creates a new DAP Server. It takes an opened Listener
@@ -1357,7 +1359,7 @@ func (s *Server) onThreadsRequest(request *dap.ThreadsRequest) {
 		return
 	}
 
-	gs, _, err := s.debugger.Goroutines(0, 0)
+	gs, next, err := s.debugger.Goroutines(0, maxGoroutines)
 	if err != nil {
 		switch err.(type) {
 		case proc.ErrProcessExited:
@@ -1368,6 +1370,10 @@ func (s *Server) onThreadsRequest(request *dap.ThreadsRequest) {
 			s.sendErrorResponse(request.Request, UnableToDisplayThreads, "Unable to display threads", err.Error())
 		}
 		return
+	}
+
+	if next >= 0 {
+		s.logToConsole(fmt.Sprintf("too many goroutines, only loaded %d", len(gs)))
 	}
 
 	threads := make([]dap.Thread, len(gs))


### PR DESCRIPTION
This adds a cap and a log message if there are many goroutines. This will help
prevent the debugger from freezing, but does not yet address making sure the
interesting goroutines are the ones that are returned.

Updates golang/vscode-go#129