### PR TITLE
proc/gdbserial: support call injection with rr backend

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -278,6 +278,9 @@ func (dbp *process) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProb
 	panic("not implemented")
 }
 
+// StartCallInjection notifies the backend that we are about to inject a function call.
+func (p *process) StartCallInjection() (func(), error) { return func() {}, nil }
+
 // ReadMemory will return memory from the core file at the specified location and put the
 // read memory into `data`, returning the length read, and returning an error if
 // the length read is shorter than the length of the `data` buffer.

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -154,6 +154,7 @@ func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string)
 
 	p := newProcess(rrcmd.Process)
 	p.tracedir = tracedir
+	p.conn.useXcmd = true // 'rr' does not support the 'M' command which is what we would usually use to write memory, this is only important during function calls, in any other situation writing memory will fail anyway.
 	if deleteOnDetach {
 		p.onDetach = func() {
 			safeRemoveAll(p.tracedir)

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -55,6 +55,9 @@ type ProcessInternal interface {
 	MemoryMap() ([]MemoryMapEntry, error)
 
 	GetBufferedTracepoints() []ebpf.RawUProbeParams
+
+	// StartCallInjection notifies the backend that we are about to inject a function call.
+	StartCallInjection() (func(), error)
 }
 
 // RecordingManipulation is an interface for manipulating process recordings.

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -106,6 +106,9 @@ func (dbp *nativeProcess) Checkpoints() ([]proc.Checkpoint, error) { return nil,
 // only supported in recorded traces.
 func (dbp *nativeProcess) ClearCheckpoint(int) error { return proc.ErrNotRecorded }
 
+// StartCallInjection notifies the backend that we are about to inject a function call.
+func (dbp *nativeProcess) StartCallInjection() (func(), error) { return func() {}, nil }
+
 // Detach from the process being debugged, optionally killing it.
 func (dbp *nativeProcess) Detach(kill bool) (err error) {
 	if dbp.exited {

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -246,9 +246,6 @@ func (t *Target) Valid() (bool, error) {
 // Currently only non-recorded processes running on AMD64 support
 // function calls.
 func (t *Target) SupportsFunctionCalls() bool {
-	if ok, _ := t.Process.Recorded(); ok {
-		return false
-	}
 	return t.Process.BinInfo().Arch.Name == "amd64"
 }
 

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -125,10 +125,6 @@ func (dbp *Target) Continue() error {
 		switch {
 		case curbp.Breakpoint == nil:
 			// runtime.Breakpoint, manual stop or debugCallV1-related stop
-			recorded, _ := dbp.Recorded()
-			if recorded {
-				return conditionErrors(threads)
-			}
 
 			loc, err := curthread.Location()
 			if err != nil || loc.Fn == nil {
@@ -139,6 +135,9 @@ func (dbp *Target) Continue() error {
 
 			switch {
 			case loc.Fn.Name == "runtime.breakpoint":
+				if recorded, _ := dbp.Recorded(); recorded {
+					return conditionErrors(threads)
+				}
 				// In linux-arm64, PtraceSingleStep seems cannot step over BRK instruction
 				// (linux-arm64 feature or kernel bug maybe).
 				if !arch.BreakInstrMovesPC() {

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -314,7 +314,7 @@ func MustSupportFunctionCalls(t *testing.T, testBackend string) {
 		t.Skip("this version of Go does not support function calls")
 	}
 
-	if testBackend == "rr" || (runtime.GOOS == "darwin" && testBackend == "native") {
+	if runtime.GOOS == "darwin" && testBackend == "native" {
 		t.Skip("this backend does not support function calls")
 	}
 

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1171,6 +1171,7 @@ type testCaseCallFunction struct {
 
 func TestCallFunction(t *testing.T) {
 	protest.MustSupportFunctionCalls(t, testBackend)
+	protest.AllowRecording(t)
 
 	var testcases = []testCaseCallFunction{
 		// Basic function call injection tests
@@ -1396,7 +1397,7 @@ func testCallFunction(t *testing.T, p *proc.Target, tc testCaseCallFunction) {
 	}
 
 	if len(retvals) != len(tc.outs) {
-		t.Fatalf("call %q: wrong number of return parameters", tc.expr)
+		t.Fatalf("call %q: wrong number of return parameters (%#v)", tc.expr, retvals)
 	}
 
 	for i := range retvals {


### PR DESCRIPTION
Normally calls can't be performed on recorded processes, becuase the
future instructions executed by the target are predetermined. The rr
debugger however has a mechanism that allows this by taking the current
state of the recording and allowing it to diverge from the recording,
temporarily.

This commit adds support for starting and ending such diversions around
function calls.

Note: this requires rr version 5.5 of later to work, see:
https://github.com/rr-debugger/rr/pull/2748
