### PR TITLE
cmd/dlv: Parse Go+BoringCrypto version

### DIFF
--- a/pkg/goversion/go_version.go
+++ b/pkg/goversion/go_version.go
@@ -37,9 +37,14 @@ func Parse(ver string) (GoVersion, bool) {
 		switch len(v) {
 		case 2:
 			r.Major, err1 = strconv.Atoi(v[0])
-			vr := strings.SplitN(v[1], "beta", 2)
-			if len(vr) == 2 {
+			var vr []string
+
+			if vr = strings.SplitN(v[1], "beta", 2); len(vr) == 2 {
 				r.Beta, err3 = strconv.Atoi(vr[1])
+			} else if vr = strings.SplitN(v[1], "b", 2); len(vr) == 2 {
+				if _, err := strconv.Atoi(vr[1]); err != nil {
+					return GoVersion{}, false
+				}
 			} else {
 				vr = strings.SplitN(v[1], "rc", 2)
 				if len(vr) == 2 {
@@ -67,7 +72,14 @@ func Parse(ver string) (GoVersion, bool) {
 
 			r.Major, err1 = strconv.Atoi(v[0])
 			r.Minor, err2 = strconv.Atoi(v[1])
-			r.Rev, err3 = strconv.Atoi(v[2])
+
+			vr := strings.SplitN(v[2], "b", 2)
+			if len(vr) == 2 {
+				r.Rev, err3 = strconv.Atoi(vr[0])
+			} else {
+				r.Rev, err3 = strconv.Atoi(v[2])
+			}
+
 			r.Proposal = ""
 			if err1 != nil || err2 != nil || err3 != nil {
 				return GoVersion{}, false

--- a/pkg/goversion/version_test.go
+++ b/pkg/goversion/version_test.go
@@ -24,6 +24,8 @@ func TestParseVersionString(t *testing.T) {
 	versionAfterOrEqual(t, "go1.5rc2", GoVersion{1, 5, -1, 0, 2, ""})
 	versionAfterOrEqual(t, "go1.6.1 (appengine-1.9.37)", GoVersion{1, 6, 1, 0, 0, ""})
 	versionAfterOrEqual(t, "go1.8.1.typealias", GoVersion{1, 6, 1, 0, 0, ""})
+	versionAfterOrEqual(t, "go1.8b1", GoVersion{1, 8, -1, 0, 0, ""})
+	versionAfterOrEqual(t, "go1.16.4b7", GoVersion{1, 16, 4, 0, 0, ""})
 	ver, ok := Parse("devel +17efbfc Tue Jul 28 17:39:19 2015 +0000 linux/amd64")
 	if !ok {
 		t.Fatalf("Could not parse devel version string")


### PR DESCRIPTION
This changes allow us to parse Go+BoringCrypto which formatted in <GoVersion>b<BoringCryptoVersion> so that we can surpress `Version of Go is too old for this version of Delve` error.

Fixes https://github.com/go-delve/delve/issues/2711