### PR TITLE
service/dap: log parsed and applied launch configs

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -819,6 +819,7 @@ func cleanExeName(name string) string {
 }
 
 func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
+	var err error
 	if s.debugger != nil {
 		s.sendShowUserErrorResponse(request.Request, FailedToLaunch,
 			"Failed to launch", "debugger already started - use remote attach to connect to a server with an active debug session")
@@ -831,83 +832,79 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 			FailedToLaunch, "Failed to launch", fmt.Sprintf("invalid debug configuration - %v", err))
 		return
 	}
+	s.config.log.Debug("parsed launch config: ", prettyPrint(args))
 
-	mode := args.Mode
-	if mode == "" {
-		mode = "debug"
+	if args.Mode == "" {
+		args.Mode = "debug"
 	}
-	if !isValidLaunchMode(mode) {
+	if !isValidLaunchMode(args.Mode) {
 		s.sendShowUserErrorResponse(request.Request, FailedToLaunch, "Failed to launch",
-			fmt.Sprintf("invalid debug configuration - unsupported 'mode' attribute %q", mode))
+			fmt.Sprintf("invalid debug configuration - unsupported 'mode' attribute %q", args.Mode))
 		return
 	}
 
-	program := args.Program
-	if program == "" && mode != "replay" { // Only fail on modes requiring a program
+	if args.Program == "" && args.Mode != "replay" { // Only fail on modes requiring a program
 		s.sendShowUserErrorResponse(request.Request, FailedToLaunch, "Failed to launch",
 			"The program attribute is missing in debug configuration.")
 		return
 	}
-
-	if backend := args.Backend; backend != "" {
-		s.config.Debugger.Backend = backend
-	} else {
-		s.config.Debugger.Backend = "default"
+	args.Program, err = filepath.Abs(args.Program)
+	if err != nil {
+		s.sendShowUserErrorResponse(request.Request, FailedToLaunch, "Failed to launch", err.Error())
+		return
+	}
+	if args.Backend == "" {
+		args.Backend = "default"
 	}
 
-	if mode == "replay" {
-		traceDirPath := args.TraceDirPath
+	if args.Mode == "replay" {
 		// Validate trace directory
-		if traceDirPath == "" {
+		if args.TraceDirPath == "" {
 			s.sendShowUserErrorResponse(request.Request, FailedToLaunch, "Failed to launch",
 				"The 'traceDirPath' attribute is missing in debug configuration.")
 			return
 		}
 
 		// Assign the rr trace directory path to debugger configuration
-		s.config.Debugger.CoreFile = traceDirPath
-		s.config.Debugger.Backend = "rr"
+		s.config.Debugger.CoreFile = args.TraceDirPath
+		args.Backend = "rr"
 	}
-
-	if mode == "core" {
-		coreFilePath := args.CoreFilePath
+	if args.Mode == "core" {
 		// Validate core dump path
-		if coreFilePath == "" {
+		if args.CoreFilePath == "" {
 			s.sendShowUserErrorResponse(request.Request, FailedToLaunch, "Failed to launch",
 				"The 'coreFilePath' attribute is missing in debug configuration.")
 			return
 		}
 		// Assign the non-empty core file path to debugger configuration. This will
 		// trigger a native core file replay instead of an rr trace replay
-		s.config.Debugger.CoreFile = coreFilePath
-		s.config.Debugger.Backend = "core"
+		s.config.Debugger.CoreFile = args.CoreFilePath
+		args.Backend = "core"
 	}
 
-	s.config.log.Debugf("debug backend is '%s'", s.config.Debugger.Backend)
+	s.config.Debugger.Backend = args.Backend
 
-	// Prepare the debug executable filename, build flags and build it
-	if mode == "debug" || mode == "test" {
-		output := args.Output
-		if output == "" {
-			output = defaultDebugBinary
+	// Prepare the debug executable filename, building it if necessary
+	debugbinary := args.Program
+	if args.Mode == "debug" || args.Mode == "test" {
+		if args.Output == "" {
+			args.Output = defaultDebugBinary
 		}
-		output = cleanExeName(output)
-		debugbinary, err := filepath.Abs(output)
+		args.Output, err = filepath.Abs(cleanExeName(args.Output))
 		if err != nil {
 			s.sendShowUserErrorResponse(request.Request, FailedToLaunch, "Failed to launch", err.Error())
 			return
 		}
-		buildFlags := args.BuildFlags
 
 		var cmd string
 		var out []byte
 		wd, _ := os.Getwd()
-		s.config.log.Debugf("building program '%s' in '%s' with flags '%v'", program, wd, buildFlags)
-		switch mode {
+		s.config.log.Debugf("building program '%s' in '%s' with flags '%v'", args.Program, wd, args.BuildFlags)
+		switch args.Mode {
 		case "debug":
-			cmd, out, err = gobuild.GoBuildCombinedOutput(debugbinary, []string{program}, buildFlags)
+			cmd, out, err = gobuild.GoBuildCombinedOutput(args.Output, []string{args.Program}, args.BuildFlags)
 		case "test":
-			cmd, out, err = gobuild.GoTestBuildCombinedOutput(debugbinary, []string{program}, buildFlags)
+			cmd, out, err = gobuild.GoTestBuildCombinedOutput(args.Output, []string{args.Program}, args.BuildFlags)
 		}
 		if err != nil {
 			s.send(&dap.OutputEvent{
@@ -922,10 +919,12 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 				"Build error: Check the debug console for details.")
 			return
 		}
-		program = debugbinary
+		debugbinary = args.Output
 		s.mu.Lock()
-		s.binaryToRemove = debugbinary
+		s.binaryToRemove = args.Output
 		s.mu.Unlock()
+	} else {
+		args.Output = "" // optional arg that can be ignored: no program to build
 	}
 
 	if err := s.setLaunchAttachArgs(args.LaunchAttachCommonConfig); err != nil {
@@ -933,16 +932,16 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 		return
 	}
 
-	s.config.ProcessArgs = append([]string{program}, args.Args...)
-	s.config.Debugger.WorkingDir = filepath.Dir(program)
-	if args.Cwd != "" {
-		s.config.Debugger.WorkingDir = args.Cwd
+	s.config.ProcessArgs = append([]string{debugbinary}, args.Args...)
+	if args.Cwd == "" {
+		args.Cwd = filepath.Dir(debugbinary)
 	}
+	s.config.Debugger.WorkingDir = args.Cwd
+	s.config.log.Debugf("launching binary '%s' with config: %s", debugbinary, prettyPrint(args))
 
-	s.config.log.Debugf("running binary '%s' in '%s'", program, s.config.Debugger.WorkingDir)
 	if args.NoDebug {
 		s.mu.Lock()
-		cmd, err := s.newNoDebugProcess(program, args.Args, s.config.Debugger.WorkingDir)
+		cmd, err := s.newNoDebugProcess(debugbinary, args.Args, s.config.Debugger.WorkingDir)
 		s.mu.Unlock()
 		if err != nil {
 			s.sendShowUserErrorResponse(request.Request, FailedToLaunch, "Failed to launch", err.Error())
@@ -971,7 +970,6 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 		return
 	}
 
-	var err error
 	func() {
 		s.mu.Lock()
 		defer s.mu.Unlock() // Make sure to unlock in case of panic that will become internal error
@@ -1558,11 +1556,11 @@ func (s *Session) onAttachRequest(request *dap.AttachRequest) {
 		s.sendShowUserErrorResponse(request.Request, FailedToAttach, "Failed to attach", fmt.Sprintf("invalid debug configuration - %v", err))
 		return
 	}
+	s.config.log.Debug("parsed launch config: ", prettyPrint(args))
 
-	mode := args.Mode
-	switch mode {
+	switch args.Mode {
 	case "":
-		mode = "local"
+		args.Mode = "local"
 		fallthrough
 	case "local":
 		if s.debugger != nil {
@@ -1577,12 +1575,11 @@ func (s *Session) onAttachRequest(request *dap.AttachRequest) {
 			return
 		}
 		s.config.Debugger.AttachPid = args.ProcessID
-		s.config.log.Debugf("attaching to pid %d", args.ProcessID)
-		if backend := args.Backend; backend != "" {
-			s.config.Debugger.Backend = backend
-		} else {
-			s.config.Debugger.Backend = "default"
+		if args.Backend == "" {
+			args.Backend = "default"
 		}
+		s.config.Debugger.Backend = args.Backend
+		s.config.log.Debugf("attaching to pid %d", args.ProcessID)
 		var err error
 		func() {
 			s.mu.Lock()

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -203,3 +203,11 @@ func unmarshalLaunchAttachArgs(input json.RawMessage, config interface{}) error 
 	}
 	return nil
 }
+
+func prettyPrint(config interface{}) string {
+	pretty, err := json.MarshalIndent(config, "", "\t")
+	if err != nil {
+		return fmt.Sprintf("%#v", config)
+	}
+	return string(pretty)
+}


### PR DESCRIPTION
Launch/attach requests contain way more fields than the dap server actually cares about, including sensitive information that users like to scrub out of the logs (e.g. golang/vscode-go#1701). Logging the fields that we use will help both users and maintainers make sense of what defaults are used, how relative paths are expanded, and so on.