### PR TITLE
cmd/dap: add debug test, exec and attach subcommands

### DIFF
--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -136,14 +136,9 @@ func (c *Client) ExpectOutputEventRegex(t *testing.T, want string) *dap.OutputEv
 	return e
 }
 
-func (c *Client) ExpectOutputEventProcessExited(t *testing.T, status int) *dap.OutputEvent {
+func (c *Client) ExpectOutputEventProcessExited(t *testing.T, status int, detaching string) *dap.OutputEvent {
 	t.Helper()
-	return c.ExpectOutputEventRegex(t, fmt.Sprintf(`Process [0-9]+ has exited with status %d\n`, status))
-}
-
-func (c *Client) ExpectOutputEventDetaching(t *testing.T) *dap.OutputEvent {
-	t.Helper()
-	return c.ExpectOutputEventRegex(t, `Detaching\n`)
+	return c.ExpectOutputEventRegex(t, fmt.Sprintf(`Process [0-9]+ has exited with status %d\n%s`, status, detaching))
 }
 
 func (c *Client) ExpectOutputEventDetachingKill(t *testing.T) *dap.OutputEvent {

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -770,7 +770,7 @@ func (s *Server) setClientCapabilities(args dap.InitializeRequestArguments) {
 
 // Default output file pathname for the compiled binary in debug or test modes,
 // relative to the current working directory of the server.
-const defaultDebugBinary string = "./__debug_bin"
+const DefaultDebugBinary string = "./__debug_bin"
 
 func cleanExeName(name string) string {
 	if runtime.GOOS == "windows" && filepath.Ext(name) != ".exe" {
@@ -863,7 +863,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 	if mode == "debug" || mode == "test" {
 		output, ok := request.Arguments["output"].(string)
 		if !ok || output == "" {
-			output = defaultDebugBinary
+			output = DefaultDebugBinary
 		}
 		output = cleanExeName(output)
 		debugbinary, err := filepath.Abs(output)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,6 +11,7 @@ github.com/cpuguy83/go-md2man/v2/md2man
 ## explicit
 github.com/creack/pty
 # github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9
+## explicit
 github.com/derekparker/trie
 # github.com/google/go-dap v0.5.0
 ## explicit


### PR DESCRIPTION
This is branched from #2648 - new code is only in `commands.go` and `dlv_test.go`.
This is an intermediate solution with a smaller set of features before dap server is hooked up to `dlv debug/test/exec` with its many flags.