### PR TITLE
tests: check presence of gcc for cgo tests

### DIFF
--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -367,7 +367,11 @@ var hasCgo = func() bool {
 	if err != nil {
 		panic(err)
 	}
-	return strings.TrimSpace(string(out)) == "1"
+	if strings.TrimSpace(string(out)) != "1" {
+		return false
+	}
+	_, err = exec.LookPath("gcc")
+	return err == nil
 }()
 
 func MustHaveCgo(t *testing.T) {


### PR DESCRIPTION
The install of gcc sometimes fails on our CI, it is not an error if the
tests for cgo can not run because there's no C compiler.
