### PR TITLE
terminal: add transcript command

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -91,6 +91,7 @@ Command | Description
 [list](#list) | Show source code.
 [source](#source) | Executes a file containing a list of delve commands
 [sources](#sources) | Print list of source files.
+[transcript](#transcript) | Appends command output to a file.
 [types](#types) | Print list of types
 
 ## args
@@ -635,6 +636,17 @@ A tracepoint is a breakpoint that does not stop the execution of the program, in
 See also: "help on", "help cond" and "help clear"
 
 Aliases: t
+
+## transcript
+Appends command output to a file.
+
+	transcript [-t] [-x] <output file>
+	transcript -off
+
+Output of Delve's command is appended to the specified output file. If '-t' is specified and the output file exists it is truncated. If '-x' is specified output to stdout is suppressed instead.
+
+Using the -off option disables the transcript.
+
 
 ## types
 Print list of types

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -670,6 +670,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 		}
 		cmds := terminal.DebugCommands(client)
 		t := terminal.New(client, nil)
+		t.RedirectTo(os.Stderr)
 		defer t.Close()
 		if traceUseEBPF {
 			done := make(chan struct{})

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -962,7 +962,7 @@ func TestTracePid(t *testing.T) {
 	dlvbin, tmpdir := getDlvBin(t)
 	defer os.RemoveAll(tmpdir)
 
-	expected := []byte("goroutine(1): main.A() => ()\n")
+	expected := []byte("goroutine(1): main.A()\n => ()\n")
 
 	// make process run
 	fix := protest.BuildFixture("issue2023", 0)

--- a/pkg/terminal/starbind/starlark.go
+++ b/pkg/terminal/starbind/starlark.go
@@ -3,6 +3,7 @@ package starbind
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"runtime"
 	"strings"
@@ -56,13 +57,15 @@ type Env struct {
 	cancelfn  context.CancelFunc
 
 	ctx Context
+	out EchoWriter
 }
 
 // New creates a new starlark binding environment.
-func New(ctx Context) *Env {
+func New(ctx Context, out EchoWriter) *Env {
 	env := &Env{}
 
 	env.ctx = ctx
+	env.out = out
 
 	env.env = env.starlarkPredeclare()
 	env.env[dlvCommandBuiltinName] = starlark.NewBuiltin(dlvCommandBuiltinName, func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -117,6 +120,18 @@ func New(ctx Context) *Env {
 	return env
 }
 
+// Redirect redirects starlark output to out.
+func (env *Env) Redirect(out EchoWriter) {
+	env.out = out
+	if env.thread != nil {
+		env.thread.Print = env.printFunc()
+	}
+}
+
+func (env *Env) printFunc() func(_ *starlark.Thread, msg string) {
+	return func(_ *starlark.Thread, msg string) { fmt.Fprintln(env.out, msg) }
+}
+
 // Execute executes a script. Path is the name of the file to execute and
 // source is the source code to execute.
 // Source can be either a []byte, a string or a io.Reader. If source is nil
@@ -128,7 +143,7 @@ func (env *Env) Execute(path string, source interface{}, mainFnName string, args
 		if err == nil {
 			return
 		}
-		fmt.Printf("panic executing starlark script: %v\n", err)
+		fmt.Fprintf(env.out, "panic executing starlark script: %v\n", err)
 		for i := 0; ; i++ {
 			pc, file, line, ok := runtime.Caller(i)
 			if !ok {
@@ -139,7 +154,7 @@ func (env *Env) Execute(path string, source interface{}, mainFnName string, args
 			if fn != nil {
 				fname = fn.Name()
 			}
-			fmt.Printf("%s\n\tin %s:%d\n", fname, file, line)
+			fmt.Fprintf(env.out, "%s\n\tin %s:%d\n", fname, file, line)
 		}
 	}()
 
@@ -193,7 +208,7 @@ func (env *Env) Cancel() {
 
 func (env *Env) newThread() *starlark.Thread {
 	thread := &starlark.Thread{
-		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
+		Print: env.printFunc(),
 	}
 	env.contextMu.Lock()
 	var ctx context.Context
@@ -286,4 +301,10 @@ func decorateError(thread *starlark.Thread, err error) error {
 		return fmt.Errorf("%s:%d:%d: %v", pos.Filename(), pos.Line, pos.Col, err)
 	}
 	return fmt.Errorf("%s:%d: %v", pos.Filename(), pos.Line, err)
+}
+
+type EchoWriter interface {
+	io.Writer
+	Echo(string)
+	Flush()
 }


### PR DESCRIPTION
Adds a transcript command that appends all command output to a file.

This command is equivalent to gdb's 'set logging'.

As part of this refactor the pkg/terminal commands to always write to a
io.Writer instead of using os.Stdout directly (through
fmt.Printf/fmt.Println).
