### PR TITLE
proc: fix signal handling during stepping

### DIFF
--- a/_fixtures/asmnilptr/main.go
+++ b/_fixtures/asmnilptr/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func asmFunc(*int) int
+
+func main() {
+	fmt.Printf("%d\n", asmFunc(nil))
+}

--- a/_fixtures/asmnilptr/main_386.s
+++ b/_fixtures/asmnilptr/main_386.s
@@ -1,0 +1,7 @@
+#include "textflag.h"
+
+TEXT ·asmFunc(SB),0,$0-16
+	MOVL arg+0(FP), AX
+	MOVL (AX), AX
+	MOVL AX, ret+4(FP)
+	RET

--- a/_fixtures/asmnilptr/main_amd64.s
+++ b/_fixtures/asmnilptr/main_amd64.s
@@ -1,0 +1,7 @@
+#include "textflag.h"
+
+TEXT ·asmFunc(SB),0,$0-16
+	MOVQ arg+0(FP), AX
+	MOVQ (AX), AX
+	MOVQ AX, ret+8(FP)
+	RET

--- a/_fixtures/asmnilptr/main_arm64.s
+++ b/_fixtures/asmnilptr/main_arm64.s
@@ -1,0 +1,7 @@
+#include "textflag.h"
+
+TEXT ·asmFunc(SB),0,$0-16
+	MOVD arg+0(FP), R5
+	MOVD (R5), R5
+	MOVD R5, ret+8(FP)
+	RET

--- a/pkg/proc/native/ptrace_linux.go
+++ b/pkg/proc/native/ptrace_linux.go
@@ -24,3 +24,12 @@ func ptraceDetach(tid, sig int) error {
 func ptraceCont(tid, sig int) error {
 	return sys.PtraceCont(tid, sig)
 }
+
+// ptraceSingleStep executes ptrace PTRACE_SINGLESTEP
+func ptraceSingleStep(pid, sig int) error {
+	_, _, e1 := sys.Syscall6(sys.SYS_PTRACE, uintptr(sys.PTRACE_SINGLESTEP), uintptr(pid), uintptr(0), uintptr(sig), 0, 0)
+	if e1 != 0 {
+		return e1
+	}
+	return nil
+}


### PR DESCRIPTION
Fix signal handling during thread single stepping so that signals that
are generated by executing the current instruction are immediately
propagated to the inferior, while signals other signals sent to the
thread are delayed until the full resume happens.

Fixes a bug where a breakpoint set on an instruction that causes a
SIGSEGV would make Delve hang and a bug where signals received during
single step would make it look like an instruction is executed twice.

Fixes #2801
Fixes #2792
