### PR TITLE
Updates for go1.18beta1

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -35,23 +35,23 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2020.2"
 
 val targets = arrayOf(
-        "linux/amd64/1.15",
         "linux/amd64/1.16",
         "linux/amd64/1.17",
+        "linux/amd64/1.18",
         "linux/amd64/tip",
 
-        "linux/386/1.17",
+        "linux/386/1.18",
 
-        "linux/arm64/1.17",
+        "linux/arm64/1.18",
         "linux/arm64/tip",
 
-        "windows/amd64/1.17",
+        "windows/amd64/1.18",
         "windows/amd64/tip",
 
-        "mac/amd64/1.17",
+        "mac/amd64/1.18",
         "mac/amd64/tip",
 
-        "mac/arm64/1.17",
+        "mac/arm64/1.18",
         "mac/arm64/tip"
 )
 

--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -21,10 +21,6 @@ function getgo {
 }
 
 if [ "$version" = "gotip" ]; then
-	# TODO: remove this
-	if [ "$arch" != "amd64" ]; then
-		exit 0
-	fi
 	echo Building Go from tip
 	getgo $(curl https://go.dev/VERSION?m=text)
 	export GOROOT_BOOTSTRAP=$GOROOT

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -8,10 +8,6 @@ ARCH=$2
 TMPDIR=$3
 
 if [ "$GOVERSION" = "gotip" ]; then
-    # TODO: remove this
-    if [ "$arch" != "amd64" ]; then
-        exit 0
-    fi
     bootstrapver=$(curl https://go.dev/VERSION?m=text)
     cd $TMPDIR
     curl -sSL "https://storage.googleapis.com/golang/$bootstrapver.darwin-$ARCH.tar.gz" | tar -xz

--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -34,7 +34,7 @@ function GetGo($version) {
 }
 
 if ($version -eq "gotip") {
-    Exit 0
+    #Exit 0
     $latest = Invoke-WebRequest -Uri https://golang.org/VERSION?m=text -UseBasicParsing | Select-Object -ExpandProperty Content
     GetGo $latest
     $env:GOROOT_BOOTSTRAP = $env:GOROOT

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,6 @@ require (
 	go.starlark.net v0.0.0-20200821142938-949cc6f4b097
 	golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
-	golang.org/x/tools v0.1.8-0.20211028023602-8de2a7fd1736
+	golang.org/x/tools v0.1.8
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.8-0.20211028023602-8de2a7fd1736 h1:cw6nUxdoEN5iEIWYD8aAsTZ8iYjLVNiHAb7xz/80WO4=
 golang.org/x/tools v0.1.8-0.20211028023602-8de2a7fd1736/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
+golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -10,7 +10,7 @@ var (
 	MinSupportedVersionOfGoMajor = 1
 	MinSupportedVersionOfGoMinor = 16
 	MaxSupportedVersionOfGoMajor = 1
-	MaxSupportedVersionOfGoMinor = 17
+	MaxSupportedVersionOfGoMinor = 18
 	goTooOldErr                  = fmt.Sprintf("Go version %%s is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	goTooOldWarn                 = fmt.Sprintf("WARNING: undefined behavior - Go version %%s is too old for this version of Delve (minimum supported version %d.%d)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Sprintf("Version of Delve is too old for Go version %%s (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	MinSupportedVersionOfGoMajor = 1
-	MinSupportedVersionOfGoMinor = 15
+	MinSupportedVersionOfGoMinor = 16
 	MaxSupportedVersionOfGoMajor = 1
 	MaxSupportedVersionOfGoMinor = 17
 	goTooOldErr                  = fmt.Sprintf("Go version %%s is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -266,11 +266,23 @@ func (dbp *nativeProcess) initialize(path string, debugInfoDirs []string) (*proc
 		stopReason = proc.StopAttached
 	}
 	tgt, err := proc.NewTarget(dbp, dbp.pid, dbp.memthread, proc.NewTargetConfig{
-		Path:                path,
-		DebugInfoDirs:       debugInfoDirs,
-		DisableAsyncPreempt: runtime.GOOS == "windows" || runtime.GOOS == "freebsd",
-		StopReason:          stopReason,
-		CanDump:             runtime.GOOS == "linux"})
+		Path:          path,
+		DebugInfoDirs: debugInfoDirs,
+
+		// We disable asyncpreempt for the following reasons:
+		//  - on Windows asyncpreempt is incompatible with debuggers, see:
+		//    https://github.com/golang/go/issues/36494
+		//  - freebsd's backend is generally broken and asyncpreempt makes it even more so, see:
+		//    https://github.com/go-delve/delve/issues/1754
+		//  - on linux/arm64 asyncpreempt can sometimes restart a sequence of
+		//    instructions, if the sequence happens to contain a breakpoint it will
+		//    look like the breakpoint was hit twice when it was "logically" only
+		//    executed once.
+		//    See: https://go-review.googlesource.com/c/go/+/208126
+		DisableAsyncPreempt: runtime.GOOS == "windows" || runtime.GOOS == "freebsd" || (runtime.GOOS == "linux" && runtime.GOARCH == "arm64"),
+
+		StopReason: stopReason,
+		CanDump:    runtime.GOOS == "linux"})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1335,6 +1335,10 @@ func TestFrameEvaluation(t *testing.T) {
 		g, err := proc.GetG(p.CurrentThread())
 		assertNoError(err, t, "GetG()")
 
+		frames, err := g.Stacktrace(40, 0)
+		t.Logf("Goroutine %d %#v", g.ID, g.Thread)
+		logStacktrace(t, p, frames)
+
 		for i := 0; i <= 3; i++ {
 			scope, err := proc.ConvertEvalScope(p, g.ID, i+1, 0)
 			assertNoError(err, t, fmt.Sprintf("ConvertEvalScope() on frame %d", i+1))

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -276,6 +276,9 @@ func (it *stackIterator) newStackframe(ret, retaddr uint64) Stackframe {
 		it.regs.FrameBase = it.frameBase(fn)
 	}
 	r := Stackframe{Current: Location{PC: it.pc, File: f, Line: l, Fn: fn}, Regs: it.regs, Ret: ret, addrret: retaddr, stackHi: it.stackhi, SystemStack: it.systemstack, lastpc: it.pc}
+	if r.Regs.Reg(it.regs.PCRegNum) == nil {
+		r.Regs.AddReg(it.regs.PCRegNum, op.DwarfRegisterFromUint64(it.pc))
+	}
 	r.Call = r.Current
 	if !it.top && r.Current.Fn != nil && it.pc != r.Current.Fn.Entry {
 		// if the return address is the entry point of the function that

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -383,11 +383,11 @@ func MustHaveCgo(t *testing.T) {
 func RegabiSupported() bool {
 	// Tracks regabiSupported variable in ParseGOEXPERIMENT internal/buildcfg/exp.go
 	switch {
-	case !goversion.VersionAfterOrEqual(runtime.Version(), 1, 17): // < 1.17
-		return false
+	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 18):
+		return runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64" || runtime.GOARCH == "ppc64le" || runtime.GOARCH == "ppc64"
 	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 17):
 		return runtime.GOARCH == "amd64" && (runtime.GOOS == "android" || runtime.GOOS == "linux" || runtime.GOOS == "darwin" || runtime.GOOS == "windows")
-	default: // >= 1.18
-		return runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64"
+	default:
+		return false
 	}
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2387,6 +2387,11 @@ func TestGlobalScopeAndVariables(t *testing.T) {
 			[]onBreakpoint{{
 				// Stop at line 36
 				execute: func() {
+					if runtime.GOARCH == "386" && goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) {
+						client.StepInRequest(1)
+						client.ExpectStepInResponse(t)
+						client.ExpectStoppedEvent(t)
+					}
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
 					checkStackFramesExact(t, stack, "main.main", 36, 1000, 3, 3)
@@ -2454,6 +2459,12 @@ func TestRegistersScopeAndVariables(t *testing.T) {
 			[]onBreakpoint{{
 				// Stop at line 36
 				execute: func() {
+					if runtime.GOARCH == "386" && goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) {
+						client.StepInRequest(1)
+						client.ExpectStepInResponse(t)
+						client.ExpectStoppedEvent(t)
+					}
+
 					client.StackTraceRequest(1, 0, 20)
 					stack := client.ExpectStackTraceResponse(t)
 					checkStackFramesExact(t, stack, "main.main", 36, 1000, 3, 3)

--- a/vendor/golang.org/x/tools/go/internal/gcimporter/support_go118.go
+++ b/vendor/golang.org/x/tools/go/internal/gcimporter/support_go118.go
@@ -16,5 +16,8 @@ func additionalPredeclared() []types.Type {
 	return []types.Type{
 		// comparable
 		types.Universe.Lookup("comparable").Type(),
+
+		// any
+		types.Universe.Lookup("any").Type(),
 	}
 }

--- a/vendor/golang.org/x/tools/internal/typeparams/common.go
+++ b/vendor/golang.org/x/tools/internal/typeparams/common.go
@@ -13,6 +13,7 @@ package typeparams
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 )
 
 // A IndexExprData holds data from both ast.IndexExpr and the new
@@ -22,4 +23,10 @@ type IndexExprData struct {
 	Lbrack  token.Pos  // position of "["
 	Indices []ast.Expr // index expressions
 	Rbrack  token.Pos  // position of "]"
+}
+
+// IsTypeParam reports whether t is a type parameter.
+func IsTypeParam(t types.Type) bool {
+	_, ok := t.(*TypeParam)
+	return ok
 }

--- a/vendor/golang.org/x/tools/internal/typeparams/typeparams_go117.go
+++ b/vendor/golang.org/x/tools/internal/typeparams/typeparams_go117.go
@@ -75,6 +75,7 @@ func ForFuncType(*ast.FuncType) *ast.FieldList {
 // this Go version. Its methods panic on use.
 type TypeParam struct{ types.Type }
 
+func (*TypeParam) Index() int             { unsupported(); return 0 }
 func (*TypeParam) Constraint() types.Type { unsupported(); return nil }
 func (*TypeParam) Obj() *types.TypeName   { unsupported(); return nil }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -73,7 +73,7 @@ golang.org/x/sys/execabs
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 golang.org/x/sys/windows
-# golang.org/x/tools v0.1.8-0.20211028023602-8de2a7fd1736
+# golang.org/x/tools v0.1.8
 ## explicit
 golang.org/x/tools/go/gcexportdata
 golang.org/x/tools/go/internal/gcimporter


### PR DESCRIPTION
### proc: disable asyncpreempt on linux/arm64

Asyncpreempt on linux/arm64 can sometimes restart a sequence of
instructions which will make breakpoint appear to be hit twice in some
cases.

### goversion: bump maximum supported Go version to 1.18



### proc,tests: update for regabi on arm64 and 386

Make sure that stacktrace registers always contain the PC register of
the current frame, even though the debug_frame rules might not specify
it on architectures that use a link register.

The PC register is needed to look up loclist entries for variable
evaluation.

### TeamCity: bump test matrix

Add 1.18 to test matrix. Remove 1.15 from test matrix and from support range.

### go.mod: update golang.org/x/tools to v0.1.8

Fixes TestGeneratedDoc on go1.18
