### PR TITLE
proc: add dummy files to fix vendoring of Delve

### DIFF
--- a/pkg/proc/internal/ebpf/bpf/dummy.go
+++ b/pkg/proc/internal/ebpf/bpf/dummy.go
@@ -1,0 +1,4 @@
+//go:build dummy
+// +build dummy
+
+package ebpf

--- a/pkg/proc/internal/ebpf/bpf/include/dummy.go
+++ b/pkg/proc/internal/ebpf/bpf/include/dummy.go
@@ -1,0 +1,4 @@
+//go:build dummy
+// +build dummy
+
+package ebpf

--- a/pkg/proc/internal/ebpf/dummy.go
+++ b/pkg/proc/internal/ebpf/dummy.go
@@ -1,0 +1,14 @@
+//go:build dummy
+// +build dummy
+
+// This file is part of a workaround for `go mod vendor` which won't
+// vendor C files if there are no Go files in the same directory.
+//
+// See https://github.com/golang/go/issues/26366
+
+package ebpf
+
+import (
+	_ "github.com/go-delve/delve/pkg/proc/internal/ebpf/bpf"
+	_ "github.com/go-delve/delve/pkg/proc/internal/ebpf/bpf/include"
+)


### PR DESCRIPTION
Add some dummy go files so that 'go mod vendor' works for modules that
require Delve, becuase directories that do not contain any go code will
not be vendored.
