### PR TITLE
service/dap: rename delveCwd to dlvCwd and clarify comments

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4665,15 +4665,15 @@ func TestLaunchTestRequest(t *testing.T) {
 		},
 		wantWD: absolutePkgDir,
 	}, {
-		name: "delveCWD",
+		name: "dlvCwd",
 		launchArgs: map[string]interface{}{
-			"mode": "test", "program": absolutePkgDir, "delveCWD": ".",
+			"mode": "test", "program": absolutePkgDir, "dlvCwd": ".",
 		},
 		wantWD: absolutePkgDir,
 	}, {
-		name: "delveCWD2",
+		name: "dlvCwd2",
 		launchArgs: map[string]interface{}{
-			"mode": "test", "program": ".", "delveCWD": absolutePkgDir,
+			"mode": "test", "program": ".", "dlvCwd": absolutePkgDir,
 		},
 		wantWD: absolutePkgDir,
 	}, {
@@ -4686,19 +4686,19 @@ func TestLaunchTestRequest(t *testing.T) {
 		name:  "dlv runs outside of module",
 		dlvWD: os.TempDir(),
 		launchArgs: map[string]interface{}{
-			"mode": "test", "program": absolutePkgDir, "delveCWD": absoluteFixturesDir,
+			"mode": "test", "program": absolutePkgDir, "dlvCwd": absoluteFixturesDir,
 		},
 		wantWD: absolutePkgDir,
 	}, {
-		name:  "dlv builds in delveCWD but runs in cwd",
+		name:  "dlv builds in dlvCwd but runs in cwd",
 		dlvWD: fixtures,
 		launchArgs: map[string]interface{}{
-			"mode": "test", "program": absolutePkgDir, "delveCWD": absolutePkgDir, "cwd": "..", // relative to delveCWD.
+			"mode": "test", "program": absolutePkgDir, "dlvCwd": absolutePkgDir, "cwd": "..", // relative to dlvCwd.
 		},
 		wantWD: absoluteFixturesDir,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			// Some test cases with delveCWD or dlvWD change process working directory.
+			// Some test cases with dlvCwd or dlvWD change process working directory.
 			defer os.Chdir(orgWD)
 			if tc.dlvWD != "" {
 				os.Chdir(tc.dlvWD)

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -52,7 +52,7 @@ var (
 	}
 )
 
-// LaunchConfig is the collection of launch request attributes recognized by delve DAP implementation.
+// LaunchConfig is the collection of launch request attributes recognized by DAP implementation.
 type LaunchConfig struct {
 	// Acceptable values are:
 	//   "debug": compiles your program with optimizations disabled, starts and attaches to it.
@@ -68,7 +68,7 @@ type LaunchConfig struct {
 	// when in `debug` or `test` mode, and to the pre-built binary file
 	// to debug in `exec` mode.
 	// If it is not an absolute path, it will be interpreted as a path
-	// relative to Delve's working directory.
+	// relative to dlv's working directory.
 	// Required when mode is `debug`, `test`, `exec`, and `core`.
 	Program string `json:"program,omitempty"`
 
@@ -79,27 +79,27 @@ type LaunchConfig struct {
 
 	// Working directory of the program being debugged.
 	// If a relative path is provided, it will be interpreted as
-	// a relative path to the delve's working directory. This is
-	// similar to delve's `--wd` flag.
+	// a relative path to dlv's working directory. This is
+	// similar to dlv's `--wd` flag.
 	//
-	// If not specified or empty, delve's working directory is
-	// used by default. But for `test` mode, delve tries to find
+	// If not specified or empty, dlv's working directory is
+	// used by default. But for `test` mode, dlv tries to find
 	// the test's package source directory and run tests from there.
 	// This matches the behavior of `dlv test` and `go test`.
 	Cwd string `json:"cwd,omitempty"`
 
 	// Build flags, to be passed to the Go compiler.
 	// Relative paths used in BuildFlags will be interpreted as paths
-	// relative to Delve's current working directory.
+	// relative to dlv's current working directory.
 	//
-	// It is like delve's `--build-flags`. For example,
+	// It is like dlv's `--build-flags`. For example,
 	//
 	//    "buildFlags": "-tags=integration -mod=vendor -cover -v"
 	BuildFlags string `json:"buildFlags,omitempty"`
 
 	// Output path for the binary of the debugee.
 	// Relative path is interpreted as the path relative to
-	// the delve's current working directory.
+	// the dlv's current working directory.
 	// This is deleted after the debug session ends.
 	Output string `json:"output,omitempty"`
 
@@ -107,7 +107,7 @@ type LaunchConfig struct {
 	NoDebug bool `json:"noDebug,omitempty"`
 
 	// TraceDirPath is the trace directory path for replay mode.
-	// Relative path is interpreted as a path relative to Delve's
+	// Relative path is interpreted as a path relative to dlv's
 	// current working directory.
 	// This is required for "replay" mode but unused in other modes.
 	TraceDirPath string `json:"traceDirPath,omitempty"`
@@ -117,19 +117,18 @@ type LaunchConfig struct {
 	// This is required for "core" mode but unused in other modes.
 	CoreFilePath string `json:"coreFilePath,omitempty"`
 
-	// DelveCwd is the working directory of Delve.
-	// If specified, the delve DAP server will change its working
+	// DlvCwd is the new working directory for dlv server.
+	// If specified, the server will change its working
 	// directory to the specified directory using os.Chdir.
-	// Any relative paths used in most of other attributes are
-	// interpreted as paths relative to Delve's working directory
-	// unless explicitely stated otherwise. When Delve needs to
-	// build the program (in debug/test modes), Delve runs the
-	// go command from the Delve's working directory.
+	// Any other launch attributes with relative paths interpreted
+	// using dlv's working directory will use this new directory.
+	// When dlv needs to build the program (in debug/test modes),
+	// it will run the go command from this directory as well.
 	//
-	// If a relative path is provided as DelveCwd, it will be
-	// interpreted as a path relative to Delve's current working
+	// If a relative path is provided as DlvCwd, it will be
+	// interpreted as a path relative to dlv's current working
 	// directory.
-	DelveCwd string `json:"delveCwd,omitempty"`
+	DlvCwd string `json:"dlvCwd,omitempty"`
 
 	LaunchAttachCommonConfig
 }
@@ -139,11 +138,11 @@ type LaunchAttachCommonConfig struct {
 	// Automatically stop program after launch or attach.
 	StopOnEntry bool `json:"stopOnEntry,omitempty"`
 
-	// Backend used by delve. See `dlv backend` for allowed values.
+	// Backend used for debugging. See `dlv backend` for allowed values.
 	// Default is "default".
 	Backend string `json:"backend,omitempty"`
 
-	// Maximum depth of stack trace collected from Delve.
+	// Maximum depth of stack trace to return.
 	// Default is 50.
 	StackTraceDepth int `json:"stackTraceDepth,omitempty"`
 
@@ -185,7 +184,7 @@ func (m *SubstitutePath) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// AttachConfig is the collection of attach request attributes recognized by delve DAP implementation.
+// AttachConfig is the collection of attach request attributes recognized by DAP implementation.
 type AttachConfig struct {
 	// Acceptable values are:
 	//   "local": attaches to the local process with the given ProcessID.


### PR DESCRIPTION
Let's use `dlvCwd` to match the tool's name as well as other launch attributes like `dlvFlags` or `dlvLoadConfig`.