### PR TITLE
proc/native: ignore 'pf' mappings during core dump creation

### DIFF
--- a/pkg/proc/native/dump_linux.go
+++ b/pkg/proc/native/dump_linux.go
@@ -47,6 +47,9 @@ smapsLinesLoop:
 
 		for i := range vmflags {
 			switch vmflags[i] {
+			case "pf":
+				// pure PFN range, see https://github.com/go-delve/delve/issues/2630
+				continue smapsLinesLoop
 			case "dd":
 				// "don't dump"
 				continue smapsLinesLoop


### PR DESCRIPTION
Fixes #2630
