### PR TITLE
service/dap: expect TestNextParked to finish terminated

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4290,6 +4290,7 @@ func TestNextParked(t *testing.T) {
 						}
 					}
 				},
+				disconnect: true,
 				terminated: true,
 			}})
 	})


### PR DESCRIPTION
Updates TestNextParked to always run until program terminates.

Updates #2762 