### PR TITLE
pkg/goversion: visibly warn the user with --check-go-version=false

### DIFF
--- a/Documentation/usage/dlv.md
+++ b/Documentation/usage/dlv.md
@@ -23,7 +23,7 @@ Pass flags to the program you are debugging using `--`, for example:
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
   -h, --help                             help for dlv

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -30,7 +30,7 @@ dlv attach pid [executable] [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_backend.md
+++ b/Documentation/usage/dlv_backend.md
@@ -28,7 +28,7 @@ are:
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_connect.md
+++ b/Documentation/usage/dlv_connect.md
@@ -24,7 +24,7 @@ dlv connect addr [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_core.md
+++ b/Documentation/usage/dlv_core.md
@@ -30,7 +30,7 @@ dlv core <executable> <core> [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_dap.md
+++ b/Documentation/usage/dlv_dap.md
@@ -38,7 +38,7 @@ dlv dap [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -32,7 +32,7 @@ dlv debug [package] [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_exec.md
+++ b/Documentation/usage/dlv_exec.md
@@ -32,7 +32,7 @@ dlv exec <path/to/binary> [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_log.md
+++ b/Documentation/usage/dlv_log.md
@@ -43,7 +43,7 @@ and dap modes.
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_redirect.md
+++ b/Documentation/usage/dlv_redirect.md
@@ -31,7 +31,7 @@ File redirects can also be changed using the 'restart' command.
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_replay.md
+++ b/Documentation/usage/dlv_replay.md
@@ -28,7 +28,7 @@ dlv replay [trace directory] [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_run.md
+++ b/Documentation/usage/dlv_run.md
@@ -20,7 +20,7 @@ dlv run [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -34,7 +34,7 @@ dlv test [package] [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -38,7 +38,7 @@ dlv trace [package] regexp [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/Documentation/usage/dlv_version.md
+++ b/Documentation/usage/dlv_version.md
@@ -21,7 +21,7 @@ dlv version [flags]
       --api-version int                  Selects API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
       --backend string                   Backend selection (see 'dlv help backend'). (default "default")
       --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
-      --check-go-version                 Checks that the version of Go in use is compatible with Delve. (default true)
+      --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
       --headless                         Run debug server only, in headless mode.
       --init string                      Init file, executed by the terminal client.

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -130,7 +130,7 @@ func New(docCall bool) *cobra.Command {
 	rootCommand.PersistentFlags().StringVar(&initFile, "init", "", "Init file, executed by the terminal client.")
 	rootCommand.PersistentFlags().StringVar(&buildFlags, "build-flags", buildFlagsDefault, "Build flags, to be passed to the compiler. For example: --build-flags=\"-tags=integration -mod=vendor -cover -v\"")
 	rootCommand.PersistentFlags().StringVar(&workingDir, "wd", "", "Working directory for running the program.")
-	rootCommand.PersistentFlags().BoolVarP(&checkGoVersion, "check-go-version", "", true, "Checks that the version of Go in use is compatible with Delve.")
+	rootCommand.PersistentFlags().BoolVarP(&checkGoVersion, "check-go-version", "", true, "Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve.")
 	rootCommand.PersistentFlags().BoolVarP(&checkLocalConnUser, "only-same-user", "", true, "Only connections from the same user that started this instance of Delve are allowed to connect.")
 	rootCommand.PersistentFlags().StringVar(&backend, "backend", "default", `Backend selection (see 'dlv help backend').`)
 	rootCommand.PersistentFlags().StringArrayVarP(&redirects, "redirect", "r", []string{}, "Specifies redirect rules for target process (see 'dlv help redirect')")

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -2,6 +2,7 @@ package goversion
 
 import (
 	"fmt"
+	"os"
 )
 
 var (
@@ -10,20 +11,30 @@ var (
 	MaxSupportedVersionOfGoMajor = 1
 	MaxSupportedVersionOfGoMinor = 17
 	goTooOldErr                  = fmt.Errorf("Version of Go is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
+	goTooOldWarn                 = fmt.Errorf("Warning: version of Go is too old for this version of Delve (minimum supported version %d.%d)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Errorf("Version of Delve is too old for this version of Go (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
+	dlvTooOldWarn                = fmt.Errorf("Warning: version of Delve is too old for this version of Go (maximum supported version %d.%d)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
 )
 
 // Compatible checks that the version specified in the producer string is compatible with
 // this version of delve.
-func Compatible(producer string) error {
+func Compatible(producer string, warnonly bool) error {
 	ver := ParseProducer(producer)
 	if ver.IsDevel() {
 		return nil
 	}
 	if !ver.AfterOrEqual(GoVersion{MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor, -1, 0, 0, ""}) {
+		if warnonly {
+			fmt.Fprintf(os.Stderr, "%v\n", goTooOldWarn)
+			return nil
+		}
 		return goTooOldErr
 	}
 	if ver.AfterOrEqual(GoVersion{MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor + 1, -1, 0, 0, ""}) {
+		if warnonly {
+			fmt.Fprintf(os.Stderr, "%v\n", dlvTooOldWarn)
+			return nil
+		}
 		return dlvTooOldErr
 	}
 	return nil

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -10,10 +10,10 @@ var (
 	MinSupportedVersionOfGoMinor = 15
 	MaxSupportedVersionOfGoMajor = 1
 	MaxSupportedVersionOfGoMinor = 17
-	goTooOldErr                  = fmt.Errorf("Version of Go may be too old to work with this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
-	goTooOldWarn                 = fmt.Errorf("Warning: version of Go may be too old to work with this version of Delve (minimum supported version %d.%d)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
-	dlvTooOldErr                 = fmt.Errorf("Version of Delve is too old for this version of Go (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
-	dlvTooOldWarn                = fmt.Errorf("Warning: version of Delve is too old for this version of Go (maximum supported version %d.%d)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
+	goTooOldErr                  = fmt.Sprintf("Go version %%s is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
+	goTooOldWarn                 = fmt.Sprintf("WARNING: undefined behavior - Go version %%s is too old for this version of Delve (minimum supported version %d.%d)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
+	dlvTooOldErr                 = fmt.Sprintf("Version of Delve is too old for Go version %%s (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
+	dlvTooOldWarn                = fmt.Sprintf("WARNING: undefined behavior - version of Delve is too old for Go version %%s (maximum supported version %d.%d)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
 )
 
 // Compatible checks that the version specified in the producer string is compatible with
@@ -23,19 +23,20 @@ func Compatible(producer string, warnonly bool) error {
 	if ver.IsDevel() {
 		return nil
 	}
+	verstr := fmt.Sprintf("%d.%d.%d", ver.Major, ver.Minor, ver.Rev)
 	if !ver.AfterOrEqual(GoVersion{MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor, -1, 0, 0, ""}) {
 		if warnonly {
-			fmt.Fprintf(os.Stderr, "%v\n", goTooOldWarn)
+			fmt.Fprintf(os.Stderr, "%v\n", fmt.Sprintf(goTooOldWarn, verstr))
 			return nil
 		}
-		return goTooOldErr
+		return fmt.Errorf(goTooOldErr, verstr)
 	}
 	if ver.AfterOrEqual(GoVersion{MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor + 1, -1, 0, 0, ""}) {
 		if warnonly {
-			fmt.Fprintf(os.Stderr, "%v\n", dlvTooOldWarn)
+			fmt.Fprintf(os.Stderr, "%v\n", fmt.Sprintf(dlvTooOldWarn, verstr))
 			return nil
 		}
-		return dlvTooOldErr
+		return fmt.Errorf(dlvTooOldErr, verstr)
 	}
 	return nil
 }

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -2,7 +2,8 @@ package goversion
 
 import (
 	"fmt"
-	"os"
+
+	"github.com/go-delve/delve/pkg/logflags"
 )
 
 var (
@@ -26,14 +27,14 @@ func Compatible(producer string, warnonly bool) error {
 	verstr := fmt.Sprintf("%d.%d.%d", ver.Major, ver.Minor, ver.Rev)
 	if !ver.AfterOrEqual(GoVersion{MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor, -1, 0, 0, ""}) {
 		if warnonly {
-			fmt.Fprintf(os.Stderr, "%v\n", fmt.Sprintf(goTooOldWarn, verstr))
+			logflags.WriteError(fmt.Sprintf(goTooOldWarn, verstr))
 			return nil
 		}
 		return fmt.Errorf(goTooOldErr, verstr)
 	}
 	if ver.AfterOrEqual(GoVersion{MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor + 1, -1, 0, 0, ""}) {
 		if warnonly {
-			fmt.Fprintf(os.Stderr, "%v\n", fmt.Sprintf(dlvTooOldWarn, verstr))
+			logflags.WriteError(fmt.Sprintf(dlvTooOldWarn, verstr))
 			return nil
 		}
 		return fmt.Errorf(dlvTooOldErr, verstr)

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -10,8 +10,8 @@ var (
 	MinSupportedVersionOfGoMinor = 15
 	MaxSupportedVersionOfGoMajor = 1
 	MaxSupportedVersionOfGoMinor = 17
-	goTooOldErr                  = fmt.Errorf("Version of Go is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
-	goTooOldWarn                 = fmt.Errorf("Warning: version of Go is too old for this version of Delve (minimum supported version %d.%d)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
+	goTooOldErr                  = fmt.Errorf("Version of Go may be too old to work with this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
+	goTooOldWarn                 = fmt.Errorf("Warning: version of Go may be too old to work with this version of Delve (minimum supported version %d.%d)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Errorf("Version of Delve is too old for this version of Go (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
 	dlvTooOldWarn                = fmt.Errorf("Warning: version of Delve is too old for this version of Go (maximum supported version %d.%d)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)
 )

--- a/pkg/logflags/logflags.go
+++ b/pkg/logflags/logflags.go
@@ -136,6 +136,14 @@ func writeListeningMessage(server, addr string) {
 	}
 }
 
+func WriteError(msg string) {
+	if logOut != nil {
+		fmt.Fprintln(logOut, msg)
+	} else {
+		fmt.Fprintln(os.Stderr, msg)
+	}
+}
+
 var errLogstrWithoutLog = errors.New("--log-output specified without --log")
 
 // Setup sets debugger flags based on the contents of logstr.

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -223,9 +223,6 @@ func (d *Debugger) canRestart() bool {
 }
 
 func (d *Debugger) checkGoVersion() error {
-	if !d.config.CheckGoVersion {
-		return nil
-	}
 	if d.isRecording() {
 		// do not do anything if we are still recording
 		return nil
@@ -234,7 +231,7 @@ func (d *Debugger) checkGoVersion() error {
 	if producer == "" {
 		return nil
 	}
-	return goversion.Compatible(producer)
+	return goversion.Compatible(producer, !d.config.CheckGoVersion)
 }
 
 func (d *Debugger) TargetGoVersion() string {


### PR DESCRIPTION
Since Delve doesn't forcefully take out support for no-longer-supported versions, users and clients might want to turn off the version check to continue debugging with older versions of Go. Add a warning to notify them of the incompatibility in this case as well.  This will apply to too-new Go versions as well. Also, log the Go version.

Before
```
$ dlv debug _fixtures/increment.go 
Version of Go is too old for this version of Delve (minimum supported version 1.15, suppress this error with --check-go-version=false)
$ dlv debug _fixtures/increment.go --check-go-version=false
Type 'help' for list of commands.
(dlv)
```

After
```
$ ./dlv debug _fixtures/increment.go
Go version 1.14.15 is too old for this version of Delve (minimum supported version 1.15, suppress this error with --check-go-version=false)
$ ./dlv debug _fixtures/increment.go --check-go-version=false
WARNING: undefined behavior - Go version 1.14.15 is too old for this version of Delve (minimum supported version 1.15)
Type 'help' for list of commands.
(dlv)
```

Updates #golang/vscode-go/issues/1716