### PR TITLE
server/dap: stop running command if conn closed - fixes nil dereference bug

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -112,6 +112,8 @@ type Server struct {
 type Session struct {
 	config *Config
 
+	id int
+
 	// stackFrameHandles maps frames of each goroutine to unique ids across all goroutines.
 	// Reset at every stop.
 	stackFrameHandles *handlesMap
@@ -131,7 +133,7 @@ type Session struct {
 	mu sync.Mutex
 
 	// conn is the accepted client connection.
-	conn io.ReadWriteCloser
+	conn *connection
 	// debugger is the underlying debugger service.
 	debugger *debugger.Debugger
 	// binaryToRemove is the temp compiled binary to be removed on disconnect (if any).
@@ -169,6 +171,29 @@ type Config struct {
 	// StopTriggered is closed when the server is Stop()-ed.
 	// Can be used to safeguard against duplicate shutdown sequences.
 	StopTriggered chan struct{}
+}
+
+type connection struct {
+	io.ReadWriteCloser
+	closed chan struct{}
+}
+
+func (c *connection) Close() error {
+	select {
+	case <-c.closed:
+	default:
+		close(c.closed)
+	}
+	return c.ReadWriteCloser.Close()
+}
+
+func (c *connection) isClosed() bool {
+	select {
+	case <-c.closed:
+		return true
+	default:
+		return false
+	}
 }
 
 type process struct {
@@ -284,20 +309,24 @@ func NewServer(config *service.Config) *Server {
 	}
 }
 
+var sessionCount = 0
+
 // NewSession creates a new client session that can handle DAP traffic.
 // It takes an open connection and provides a Close() method to shut it
 // down when the DAP session disconnects or a connection error occurs.
 func NewSession(conn io.ReadWriteCloser, config *Config, debugger *debugger.Debugger) *Session {
+	sessionCount++
 	if config.log == nil {
 		config.log = logflags.DAPLogger()
 	}
-	config.log.Debug("DAP connection started")
+	config.log.Debugf("DAP connection %d started", sessionCount)
 	if config.StopTriggered == nil {
 		config.log.Fatal("Session must be configured with StopTriggered")
 	}
 	return &Session{
 		config:            config,
-		conn:              conn,
+		id:                sessionCount,
+		conn:              &connection{conn, make(chan struct{})},
 		stackFrameHandles: newHandlesMap(),
 		variableHandles:   newVariablesHandlesMap(),
 		args:              defaultArgs,
@@ -3420,6 +3449,11 @@ func (s *Session) resumeOnce(command string, allowNextStateChange chan struct{})
 func (s *Session) runUntilStopAndNotify(command string, allowNextStateChange chan struct{}) {
 	state, err := s.runUntilStop(command, allowNextStateChange)
 
+	if s.conn.isClosed() {
+		s.config.log.Debugf("connection %d closed - stopping %q command", s.id, command)
+		return
+	}
+
 	if processExited(state, err) {
 		s.send(&dap.TerminatedEvent{Event: *newEvent("terminated")})
 		return
@@ -3547,7 +3581,7 @@ func (s *Session) resumeOnceAndCheckStop(command string, allowNextStateChange ch
 	resumed, state, err := s.resumeOnce(command, allowNextStateChange)
 	// We should not try to process the log points if the program was not
 	// resumed or there was an error.
-	if !resumed || processExited(state, err) || state == nil || err != nil {
+	if !resumed || processExited(state, err) || state == nil || err != nil || s.conn.isClosed() {
 		s.setRunningCmd(false)
 		return state, err
 	}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1229,15 +1229,11 @@ func (s *Session) stopDebugSession(killProcess bool) error {
 	if s.debugger == nil {
 		return nil
 	}
-	// TODO(polina): reset debuggeer to nil at the end
 	var err error
 	var exited error
 	// Halting will stop any debugger command that's pending on another
-	// per-request goroutine, hence unblocking that goroutine to wrap-up and exit.
-	// TODO(polina): Per-request goroutine could still not be done when this one is.
-	// To avoid goroutine leaks, we can use a wait group or have the goroutine listen
-	// for a stop signal on a dedicated quit channel at suitable points (use context?).
-	// Additional clean-up might be especially critical when we support multiple clients.
+	// per-request goroutine. Tell auto-resumer not to resume, so the
+	// goroutine can wrap-up and exit.
 	s.setHaltRequested(true)
 	state, err := s.halt()
 	if err == proc.ErrProcessDetached {


### PR DESCRIPTION
If connection is closed while the debuggee is running, any pending goroutine handling the running command and analyzing its stop reasons should stop right away without calling any debugger methods as the debugger pointer would have already been cleared at session closure.

This fixes the following failure that especially impacts repeated remote attach to a multi-client server, but can also show up when server is shutting down:
```
2021-11-08T00:12:34-08:00 error layer=dap recovered panic: runtime error: invalid memory address or nil pointer dereference
goroutine 50 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/go-delve/delve/service/dap.(*Session).recoverPanic(0xc0002421c0, {0x16c43e0, 0xc000ea32f0})
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:516 +0x66
panic({0x1570180, 0x1a37de0})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/go-delve/delve/service/debugger.(*Debugger).StopReason(0xc000b41b40)
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/debugger/debugger.go:2056 +0x38
github.com/go-delve/delve/service/dap.(*Session).stoppedGs(0xc0002421c0, 0xc000eb87e0)
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:3589 +0xab
github.com/go-delve/delve/service/dap.(*Session).resumeOnceAndCheckStop(0xc0002421c0, {0x160a819, 0xc00024227c}, 0xc000dc5bf8)
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:3556 +0x94
github.com/go-delve/delve/service/dap.glob..func1(0xb, {0x160a819, 0xc000d91518}, 0xc000099bc0)
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:3543 +0x1e
github.com/go-delve/delve/service/dap.(*Session).runUntilStop(0xc0002421c0, {0x160a819, 0x8}, 0x18)
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:3535 +0x107
github.com/go-delve/delve/service/dap.(*Session).runUntilStopAndNotify(0xc0002421c0, {0x160a819, 0x8}, 0x0)
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:3421 +0x46
github.com/go-delve/delve/service/dap.(*Session).onConfigurationDoneRequest(0xc0002421c0, 0xc000ea32f0, 0xc000099aa0)
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:1577 +0x305
github.com/go-delve/delve/service/dap.(*Session).handleRequest.func1()
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:653 +0x85
created by github.com/go-delve/delve/service/dap.(*Session).handleRequest
	/Users/polina/go/pkg/mod/github.com/go-delve/delve@v1.7.3-0.20211103164926-183bb8dffd9f/service/dap/server.go:651 +0x10c5
```

Updates #2328