### PR TITLE
service/dap: fix TestNextParked

### DIFF
--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -153,6 +153,11 @@ func (c *Client) ExpectOutputEventProcessExited(t *testing.T, status int) *dap.O
 	return c.ExpectOutputEventRegex(t, fmt.Sprintf(ProcessExited, fmt.Sprintf("%d", status)))
 }
 
+func (c *Client) ExpectOutputEventProcessExitedAnyStatus(t *testing.T) *dap.OutputEvent {
+	t.Helper()
+	return c.ExpectOutputEventRegex(t, fmt.Sprintf(ProcessExited, `-?\d+`))
+}
+
 func (c *Client) ExpectOutputEventDetaching(t *testing.T) *dap.OutputEvent {
 	t.Helper()
 	return c.ExpectOutputEventRegex(t, `Detaching\n`)


### PR DESCRIPTION
This fixes 2 issues:
(1) `testNextParkedHelper` now correctly processes `TerminatedEvents`.
(2) Test harness used by `TestNextParked` and other tests now does not care about the exit status of a terminated target. This will minimize [flakiness in tests](#2762) that do not care about exit status. This part of the fix is suggested as an alternative to #2765.

Fixes #2762