### PR TITLE
service/dap: clarify handling of relative program path

### DIFF
--- a/Documentation/usage/dlv_dap.md
+++ b/Documentation/usage/dlv_dap.md
@@ -7,13 +7,15 @@
 [EXPERIMENTAL] Starts a headless TCP server communicating via Debug Adaptor Protocol (DAP).
 
 The server is always headless and requires a DAP client like vscode to connect and request a binary
-to be launched or process to be attached to. The following modes are supported:
+to be launched or process to be attached to. The following modes can be specified via client's launch config:
 - launch + exec (executes precompiled binary, like 'dlv exec')
 - launch + debug (builds and launches, like 'dlv debug')
 - launch + test (builds and tests, like 'dlv test')
 - launch + replay (replays an rr trace, like 'dlv replay')
 - launch + core (replays a core dump file, like 'dlv core')
 - attach + local (attaches to a running process, like 'dlv attach')
+Program and output binary paths will be interpreted relative to dlv's working directory.
+
 The server does not yet accept multiple client connections (--accept-multiclient).
 While --continue is not supported, stopOnEntry launch/attach attribute can be used to control if
 execution is resumed at the start of the debug session.

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -180,13 +180,15 @@ option to let the process continue or kill it.
 		Long: `[EXPERIMENTAL] Starts a headless TCP server communicating via Debug Adaptor Protocol (DAP).
 
 The server is always headless and requires a DAP client like vscode to connect and request a binary
-to be launched or process to be attached to. The following modes are supported:
+to be launched or process to be attached to. The following modes can be specified via client's launch config:
 - launch + exec (executes precompiled binary, like 'dlv exec')
 - launch + debug (builds and launches, like 'dlv debug')
 - launch + test (builds and tests, like 'dlv test')
 - launch + replay (replays an rr trace, like 'dlv replay')
 - launch + core (replays a core dump file, like 'dlv core')
 - attach + local (attaches to a running process, like 'dlv attach')
+Program and output binary paths will be interpreted relative to dlv's working directory.
+
 The server does not yet accept multiple client connections (--accept-multiclient).
 While --continue is not supported, stopOnEntry launch/attach attribute can be used to control if
 execution is resumed at the start of the debug session.`,

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -851,8 +851,8 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 
 		var cmd string
 		var out []byte
-		// Log debug binary build
-		s.log.Debugf("building binary '%s' from '%s' with flags '%v'", debugbinary, program, buildFlags)
+		wd, _ := os.Getwd()
+		s.log.Debugf("building program '%s' in '%s' with flags '%v'", program, wd, buildFlags)
 		switch mode {
 		case "debug":
 			cmd, out, err = gobuild.GoBuildCombinedOutput(debugbinary, []string{program}, buildFlags)
@@ -923,7 +923,7 @@ func (s *Server) onLaunchRequest(request *dap.LaunchRequest) {
 		s.config.Debugger.WorkingDir = wdParsed
 	}
 
-	s.log.Debugf("running program in %s\n", s.config.Debugger.WorkingDir)
+	s.log.Debugf("running binary '%s' in '%s'", program, s.config.Debugger.WorkingDir)
 	if noDebug, ok := request.Arguments["noDebug"].(bool); ok && noDebug {
 		s.mu.Lock()
 		cmd, err := s.startNoDebugProcess(program, targetArgs, s.config.Debugger.WorkingDir)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4170,7 +4170,7 @@ func runNoDebugDebugSession(t *testing.T, client *daptest.Client, cmdRequest fun
 	client.ExpectTerminatedEvent(t)
 }
 
-func TestLaunchRequestWithRelativeProgramPath(t *testing.T) {
+func TestLaunchRequestWithRelativeBuildPath(t *testing.T) {
 	client := startDapServer(t)
 	defer client.Close() // will trigger Stop()
 
@@ -4186,6 +4186,21 @@ func TestLaunchRequestWithRelativeProgramPath(t *testing.T) {
 	runDebugSession(t, client, "launch", func() {
 		client.LaunchRequestWithArgs(map[string]interface{}{
 			"mode": "debug", "program": program, "cwd": filepath.Dir(dlvwd)})
+	})
+}
+
+func TestLaunchRequestWithRelativeExecPath(t *testing.T) {
+	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
+		symlink := "./__thisexe"
+		err := os.Symlink(fixture.Path, symlink)
+		defer os.Remove(symlink)
+		if err != nil {
+			t.Fatal("unable to create relative symlink:", err)
+		}
+		runDebugSession(t, client, "launch", func() {
+			client.LaunchRequestWithArgs(map[string]interface{}{
+				"mode": "exec", "program": symlink})
+		})
 	})
 }
 


### PR DESCRIPTION
Closes #2392
Updates golang/vscode-go#1680
Updates golang/vscode-go#1348

This PR adds tests, logging and `--help` documentation note confirming that relative program paths are indeed handled and are interpreted relative to server's working directory.