### PR TITLE
service/dap: move presentationHint to frame from source

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -3264,7 +3264,7 @@ func (s *Session) stacktrace(goroutineID int, g *proc.G) (string, error) {
 	}
 
 	var buf bytes.Buffer
-	fmt.Fprintln(&buf, "User Stack:")
+	fmt.Fprintln(&buf, "Stack:")
 	userLoc := g.UserCurrent()
 	userFuncPkg := fnPackageName(&userLoc)
 	api.PrintStack(s.toClientPath, &buf, apiFrames, "\t", false, func(s api.Stackframe) bool {

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1991,7 +1991,7 @@ func (s *Session) onStackTraceRequest(request *dap.StackTraceRequest) {
 
 		packageName := fnPackageName(loc)
 		if !isSystemGoroutine && packageName == "runtime" {
-			stackFrame.Source.PresentationHint = "deemphasize"
+			stackFrame.PresentationHint = "subtle"
 		}
 		stackFrames = append(stackFrames, stackFrame)
 	}
@@ -3264,7 +3264,7 @@ func (s *Session) stacktrace(goroutineID int, g *proc.G) (string, error) {
 	}
 
 	var buf bytes.Buffer
-	fmt.Fprintln(&buf, "Stack:")
+	fmt.Fprintln(&buf, "User Stack:")
 	userLoc := g.UserCurrent()
 	userFuncPkg := fnPackageName(&userLoc)
 	api.PrintStack(s.toClientPath, &buf, apiFrames, "\t", false, func(s api.Stackframe) bool {

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4786,8 +4786,8 @@ func TestPanicBreakpointOnContinue(t *testing.T) {
 					st := client.ExpectStackTraceResponse(t)
 					for i, frame := range st.Body.StackFrames {
 						if strings.HasPrefix(frame.Name, "runtime.") {
-							if frame.Source.PresentationHint != "deemphasize" {
-								t.Errorf("\ngot Body.StackFrames[%d]=%#v\nwant Source.PresentationHint=\"deemphasize\"", i, frame)
+							if frame.PresentationHint != "subtle" {
+								t.Errorf("\ngot Body.StackFrames[%d]=%#v\nwant Source.PresentationHint=\"subtle\"", i, frame)
 							}
 						} else if frame.Source.PresentationHint != "" {
 							t.Errorf("\ngot Body.StackFrames[%d]=%#v\nwant Source.PresentationHint=\"\"", i, frame)


### PR DESCRIPTION
This change visually indicates which frames are runtime code using frame.presentationHint. This removes "deemphasize" from the source presentation hint. "deemphasize" indicated that the source should be skipped in stepping, causing the frames to be collapsed. This was inconvenient for users if they wanted to inspect the runtime code that they were stepping through.

Updates golang/vscode-go#1916
