### PR TITLE
documentation: remove unnecessary pages for install instructions

### DIFF
--- a/Documentation/installation/README.md
+++ b/Documentation/installation/README.md
@@ -1,4 +1,5 @@
 # Installation
+The following instructions are known to work on Linux, macOS, Windows and FreeBSD.
 
 Clone the git repository and build:
 
@@ -14,7 +15,7 @@ On Go version 1.16 or later, this command will also work:
 $ go install github.com/go-delve/delve/cmd/dlv@latest
 ```
 
-See `go help install` for details on where the `dlv` executable is saved. 
+See `go help install` for details on where the `dlv` executable is saved.
 
 If during the install step you receive an error similar to this:
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ The GitHub issue tracker is for **bugs** only. Please use the [developer mailing
 ### About Delve
 
 - [Installation](Documentation/installation)
-  - [Linux](Documentation/installation/linux/install.md)
-  - [macOS](Documentation/installation/osx/install.md)
-  - [Windows](Documentation/installation/windows/install.md)
-  - [FreeBSD](Documentation/installation/freebsd/install.md)
 - [Getting Started](Documentation/cli/getting_started.md)
 - [Documentation](Documentation)
   - [Command line options](Documentation/usage/dlv.md)


### PR DESCRIPTION
These 4 pages don't really have any value.
https://github.com/go-delve/delve/blob/master/Documentation/installation/linux/install.md
https://github.com/go-delve/delve/blob/master/Documentation/installation/osx/install.md
https://github.com/go-delve/delve/blob/master/Documentation/installation/windows/install.md
https://github.com/go-delve/delve/blob/master/Documentation/installation/freebsd/install.md