### PR TITLE
pkg/terminal: Ignore existing breakpoints for continue until

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1410,7 +1410,9 @@ func (c *Commands) cont(t *Term, ctx callContext, args string) error {
 	if args != "" {
 		tmp, err := setBreakpoint(t, ctx, false, args)
 		if err != nil {
-			return err
+			if !strings.Contains(err.Error(), "Breakpoint exists") {
+				return err
+			}
 		}
 		defer func() {
 			for _, bp := range tmp {

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1130,6 +1130,18 @@ func TestContinueUntil(t *testing.T) {
 	})
 }
 
+func TestContinueUntilExistingBreakpoint(t *testing.T) {
+	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
+		term.MustExec("break main.main")
+		if runtime.GOARCH != "386" {
+			listIsAt(t, term, "continue main.main", 16, -1, -1)
+		} else {
+			listIsAt(t, term, "continue main.main", 17, -1, -1)
+		}
+		listIsAt(t, term, "continue main.sayhi", 12, -1, -1)
+	})
+}
+
 func TestPrintFormat(t *testing.T) {
 	withTestTerminal("testvariables2", t, func(term *FakeTerminal) {
 		term.MustExec("continue")


### PR DESCRIPTION
Ignore existing breakpoints when using the continue command to continue
to a specific location such as `continue main.main`. The point of this
command is to continue to a specific location, so if there is already a
breakpoint set there there should be no error returned, just continue
until we hit the breakpoint already set in that location.