### PR TITLE
terminal: config -list should print strings in quotes

### DIFF
--- a/pkg/terminal/config.go
+++ b/pkg/terminal/config.go
@@ -81,13 +81,16 @@ func configureList(t *Term) error {
 			continue
 		}
 
-		if field.Kind() == reflect.Ptr {
+		switch field.Kind() {
+		case reflect.Ptr:
 			if !field.IsNil() {
 				fmt.Fprintf(w, "%s\t%v\n", fieldName, field.Elem())
 			} else {
 				fmt.Fprintf(w, "%s\t<not defined>\n", fieldName)
 			}
-		} else {
+		case reflect.String:
+			fmt.Fprintf(w, "%s\t%q\n", fieldName, field)
+		default:
 			fmt.Fprintf(w, "%s\t%v\n", fieldName, field)
 		}
 	}


### PR DESCRIPTION
Commit 8e91d3b0b added a number of configuration options to control the
colors of sytnax highlighting, unfortunately 'config -list' will print
all of those to stdout without quoting them, resulting in the color of
the last one being applied to all subsequent text.

Change 'config -list' to print strings in quotes so that we don't
accidentally send escape sequences to the terminal.
