### PR TITLE
cmd/dlv: dlv version --verbose

### DIFF
--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -9,7 +9,8 @@ dlv version [flags]
 ### Options
 
 ```
-  -h, --help   help for version
+  -h, --help      help for version
+  -v, --verbose   print verbose version info
 ```
 
 ### Options inherited from parent commands

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -308,13 +308,18 @@ Currently supports linux/amd64 and linux/arm64 core files, windows/amd64 minidum
 	rootCommand.AddCommand(coreCommand)
 
 	// 'version' subcommand.
+	var versionVerbose = false
 	versionCommand := &cobra.Command{
 		Use:   "version",
 		Short: "Prints version.",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Delve Debugger\n%s\n", version.DelveVersion)
+			if versionVerbose {
+				fmt.Printf("Build Details: %s\n", version.BuildInfo())
+			}
 		},
 	}
+	versionCommand.Flags().BoolVarP(&versionVerbose, "verbose", "v", false, "print verbose version info")
 	rootCommand.AddCommand(versionCommand)
 
 	if path, _ := exec.LookPath("rr"); path != "" || docCall {

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -781,3 +781,18 @@ func TestDlvTestChdir(t *testing.T) {
 		t.Errorf("output did not contain expected string %q", tgt)
 	}
 }
+
+func TestVersion(t *testing.T) {
+	dlvbin, tmpdir := getDlvBin(t)
+	defer os.RemoveAll(tmpdir)
+
+	got, err := exec.Command(dlvbin, "version", "-v").CombinedOutput()
+	if err != nil {
+		t.Fatalf("error executing `dlv version`: %v\n%s\n", err, got)
+	}
+	want1 := []byte("mod\tgithub.com/go-delve/delve")
+	want2 := []byte("dep\tgithub.com/google/go-dap")
+	if !bytes.Contains(got, want1) || !bytes.Contains(got, want2) {
+		t.Errorf("got %s\nwant %v and %v in the output", got, want1, want2)
+	}
+}

--- a/pkg/version/buildinfo.go
+++ b/pkg/version/buildinfo.go
@@ -1,0 +1,32 @@
+// +build go1.12
+
+package version
+
+import (
+	"bytes"
+	"runtime/debug"
+	"text/template"
+)
+
+func init() {
+	buildInfo = moduleBuildInfo
+}
+
+var buildInfoTmpl = ` mod	{{.Main.Path}}	{{.Main.Version}}	{{.Main.Sum}}
+{{range .Deps}} dep	{{.Path}}	{{.Version}}	{{.Sum}}{{if .Replace}}
+	=> {{.Replace.Path}}	{{.Replace.Version}}	{{.Replace.Sum}}{{end}}
+{{end}}`
+
+func moduleBuildInfo() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "not built in module mode"
+	}
+
+	buf := new(bytes.Buffer)
+	err := template.Must(template.New("buildinfo").Parse(buildInfoTmpl)).Execute(buf, info)
+	if err != nil {
+		panic(err)
+	}
+	return buf.String()
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,9 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+)
 
 // Version represents the current version of Delve.
 type Version struct {
@@ -25,4 +28,12 @@ func (v Version) String() string {
 		ver += "-" + v.Metadata
 	}
 	return fmt.Sprintf("%s\nBuild: %s", ver, v.Build)
+}
+
+var buildInfo = func() string {
+	return ""
+}
+
+func BuildInfo() string {
+	return fmt.Sprintf("%s\n%s", runtime.Version(), buildInfo())
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,7 +1,0 @@
-package version
-
-import "testing"
-
-func TestBuildInfo(t *testing.T) {
-	t.Error(BuildInfo())
-}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,7 @@
+package version
+
+import "testing"
+
+func TestBuildInfo(t *testing.T) {
+	t.Error(BuildInfo())
+}


### PR DESCRIPTION
With `-v` or `--verbose`, dlv version prints out runtime/debug.BuildInfo 
read from the dlv binary. Users can retrieve the same info using 
`go version -m <path_to_dlv>` but I think it is convenient to have.

runtime/debug.BuildInfo is available since go1.12. I placed built tag
but already the current delve repo requires go1.12, so maybe that isn't
necessary. A different approach is exec `go version -m <self>`, but if
the user's go version in PATH is older than go1.12 this won't work.

If dlv was built from cloned delve repo:

```
$ ./dlv version -v
Delve Debugger
Version: 1.7.0
Build: $Id: e353a65161e6ed74952b96bbb62ebfc56090832b $
Build Details: go1.16.5
 mod    github.com/go-delve/delve       (devel)
 dep    github.com/cosiner/argv v0.1.0  h1:BVDiEL32lwHukgJKP87btEPenzrrHUjajs/8yzaqcXg=
...
```

If dlv was built with `go install github.com/go-delve/delve@latest`
with go1.16+, or
`GO111MODULE=on go get github.com/go-delve/delve@latest`
from a clean main module:

```
$ ./dlv version -v
Delve Debugger
Version: 1.7.0
Build: $Id: e353a65161e6ed74952b96bbb62ebfc56090832b $
Build Details: go1.16.5
 mod    github.com/go-delve/delve       v1.7.0
 dep    github.com/cosiner/argv v0.1.0  h1:BVDiEL32lwHukgJKP87btEPenzrrHUjajs/8yzaqcXg=
...
```