### PR TITLE
proc/gdbserial: workaround for debugserver register set bug

### DIFF
--- a/_fixtures/setymmreg/main.go
+++ b/_fixtures/setymmreg/main.go
@@ -1,0 +1,7 @@
+package main
+
+func asmFunc()
+
+func main() {
+	asmFunc()
+}

--- a/_fixtures/setymmreg/setymmreg_amd64.s
+++ b/_fixtures/setymmreg/setymmreg_amd64.s
@@ -1,0 +1,9 @@
+#include "textflag.h"
+
+TEXT ·asmFunc(SB),0,$0-0
+	XORQ AX, AX
+	XORQ AX, AX
+	XORQ AX, AX
+	XORQ AX, AX
+	XORQ AX, AX
+	RET

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -37,6 +37,8 @@ type gdbConn struct {
 	packetSize int               // maximum packet size supported by stub
 	regsInfo   []gdbRegisterInfo // list of registers
 
+	workaroundReg *gdbRegisterInfo // used to work-around a register setting bug in debugserver, see use in gdbserver.go
+
 	pid int // cache process id
 
 	ack                   bool // when ack is true acknowledgment packets are enabled
@@ -338,6 +340,9 @@ func (conn *gdbConn) readRegisterInfo(regFound map[string]bool) (err error) {
 		}
 
 		if contained {
+			if regname == "xmm0" {
+				conn.workaroundReg = &gdbRegisterInfo{Regnum: regnum, Name: regname, Bitsize: bitsize, Offset: offset, ignoreOnWrite: ignoreOnWrite}
+			}
 			regnum++
 			continue
 		}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-delve/delve/pkg/dwarf/frame"
 	"github.com/go-delve/delve/pkg/dwarf/op"
+	"github.com/go-delve/delve/pkg/dwarf/regnum"
 	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/go-delve/delve/pkg/proc"
@@ -5690,6 +5691,45 @@ func TestSetOnFunctions(t *testing.T) {
 		err = scope.SetVariable("main.func1", "main.func2")
 		if err == nil {
 			t.Fatal("expected error when assigning between function variables")
+		}
+	})
+}
+
+func TestSetYMMRegister(t *testing.T) {
+	skipUnlessOn(t, "N/A", "darwin", "amd64")
+	// Checks that setting a XMM register works. This checks that the
+	// workaround for a bug in debugserver works.
+	// See issue #2767.
+	withTestProcess("setymmreg/", t, func(p *proc.Target, fixture protest.Fixture) {
+		setFunctionBreakpoint(p, t, "main.asmFunc")
+		assertNoError(p.Continue(), t, "Continue()")
+
+		getReg := func(pos string) *op.DwarfRegister {
+			regs := getRegisters(p, t)
+
+			arch := p.BinInfo().Arch
+			dregs := arch.RegistersToDwarfRegisters(0, regs)
+
+			r := dregs.Reg(regnum.AMD64_XMM0)
+			t.Logf("%s: %#v", pos, r)
+			return r
+		}
+
+		getReg("before")
+
+		p.CurrentThread().SetReg(regnum.AMD64_XMM0, op.DwarfRegisterFromBytes([]byte{
+			0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+			0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+			0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+			0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44}))
+		assertNoError(p.CurrentThread().StepInstruction(), t, "SetpInstruction")
+
+		xmm0 := getReg("after")
+
+		for i := range xmm0.Bytes {
+			if xmm0.Bytes[i] != 0x44 {
+				t.Fatalf("wrong register value")
+			}
 		}
 	})
 }


### PR DESCRIPTION
Debugserver has a bug where writing to a AVX-2 or AVX-512 register does
not work unless it is followed by at least a write to a AVX (not 2 or
512) register.

See also: https://bugs.llvm.org/show_bug.cgi?id=52362

Fixes #2767
