### PR TITLE
proc: use signed comparison when searching image for module data

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -722,10 +722,10 @@ func (bi *BinaryInfo) moduleDataToImage(md *moduleData) *Image {
 	// Try searching for the image with the closest address preceding md.text
 	var so *Image
 	for i := range bi.Images {
-		if bi.Images[i].StaticBase > md.text {
+		if int64(bi.Images[i].StaticBase) > int64(md.text) {
 			continue
 		}
-		if so == nil || bi.Images[i].StaticBase > so.StaticBase {
+		if so == nil || int64(bi.Images[i].StaticBase) > int64(so.StaticBase) {
 			so = bi.Images[i]
 		}
 	}


### PR DESCRIPTION
StaticBase is the difference between the entry point declared in the
image file and the entry point as loaded in memory, since this
difference could be a negative number we have to use a signed
comparison when searching for a mapping.

Causes intermittent test failures on windows when resolving interface
types for position independent executables.

Fixes #2620
