### PR TITLE
service: use name w/o parameters for breakpoints on generic funcs

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -904,19 +904,12 @@ func (d *Debugger) clearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint
 		return bp, nil
 	}
 
-	var clearedBp *api.Breakpoint
-	var errs []error
+	var clearBps []*proc.Breakpoint
 
-	clear := func(addr uint64) {
-		if clearedBp == nil {
-			bp := d.target.Breakpoints().M[addr]
-			if bp != nil {
-				clearedBp = api.ConvertBreakpoint(bp)
-			}
-		}
-		err := d.target.ClearBreakpoint(addr)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("address %#x: %v", addr, err))
+	toclear := func(addr uint64) {
+		bp := d.target.Breakpoints().M[addr]
+		if bp != nil {
+			clearBps = append(clearBps, bp)
 		}
 	}
 
@@ -925,10 +918,23 @@ func (d *Debugger) clearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint
 		if addr == requestedBp.Addr {
 			clearAddr = false
 		}
-		clear(addr)
+		toclear(addr)
 	}
 	if clearAddr {
-		clear(requestedBp.Addr)
+		toclear(requestedBp.Addr)
+	}
+
+	// Breakpoints need to be converted before clearing them or they won't have
+	// an ID anymore.
+	sort.Sort(breakpointsByLogicalID(clearBps))
+	clearedBp := api.ConvertBreakpoints(clearBps)[0]
+
+	var errs []error
+	for _, bp := range clearBps {
+		err := d.target.ClearBreakpoint(bp.Addr)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("address %#x: %v", bp.Addr, err))
+		}
 	}
 
 	if len(errs) > 0 {
@@ -940,7 +946,7 @@ func (d *Debugger) clearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint
 			}
 		}
 
-		if clearedBp == nil {
+		if len(errs) == len(clearBps) {
 			return nil, fmt.Errorf("unable to clear breakpoint %d: %v", requestedBp.ID, buf.String())
 		}
 		return nil, fmt.Errorf("unable to clear breakpoint %d (partial): %s", requestedBp.ID, buf.String())

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2588,5 +2588,27 @@ func TestGenericsBreakpoint(t *testing.T) {
 		if line := frame1Line(); line != 11 {
 			t.Errorf("wrong line after first continue, expected 11, got %d", line)
 		}
+
+		if bp.FunctionName != "main.testfn" {
+			t.Errorf("wrong name for breakpoint (CreateBreakpoint): %q", bp.FunctionName)
+		}
+
+		bps, err := c.ListBreakpoints(false)
+		assertNoError(err, t, "ListBreakpoints")
+
+		for _, bp := range bps {
+			if bp.ID > 0 {
+				if bp.FunctionName != "main.testfn" {
+					t.Errorf("wrong name for breakpoint (ListBreakpoints): %q", bp.FunctionName)
+				}
+				break
+			}
+		}
+
+		rmbp, err := c.ClearBreakpoint(bp.ID)
+		assertNoError(err, t, "ClearBreakpoint")
+		if rmbp.FunctionName != "main.testfn" {
+			t.Errorf("wrong name for breakpoint (ClearBreakpoint): %q", rmbp.FunctionName)
+		}
 	})
 }


### PR DESCRIPTION
When printing breakpoints on generic functions use the function name
without parameters instead of using the name of the first instantiation
that appears on the list.
