### PR TITLE
service/dap: disable TestFatalThrowBreakpoint for Go 1.17

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2663,9 +2663,8 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 			body.Description, err = s.throwReason(goroutineID)
 			if err != nil {
 				body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())
-				// This is not currently working for Go 1.16.
-				ver := goversion.ParseProducer(s.debugger.TargetGoVersion())
-				if ver.Major == 1 && ver.Minor == 16 {
+				// This is not currently working for >= Go 1.16 see https://github.com/golang/go/issues/46425.
+				if goversion.ProducerAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
 					body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
 				}
 			}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2663,8 +2663,9 @@ func (s *Server) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 			body.Description, err = s.throwReason(goroutineID)
 			if err != nil {
 				body.Description = fmt.Sprintf("Error getting throw reason: %s", err.Error())
-				// This is not currently working for >= Go 1.16 see https://github.com/golang/go/issues/46425.
-				if goversion.ProducerAfterOrEqual(s.debugger.TargetGoVersion(), 1, 16) {
+				// This is not currently working for Go 1.16.
+				ver := goversion.ParseProducer(s.debugger.TargetGoVersion())
+				if ver.Major == 1 && ver.Minor == 16 {
 					body.Description = "Throw reason unavailable, see https://github.com/golang/go/issues/46425"
 				}
 			}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3689,6 +3689,10 @@ func TestPanicBreakpointOnNext(t *testing.T) {
 }
 
 func TestFatalThrowBreakpoint(t *testing.T) {
+	// This is not currently flaky for Go 1.17 see https://github.com/golang/go/issues/46425.
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) {
+		t.Skip()
+	}
 	runTest(t, "fatalerror", func(client *daptest.Client, fixture protest.Fixture) {
 		runDebugSessionWithBPs(t, client, "launch",
 			// Launch
@@ -3705,8 +3709,9 @@ func TestFatalThrowBreakpoint(t *testing.T) {
 					client.ExpectContinueResponse(t)
 
 					var text string
-					// This is not currently working for >= Go 1.16 see https://github.com/golang/go/issues/46425.
-					if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 16) {
+					// This does not work for Go 1.16.
+					ver, _ := goversion.Parse(runtime.Version())
+					if ver.Major != 1 || ver.Minor != 16 {
 						text = "\"go of nil func value\""
 					}
 

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3705,9 +3705,8 @@ func TestFatalThrowBreakpoint(t *testing.T) {
 					client.ExpectContinueResponse(t)
 
 					var text string
-					// This does not work for Go 1.16.
-					ver, _ := goversion.Parse(runtime.Version())
-					if ver.Major != 1 || ver.Minor != 16 {
+					// This is not currently working for >= Go 1.16 see https://github.com/golang/go/issues/46425.
+					if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 16) {
 						text = "\"go of nil func value\""
 					}
 
@@ -4573,7 +4572,6 @@ func TestOptionalNotYetImplementedResponses(t *testing.T) {
 
 		client.RestartRequest()
 		expectNotYetImplemented("restart")
-
 
 		client.SetExpressionRequest()
 		expectNotYetImplemented("setExpression")


### PR DESCRIPTION
Disable this test for Go 1.17 for the time being so it doesn't block test CI for unrelated PRs.