### PR TITLE
_scripts: fix test_linux.sh version check

### DIFF
--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -57,7 +57,7 @@ cd delve
 # with the current VCS revision, which does not work with TeamCity
 if [ "$version" = "gotip" ]; then
 	export GOFLAGS=-buildvcs=false
-elif [ ${version:4} -gt 17 ]; then
+elif [ ${version:4:2} -gt 17 ]; then
 	export GOFLAGS=-buildvcs=false
 fi
 


### PR DESCRIPTION
The version check to disable the buildvcs option is wrong, it doesn't
matter now but it will start failing when 1.18.1 is released.
