### PR TITLE
service/debugger: Remove target lock on GetBufferedTracepoints

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2124,9 +2124,6 @@ func (d *Debugger) Target() *proc.Target {
 }
 
 func (d *Debugger) GetBufferedTracepoints() []api.TracepointResult {
-	d.targetMutex.Lock()
-	defer d.targetMutex.Unlock()
-
 	traces := d.target.GetBufferedTracepoints()
 	if traces == nil {
 		return nil


### PR DESCRIPTION
There is already a lock on the actual buffered tracepoints collection
within proc, and this method call doesn't do anything to mutate Target
otherwise so we shouldn't be opening ourselves up for a race condition
error or any other kind of parallelism problem.

Additionally, with this lock we essentially can never get the data until
the process has exited becuase `continue` will lock the target. This
change allows us to get the buffered tracepoint information immediately
and display it as the program is running.