### PR TITLE
version: fix build version using buildInfo

### DIFF
--- a/pkg/version/fixbuild.go
+++ b/pkg/version/fixbuild.go
@@ -1,0 +1,23 @@
+//go:build go1.18
+// +build go1.18
+
+package version
+
+import "runtime/debug"
+
+func init() {
+	fixBuild = buildInfoFixBuild
+}
+
+func buildInfoFixBuild(v *Version) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for i := range info.Settings {
+		if info.Settings[i].Key == "gitrevision" {
+			v.Build = info.Settings[i].Value
+			break
+		}
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -24,6 +24,7 @@ var (
 )
 
 func (v Version) String() string {
+	fixBuild(&v)
 	ver := fmt.Sprintf("Version: %s.%s.%s", v.Major, v.Minor, v.Patch)
 	if v.Metadata != "" {
 		ver += "-" + v.Metadata
@@ -37,4 +38,8 @@ var buildInfo = func() string {
 
 func BuildInfo() string {
 	return fmt.Sprintf("%s\n%s", runtime.Version(), buildInfo())
+}
+
+var fixBuild = func(v *Version) {
+	// does nothing
 }


### PR DESCRIPTION
In go1.18 buildInfo will include the git revision hash, use that to fix
the Build field of Version so that it is correct even if Delve wasn't
built using make.go.
