### PR TITLE
TeamCity: remove 1.16 testing for linux/arm64, windows/amd64 and mac/*

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -40,21 +40,17 @@ val targets = arrayOf(
         "linux/amd64/1.17",
         "linux/amd64/tip",
 
-        "linux/386/1.16",
+        "linux/386/1.17",
 
-        "linux/arm64/1.16",
         "linux/arm64/1.17",
         "linux/arm64/tip",
 
-        "windows/amd64/1.16",
         "windows/amd64/1.17",
         "windows/amd64/tip",
 
-        "mac/amd64/1.16",
         "mac/amd64/1.17",
         "mac/amd64/tip",
 
-        "mac/arm64/1.16",
         "mac/arm64/1.17",
         "mac/arm64/tip"
 )


### PR DESCRIPTION
We've only ever tested the latest version of Go on everything except
linux/amd64.
