### PR TITLE
tests: correct checks that depend on regabi (fixes Cirrus-CI builds)

### DIFF
--- a/pkg/proc/proc_general_test.go
+++ b/pkg/proc/proc_general_test.go
@@ -1,12 +1,12 @@
 package proc
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"unsafe"
 
-	"github.com/go-delve/delve/pkg/goversion"
 	protest "github.com/go-delve/delve/pkg/proc/test"
 )
 
@@ -122,13 +122,13 @@ func TestDwarfVersion(t *testing.T) {
 
 func TestRegabiFlagSentinel(t *testing.T) {
 	// Detect if the regabi flag in the producer string gets removed
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) || runtime.GOARCH != "amd64" {
+	if !protest.RegabiSupported() {
 		t.Skip("irrelevant before Go 1.17 or on non-amd64 architectures")
 	}
 	fixture := protest.BuildFixture("math", 0)
 	bi := NewBinaryInfo(runtime.GOOS, runtime.GOARCH)
 	assertNoError(bi.LoadBinaryInfo(fixture.Path, 0, nil), t, "LoadBinaryInfo")
 	if !bi.regabi {
-		t.Errorf("regabi flag not set")
+		t.Errorf("regabi flag not set %s GOEXPERIMENT=%s", runtime.Version(), os.Getenv("GOEXPERIMENT"))
 	}
 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2238,7 +2238,7 @@ func TestStepCall(t *testing.T) {
 func TestStepCallPtr(t *testing.T) {
 	// Tests that Step works correctly when calling functions with a
 	// function pointer.
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) && !(goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) && (runtime.GOARCH == "amd64")) {
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) && !protest.RegabiSupported() {
 		testseq("teststepprog", contStep, []nextTest{
 			{9, 10},
 			{10, 6},
@@ -2328,7 +2328,7 @@ func TestStepIgnorePrivateRuntime(t *testing.T) {
 	// Tests that Step will ignore calls to private runtime functions
 	// (such as runtime.convT2E in this case)
 	switch {
-	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) && (runtime.GOARCH == "amd64"):
+	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) && protest.RegabiSupported():
 		testseq("teststepprog", contStep, []nextTest{
 			{21, 13},
 			{13, 14},
@@ -2664,7 +2664,7 @@ func TestStepOnCallPtrInstr(t *testing.T) {
 
 		assertNoError(p.Step(), t, "Step()")
 
-		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) && !(goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) && (runtime.GOARCH == "amd64")) {
+		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) && !protest.RegabiSupported() {
 			assertLineNumber(p, t, 6, "Step continued to wrong line,")
 		} else {
 			assertLineNumber(p, t, 5, "Step continued to wrong line,")

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -379,3 +379,13 @@ func MustHaveCgo(t *testing.T) {
 		t.Skip("Cgo not enabled")
 	}
 }
+
+func RegabiSupported() bool {
+	// Tracks regabiSupported variable in ParseGOEXPERIMENT internal/buildcfg/exp.go
+	switch {
+	case !goversion.VersionAfterOrEqual(runtime.Version(), 1, 17): // < 1.17
+		return false
+	default: // >= 1.17
+		return runtime.GOARCH == "amd64" && (runtime.GOOS == "android" || runtime.GOOS == "linux" || runtime.GOOS == "darwin" || runtime.GOOS == "windows")
+	}
+}


### PR DESCRIPTION
The tests incorrectly assumed that regabi was enabled everywhere on Go1.17/amd64, in fact it is not enabled on freebsd.