### PR TITLE
service/dap: expose sources command in evaluate request

### DIFF
--- a/service/dap/command.go
+++ b/service/dap/command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/go-delve/delve/pkg/config"
@@ -37,24 +38,29 @@ type command struct {
 const (
 	msgHelp = `Prints the help message.
 	
-help [command]
+dlv help [command]
 
 Type "help" followed by the name of a command for more information about it.`
 
 	msgConfig = `Changes configuration parameters.
 	
-	config -list
+	dlv config -list
 	
 	Show all configuration parameters.
 	
-	config <parameter> <value>
+	dlv config <parameter> <value>
 	
 	Changes the value of a configuration parameter.
 	
-	config substitutePath <from> <to>
-	config substitutePath <from>
+	dlv config substitutePath <from> <to>
+	dlv config substitutePath <from>
 	
 	Adds or removes a path substitution rule.`
+	msgSources = `Print list of source files.
+
+	dlv sources [<regex>]
+
+If regex is specified only the source files matching it will be returned.`
 )
 
 // debugCommands returns a list of commands with default commands defined.
@@ -62,6 +68,7 @@ func debugCommands(s *Session) []command {
 	return []command{
 		{aliases: []string{"help", "h"}, cmdFn: s.helpMessage, helpMsg: msgHelp},
 		{aliases: []string{"config"}, cmdFn: s.evaluateConfig, helpMsg: msgConfig},
+		{aliases: []string{"sources", "s"}, cmdFn: s.sources, helpMsg: msgSources},
 	}
 }
 
@@ -88,14 +95,14 @@ func (s *Session) helpMessage(_, _ int, args string) (string, error) {
 			h = h[:idx]
 		}
 		if len(cmd.aliases) > 1 {
-			fmt.Fprintf(&buf, "    %s (alias: %s) \t %s\n", cmd.aliases[0], strings.Join(cmd.aliases[1:], " | "), h)
+			fmt.Fprintf(&buf, "    dlv %s (alias: %s) \t %s\n", cmd.aliases[0], strings.Join(cmd.aliases[1:], " | "), h)
 		} else {
-			fmt.Fprintf(&buf, "    %s \t %s\n", cmd.aliases[0], h)
+			fmt.Fprintf(&buf, "    dlv %s \t %s\n", cmd.aliases[0], h)
 		}
 	}
 
 	fmt.Fprintln(&buf)
-	fmt.Fprintln(&buf, "Type help followed by a command for full documentation.")
+	fmt.Fprintln(&buf, "Type 'dlv help' followed by a command for full documentation.")
 	return buf.String(), nil
 }
 
@@ -112,4 +119,17 @@ func (s *Session) evaluateConfig(_, _ int, expr string) (string, error) {
 		}
 		return res, nil
 	}
+}
+
+func (s *Session) sources(_, _ int, args string) (string, error) {
+	sources, err := s.debugger.Sources(args)
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(sources)
+	var buf bytes.Buffer
+	for _, d := range sources {
+		fmt.Fprintln(&buf, d)
+	}
+	return buf.String(), nil
 }

--- a/service/dap/command.go
+++ b/service/dap/command.go
@@ -121,15 +121,11 @@ func (s *Session) evaluateConfig(_, _ int, expr string) (string, error) {
 	}
 }
 
-func (s *Session) sources(_, _ int, args string) (string, error) {
-	sources, err := s.debugger.Sources(args)
+func (s *Session) sources(_, _ int, filter string) (string, error) {
+	sources, err := s.debugger.Sources(filter)
 	if err != nil {
 		return "", err
 	}
 	sort.Strings(sources)
-	var buf bytes.Buffer
-	for _, d := range sources {
-		fmt.Fprintln(&buf, d)
-	}
-	return buf.String(), nil
+	return strings.Join(sources, "\n"), nil
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3919,8 +3919,8 @@ Type 'dlv help' followed by a command for full documentation.
 
 					client.EvaluateRequest(fmt.Sprintf("dlv sources .*%s", strings.ReplaceAll(filepath.Base(fixture.Source), ".", "\\.")), 1000, "repl")
 					got = client.ExpectEvaluateResponse(t)
-					if got.Body.Result != fixture.Source+"\n" {
-						t.Errorf("\ngot: %#v, want sources=%q", got, fixture.Source+"\n")
+					if got.Body.Result != fixture.Source {
+						t.Errorf("\ngot: %#v, want sources=%q", got, fixture.Source)
 					}
 
 					client.EvaluateRequest("dlv sources nonexistentsource", 1000, "repl")


### PR DESCRIPTION
This change exposes the list sources feature in the debug console in order to facilitate easier substitute path mappings. When user's have symlinks, are debugging on a remote host, or use trimpath to build, the source paths may not line up with the source files sent from the dap client. By allowing users to see the source names that the program was actually built with, this will allow users to more easily set up a correct configuration of substitutePath to debug their programs.

Updates #2795 