### PR TITLE
proc: enable core dumping on windows

### DIFF
--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -282,7 +282,8 @@ func (dbp *nativeProcess) initialize(path string, debugInfoDirs []string) (*proc
 		DisableAsyncPreempt: runtime.GOOS == "windows" || runtime.GOOS == "freebsd" || (runtime.GOOS == "linux" && runtime.GOARCH == "arm64"),
 
 		StopReason: stopReason,
-		CanDump:    runtime.GOOS == "linux"})
+		CanDump:    runtime.GOOS == "linux" || runtime.GOOS == "windows",
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Core dumping for Windows was implemented a while ago but never enabled.
