### PR TITLE
proc/gdbserial: allow rewind to work after process exit with rr

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -640,7 +640,10 @@ func (t *Target) SetWatchpoint(scope *EvalScope, expr string, wtype WatchType, c
 
 func (t *Target) setBreakpointInternal(addr uint64, kind BreakpointKind, wtype WatchType, cond ast.Expr) (*Breakpoint, error) {
 	if valid, err := t.Valid(); !valid {
-		return nil, err
+		recorded, _ := t.Recorded()
+		if !recorded {
+			return nil, err
+		}
 	}
 	bpmap := t.Breakpoints()
 	newBreaklet := &Breaklet{Kind: kind, Cond: cond}
@@ -739,7 +742,10 @@ func (bp *Breakpoint) canOverlap(kind BreakpointKind) bool {
 // ClearBreakpoint clears the breakpoint at addr.
 func (t *Target) ClearBreakpoint(addr uint64) error {
 	if valid, err := t.Valid(); !valid {
-		return err
+		recorded, _ := t.Recorded()
+		if !recorded {
+			return err
+		}
 	}
 	bp, ok := t.Breakpoints().M[addr]
 	if !ok {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -453,6 +453,7 @@ func (d *Debugger) Restart(rerecord bool, pos string, resetArgs bool, newArgs []
 
 	recorded, _ := d.target.Recorded()
 	if recorded && !rerecord {
+		d.target.ResumeNotify(nil)
 		return nil, d.target.Restart(pos)
 	}
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2595,6 +2595,9 @@ func TestRestartRewindAfterEnd(t *testing.T) {
 	if testBackend != "rr" {
 		t.Skip("not relevant")
 	}
+	// Check that Restart works after the program has terminated, even if a
+	// Continue is requested just before it.
+	// Also check that Rewind can be used after the program has terminated.
 	protest.AllowRecording(t)
 	withTestClient2("math", t, func(c service.Client) {
 		state := <-c.Continue()
@@ -2609,6 +2612,21 @@ func TestRestartRewindAfterEnd(t *testing.T) {
 		_, err := c.Restart(false)
 		if err != nil {
 			t.Fatalf("Restart: %v", err)
+		}
+		state = <-c.Continue()
+		if !state.Exited {
+			t.Fatalf("program did not exit exited")
+		}
+		_, err = c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 0})
+		if err != nil {
+			t.Fatalf("CreateBreakpoint: %v", err)
+		}
+		state = <-c.Rewind()
+		if state.Exited || state.Err != nil {
+			t.Errorf("bad Rewind return state: %v", state)
+		}
+		if state.CurrentThread.Line != 7 {
+			t.Errorf("wrong stop location %s:%d", state.CurrentThread.File, state.CurrentThread.Line)
 		}
 	})
 }

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2590,3 +2590,25 @@ func TestGenericsBreakpoint(t *testing.T) {
 		}
 	})
 }
+
+func TestRestartRewindAfterEnd(t *testing.T) {
+	if testBackend != "rr" {
+		t.Skip("not relevant")
+	}
+	protest.AllowRecording(t)
+	withTestClient2("math", t, func(c service.Client) {
+		state := <-c.Continue()
+		if !state.Exited {
+			t.Fatalf("program did not exit")
+		}
+		state = <-c.Continue()
+		if !state.Exited {
+			t.Errorf("bad Continue return state: %v", state)
+		}
+		time.Sleep(1 * time.Second) // bug only happens if there is some time for the server to close the notify channel
+		_, err := c.Restart(false)
+		if err != nil {
+			t.Fatalf("Restart: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
### proc/gdbserial: allow rewind to work after process exit with rr

It is sometimes useful to set breakpoints and rewind a terminated
process when using rr, for example if interested in the last execution
of some function.

RR will not allow a backward continue after the process exit packet has
been  sent, however rr will also generate a synthetic SIGKILL right
before process exit.

Treat this packet as a process exit and change some things so both
continuing backwards and setting breakpoints can be done, on recorded
targets, after process exit has been reported.

### service/debugger: fix bug internal err with Restart on recorded target

If Restart is called after a Continue and Rewind on a recorded target
that has already terminated it will return an internal error.
