### PR TITLE
TeamCity: disable Windows Defender

### DIFF
--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -3,6 +3,8 @@ param (
     [Parameter(Mandatory = $true)][string]$arch
 )
 
+Set-MpPreference -DisableRealtimeMonitoring $true
+
 # Install Chocolatey
 #Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 


### PR DESCRIPTION
Shaves off 3 minutes out of every windows build.
