### PR TITLE
proc/native: disable watchpoints on Windows

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -20,6 +20,7 @@ Tests skipped by each supported backend:
 	* 1 broken - cgo stacktraces
 * pie skipped = 2
 	* 2 upstream issue - https://github.com/golang/go/issues/29322
-* windows skipped = 2
+* windows skipped = 5
 	* 1 broken
+	* 3 see https://github.com/go-delve/delve/issues/2768
 	* 1 upstream issue

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -11,6 +11,8 @@ import (
 	"github.com/go-delve/delve/pkg/proc/winutil"
 )
 
+const enableHardwareBreakpoints = false // see https://github.com/go-delve/delve/issues/2768
+
 // waitStatus is a synonym for the platform-specific WaitStatus
 type waitStatus sys.WaitStatus
 
@@ -159,6 +161,10 @@ func (t *nativeThread) restoreRegisters(savedRegs proc.Registers) error {
 }
 
 func (t *nativeThread) withDebugRegisters(f func(*amd64util.DebugRegisters) error) error {
+	if !enableHardwareBreakpoints {
+		return errors.New("hardware breakpoints not supported")
+	}
+
 	context := winutil.NewCONTEXT()
 	context.ContextFlags = _CONTEXT_DEBUG_REGISTERS
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -5378,6 +5378,7 @@ func TestVariablesWithExternalLinking(t *testing.T) {
 func TestWatchpointsBasic(t *testing.T) {
 	skipOn(t, "not implemented", "freebsd")
 	skipOn(t, "not implemented", "386")
+	skipOn(t, "see https://github.com/go-delve/delve/issues/2768", "windows")
 	protest.AllowRecording(t)
 
 	position1 := 19
@@ -5436,6 +5437,7 @@ func TestWatchpointsBasic(t *testing.T) {
 func TestWatchpointCounts(t *testing.T) {
 	skipOn(t, "not implemented", "freebsd")
 	skipOn(t, "not implemented", "386")
+	skipOn(t, "see https://github.com/go-delve/delve/issues/2768", "windows")
 	protest.AllowRecording(t)
 
 	withTestProcess("databpcountstest", t, func(p *proc.Target, fixture protest.Fixture) {
@@ -5550,6 +5552,7 @@ func TestDwrapStartLocation(t *testing.T) {
 func TestWatchpointStack(t *testing.T) {
 	skipOn(t, "not implemented", "freebsd")
 	skipOn(t, "not implemented", "386")
+	skipOn(t, "see https://github.com/go-delve/delve/issues/2768", "windows")
 	protest.AllowRecording(t)
 
 	position1 := 17


### PR DESCRIPTION
There are persistent issues with watchpoints on Windows, it is not
clear whether it's a problem with the VM running the tests or if there
is a real bug in our implementation of hardware breakpoints on Windows.

Until the cause can be determined watchpoints on Windows will be
disabled.

Updates #2768
