### PR TITLE
service/dap: fix backend parsing in replay mode

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -772,6 +772,20 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 		return
 	}
 
+	backend, ok := request.Arguments["backend"]
+	if ok {
+		backendParsed, ok := backend.(string)
+		if !ok {
+			s.sendErrorResponse(request.Request,
+				FailedToLaunch, "Failed to launch",
+				fmt.Sprintf("'backend' attribute '%v' in debug configuration is not a string.", backend))
+			return
+		}
+		s.config.Debugger.Backend = backendParsed
+	} else {
+		s.config.Debugger.Backend = "default"
+	}
+
 	if mode == "replay" {
 		traceDirPath, _ := request.Arguments["traceDirPath"].(string)
 
@@ -889,20 +903,6 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 			}
 			targetArgs = append(targetArgs, argParsed)
 		}
-	}
-
-	backend, ok := request.Arguments["backend"]
-	if ok {
-		backendParsed, ok := backend.(string)
-		if !ok {
-			s.sendErrorResponse(request.Request,
-				FailedToLaunch, "Failed to launch",
-				fmt.Sprintf("'backend' attribute '%v' in debug configuration is not a string.", backend))
-			return
-		}
-		s.config.Debugger.Backend = backendParsed
-	} else {
-		s.config.Debugger.Backend = "default"
 	}
 
 	s.config.ProcessArgs = append([]string{program}, targetArgs...)


### PR DESCRIPTION
Replay mode configuration suffered during a rebase, and the issue was not caught by the unittests because there were none testing that replay mode args get set up and passed to `debugger.New` correctly. Because we added backend parsing (#2567) in parallel with replay/core support (#2367), `CoreFile` was set in `replay` mode, but `rr` backend was replaced with `"default"`, so this was treated as a `core` mode instead:
https://github.com/go-delve/delve/blob/658d36cb1909cd4267e538b10f2f84df8f752216/service/debugger/debugger.go#L167-L177

@lggomez 