### PR TITLE
pkg/proc: Parse Goroutine ID in eBPF tracer

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -173,17 +173,11 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
                         arch
                     }
                 }
-                val dockerImg = when (arch) {
-                    "386" -> "ubuntu:20.04"
-                    else -> {
-                        "ubuntu:21.04"
-                    }
-                }
                 dockerCommand {
                     name = "Pull Ubuntu"
                     commandType = other {
                         subCommand = "pull"
-                        commandArgs = "$dockerArch/$dockerImg"
+                        commandArgs = "$dockerArch/ubuntu:20.04"
                     }
                 }
                 dockerCommand {
@@ -195,7 +189,7 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
                         --env TEAMCITY_VERSION=${'$'}TEAMCITY_VERSION
                         --env CI=true
                         --privileged
-                        $dockerArch/$dockerImg
+                        $dockerArch/ubuntu:20.04
                         /delve/_scripts/test_linux.sh ${"go$version"} $arch
                     """.trimIndent()
                     }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -173,11 +173,17 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
                         arch
                     }
                 }
+                val dockerImg = when (arch) {
+                    "386" -> "ubuntu:20.04"
+                    else -> {
+                        "ubuntu:21.04"
+                    }
+                }
                 dockerCommand {
                     name = "Pull Ubuntu"
                     commandType = other {
                         subCommand = "pull"
-                        commandArgs = "$dockerArch/ubuntu:20.04"
+                        commandArgs = "$dockerArch/$dockerImg"
                     }
                 }
                 dockerCommand {
@@ -189,7 +195,7 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
                         --env TEAMCITY_VERSION=${'$'}TEAMCITY_VERSION
                         --env CI=true
                         --privileged
-                        $dockerArch/ubuntu:20.04
+                        $dockerArch/$dockerImg
                         /delve/_scripts/test_linux.sh ${"go$version"} $arch
                     """.trimIndent()
                     }

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ check-cert:
 build: $(GO_SRC)
 	@go run _scripts/make.go build
 
+docker-image-build:
+	@docker build -t ebpf-builder:latest -f ./pkg/proc/internal/ebpf/Dockerfile ./pkg/proc/internal/ebpf/
+
+docker-ebpf-obj-build: docker-image-build
+	@docker run -it --rm \
+	-v $(abspath .):/delve \
+	ebpf-builder:latest
+
 $(BPF_OBJ): $(BPF_SRC)
 	clang \
 		-I /usr/include \
@@ -45,4 +53,4 @@ test-integration-run:
 vendor:
 	@go run _scripts/make.go vendor
 
-.PHONY: vendor test-integration-run test-proc-run test check-cert install build vet build-bpf uninstall
+.PHONY: vendor test-integration-run test-proc-run test check-cert install build vet build-bpf uninstall docker-build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: $(GO_SRC)
 	@go run _scripts/make.go build
 
 docker-image-build:
-	@docker build -t ebpf-builder:latest -f ./pkg/proc/internal/ebpf/Dockerfile ./pkg/proc/internal/ebpf/
+	@docker build -t ebpf-builder:latest -f ./pkg/proc/internal/ebpf/trace_probe/Dockerfile ./pkg/proc/internal/ebpf/
 
 docker-ebpf-obj-build: docker-image-build
 	@docker run -it --rm \
@@ -30,7 +30,7 @@ $(BPF_OBJ): $(BPF_SRC)
 		pkg/proc/internal/ebpf/trace_probe/trace.bpf.c
 
 build-bpf: $(BPF_OBJ) $(GO_SRC)
-	@env CGO_LDFLAGS="/usr/lib64/libbpf.a" go run _scripts/make.go build --tags=ebpf
+	@env CGO_LDFLAGS="/usr/lib/libbpf.a" go run _scripts/make.go build --tags=ebpf
 
 install: $(GO_SRC)
 	@go run _scripts/make.go install
@@ -53,4 +53,4 @@ test-integration-run:
 vendor:
 	@go run _scripts/make.go vendor
 
-.PHONY: vendor test-integration-run test-proc-run test check-cert install build vet build-bpf uninstall docker-build
+.PHONY: vendor test-integration-run test-proc-run test check-cert install build vet build-bpf uninstall docker-build docker-ebpf-obj-build

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ test-integration-run:
 vendor:
 	@go run _scripts/make.go vendor
 
-.PHONY: vendor test-integration-run test-proc-run test check-cert install build vet build-bpf uninstall docker-build docker-ebpf-obj-build
+.PHONY: vendor test-integration-run test-proc-run test check-cert install build vet build-bpf uninstall docker-image-build docker-ebpf-obj-build

--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -4,6 +4,7 @@ set -x
 
 apt-get -qq update
 apt-get install -y dwz wget make git gcc curl jq lsof
+
 dwz --version
 
 version=$1
@@ -47,4 +48,5 @@ echo "$PATH"
 echo "$GOROOT"
 echo "$GOPATH"
 cd delve
+
 make test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -45,7 +45,7 @@ go version
 # go test -v ./cmd/dlv/...
 
 go run _scripts/make.go build
-go run _scripts/make.go test
+go run _scripts/make.go test || true
 dmesg
 
 make --debug=v test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -41,6 +41,7 @@ export GOARCH="$ARCH"
 export PATH="$GOROOT/bin:$PATH"
 go version
 
+go build ./cmd/dlv
 go test -v ./cmd/dlv/...
 
 make test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -41,7 +41,7 @@ export GOARCH="$ARCH"
 export PATH="$GOROOT/bin:$PATH"
 go version
 
-go build ./cmd/dlv
+go build -x ./cmd/dlv
 go test -v ./cmd/dlv/...
 
-make test
+make --debug=v test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -45,6 +45,7 @@ go version
 # go test -v ./cmd/dlv/...
 
 go run _scripts/make.go build || true
-dmesg
+go run _scripts/make.go test || true
+sudo dmesg
 
 make --debug=v test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -36,16 +36,11 @@ fi
 
 mkdir -p $TMPDIR/gopath
 
+go env
+
 export GOPATH="$TMPDIR/gopath"
 export GOARCH="$ARCH"
 export PATH="$GOROOT/bin:$PATH"
 go version
 
-# go build -x ./cmd/dlv
-# go test -v ./cmd/dlv/...
-
-go run _scripts/make.go build || true
-go run _scripts/make.go test || true
-sudo dmesg
-
-make --debug=v test
+make test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -44,8 +44,7 @@ go version
 # go build -x ./cmd/dlv
 # go test -v ./cmd/dlv/...
 
-go run _scripts/make.go build
-go run _scripts/make.go test || true
+go run _scripts/make.go build || true
 dmesg
 
 make --debug=v test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -41,7 +41,9 @@ export GOARCH="$ARCH"
 export PATH="$GOROOT/bin:$PATH"
 go version
 
-go build -x ./cmd/dlv
-go test -v ./cmd/dlv/...
+# go build -x ./cmd/dlv
+# go test -v ./cmd/dlv/...
+
+go run _scripts/make.go build
 
 make --debug=v test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -46,5 +46,6 @@ go version
 
 go run _scripts/make.go build
 go run _scripts/make.go test
+dmesg
 
 make --debug=v test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -45,5 +45,6 @@ go version
 # go test -v ./cmd/dlv/...
 
 go run _scripts/make.go build
+go run _scripts/make.go test
 
 make --debug=v test

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -41,4 +41,6 @@ export GOARCH="$ARCH"
 export PATH="$GOROOT/bin:$PATH"
 go version
 
+go test -v ./cmd/dlv/...
+
 make test

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -657,7 +657,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 									params.WriteString(p.Value)
 								}
 							}
-							fmt.Printf("%s:%d %s(%s)\n", t.File, t.Line, t.FunctionName, params.String())
+							fmt.Fprintf(os.Stderr, "> (%d) %s(%s)\n", t.GoroutineID, t.FunctionName, params.String())
 						}
 					}
 				}

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -199,7 +199,7 @@ func getDlvBin(t *testing.T) (string, string) {
 }
 
 func getDlvBinEBPF(t *testing.T) (string, string) {
-	os.Setenv("CGO_LDFLAGS", "/usr/lib64/libbpf.a")
+	os.Setenv("CGO_LDFLAGS", "/usr/lib/libbpf.a")
 	return getDlvBinInternal(t, "-tags", "ebpf")
 }
 

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -785,6 +785,9 @@ func TestTracePrintStack(t *testing.T) {
 }
 
 func TestTraceEBPF(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("cannot run test in CI, requires kernel compiled with btf support")
+	}
 	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
 		t.Skip("not implemented on non linux/amd64 systems")
 	}

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -29,6 +29,11 @@ import (
 )
 
 var testBackend string
+var ldFlags string
+
+func init() {
+	ldFlags = os.Getenv("CGO_LDFLAGS")
+}
 
 func TestMain(m *testing.M) {
 	flag.StringVar(&testBackend, "backend", "", "selects backend")
@@ -194,7 +199,7 @@ func getDlvBin(t *testing.T) (string, string) {
 	// from getDlvBinEBPF lets clear it here so
 	// we can ensure we don't get build errors
 	// depending on the test ordering.
-	os.Setenv("CGO_LDFLAGS", "")
+	os.Setenv("CGO_LDFLAGS", ldFlags)
 	return getDlvBinInternal(t)
 }
 

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -274,7 +274,7 @@ func (p *process) SupportsBPF() bool {
 	return false
 }
 
-func (dbp *process) SetUProbe(fnName string, args []ebpf.UProbeArgMap) error {
+func (dbp *process) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	panic("not implemented")
 }
 

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -370,7 +370,7 @@ func (dbp *gdbProcess) GetBufferedTracepoints() []ebpf.RawUProbeParams {
 	return nil
 }
 
-func (dbp *gdbProcess) SetUProbe(fnName string, args []ebpf.UProbeArgMap) error {
+func (dbp *gdbProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	panic("not implemented")
 }
 

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -46,7 +46,7 @@ type ProcessInternal interface {
 	EraseBreakpoint(*Breakpoint) error
 
 	SupportsBPF() bool
-	SetUProbe(string, []ebpf.UProbeArgMap) error
+	SetUProbe(string, int64, []ebpf.UProbeArgMap) error
 
 	// DumpProcessNotes returns ELF core notes describing the process and its threads.
 	// Implementing this method is optional.

--- a/pkg/proc/internal/ebpf/context.go
+++ b/pkg/proc/internal/ebpf/context.go
@@ -27,5 +27,6 @@ type RawUProbeParam struct {
 
 type RawUProbeParams struct {
 	FnAddr      int
+	GoroutineID int
 	InputParams []*RawUProbeParam
 }

--- a/pkg/proc/internal/ebpf/helpers.go
+++ b/pkg/proc/internal/ebpf/helpers.go
@@ -51,11 +51,12 @@ func (ctx *EBPFContext) AttachUprobe(pid int, name string, offset uint32) error 
 	return err
 }
 
-func (ctx *EBPFContext) UpdateArgMap(key uint64, goidOffset int64, args []UProbeArgMap) error {
+func (ctx *EBPFContext) UpdateArgMap(key uint64, goidOffset int64, args []UProbeArgMap, gAddrOffset uint64) error {
 	if ctx.bpfArgMap == nil {
 		return errors.New("eBPF map not loaded")
 	}
 	params := createFunctionParameterList(key, goidOffset, args)
+	params.g_addr_offset = C.longlong(gAddrOffset)
 	return ctx.bpfArgMap.Update(unsafe.Pointer(&key), unsafe.Pointer(&params))
 }
 

--- a/pkg/proc/internal/ebpf/helpers_disabled.go
+++ b/pkg/proc/internal/ebpf/helpers_disabled.go
@@ -18,7 +18,7 @@ func (ctx *EBPFContext) AttachUprobe(pid int, name string, offset uint32) error 
 	return errors.New("eBPF is disabled")
 }
 
-func (ctx *EBPFContext) UpdateArgMap(key uint64, goidOffset int64, args []UProbeArgMap) error {
+func (ctx *EBPFContext) UpdateArgMap(key uint64, goidOffset int64, args []UProbeArgMap, gAddrOffset uint64) error {
 	return errors.New("eBPF is disabled")
 }
 

--- a/pkg/proc/internal/ebpf/helpers_disabled.go
+++ b/pkg/proc/internal/ebpf/helpers_disabled.go
@@ -18,7 +18,7 @@ func (ctx *EBPFContext) AttachUprobe(pid int, name string, offset uint32) error 
 	return errors.New("eBPF is disabled")
 }
 
-func (ctx *EBPFContext) UpdateArgMap(key uint64, args []UProbeArgMap) error {
+func (ctx *EBPFContext) UpdateArgMap(key uint64, goidOffset int64, args []UProbeArgMap) error {
 	return errors.New("eBPF is disabled")
 }
 

--- a/pkg/proc/internal/ebpf/trace_probe/Dockerfile
+++ b/pkg/proc/internal/ebpf/trace_probe/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.16-alpine
+RUN apk --no-cache update && apk --no-cache add clang llvm make gcc libc6-compat coreutils linux-headers musl-dev elfutils-dev libelf-static zlib-static make libbpf-dev libbpf git
+
+WORKDIR /delve
+
+CMD [ "/usr/bin/make", "build-bpf" ]

--- a/pkg/proc/internal/ebpf/trace_probe/function_vals.bpf.h
+++ b/pkg/proc/internal/ebpf/trace_probe/function_vals.bpf.h
@@ -26,8 +26,11 @@ typedef struct function_parameter {
 } function_parameter_t;
 
 // function_parameter_list holds info about the function parameters and
-// stores information on up to 8 parameters.
+// stores information on up to 6 parameters.
 typedef struct function_parameter_list {
+      unsigned int goid_offset;
+      int goroutine_id;
+
       unsigned int fn_addr;
       unsigned int n_parameters;          // number of parameters.
       function_parameter_t params[6];     // list of parameters.

--- a/pkg/proc/internal/ebpf/trace_probe/function_vals.bpf.h
+++ b/pkg/proc/internal/ebpf/trace_probe/function_vals.bpf.h
@@ -28,7 +28,8 @@ typedef struct function_parameter {
 // function_parameter_list holds info about the function parameters and
 // stores information on up to 6 parameters.
 typedef struct function_parameter_list {
-      unsigned int goid_offset;
+      unsigned int goid_offset; // Offset of the `goid` struct member.
+      long long g_addr_offset;  // Offset of the Goroutine struct from the TLS segment.
       int goroutine_id;
 
       unsigned int fn_addr;

--- a/pkg/proc/internal/ebpf/trace_probe/trace.bpf.c
+++ b/pkg/proc/internal/ebpf/trace_probe/trace.bpf.c
@@ -166,7 +166,7 @@ int get_goroutine_id(function_parameter_list_t *parsed_args) {
     // Get the Goroutine ID which is stored in thread local storage.
     __u64  goid;
     size_t g_addr;
-    bpf_probe_read_user(&g_addr, sizeof(void *), (void*)(task->thread.fsbase-8));
+    bpf_probe_read_user(&g_addr, sizeof(void *), (void*)(task->thread.fsbase+parsed_args->g_addr_offset));
     bpf_probe_read_user(&goid, sizeof(void *), (void*)(g_addr+parsed_args->goid_offset));
     parsed_args->goroutine_id = goid;
 

--- a/pkg/proc/internal/ebpf/trace_probe/trace.bpf.h
+++ b/pkg/proc/internal/ebpf/trace_probe/trace.bpf.h
@@ -12,6 +12,11 @@ struct {
 } events SEC(".maps");
 
 struct {
+   __uint(type, BPF_MAP_TYPE_RINGBUF);
+   __uint(max_entries, BPF_MAX_VAR_SIZ);
+} heap SEC(".maps");
+
+struct {
     __uint(max_entries, 42);
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, u64);

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -90,7 +90,7 @@ func (dbp *nativeProcess) SupportsBPF() bool {
 	panic(ErrNativeBackendDisabled)
 }
 
-func (dbp *nativeProcess) SetUProbe(fnName string, args []ebpf.UProbeArgMap) error {
+func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	panic(ErrNativeBackendDisabled)
 }
 

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -477,7 +477,7 @@ func (dbp *nativeProcess) SupportsBPF() bool {
 	return false
 }
 
-func (dbp *nativeProcess) SetUProbe(fnName string, args []ebpf.UProbeArgMap) error {
+func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	panic("not implemented")
 }
 

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -381,7 +381,7 @@ func (dbp *nativeProcess) SupportsBPF() bool {
 	return false
 }
 
-func (dbp *nativeProcess) SetUProbe(fnName string, args []ebpf.UProbeArgMap) error {
+func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	panic("not implemented")
 }
 

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -705,7 +705,7 @@ func (dbp *nativeProcess) EntryPoint() (uint64, error) {
 	return linutil.EntryPointFromAuxv(auxvbuf, dbp.bi.Arch.PtrSize()), nil
 }
 
-func (dbp *nativeProcess) SetUProbe(fnName string, args []ebpf.UProbeArgMap) error {
+func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	// Lazily load and initialize the BPF program upon request to set a uprobe.
 	if dbp.os.ebpf == nil {
 		dbp.os.ebpf, _ = ebpf.LoadEBPFTracingProgram()
@@ -717,22 +717,23 @@ func (dbp *nativeProcess) SetUProbe(fnName string, args []ebpf.UProbeArgMap) err
 		return errors.New("too many arguments in traced function, max is 6")
 	}
 
-	debugname := dbp.bi.Images[0].Path
-	offset, err := ebpf.SymbolToOffset(debugname, fnName)
-	if err != nil {
-		return err
-	}
-	err = dbp.os.ebpf.AttachUprobe(dbp.Pid(), debugname, offset)
-	if err != nil {
-		return err
-	}
 	fn, ok := dbp.bi.LookupFunc[fnName]
 	if !ok {
 		return fmt.Errorf("could not find function: %s", fnName)
 	}
 
 	key := fn.Entry
-	return dbp.os.ebpf.UpdateArgMap(key, args)
+	err := dbp.os.ebpf.UpdateArgMap(key, goidOffset, args)
+	if err != nil {
+		return err
+	}
+
+	debugname := dbp.bi.Images[0].Path
+	offset, err := ebpf.SymbolToOffset(debugname, fnName)
+	if err != nil {
+		return err
+	}
+	return dbp.os.ebpf.AttachUprobe(dbp.Pid(), debugname, offset)
 }
 
 func killProcess(pid int) error {

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -723,7 +723,7 @@ func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf
 	}
 
 	key := fn.Entry
-	err := dbp.os.ebpf.UpdateArgMap(key, goidOffset, args)
+	err := dbp.os.ebpf.UpdateArgMap(key, goidOffset, args, dbp.BinInfo().GStructOffset())
 	if err != nil {
 		return err
 	}

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -524,7 +524,7 @@ func (dbp *nativeProcess) SupportsBPF() bool {
 	return false
 }
 
-func (dbp *nativeProcess) SetUProbe(fnName string, args []ebpf.UProbeArgMap) error {
+func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	return nil
 }
 

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -405,6 +405,7 @@ func (t *Target) CurrentThread() Thread {
 
 type UProbeTraceResult struct {
 	FnAddr      int
+	GoroutineID int
 	InputParams []*Variable
 }
 
@@ -414,6 +415,7 @@ func (t *Target) GetBufferedTracepoints() []*UProbeTraceResult {
 	for _, tp := range tracepoints {
 		r := &UProbeTraceResult{}
 		r.FnAddr = tp.FnAddr
+		r.GoroutineID = tp.GoroutineID
 		for _, ip := range tp.InputParams {
 			v := &Variable{}
 			v.RealType = ip.RealType

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -843,10 +843,11 @@ func (v *Variable) parseG() (*G, error) {
 		}
 		return nil, ErrNoGoroutine{tid: id}
 	}
-	for {
-		if _, isptr := v.RealType.(*godwarf.PtrType); !isptr {
-			break
-		}
+	isptr := func(t godwarf.Type) bool {
+		_, ok := t.(*godwarf.PtrType)
+		return ok
+	}
+	for isptr(v.RealType) {
 		v = v.maybeDereference() // +rtype g
 	}
 

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -52,7 +52,7 @@ type DebuggerState struct {
 }
 
 type TracepointResult struct {
-	// Addr is deprecated, use Addrs.
+	// Addr is the address of this tracepoint.
 	Addr uint64 `json:"addr"`
 	// File is the source file for the breakpoint.
 	File string `json:"file"`
@@ -61,6 +61,8 @@ type TracepointResult struct {
 	// FunctionName is the name of the function at the current breakpoint, and
 	// may not always be available.
 	FunctionName string `json:"functionName,omitempty"`
+
+	GoroutineID int `json:"goroutineID"`
 
 	InputParams  []Variable `json:"inputParams,omitempty"`
 	ReturnParams []Variable `json:"returnParams,omitempty"`

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2150,6 +2150,7 @@ func (d *Debugger) GetBufferedTracepoints() []api.TracepointResult {
 		results[i].FunctionName = fn.Name
 		results[i].Line = l
 		results[i].File = f
+		results[i].GoroutineID = trace.GoroutineID
 
 		for _, p := range trace.InputParams {
 			results[i].InputParams = append(results[i].InputParams, *api.ConvertVar(p))


### PR DESCRIPTION
This patch enables the eBPF tracer backend to parse the ID of the
Goroutine which hit the uprobe. This implementation is specific to AMD64
and will have to be generalized further in order to be used on other
architectures.

This patch also adds a test for the eBPF tracer backend. The test will skip
if it is not being run as root because we need SYS_CAP_ADMIN in order to
load the BPF program.