### PR TITLE
terminal/make: Add GOARCH and GOOS arguments

### DIFF
--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -22,6 +22,8 @@ var NOTimeout bool
 var TestIncludePIE bool
 var TestSet, TestRegex, TestBackend, TestBuildMode string
 var Tags *[]string
+var Architecture string
+var OS string
 
 func NewMakeCommands() *cobra.Command {
 	RootCommand := &cobra.Command{
@@ -48,13 +50,26 @@ func NewMakeCommands() *cobra.Command {
 				}
 				tagFlag += strings.Join(*Tags, ",")
 			}
-			execute("go", "build", "-ldflags", "-extldflags -static", tagFlag, buildFlags(), DelveMainPackagePath)
+			envflags := []string{}
+			if len(Architecture) > 0 {
+				envflags = append(envflags, "GOARCH="+Architecture)
+			}
+			if len(OS) > 0 {
+				envflags = append(envflags, "GOOS="+OS)
+			}
+			if len(envflags) > 0 {
+				executeEnv(envflags, "go", "build", "-ldflags", "-extldflags -static", tagFlag, buildFlags(), DelveMainPackagePath)
+			} else {
+				execute("go", "build", "-ldflags", "-extldflags -static", tagFlag, buildFlags(), DelveMainPackagePath)
+			}
 			if runtime.GOOS == "darwin" && os.Getenv("CERT") != "" && canMacnative() {
 				codesign("./dlv")
 			}
 		},
 	}
 	Tags = buildCmd.PersistentFlags().StringArray("tags", []string{}, "Build tags")
+	buildCmd.PersistentFlags().StringVar(&Architecture, "GOARCH", "", "Architecture to build for")
+	buildCmd.PersistentFlags().StringVar(&OS, "GOOS", "", "OS to build for")
 	RootCommand.AddCommand(buildCmd)
 
 	RootCommand.AddCommand(&cobra.Command{
@@ -165,11 +180,14 @@ func strflatten(v []interface{}) []string {
 	return r
 }
 
-func executeq(cmd string, args ...interface{}) {
+func executeq(env []string, cmd string, args ...interface{}) {
 	x := exec.Command(cmd, strflatten(args)...)
 	x.Stdout = os.Stdout
 	x.Stderr = os.Stderr
 	x.Env = os.Environ()
+	for _, e := range env {
+		x.Env = append(x.Env, e)
+	}
 	err := x.Run()
 	if x.ProcessState != nil && !x.ProcessState.Success() {
 		os.Exit(1)
@@ -181,7 +199,14 @@ func executeq(cmd string, args ...interface{}) {
 
 func execute(cmd string, args ...interface{}) {
 	fmt.Printf("%s %s\n", cmd, strings.Join(quotemaybe(strflatten(args)), " "))
-	executeq(cmd, args...)
+	env := []string{}
+	executeq(env, cmd, args...)
+}
+
+func executeEnv(env []string, cmd string, args ...interface{}) {
+	fmt.Printf("%s %s %s\n", strings.Join(env, " "),
+		cmd, strings.Join(quotemaybe(strflatten(args)), " "))
+	executeq(env, cmd, args...)
 }
 
 func quotemaybe(args []string) []string {
@@ -313,7 +338,8 @@ func testCmd(cmd *cobra.Command, args []string) {
 
 		fmt.Println("\nTesting")
 		os.Setenv("PROCTEST", "lldb")
-		executeq("sudo", "-E", "go", "test", testFlags(), allPackages())
+		env := []string{}
+		executeq(env, "sudo", "-E", "go", "test", testFlags(), allPackages())
 		return
 	}
 
@@ -415,7 +441,8 @@ func testCmdIntl(testSet, testRegex, testBackend, testBuildMode string) {
 	}
 
 	if len(testPackages) > 3 {
-		executeq("go", "test", testFlags(), buildFlags(), testPackages, backendFlag, buildModeFlag)
+		env := []string{}
+		executeq(env, "go", "test", testFlags(), buildFlags(), testPackages, backendFlag, buildModeFlag)
 	} else if testRegex != "" {
 		execute("go", "test", testFlags(), buildFlags(), testPackages, "-run="+testRegex, backendFlag, buildModeFlag)
 	} else {


### PR DESCRIPTION
This change adds `--GOARCH=[arch]` and `--GOOS=[os]` as arguments for
the make script to simplify the process of cross compilling.