### PR TITLE
Make teamcity ui settings readonly

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -68,6 +68,9 @@ project {
         }))
     }
     buildType(AggregatorBuild(tests))
+    params {
+        param("teamcity.ui.settings.readOnly", "true")
+    }
 }
 
 class AggregatorBuild(tests: Collection<BuildType>) : BuildType({

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -105,7 +105,7 @@ class AggregatorBuild(tests: Collection<BuildType>) : BuildType({
             publisher = github {
                 githubUrl = "https://api.github.com"
                 authType = personalToken {
-                    token = "credentialsJSON:a7e7526c-7195-4790-bbb6-9fb4692f92d0"
+                    token = "credentialsJSON:1312c856-0e13-4b04-8c40-ac26d4a5f700"
                 }
             }
             param("github_oauth_user", "")


### PR DESCRIPTION
It looks like editing settings both in UI and in git leads to problems. This change disables settings editing in UI. If applied, all changes should be made by editing settings.kts. Feel free to reject if you want edit settings in UI, but in this case it is better to give teamcity permissions to push changes in settings to the repository, currently push fails. Otherwise every failed push disables settings synchronization.