### PR TITLE
First stab at support for Solaris/illumos.

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -17,6 +17,9 @@ Tests skipped by each supported backend:
 * freebsd skipped = 15
 	* 11 broken
 	* 4 not implemented
+* illumos skipped = 15
+	* 11 broken
+	* 4 not implemented
 * linux/386/pie skipped = 1
 	* 1 broken
 * linux/arm64 skipped = 1
@@ -25,6 +28,9 @@ Tests skipped by each supported backend:
 	* 2 upstream issue - https://github.com/golang/go/issues/29322
 * rr skipped = 3
 	* 3 not implemented
+* solaris skipped = 15
+	* 11 broken
+	* 4 not implemented
 * windows skipped = 5
 	* 1 broken
 	* 3 not implemented

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -461,7 +461,7 @@ func loadBinaryInfo(bi *BinaryInfo, image *Image, path string, entryPoint uint64
 	defer wg.Wait()
 
 	switch bi.GOOS {
-	case "linux", "freebsd":
+	case "linux", "freebsd", "solaris", "illumos":
 		return loadBinaryInfoElf(bi, image, path, entryPoint, &wg)
 	case "windows":
 		return loadBinaryInfoPE(bi, image, path, entryPoint, &wg)

--- a/pkg/proc/dump.go
+++ b/pkg/proc/dump.go
@@ -122,6 +122,8 @@ func (t *Target) Dump(out elfwriter.WriteCloserSeeker, flags DumpFlags, state *D
 		fhdr.OSABI = elf.ELFOSABI_LINUX
 	case "freebsd":
 		fhdr.OSABI = elf.ELFOSABI_FREEBSD
+	case "solaris":
+		fhdr.OSABI = elf.ELFOSABI_SOLARIS
 	default:
 		// There is no OSABI value for windows or macOS because nobody generates ELF core dumps on those systems.
 		fhdr.OSABI = 0xff

--- a/pkg/proc/gdbserial/gdbserver_unix.go
+++ b/pkg/proc/gdbserial/gdbserver_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd
+// +build linux darwin freebsd solaris
 
 package gdbserial
 

--- a/pkg/proc/native/Pcreate_solaris.c
+++ b/pkg/proc/native/Pcreate_solaris.c
@@ -1,0 +1,25 @@
+#include <libproc.h>
+
+char *Pcreate_dir = NULL;
+int Pcreate_stdin = STDIN_FILENO;
+int Pcreate_stdout = STDOUT_FILENO;
+int Pcreate_stderr = STDERR_FILENO;
+
+// Pcreate_callback is called by libproc when Pcreate is called,
+// after forking and prior to execing the victim process.
+void
+Pcreate_callback(struct ps_prochandle *P)
+{
+	if (Pcreate_dir != NULL) {
+		(void) chdir(Pcreate_dir);
+	}
+	if (Pcreate_stdin != STDIN_FILENO) {
+		(void) dup2(Pcreate_stdin, STDIN_FILENO);
+	}
+	if (Pcreate_stdout != STDOUT_FILENO) {
+		(void) dup2(Pcreate_stdout, STDOUT_FILENO);
+	}
+	if (Pcreate_stderr != STDERR_FILENO) {
+		(void) dup2(Pcreate_stderr, STDERR_FILENO);
+	}
+}

--- a/pkg/proc/native/Pcreate_solaris.go
+++ b/pkg/proc/native/Pcreate_solaris.go
@@ -1,0 +1,45 @@
+package native
+
+import (
+	"errors"
+	"unsafe"
+)
+
+// #cgo LDFLAGS: -lproc
+// #include <libproc.h>
+import "C"
+
+func makeArgvSlice(argv []string) []*C.char {
+	s := make([]*C.char, len(argv)+1)
+	for i := 0; i < len(argv); i++ {
+		s[i] = C.CString(argv[i])
+	}
+	return s
+}
+
+func freeArgvSlice(s []*C.char) {
+	for i := 0; i < len(s); i++ {
+		C.free(unsafe.Pointer(s[i]))
+	}
+}
+
+// Pcreate_helper creates a victim process. It returns a process handle along
+// with the full path to the file, which may have been found by looking in PATH.
+func Pcreate_helper(file string, argv []string) (*C.struct_ps_prochandle, string, error) {
+	cFile := C.CString(file)
+	defer C.free(unsafe.Pointer(cFile))
+	cArgv := makeArgvSlice(argv)
+	defer freeArgvSlice(cArgv)
+	var cCode C.int
+	cPath := make([]C.char, C.MAXPATHLEN)
+	P := C.Pcreate(
+		cFile,
+		(**C.char)(unsafe.Pointer(&cArgv[0])),
+		&cCode,
+		(*C.char)(unsafe.Pointer(&cPath[0])),
+		C.MAXPATHLEN)
+	if P == nil {
+		return nil, "", errors.New(C.GoString(C.Pcreate_error(cCode)))
+	}
+	return P, C.GoString((*C.char)(unsafe.Pointer(&cPath[0]))), nil
+}

--- a/pkg/proc/native/Pcreate_solaris.h
+++ b/pkg/proc/native/Pcreate_solaris.h
@@ -1,0 +1,4 @@
+extern char *Pcreate_dir;
+extern int Pcreate_stdin;
+extern int Pcreate_stdout;
+extern int Pcreate_stderr;

--- a/pkg/proc/native/dump_other.go
+++ b/pkg/proc/native/dump_other.go
@@ -1,4 +1,4 @@
-//+build freebsd,amd64 darwin
+//+build freebsd,amd64 darwin solaris
 
 package native
 

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -306,7 +306,7 @@ func (dbp *nativeProcess) initialize(path string, debugInfoDirs []string) (*proc
 	tgt, err := proc.NewTarget(dbp, dbp.memthread, proc.NewTargetConfig{
 		Path:                path,
 		DebugInfoDirs:       debugInfoDirs,
-		DisableAsyncPreempt: runtime.GOOS == "windows" || runtime.GOOS == "freebsd",
+		DisableAsyncPreempt: runtime.GOOS == "windows" || runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos",
 		StopReason:          stopReason,
 		CanDump:             runtime.GOOS == "linux"})
 	if err != nil {

--- a/pkg/proc/native/proc_solaris.go
+++ b/pkg/proc/native/proc_solaris.go
@@ -1,0 +1,339 @@
+package native
+
+// #include <libproc.h>
+// #include "Pcreate_solaris.h"
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"syscall"
+	"time"
+	"unsafe"
+
+	sys "golang.org/x/sys/unix"
+
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc/internal/ebpf"
+)
+
+// osProcessDetails contains Solaris specific
+// process details.
+type osProcessDetails struct {
+	pr         *C.struct_ps_prochandle
+	path       string
+	exitStatus int
+	waitDone   chan struct{}
+}
+
+func (os *osProcessDetails) Close() {}
+
+// Launch creates and begins debugging a new process. First entry in
+// `cmd` is the program to run, and then rest are the arguments
+// to be supplied to that process. `wd` is working directory of the program.
+// If the DWARF information cannot be found in the binary, Delve will look
+// for external debug files in the directories passed in.
+func Launch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs []string, tty string, redirects [3]string) (*proc.Target, error) {
+	if wd != "" && wd != "." {
+		if _, err := os.Stat(wd); err != nil {
+			return nil, err
+		}
+	}
+	foreground := flags&proc.LaunchForeground != 0
+	stdin, stdout, stderr, closefn, err := openRedirects(redirects, foreground)
+	if err != nil {
+		return nil, err
+	}
+	dbp := newProcess(0)
+	dbp.execPtraceFunc(func() {
+		C.Pcreate_stdin = C.int(stdin.Fd())
+		C.Pcreate_stdout = C.int(stdout.Fd())
+		C.Pcreate_stderr = C.int(stderr.Fd())
+		if wd != "" {
+			C.Pcreate_dir = C.CString(wd)
+		}
+		dbp.os.pr, dbp.os.path, err = Pcreate_helper(cmd[0], cmd)
+		if err == nil {
+			dbp.pid = int(C.Pstatus(dbp.os.pr).pr_pid)
+		}
+		C.free(unsafe.Pointer(C.Pcreate_dir))
+		C.Pcreate_dir = (*C.char)(C.NULL)
+	})
+	closefn()
+	if err != nil {
+		return nil, err
+	}
+	dbp.childProcess = true
+	tgt, err := dbp.initialize(dbp.os.path, debugInfoDirs)
+	dbp.os.waitDone = make(chan struct{})
+	go waitThread(dbp)
+	if err != nil {
+		dbp.Detach(true)
+		return nil, err
+	}
+	return tgt, nil
+}
+
+// Attach to an existing process with the given PID. Once attached, if
+// the DWARF information cannot be found in the binary, Delve will look
+// for external debug files in the directories passed in.
+func Attach(pid int, debugInfoDirs []string) (*proc.Target, error) {
+	dbp := newProcess(pid)
+	var code C.int
+	dbp.execPtraceFunc(func() { dbp.os.pr = C.Pgrab(C.int(pid), 0, &code) })
+	if dbp.os.pr == nil {
+		return nil, errors.New(C.GoString(C.Pgrab_error(code)))
+	}
+	exe, err := os.Readlink(fmt.Sprintf("/proc/%d/path/a.out", pid))
+	if err != nil {
+		return nil, err
+	}
+	var tgt *proc.Target
+	if tgt, err = dbp.initialize(exe, debugInfoDirs); err != nil {
+		dbp.Detach(false)
+		return nil, err
+	}
+	dbp.os.waitDone = make(chan struct{})
+	go waitThread(dbp)
+	return tgt, nil
+}
+
+func waitThread(dbp *nativeProcess) {
+	if _, s, err := dbp.wait(dbp.pid, 0); err == nil {
+		dbp.os.exitStatus = s.ExitStatus()
+	}
+	close(dbp.os.waitDone)
+}
+
+func initialize(dbp *nativeProcess) (err error) {
+	dbp.execPtraceFunc(func() {
+		// The process should already be stopped if we grabbed or created it,
+		// but if we created it it will be stopped on the execve syscall and
+		// for whatever reason trying to step it will cause it to exit.
+		// Telling it to run and stop seems to workaround the issue.
+		// NB: this does not as far as I know cause the process to advance,
+		// it just causes the reason for the stop to change from PR_SYSEXIT
+		// to PR_REQUESTED, and that seems to make a difference.
+		if rc, err1 := C.Psetrun(dbp.os.pr, 0, C.PRSTOP); rc == -1 {
+			err = err1
+		} else if rc, err1 = C.Pfault(dbp.os.pr, C.FLTTRACE, 1); rc == -1 {
+			err = err1
+		} else if rc, err1 = C.Pfault(dbp.os.pr, C.FLTWATCH, 1); rc == -1 {
+			err = err1
+		} else if rc, err1 = C.Pfault(dbp.os.pr, C.FLTBPT, 1); rc == -1 {
+			err = err1
+		}
+	})
+	return
+}
+
+// kill kills the target process.
+func (dbp *nativeProcess) kill() (err error) {
+	if dbp.exited {
+		return nil
+	}
+	dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Psetrun(dbp.os.pr, C.SIGKILL, 0); rc == -1 {
+			err = err1
+		}
+	})
+	if err != nil {
+		return err
+	}
+	<-dbp.os.waitDone
+	dbp.postExit()
+	return nil
+}
+
+// Used by RequestManualStop
+func (dbp *nativeProcess) requestManualStop() (err error) {
+	dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Pdstop(dbp.os.pr); rc == -1 {
+			err = err1
+		}
+	})
+	return
+}
+
+// Attach to a newly created thread, and store that thread in our list of
+// known threads.
+func (dbp *nativeProcess) addThread(tid int, attach bool) (*nativeThread, error) {
+	if thread, ok := dbp.threads[tid]; ok {
+		return thread, nil
+	}
+	var lwp *C.struct_ps_lwphandle
+	var code C.int
+	dbp.execPtraceFunc(func() { lwp = C.Lgrab(dbp.os.pr, C.uint(tid), &code) })
+	if lwp == nil {
+		return nil, errors.New(C.GoString(C.Pgrab_error(code)))
+	}
+	dbp.threads[tid] = &nativeThread{
+		ID:  tid,
+		dbp: dbp,
+		os:  &osSpecificDetails{lwp: lwp},
+	}
+	if dbp.memthread == nil {
+		dbp.memthread = dbp.threads[tid]
+	}
+	return dbp.threads[tid], nil
+}
+
+// Used by initialize
+func (dbp *nativeProcess) updateThreadList() error {
+	var tids []int32
+	dbp.execPtraceFunc(func() {
+		files, err := ioutil.ReadDir(fmt.Sprintf("/proc/%d/lwp", dbp.pid))
+		if err != nil {
+			return
+		}
+		for _, file := range files {
+			i, err := strconv.Atoi(file.Name())
+			if err == nil {
+				tids = append(tids, int32(i))
+			}
+		}
+	})
+	for _, tid := range tids {
+		if _, err := dbp.addThread(int(tid), false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (dbp *nativeProcess) trapWait(pid int) (*nativeThread, error) {
+	if pid != -1 {
+		panic("not implemented")
+	}
+	for {
+		// refresh the state stored in the proc handle
+		var err error
+		dbp.execPtraceFunc(func() {
+			if rc, err1 := C.Pstopstatus(dbp.os.pr, C.PCNULL, 0); rc == -1 {
+				err = err1
+			}
+		})
+		if err != nil {
+			if errors.Is(syscall.ENOENT, err) {
+				<-dbp.os.waitDone
+				dbp.postExit()
+				return nil, proc.ErrProcessExited{Pid: dbp.pid, Status: dbp.os.exitStatus}
+			}
+			return nil, err
+		}
+		var state C.int
+		dbp.execPtraceFunc(func() { state = C.Pstate(dbp.os.pr) })
+		switch state {
+		case C.PS_RUN, C.PS_UNDEAD:
+			time.Sleep(time.Millisecond)
+		case C.PS_STOP:
+			var lwp C.struct_lwpstatus
+			dbp.execPtraceFunc(func() { lwp = C.Pstatus(dbp.os.pr).pr_lwp })
+			switch lwp.pr_why {
+			case C.PR_REQUESTED:
+				return dbp.addThread(int(lwp.pr_lwpid), false)
+			case C.PR_FAULTED:
+				switch lwp.pr_what {
+				case C.FLTBPT, C.FLTTRACE, C.FLTWATCH:
+					return dbp.addThread(int(lwp.pr_lwpid), false)
+				default:
+					panic(fmt.Sprintf("unexpected pr_what: %d", int(lwp.pr_what)))
+				}
+			default:
+				panic(fmt.Sprintf("unexpected pr_why: %d", int(lwp.pr_why)))
+			}
+		case C.PS_LOST:
+			return nil, errors.New("trapWait: lost control")
+		default:
+			panic(fmt.Sprintf("unexpected state: %d", state))
+		}
+		// check for new threads
+		dbp.updateThreadList()
+	}
+}
+
+// Only used in this file
+func (dbp *nativeProcess) wait(pid, options int) (int, *sys.WaitStatus, error) {
+	var s sys.WaitStatus
+	wpid, err := sys.Wait4(pid, &s, options, nil)
+	return wpid, &s, err
+}
+
+// Used by ContinueOnce
+func (dbp *nativeProcess) resume() (err error) {
+	// all threads stopped over a breakpoint are made to step over it
+	for _, thread := range dbp.threads {
+		if thread.CurrentBreakpoint.Breakpoint != nil {
+			if err = thread.StepInstruction(); err != nil {
+				return err
+			}
+			thread.CurrentBreakpoint.Clear()
+		}
+	}
+	// all threads are resumed
+	dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Psetrun(dbp.os.pr, 0, C.PRCFAULT); rc == -1 {
+			err = err1
+		}
+	})
+	return
+}
+
+// Used by ContinueOnce
+// stop stops all running threads and sets breakpoints
+func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
+	if dbp.exited {
+		return nil, &proc.ErrProcessExited{Pid: dbp.Pid()}
+	}
+	// set breakpoints on all threads
+	for _, th := range dbp.threads {
+		if th.CurrentBreakpoint.Breakpoint == nil {
+			if err := th.SetCurrentBreakpoint(true); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return trapthread, nil
+}
+
+// Used by Detach
+func (dbp *nativeProcess) detach(kill bool) error {
+	// this function is called from execPtraceFunc
+	C.Pclearfault(dbp.os.pr)
+	C.Prelease(dbp.os.pr, C.PRELEASE_CLEAR)
+	dbp.os.pr = (*C.struct_ps_prochandle)(C.NULL)
+	return nil
+}
+
+// Used by PostInitializationSetup
+// EntryPoint will return the process entry point address, useful for debugging PIEs.
+func (dbp *nativeProcess) EntryPoint() (addr uint64, err error) {
+	dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Pgetauxval(dbp.os.pr, C.AT_ENTRY); rc == -1 {
+			err = err1
+		} else {
+			addr = uint64(rc)
+		}
+	})
+	return
+}
+
+func (dbp *nativeProcess) SupportsBPF() bool {
+	return false
+}
+
+func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
+	panic("not implemented")
+}
+
+func (dbp *nativeProcess) GetBufferedTracepoints() []ebpf.RawUProbeParams {
+	panic("not implemented")
+}
+
+// Used by Detach
+func killProcess(pid int) error {
+	return sys.Kill(pid, sys.SIGINT)
+}

--- a/pkg/proc/native/registers_solaris_amd64.go
+++ b/pkg/proc/native/registers_solaris_amd64.go
@@ -1,0 +1,91 @@
+package native
+
+// #include <libproc.h>
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/regnum"
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc/solutil"
+)
+
+// SetPC sets RIP to the value specified by 'pc'.
+func (thread *nativeThread) setPC(pc uint64) error {
+	ir, err := registers(thread)
+	if err != nil {
+		return err
+	}
+	r := ir.(*solutil.AMD64Registers)
+	r.Regs.Rip = int64(pc)
+	thread.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Plwp_setregs(thread.dbp.os.pr, C.uint(thread.ID), (*C.long)(unsafe.Pointer(&r.Regs))); rc == -1 {
+			err = err1
+		}
+	})
+	return err
+}
+
+// SetReg changes the value of the specified register.
+func (thread *nativeThread) SetReg(regNum uint64, reg *op.DwarfRegister) error {
+	ir, err := registers(thread)
+	if err != nil {
+		return err
+	}
+	r := ir.(*solutil.AMD64Registers)
+	switch regNum {
+	case regnum.AMD64_Rip:
+		r.Regs.Rip = int64(reg.Uint64Val)
+	case regnum.AMD64_Rsp:
+		r.Regs.Rsp = int64(reg.Uint64Val)
+	case regnum.AMD64_Rdx:
+		r.Regs.Rdx = int64(reg.Uint64Val)
+	default:
+		return fmt.Errorf("changing register %d not implemented", regNum)
+	}
+	thread.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Plwp_setregs(thread.dbp.os.pr, C.uint(thread.ID), (*C.long)(unsafe.Pointer(&r.Regs))); rc == -1 {
+			err = err1
+		}
+	})
+	return err
+}
+
+func registers(thread *nativeThread) (proc.Registers, error) {
+	var (
+		err error
+		regs solutil.AMD64Regset
+	)
+	thread.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Plwp_getregs(thread.dbp.os.pr, C.uint(thread.ID), (*C.long)(unsafe.Pointer(&regs))); rc == -1 {
+			err = err1
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	r := solutil.NewAMD64Registers(regs, func(r *solutil.AMD64Registers) (err error) {
+		var fpregset solutil.AMD64Fpregset
+		var floatLoadError error
+		r.Fpregs, fpregset, floatLoadError = thread.fpRegisters()
+		r.Fpregset = &fpregset
+		return floatLoadError
+	})
+	return r, nil
+}
+
+func (thread *nativeThread) fpRegisters() (regs []proc.Register, fpregs solutil.AMD64Fpregset, err error) {
+	thread.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Plwp_getfpregs(thread.dbp.os.pr, C.uint(thread.ID), (*C.prfpregset_t)(unsafe.Pointer(&fpregs))); rc == -1 {
+			err = err1
+		}
+	})
+	if err != nil {
+		err = fmt.Errorf("could not get floating point registers: %w", err)
+	} else {
+		regs = fpregs.Decode()
+	}
+	return
+}

--- a/pkg/proc/native/support_sentinel.go
+++ b/pkg/proc/native/support_sentinel.go
@@ -1,5 +1,5 @@
 // This file is used to detect build on unsupported GOOS/GOARCH combinations.
 
-//+build !linux,!darwin,!windows,!freebsd linux,!amd64,!arm64,!386 darwin,!amd64,!arm64 windows,!amd64 freebsd,!amd64
+//+build !linux,!darwin,!windows,!freebsd,!solaris linux,!amd64,!arm64,!386 darwin,!amd64 windows,!amd64 freebsd,!amd64 solaris,!amd64
 
 package your_operating_system_and_architecture_combination_is_not_supported_by_delve

--- a/pkg/proc/native/threads_solaris.go
+++ b/pkg/proc/native/threads_solaris.go
@@ -1,0 +1,132 @@
+package native
+
+// #include <libproc.h>
+import "C"
+import (
+	"unsafe"
+
+	sys "golang.org/x/sys/unix"
+
+	"github.com/go-delve/delve/pkg/proc"
+	"github.com/go-delve/delve/pkg/proc/solutil"
+)
+
+type waitStatus sys.WaitStatus
+
+// osSpecificDetails hold Solaris specific process details.
+type osSpecificDetails struct {
+	lwp *C.struct_ps_lwphandle
+}
+
+func (t *nativeThread) stop() (err error) {
+	t.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Ldstop(t.os.lwp); rc == -1 {
+			err = err1
+		}
+	})
+	return err
+}
+
+func (t *nativeThread) resume() (err error) {
+	t.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Lsetrun(t.os.lwp, 0, C.PRCSIG|C.PRCFAULT); rc == -1 {
+			err = err1
+		}
+	})
+	return err
+}
+
+func (t *nativeThread) singleStep() (err error) {
+	t.dbp.execPtraceFunc(func() {
+		// We call Lwait on the thread even though it should already
+		// be stopped because it causes the status which is cached
+		// in the handle to get updated. If we don't do this Lsetrun
+		// can return EBUSY because it thinks it's already running.
+		if rc, err1 := C.Lwait(t.os.lwp, 0); rc == -1 {
+			err = err1
+		} else if rc, err1 = C.Lsetrun(t.os.lwp, 0, C.PRSTEP|C.PRCFAULT); rc == -1 {
+			err = err1
+		}
+	})
+	if err != nil {
+		return err
+	}
+	for {
+		th, err := t.dbp.trapWait(-1)
+		if err != nil {
+			return err
+		}
+		if th.ID == t.ID {
+			break
+		}
+		if err = th.resume(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *nativeThread) restoreRegisters(savedRegs proc.Registers) error {
+	currentRegs, err := registers(t)
+	if err != nil {
+		return err
+	}
+	cr := currentRegs.(*solutil.AMD64Registers)
+	sr := savedRegs.(*solutil.AMD64Registers)
+	sr.Regs.FsBase = cr.Regs.FsBase
+	sr.Regs.GsBase = cr.Regs.GsBase
+	t.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Plwp_setregs(t.dbp.os.pr, C.uint(t.ID), (*C.long)(unsafe.Pointer(&sr.Regs))); rc == -1 {
+			err = err1
+		} else if rc, err1 = C.Plwp_setfpregs(t.dbp.os.pr, C.uint(t.ID), (*C.prfpregset_t)(unsafe.Pointer(sr.Fpregset))); rc == -1 {
+			err = err1
+		}
+	})
+	return err
+}
+
+func (t *nativeThread) WriteMemory(addr uint64, data []byte) (n int, err error) {
+	if t.dbp.exited {
+		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	}
+	if len(data) == 0 {
+		return 0, nil
+	}
+	t.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Pwrite(t.dbp.os.pr, unsafe.Pointer(&data[0]), C.ulong(len(data)), C.uintptr_t(addr)); rc == -1 {
+			err = err1
+		} else {
+			n = int(rc)
+		}
+	})
+	return n, err
+}
+
+func (t *nativeThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
+	if t.dbp.exited {
+		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	}
+	if len(data) == 0 {
+		return 0, nil
+	}
+	t.dbp.execPtraceFunc(func() {
+		if rc, err1 := C.Pread(t.dbp.os.pr, unsafe.Pointer(&data[0]), C.ulong(len(data)), C.uintptr_t(addr)); rc == -1 {
+			err = err1
+		} else {
+			n = int(rc)
+		}
+	})
+	return n, err
+}
+
+func (t *nativeThread) writeHardwareBreakpoint(addr uint64, wtype proc.WatchType, idx uint8) error {
+	return proc.ErrHWBreakUnsupported
+}
+
+func (t *nativeThread) clearHardwareBreakpoint(addr uint64, wtype proc.WatchType, idx uint8) error {
+	return proc.ErrHWBreakUnsupported
+}
+
+func (t *nativeThread) findHardwareBreakpoint() (*proc.Breakpoint, error) {
+	return nil, nil
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -584,6 +584,8 @@ func TestNextGeneral(t *testing.T) {
 
 func TestNextConcurrent(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	testcases := []nextTest{
 		{8, 9},
 		{9, 10},
@@ -620,6 +622,8 @@ func TestNextConcurrent(t *testing.T) {
 
 func TestNextConcurrentVariant2(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	// Just like TestNextConcurrent but instead of removing the initial breakpoint we check that when it happens is for other goroutines
 	testcases := []nextTest{
 		{8, 9},
@@ -1440,6 +1444,8 @@ func TestIssue325(t *testing.T) {
 
 func TestBreakpointCounts(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	protest.AllowRecording(t)
 	withTestProcess("bpcountstest", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 12)
@@ -1646,6 +1652,8 @@ func BenchmarkLocalVariables(b *testing.B) {
 
 func TestCondBreakpoint(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	protest.AllowRecording(t)
 	withTestProcess("parallel_next", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 9)
@@ -1668,6 +1676,8 @@ func TestCondBreakpoint(t *testing.T) {
 
 func TestCondBreakpointError(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	protest.AllowRecording(t)
 	withTestProcess("parallel_next", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 9)
@@ -2030,6 +2040,8 @@ func TestIssue462(t *testing.T) {
 
 func TestNextParked(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	protest.AllowRecording(t)
 	withTestProcess("parallel_next", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFunctionBreakpoint(p, t, "main.sayhi")
@@ -2081,6 +2093,8 @@ func TestNextParked(t *testing.T) {
 
 func TestStepParked(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	protest.AllowRecording(t)
 	withTestProcess("parallel_next", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFunctionBreakpoint(p, t, "main.sayhi")
@@ -2410,6 +2424,8 @@ func TestStepOut(t *testing.T) {
 
 func TestStepConcurrentDirect(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	protest.AllowRecording(t)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 37)
@@ -2474,6 +2490,8 @@ func TestStepConcurrentDirect(t *testing.T) {
 
 func TestStepConcurrentPtr(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	protest.AllowRecording(t)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 24)
@@ -3506,7 +3524,11 @@ func TestIssue1034(t *testing.T) {
 	withTestProcess("cgostacktest/", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")
 		assertNoError(p.Continue(), t, "Continue()")
-		frames, err := p.SelectedGoroutine().Stacktrace(10, 0)
+		g := p.SelectedGoroutine()
+		if g == nil {
+			t.Fatal("selected goroutine is nil")
+		}
+		frames, err := g.Stacktrace(10, 0)
 		assertNoError(err, t, "Stacktrace")
 		scope := proc.FrameToScope(p, p.Memory(), nil, frames[2:]...)
 		args, _ := scope.FunctionArguments(normalLoadConfig)
@@ -4495,6 +4517,8 @@ func testCallConcurrentCheckReturns(p *proc.Target, t *testing.T, gid1, gid2 int
 
 func TestCallConcurrent(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 24)
@@ -4980,6 +5004,8 @@ func TestRequestManualStopWhileStopped(t *testing.T) {
 func TestStepOutPreservesGoroutine(t *testing.T) {
 	// Checks that StepOut preserves the currently selected goroutine.
 	skipOn(t, "broken", "freebsd")
+	skipOn(t, "broken", "solaris")
+	skipOn(t, "broken", "illumos")
 	rand.Seed(time.Now().Unix())
 	withTestProcess("issue2113", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
@@ -5082,7 +5108,7 @@ func TestIssue2319(t *testing.T) {
 }
 
 func TestDump(t *testing.T) {
-	if runtime.GOOS == "freebsd" || (runtime.GOOS == "darwin" && testBackend == "native") {
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" || (runtime.GOOS == "darwin" && testBackend == "native") {
 		t.Skip("not supported")
 	}
 
@@ -5246,6 +5272,8 @@ func TestCompositeMemoryWrite(t *testing.T) {
 		t.Skip("only valid on amd64")
 	}
 	skipOn(t, "not implemented", "freebsd")
+	skipOn(t, "not implemented", "solaris")
+	skipOn(t, "not implemented", "illumos")
 	withTestProcess("fputest/", t, func(p *proc.Target, fixture protest.Fixture) {
 		getregs := func() (pc, rax, xmm1 uint64) {
 			regs, err := p.CurrentThread().Registers()
@@ -5334,6 +5362,8 @@ func TestVariablesWithExternalLinking(t *testing.T) {
 func TestWatchpointsBasic(t *testing.T) {
 	skipOn(t, "not implemented", "windows")
 	skipOn(t, "not implemented", "freebsd")
+	skipOn(t, "not implemented", "solaris")
+	skipOn(t, "not implemented", "illumos")
 	skipOn(t, "not implemented", "darwin")
 	skipOn(t, "not implemented", "386")
 	skipOn(t, "not implemented", "arm64")
@@ -5380,6 +5410,8 @@ func TestWatchpointsBasic(t *testing.T) {
 func TestWatchpointCounts(t *testing.T) {
 	skipOn(t, "not implemented", "windows")
 	skipOn(t, "not implemented", "freebsd")
+	skipOn(t, "not implemented", "solaris")
+	skipOn(t, "not implemented", "illumos")
 	skipOn(t, "not implemented", "darwin")
 	skipOn(t, "not implemented", "386")
 	skipOn(t, "not implemented", "arm64")
@@ -5498,6 +5530,8 @@ func TestDwrapStartLocation(t *testing.T) {
 func TestWatchpointStack(t *testing.T) {
 	skipOn(t, "not implemented", "windows")
 	skipOn(t, "not implemented", "freebsd")
+	skipOn(t, "not implemented", "solaris")
+	skipOn(t, "not implemented", "illumos")
 	skipOn(t, "not implemented", "darwin")
 	skipOn(t, "not implemented", "386")
 	skipOn(t, "not implemented", "arm64")

--- a/pkg/proc/solutil/regs.go
+++ b/pkg/proc/solutil/regs.go
@@ -1,0 +1,201 @@
+package solutil
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/go-delve/delve/pkg/proc"
+)
+
+type AMD64Registers struct {
+	Regs     AMD64Regset
+	Fpregs   []proc.Register
+	Fpregset *AMD64Fpregset
+
+	loadFpRegs func(*AMD64Registers) error
+}
+
+func NewAMD64Registers(Regs AMD64Regset, loadFpRegs func(*AMD64Registers) error) *AMD64Registers {
+	return &AMD64Registers{Regs: Regs, loadFpRegs: loadFpRegs}
+}
+
+// AMD64Regset represents CPU registers on an AMD64 processor.
+// This order is determined by the defines in /usr/include/sys/regset.h.
+type AMD64Regset struct {
+	R15    int64
+	R14    int64
+	R13    int64
+	R12    int64
+	R11    int64
+	R10    int64
+	R9     int64
+	R8     int64
+	Rdi    int64
+	Rsi    int64
+	Rbp    int64
+	Rbx    int64
+	Rdx    int64
+	Rcx    int64
+	Rax    int64
+	Trapno int64
+	Err    int64
+	Rip    int64
+	Cs     int64
+	Rflags int64
+	Rsp    int64
+	Ss     int64
+	Fs     int64
+	Gs     int64
+	Es     int64
+	Ds     int64
+	FsBase int64
+	GsBase int64
+}
+
+// AMD64FpRegset tracks fpregset_t in /usr/include/sys/mcontext.h.
+type AMD64Fpregset struct {
+	Cw        uint16
+	Sw        uint16
+	Fctw      uint8
+	fxRsvd    uint8
+	Fop       uint16
+	Rip       uint64
+	Rdp       uint64
+	Mxcsr     uint32
+	MxcsrMask uint32
+	St        [32]uint32
+	Xmm       [256]byte
+	fxIgn2    [24]uint32
+	Status    uint32
+	Xstatus   uint32
+}
+
+// Decode decodes fpregset_t to a list of name/value pairs of registers.
+func (r *AMD64Fpregset) Decode() []proc.Register {
+	var regs []proc.Register
+	// x87 registers
+	regs = proc.AppendUint64Register(regs, "CW", uint64(r.Cw))
+	regs = proc.AppendUint64Register(regs, "SW", uint64(r.Sw))
+	regs = proc.AppendUint64Register(regs, "FCTW", uint64(r.Fctw))
+	regs = proc.AppendUint64Register(regs, "FOP", uint64(r.Fop))
+	regs = proc.AppendUint64Register(regs, "FIP", r.Rip)
+	regs = proc.AppendUint64Register(regs, "FDP", r.Rdp)
+
+	for i := 0; i < len(r.St); i += 4 {
+		var buf bytes.Buffer
+		binary.Write(&buf, binary.LittleEndian, uint64(r.St[i+1])<<32|uint64(r.St[i]))
+		binary.Write(&buf, binary.LittleEndian, uint16(r.St[i+2]))
+		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("ST(%d)", i/4), buf.Bytes())
+	}
+
+	// SSE registers
+	regs = proc.AppendUint64Register(regs, "MXCSR", uint64(r.Mxcsr))
+	regs = proc.AppendUint64Register(regs, "MXCSR_MASK", uint64(r.MxcsrMask))
+
+	for i := 0; i < len(r.Xmm); i += 16 {
+		n := i / 16
+		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("XMM%d", n), r.Xmm[i:i+16])
+	}
+
+	return regs
+}
+
+// Slice returns the registers as a list of (name, value) pairs.
+func (r *AMD64Registers) Slice(floatingPoint bool) ([]proc.Register, error) {
+	var regs = [28]struct {
+		k string
+		v int64
+	}{
+		{"R15", r.Regs.R15},
+		{"R14", r.Regs.R14},
+		{"R13", r.Regs.R13},
+		{"R12", r.Regs.R12},
+		{"R11", r.Regs.R11},
+		{"R10", r.Regs.R10},
+		{"R9", r.Regs.R9},
+		{"R8", r.Regs.R8},
+		{"Rdi", r.Regs.Rdi},
+		{"Rsi", r.Regs.Rsi},
+		{"Rbp", r.Regs.Rbp},
+		{"Rbx", r.Regs.Rbx},
+		{"Rdx", r.Regs.Rdx},
+		{"Rcx", r.Regs.Rcx},
+		{"Rax", r.Regs.Rax},
+		{"Trapno", r.Regs.Trapno},
+		{"Err", r.Regs.Err},
+		{"Rip", r.Regs.Rip},
+		{"Cs", r.Regs.Cs},
+		{"Rflags", r.Regs.Rflags},
+		{"Rsp", r.Regs.Rsp},
+		{"Ss", r.Regs.Ss},
+		{"Fs", r.Regs.Fs},
+		{"Gs", r.Regs.Gs},
+		{"Es", r.Regs.Es},
+		{"Ds", r.Regs.Ds},
+		{"Fs_base", r.Regs.FsBase},
+		{"Gs_base", r.Regs.GsBase},
+	}
+	out := make([]proc.Register, 0, len(regs))
+	for _, reg := range regs {
+		// Solaris defines the registers as signed, but Linux defines
+		// them as unsigned.  Of course, a register doesn't really have
+		// a concept of signedness.  Cast to what Delve expects.
+		out = proc.AppendUint64Register(out, reg.k, uint64(reg.v))
+	}
+	var floatLoadError error
+	if floatingPoint {
+		if r.loadFpRegs != nil {
+			floatLoadError = r.loadFpRegs(r)
+			r.loadFpRegs = nil
+		}
+		out = append(out, r.Fpregs...)
+	}
+	return out, floatLoadError
+}
+
+// PC returns the current program counter
+// i.e. the RIP CPU register.
+func (r *AMD64Registers) PC() uint64 {
+	return uint64(r.Regs.Rip)
+}
+
+// SP returns the stack pointer location,
+// i.e. the RSP register.
+func (r *AMD64Registers) SP() uint64 {
+	return uint64(r.Regs.Rsp)
+}
+
+func (r *AMD64Registers) BP() uint64 {
+	return uint64(r.Regs.Rbp)
+}
+
+// TLS returns the value of the register
+// that contains the location of the thread
+// local storage segment.
+func (r *AMD64Registers) TLS() uint64 {
+	return uint64(r.Regs.FsBase)
+}
+
+func (r *AMD64Registers) GAddr() (uint64, bool) {
+	return 0, false
+}
+
+// Copy returns a copy of these registers that is guaranteed not to change.
+func (r *AMD64Registers) Copy() (proc.Registers, error) {
+	if r.loadFpRegs != nil {
+		err := r.loadFpRegs(r)
+		r.loadFpRegs = nil
+		if err != nil {
+			return nil, err
+		}
+	}
+	var rr AMD64Registers
+	rr.Regs = r.Regs
+	rr.Fpregset = r.Fpregset
+	if r.Fpregs != nil {
+		rr.Fpregs = make([]proc.Register, len(r.Fpregs))
+		copy(rr.Fpregs, r.Fpregs)
+	}
+	return &rr, nil
+}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -469,8 +469,8 @@ func TestScopePrefix(t *testing.T) {
 }
 
 func TestOnPrefix(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
+		t.Skip("test is not valid on FreeBSD/Solaris")
 	}
 	const prefix = "\ti: "
 	test.AllowRecording(t)
@@ -525,8 +525,8 @@ func TestNoVars(t *testing.T) {
 }
 
 func TestOnPrefixLocals(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
+		t.Skip("test is not valid on FreeBSD/Solaris")
 	}
 	const prefix = "\ti: "
 	test.AllowRecording(t)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -293,7 +293,7 @@ func TestLaunchStopOnEntry(t *testing.T) {
 
 // TestAttachStopOnEntry is like TestLaunchStopOnEntry, but with attach request.
 func TestAttachStopOnEntry(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
 		t.SkipNow()
 	}
 	runTest(t, "loopprog", func(client *daptest.Client, fixture protest.Fixture) {
@@ -2923,7 +2923,7 @@ func TestLaunchSubstitutePath(t *testing.T) {
 // that does not exist and expects the substitutePath attribute
 // in the launch configuration to take care of the mapping.
 func TestAttachSubstitutePath(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
 		t.SkipNow()
 	}
 	if runtime.GOOS == "windows" {
@@ -3599,7 +3599,7 @@ func TestNextAndStep(t *testing.T) {
 }
 
 func TestNextParked(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
 		t.SkipNow()
 	}
 	runTest(t, "parallel_next", func(client *daptest.Client, fixture protest.Fixture) {
@@ -3687,7 +3687,7 @@ func testStepParkedHelper(t *testing.T, client *daptest.Client, fixture protest.
 // and checks that StepOut preserves the currently selected goroutine.
 func TestStepOutPreservesGoroutine(t *testing.T) {
 	// Checks that StepOut preserves the currently selected goroutine.
-	if runtime.GOOS == "freebsd" {
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
 		t.SkipNow()
 	}
 	rand.Seed(time.Now().Unix())
@@ -3840,8 +3840,8 @@ func TestBadAccess(t *testing.T) {
 // again will produce an error with a helpful message, and 'continue'
 // will resume the program.
 func TestNextWhileNexting(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
+		t.Skip("test is not valid on FreeBSD/Solaris")
 	}
 	// a breakpoint triggering during a 'next' operation will interrupt 'next''
 	// Unlike the test for the terminal package, we cannot be certain
@@ -4457,7 +4457,7 @@ func TestLaunchRequestWithBuildFlags(t *testing.T) {
 }
 
 func TestAttachRequest(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
 		t.SkipNow()
 	}
 	if runtime.GOOS == "windows" {

--- a/service/debugger/debugger_solaris.go
+++ b/service/debugger/debugger_solaris.go
@@ -1,0 +1,14 @@
+package debugger
+
+import (
+	"fmt"
+	sys "golang.org/x/sys/unix"
+)
+
+func attachErrorMessage(pid int, err error) error {
+	return fmt.Errorf("could not attach to pid %d: %s", pid, err)
+}
+
+func stopProcess(pid int) error {
+	return sys.Kill(pid, sys.SIGSTOP)
+}

--- a/service/debugger/debugger_test.go
+++ b/service/debugger/debugger_test.go
@@ -46,8 +46,10 @@ func TestDebugger_LaunchInvalidFormat(t *testing.T) {
 	switchOS := map[string]string{
 		"darwin":  "linux",
 		"windows": "linux",
+		"solaris": "linux",
 		"freebsd": "windows",
 		"linux":   "windows",
+		"illumos": "windows",
 	}
 	if runtime.GOARCH == "arm64" && runtime.GOOS == "linux" {
 		os.Setenv("GOARCH", "amd64")

--- a/service/debugger/debugger_unix.go
+++ b/service/debugger/debugger_unix.go
@@ -30,7 +30,7 @@ func verifyBinaryFormat(exePath string) error {
 	switch runtime.GOOS {
 	case "darwin":
 		_, err = macho.NewFile(f)
-	case "linux", "freebsd":
+	case "linux", "freebsd", "solaris", "illumos":
 		_, err = elf.NewFile(f)
 	default:
 		panic("attempting to open file Delve cannot parse")

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -975,8 +975,8 @@ func Test1NegativeStackDepthBug(t *testing.T) {
 }
 
 func Test1ClientServer_CondBreakpoint(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
+		t.Skip("test is not valid on FreeBSD/Solaris")
 	}
 	withTestClient1("parallel_next", t, func(c *rpc1.RPCClient) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sayhi", Line: 1})

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1301,8 +1301,8 @@ func TestNegativeStackDepthBug(t *testing.T) {
 }
 
 func TestClientServer_CondBreakpoint(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
+	if runtime.GOOS == "freebsd" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
+		t.Skip("test is not valid on FreeBSD/Solaris")
 	}
 	protest.AllowRecording(t)
 	withTestClient2("parallel_next", t, func(c service.Client) {
@@ -1550,7 +1550,7 @@ func TestClientServer_FpRegisters(t *testing.T) {
 		avx2 := boolvar("avx2")
 		avx512 := boolvar("avx512")
 
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == "windows" || runtime.GOOS == "solaris" || runtime.GOOS == "illumos" {
 			// not supported
 			avx2 = false
 			avx512 = false

--- a/vendor/go.starlark.net/starlark/int_generic.go
+++ b/vendor/go.starlark.net/starlark/int_generic.go
@@ -1,4 +1,4 @@
-//+build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris darwin,arm64 !amd64,!arm64,!mips64x,!ppc64x
+//+build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!openbsd,!solaris darwin,arm64 solaris,amd64 !amd64,!arm64,!mips64x,!ppc64x
 
 package starlark
 

--- a/vendor/go.starlark.net/starlark/int_posix64.go
+++ b/vendor/go.starlark.net/starlark/int_posix64.go
@@ -1,4 +1,4 @@
-//+build linux darwin dragonfly freebsd netbsd openbsd solaris
+//+build linux darwin dragonfly freebsd netbsd openbsd
 //+build amd64 arm64,!darwin mips64x ppc64x
 
 package starlark


### PR DESCRIPTION
This is my first stab at porting the delve debugger to Solaris/illumos.  This has been tested on OmniOSce LTS.

There are a few test failures which I haven't yet been able to find fixes for, though I have hacks which do allow the tests to pass (which aren't included) that may provide some idea where the problems are.  Those tests are:

<pre>
andy@omnios-lts:~/delve$ grep FAIL: test.log 
--- FAIL: TestGetG (0.15s)
--- FAIL: TestCgoStacktrace (0.58s)
--- FAIL: TestIssue1034 (0.06s)
--- FAIL: TestIssue1601 (0.43s)
--- FAIL: TestVariablesWithExternalLinking (0.58s)
--- FAIL: TestScopesAndVariablesRequests2 (0.80s)
--- FAIL: TestEvaluateRequest (0.28s)
--- FAIL: TestCgoEval (0.58s)
</pre>

Everything else passes, though I did disable a bunch of tests which are also disabled on FreeBSD.