### PR TITLE
fix/cmds: use simple chan read instead of select-case

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -746,15 +746,10 @@ func waitForDisconnectSignal(disconnectChan chan struct{}) {
 		// as SIGINT to delve. Ignore it instead of stopping the server
 		// in order to be able to debug signal handlers.
 		go func() {
-			for {
-				select {
-				case <-ch:
-				}
+			for range ch {
 			}
 		}()
-		select {
-		case <-disconnectChan:
-		}
+		<-disconnectChan
 	} else {
 		select {
 		case <-ch:


### PR DESCRIPTION
Use simple chan read instead of select-case on only one chan.

When run `golangci-lint run .`, it reports several chan receive problems that use select-case on only one chan. We can use simple chan receive instead of select-case.