### PR TITLE
proc/gdbserver: support watchpoints

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -4,12 +4,9 @@ Tests skipped by each supported backend:
 	* 1 broken
 	* 3 broken - cgo stacktraces
 	* 3 not implemented
-* arm64 skipped = 5
+* arm64 skipped = 2
 	* 1 broken
 	* 1 broken - global variable symbolication
-	* 3 not implemented
-* darwin skipped = 3
-	* 3 not implemented
 * darwin/arm64 skipped = 1
 	* 1 broken - cgo stacktraces
 * darwin/lldb skipped = 1
@@ -19,12 +16,11 @@ Tests skipped by each supported backend:
 	* 4 not implemented
 * linux/386/pie skipped = 1
 	* 1 broken
-* linux/arm64 skipped = 1
+* linux/arm64 skipped = 4
 	* 1 broken - cgo stacktraces
+	* 3 not implemented
 * pie skipped = 2
 	* 2 upstream issue - https://github.com/golang/go/issues/29322
-* rr skipped = 3
-	* 3 not implemented
 * windows skipped = 2
 	* 1 broken
 	* 1 upstream issue

--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -669,6 +669,8 @@ The memory location is specified with the same expression language used by 'prin
 
 will watch the address of variable 'v'.
 
+Note that writes that do not change the value of the watched memory address might not be reported.
+
 See also: "help print".
 
 

--- a/_fixtures/databpeasy.go
+++ b/_fixtures/databpeasy.go
@@ -15,13 +15,13 @@ func main() { // Position 0
 	globalvar2 = globalvar1 + 1
 	globalvar1 = globalvar2 + 1
 	fmt.Printf("%d %d\n", globalvar1, globalvar2) // Position 1
-	runtime.Breakpoint()
+
 	globalvar2 = globalvar2 + 1          // Position 2
 	globalvar2 = globalvar1 + globalvar2 // Position 3
 	fmt.Printf("%d %d\n", globalvar1, globalvar2)
 	globalvar1 = globalvar2 + 1
 	fmt.Printf("%d %d\n", globalvar1, globalvar2)
-	runtime.Breakpoint()
+
 	done := make(chan struct{}) // Position 4
 	go f(done)
 	<-done
@@ -29,6 +29,6 @@ func main() { // Position 0
 
 func f(done chan struct{}) {
 	runtime.LockOSThread()
-	globalvar1 = globalvar2 + 1
+	globalvar1 = globalvar2 + 2
 	close(done) // Position 5
 }

--- a/_fixtures/databpstack.go
+++ b/_fixtures/databpstack.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"runtime"
+	//
 )
 
 func f() {
 	w := 0
-	runtime.Breakpoint()
+
 	g(1000, &w) // Position 0
 }
 

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -174,8 +174,9 @@ type gdbThread struct {
 	regs              gdbRegisters
 	CurrentBreakpoint proc.BreakpointState
 	p                 *gdbProcess
-	sig               uint8 // signal received by thread after last stop
-	setbp             bool  // thread was stopped because of a breakpoint
+	sig               uint8  // signal received by thread after last stop
+	setbp             bool   // thread was stopped because of a breakpoint
+	watchAddr         uint64 // if > 0 this is the watchpoint address
 	common            proc.CommonThread
 }
 
@@ -225,6 +226,7 @@ func newProcess(process *os.Process) *gdbProcess {
 			inbuf:               make([]byte, 0, initialInputBufferSize),
 			direction:           proc.Forward,
 			log:                 logger,
+			goarch:              runtime.GOARCH,
 		},
 		threads:        make(map[int]*gdbThread),
 		bi:             proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH),
@@ -822,10 +824,9 @@ func (p *gdbProcess) ContinueOnce() (proc.Thread, proc.StopReason, error) {
 	var atstart bool
 continueLoop:
 	for {
-		var err error
-		var sig uint8
 		tu.Reset()
-		threadID, sig, err = p.conn.resume(p.threads, &tu)
+		sp, err := p.conn.resume(p.threads, &tu)
+		threadID = sp.threadID
 		if err != nil {
 			if _, exited := err.(proc.ErrProcessExited); exited {
 				p.exited = true
@@ -842,7 +843,8 @@ continueLoop:
 		if trapthread != nil && !p.threadStopInfo {
 			// For stubs that do not support qThreadStopInfo we manually set the
 			// reason the thread returned by resume() stopped.
-			trapthread.sig = sig
+			trapthread.sig = sp.sig
+			trapthread.watchAddr = sp.watchAddr
 		}
 
 		var shouldStop bool
@@ -1075,7 +1077,7 @@ func (p *gdbProcess) Restart(pos string) (proc.Thread, error) {
 
 	// for some reason we have to send a vCont;c after a vRun to make rr behave
 	// properly, because that's what gdb does.
-	_, _, err = p.conn.resume(nil, nil)
+	_, err = p.conn.resume(nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1087,8 +1089,8 @@ func (p *gdbProcess) Restart(pos string) (proc.Thread, error) {
 	p.clearThreadSignals()
 	p.clearThreadRegisters()
 
-	for addr := range p.breakpoints.M {
-		p.conn.setBreakpoint(addr, p.breakpointKind)
+	for _, bp := range p.breakpoints.M {
+		p.WriteBreakpoint(bp)
 	}
 
 	return p.currentThread, p.setCurrentBreakpoints()
@@ -1224,15 +1226,33 @@ func (p *gdbProcess) FindBreakpoint(pc uint64) (*proc.Breakpoint, bool) {
 	return nil, false
 }
 
-func (p *gdbProcess) WriteBreakpoint(bp *proc.Breakpoint) error {
-	if bp.WatchType != 0 {
-		return errors.New("hardware breakpoints not supported")
+func watchTypeToBreakpointType(wtype proc.WatchType) breakpointType {
+	switch {
+	case wtype.Read() && wtype.Write():
+		return accessWatchpoint
+	case wtype.Write():
+		return writeWatchpoint
+	case wtype.Read():
+		return readWatchpoint
+	default:
+		return swBreakpoint
 	}
-	return p.conn.setBreakpoint(bp.Addr, p.breakpointKind)
+}
+
+func (p *gdbProcess) WriteBreakpoint(bp *proc.Breakpoint) error {
+	kind := p.breakpointKind
+	if bp.WatchType != 0 {
+		kind = bp.WatchType.Size()
+	}
+	return p.conn.setBreakpoint(bp.Addr, watchTypeToBreakpointType(bp.WatchType), kind)
 }
 
 func (p *gdbProcess) EraseBreakpoint(bp *proc.Breakpoint) error {
-	return p.conn.clearBreakpoint(bp.Addr, p.breakpointKind)
+	kind := p.breakpointKind
+	if bp.WatchType != 0 {
+		kind = bp.WatchType.Size()
+	}
+	return p.conn.clearBreakpoint(bp.Addr, watchTypeToBreakpointType(bp.WatchType), kind)
 }
 
 type threadUpdater struct {
@@ -1324,7 +1344,7 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater) error {
 
 	for _, th := range p.threads {
 		if p.threadStopInfo {
-			sig, reason, err := p.conn.threadStopInfo(th.strID)
+			sp, err := p.conn.threadStopInfo(th.strID)
 			if err != nil {
 				if isProtocolErrorUnsupported(err) {
 					p.threadStopInfo = false
@@ -1332,10 +1352,12 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater) error {
 				}
 				return err
 			}
-			th.setbp = (reason == "breakpoint" || (reason == "" && sig == breakpointSignal))
-			th.sig = sig
+			th.setbp = (sp.reason == "breakpoint" || (sp.reason == "" && sp.sig == breakpointSignal) || (sp.watchAddr > 0))
+			th.sig = sp.sig
+			th.watchAddr = sp.watchAddr
 		} else {
 			th.sig = 0
+			th.watchAddr = 0
 		}
 	}
 
@@ -1452,12 +1474,12 @@ func (t *gdbThread) Common() *proc.CommonThread {
 // StepInstruction will step exactly 1 CPU instruction.
 func (t *gdbThread) StepInstruction() error {
 	pc := t.regs.PC()
-	if _, atbp := t.p.breakpoints.M[pc]; atbp {
-		err := t.p.conn.clearBreakpoint(pc, t.p.breakpointKind)
+	if bp, atbp := t.p.breakpoints.M[pc]; atbp && bp.WatchType == 0 {
+		err := t.p.conn.clearBreakpoint(pc, swBreakpoint, t.p.breakpointKind)
 		if err != nil {
 			return err
 		}
-		defer t.p.conn.setBreakpoint(pc, t.p.breakpointKind)
+		defer t.p.conn.setBreakpoint(pc, swBreakpoint, t.p.breakpointKind)
 	}
 	// Reset thread registers so the next call to
 	// Thread.Registers will not be cached.
@@ -1677,13 +1699,16 @@ func (t *gdbThread) reloadGAtPC() error {
 	// around by clearing and re-setting the breakpoint in a specific sequence
 	// with the memory writes.
 	// Additionally all breakpoints in [pc, pc+len(movinstr)] need to be removed
-	for addr := range t.p.breakpoints.M {
+	for addr, bp := range t.p.breakpoints.M {
+		if bp.WatchType != 0 {
+			continue
+		}
 		if addr >= pc && addr <= pc+uint64(len(movinstr)) {
-			err := t.p.conn.clearBreakpoint(addr, t.p.breakpointKind)
+			err := t.p.conn.clearBreakpoint(addr, swBreakpoint, t.p.breakpointKind)
 			if err != nil {
 				return err
 			}
-			defer t.p.conn.setBreakpoint(addr, t.p.breakpointKind)
+			defer t.p.conn.setBreakpoint(addr, swBreakpoint, t.p.breakpointKind)
 		}
 	}
 
@@ -1795,6 +1820,13 @@ func (t *gdbThread) SetCurrentBreakpoint(adjustPC bool) error {
 	// adjustPC is ignored, it is the stub's responsibiility to set the PC
 	// address correctly after hitting a breakpoint.
 	t.clearBreakpointState()
+	if t.watchAddr > 0 {
+		t.CurrentBreakpoint.Breakpoint = t.p.Breakpoints().M[t.watchAddr]
+		if t.CurrentBreakpoint.Breakpoint == nil {
+			return fmt.Errorf("could not find watchpoint at address %#x", t.watchAddr)
+		}
+		return nil
+	}
 	regs, err := t.Registers()
 	if err != nil {
 		return err

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -5333,13 +5333,22 @@ func TestVariablesWithExternalLinking(t *testing.T) {
 
 func TestWatchpointsBasic(t *testing.T) {
 	skipOn(t, "not implemented", "freebsd")
-	skipOn(t, "not implemented", "darwin")
 	skipOn(t, "not implemented", "386")
-	skipOn(t, "not implemented", "arm64")
-	skipOn(t, "not implemented", "rr")
+	skipOn(t, "not implemented", "linux", "arm64")
+	protest.AllowRecording(t)
+
+	position1 := 17
+	position5 := 33
+
+	if runtime.GOARCH == "arm64" {
+		position1 = 16
+		position5 = 32
+	}
 
 	withTestProcess("databpeasy", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")
+		setFileBreakpoint(p, t, fixture.Source, 19) // Position 2 breakpoint
+		setFileBreakpoint(p, t, fixture.Source, 25) // Position 4 breakpoint
 		assertNoError(p.Continue(), t, "Continue 0")
 		assertLineNumber(p, t, 11, "Continue 0") // Position 0
 
@@ -5350,7 +5359,11 @@ func TestWatchpointsBasic(t *testing.T) {
 		assertNoError(err, t, "SetDataBreakpoint(write-only)")
 
 		assertNoError(p.Continue(), t, "Continue 1")
-		assertLineNumber(p, t, 17, "Continue 1") // Position 1
+		assertLineNumber(p, t, position1, "Continue 1") // Position 1
+
+		if curbp := p.CurrentThread().Breakpoint().Breakpoint; curbp == nil || (curbp.LogicalID() != bp.LogicalID()) {
+			t.Fatal("breakpoint not set")
+		}
 
 		p.ClearBreakpoint(bp.Addr)
 
@@ -5368,22 +5381,21 @@ func TestWatchpointsBasic(t *testing.T) {
 		assertNoError(p.Continue(), t, "Continue 4")
 		assertLineNumber(p, t, 25, "Continue 4") // Position 4
 
+		t.Logf("setting final breakpoint")
 		_, err = p.SetWatchpoint(scope, "globalvar1", proc.WatchWrite, nil)
 		assertNoError(err, t, "SetDataBreakpoint(write-only, again)")
 
 		assertNoError(p.Continue(), t, "Continue 5")
-		assertLineNumber(p, t, 33, "Continue 5") // Position 5
+		assertLineNumber(p, t, position5, "Continue 5") // Position 5
 	})
 }
 
 func TestWatchpointCounts(t *testing.T) {
 	skipOn(t, "not implemented", "freebsd")
-	skipOn(t, "not implemented", "darwin")
 	skipOn(t, "not implemented", "386")
-	skipOn(t, "not implemented", "arm64")
-	skipOn(t, "not implemented", "rr")
-
+	skipOn(t, "not implemented", "linux", "arm64")
 	protest.AllowRecording(t)
+
 	withTestProcess("databpcountstest", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")
 		assertNoError(p.Continue(), t, "Continue 0")
@@ -5495,12 +5507,18 @@ func TestDwrapStartLocation(t *testing.T) {
 
 func TestWatchpointStack(t *testing.T) {
 	skipOn(t, "not implemented", "freebsd")
-	skipOn(t, "not implemented", "darwin")
 	skipOn(t, "not implemented", "386")
-	skipOn(t, "not implemented", "arm64")
-	skipOn(t, "not implemented", "rr")
+	skipOn(t, "not implemented", "linux", "arm64")
+	protest.AllowRecording(t)
+
+	position1 := 17
+
+	if runtime.GOARCH == "arm64" {
+		position1 = 16
+	}
 
 	withTestProcess("databpstack", t, func(p *proc.Target, fixture protest.Fixture) {
+		setFileBreakpoint(p, t, fixture.Source, 11) // Position 0 breakpoint
 		clearlen := len(p.Breakpoints().M)
 
 		assertNoError(p.Continue(), t, "Continue 0")
@@ -5512,8 +5530,13 @@ func TestWatchpointStack(t *testing.T) {
 		_, err = p.SetWatchpoint(scope, "w", proc.WatchWrite, nil)
 		assertNoError(err, t, "SetDataBreakpoint(write-only)")
 
-		if len(p.Breakpoints().M) != clearlen+3 {
-			// want 1 watchpoint, 1 stack resize breakpoint, 1 out of scope sentinel
+		watchbpnum := 3
+		if recorded, _ := p.Recorded(); recorded {
+			watchbpnum = 4
+		}
+
+		if len(p.Breakpoints().M) != clearlen+watchbpnum {
+			// want 1 watchpoint, 1 stack resize breakpoint, 1 out of scope sentinel (2 if recorded)
 			t.Errorf("wrong number of breakpoints after setting watchpoint: %d", len(p.Breakpoints().M)-clearlen)
 		}
 
@@ -5527,16 +5550,21 @@ func TestWatchpointStack(t *testing.T) {
 			}
 		}
 
+		// Note: for recorded processes retaddr will not always be the return
+		// address, ~50% of the times it will be the address of the CALL
+		// instruction preceding the return address, this does not matter for this
+		// test.
+
 		_, err = p.SetBreakpoint(retaddr, proc.UserBreakpoint, nil)
 		assertNoError(err, t, "SetBreakpoint")
 
-		if len(p.Breakpoints().M) != clearlen+3 {
-			// want 1 watchpoint, 1 stack resize breakpoint, 1 out of scope sentinel (which is also a user breakpoint)
+		if len(p.Breakpoints().M) != clearlen+watchbpnum {
+			// want 1 watchpoint, 1 stack resize breakpoint, 1 out of scope sentinel (which is also a user breakpoint) (and another out of scope sentinel if recorded)
 			t.Errorf("wrong number of breakpoints after setting watchpoint: %d", len(p.Breakpoints().M)-clearlen)
 		}
 
 		assertNoError(p.Continue(), t, "Continue 1")
-		assertLineNumber(p, t, 17, "Continue 1") // Position 1
+		assertLineNumber(p, t, position1, "Continue 1") // Position 1
 
 		assertNoError(p.Continue(), t, "Continue 2")
 		t.Logf("%#v", p.CurrentThread().Breakpoint().Breakpoint)
@@ -5553,6 +5581,55 @@ func TestWatchpointStack(t *testing.T) {
 
 		err = p.ClearBreakpoint(retaddr)
 		assertNoError(err, t, "ClearBreakpoint")
+
+		if len(p.Breakpoints().M) != clearlen {
+			// want 1 user breakpoint set at retaddr
+			t.Errorf("wrong number of breakpoints after removing user breakpoint: %d", len(p.Breakpoints().M)-clearlen)
+		}
+	})
+}
+
+func TestWatchpointStackBackwardsOutOfScope(t *testing.T) {
+	skipUnlessOn(t, "only for recorded targets", "rr")
+	protest.AllowRecording(t)
+
+	withTestProcess("databpstack", t, func(p *proc.Target, fixture protest.Fixture) {
+		setFileBreakpoint(p, t, fixture.Source, 11) // Position 0 breakpoint
+		clearlen := len(p.Breakpoints().M)
+
+		assertNoError(p.Continue(), t, "Continue 0")
+		assertLineNumber(p, t, 11, "Continue 0") // Position 0
+
+		scope, err := proc.GoroutineScope(p, p.CurrentThread())
+		assertNoError(err, t, "GoroutineScope")
+
+		_, err = p.SetWatchpoint(scope, "w", proc.WatchWrite, nil)
+		assertNoError(err, t, "SetDataBreakpoint(write-only)")
+
+		assertNoError(p.Continue(), t, "Continue 1")
+		assertLineNumber(p, t, 17, "Continue 1") // Position 1
+
+		p.ChangeDirection(proc.Backward)
+
+		assertNoError(p.Continue(), t, "Continue 2")
+		t.Logf("%#v", p.CurrentThread().Breakpoint().Breakpoint)
+		assertLineNumber(p, t, 16, "Continue 2") // Position 1 again (because of inverted movement)
+
+		assertNoError(p.Continue(), t, "Continue 3")
+		t.Logf("%#v", p.CurrentThread().Breakpoint().Breakpoint)
+		assertLineNumber(p, t, 11, "Continue 3") // Position 0 (breakpoint 1 hit)
+
+		assertNoError(p.Continue(), t, "Continue 4")
+		t.Logf("%#v", p.CurrentThread().Breakpoint().Breakpoint)
+		assertLineNumber(p, t, 23, "Continue 4") // Position 2 (watchpoint gone out of scope)
+
+		if len(p.Breakpoints().M) != clearlen {
+			t.Errorf("wrong number of breakpoints after watchpoint goes out of scope: %d", len(p.Breakpoints().M)-clearlen)
+		}
+
+		if len(p.Breakpoints().WatchOutOfScope) != 1 {
+			t.Errorf("wrong number of out-of-scope watchpoints after watchpoint goes out of scope: %d", len(p.Breakpoints().WatchOutOfScope))
+		}
 
 		if len(p.Breakpoints().M) != clearlen {
 			// want 1 user breakpoint set at retaddr

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -147,6 +147,8 @@ The memory location is specified with the same expression language used by 'prin
 
 will watch the address of variable 'v'.
 
+Note that writes that do not change the value of the watched memory address might not be reported.
+
 See also: "help print".`},
 		{aliases: []string{"restart", "r"}, group: runCmds, cmdFn: restart, helpMsg: `Restart process.
 


### PR DESCRIPTION
### proc/gdbserver: support watchpoints

Adds watchpoint support to gdbserver backend for rr debugger and
debugserver on macOS/amd64 and macOS/arm64.

### proc/native: support watchpoints on Windows


