### PR TITLE
terminal: config -list to print strings inside interfaces in quotes

### DIFF
--- a/pkg/terminal/config.go
+++ b/pkg/terminal/config.go
@@ -82,6 +82,13 @@ func configureList(t *Term) error {
 		}
 
 		switch field.Kind() {
+		case reflect.Interface:
+			switch field := field.Interface().(type) {
+			case string:
+				fmt.Fprintf(w, "%s\t%q\n", fieldName, field)
+			default:
+				fmt.Fprintf(w, "%s\t%v\n", fieldName, field)
+			}
 		case reflect.Ptr:
 			if !field.IsNil() {
 				fmt.Fprintf(w, "%s\t%v\n", fieldName, field.Elem())


### PR DESCRIPTION
Commit 3d6bbbe9 made "config -list" print strings in quotes to avoid
the strings being interpreted as terminal escape codes.  This commit
does the same for "source-list-line-color", which is a raw interface.
This fixes "config -list" with a config like

	source-list-line-color: "\x1b[34m"

The "int" variant is already printed correctly, so just use the
default case for that.