### PR TITLE
proc: better handling of hardcoded breakpoints

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -11,8 +11,8 @@ Tests skipped by each supported backend:
 	* 1 broken - cgo stacktraces
 * darwin/lldb skipped = 1
 	* 1 upstream issue
-* freebsd skipped = 15
-	* 11 broken
+* freebsd skipped = 16
+	* 12 broken
 	* 4 not implemented
 * linux/386/pie skipped = 1
 	* 1 broken

--- a/_fixtures/hcbpcountstest.go
+++ b/_fixtures/hcbpcountstest.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"sync"
+	"time"
+)
+
+func demo(id int, wait *sync.WaitGroup) {
+	for i := 0; i < 100; i++ {
+		sleep := rand.Intn(10) + 1
+		runtime.Breakpoint()
+		fmt.Printf("id: %d step: %d sleeping %d\n", id, i, sleep)
+		time.Sleep(time.Duration(sleep) * time.Millisecond)
+	}
+
+	wait.Done()
+}
+
+func main() {
+	wait := new(sync.WaitGroup)
+	wait.Add(1)
+	wait.Add(1)
+	go demo(1, wait)
+	go demo(2, wait)
+
+	wait.Wait()
+}

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -25,8 +25,13 @@ const (
 	// process dies because of a fatal runtime error.
 	FatalThrow = "runtime-fatal-throw"
 
-	unrecoveredPanicID = -1
-	fatalThrowID       = -2
+	// HardcodedBreakpoint is the name given to hardcoded breakpoints (for
+	// example: calls to runtime.Breakpoint)
+	HardcodedBreakpoint = "hardcoded-breakpoint"
+
+	unrecoveredPanicID    = -1
+	fatalThrowID          = -2
+	hardcodedBreakpointID = -3
 
 	NoLogicalID = -1000 // Logical breakpoint ID for breakpoints internal breakpoints.
 )

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -355,16 +355,15 @@ func (t *thread) StepInstruction() error {
 	return ErrContinueCore
 }
 
-// Blocked will return false always for core files as there is
-// no execution.
-func (t *thread) Blocked() bool {
-	return false
-}
-
 // SetCurrentBreakpoint will always just return nil
 // for core files, as there are no breakpoints in core files.
 func (t *thread) SetCurrentBreakpoint(adjustPC bool) error {
 	return nil
+}
+
+// SoftExc returns true if this thread received a software exception during the last resume.
+func (t *thread) SoftExc() bool {
+	return false
 }
 
 // Common returns a struct containing common information

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -795,8 +795,8 @@ const (
 	childSignal      = 0x11
 	stopSignal       = 0x13
 
-	_SIGILL = 0x4
-	_SIGFPE = 0x8
+	_SIGILL  = 0x4
+	_SIGFPE  = 0x8
 	_SIGKILL = 0x9
 
 	debugServerTargetExcBadAccess      = 0x91
@@ -1541,6 +1541,11 @@ func (t *gdbThread) StepInstruction() error {
 	return t.p.conn.step(t, &threadUpdater{p: t.p}, false)
 }
 
+// SoftExc returns true if this thread received a software exception during the last resume.
+func (t *gdbThread) SoftExc() bool {
+	return t.setbp
+}
+
 // Blocked returns true if the thread is blocked in runtime or kernel code.
 func (t *gdbThread) Blocked() bool {
 	regs, err := t.Registers()
@@ -1883,7 +1888,7 @@ func (t *gdbThread) clearBreakpointState() {
 func (t *gdbThread) SetCurrentBreakpoint(adjustPC bool) error {
 	// adjustPC is ignored, it is the stub's responsibiility to set the PC
 	// address correctly after hitting a breakpoint.
-	t.clearBreakpointState()
+	t.CurrentBreakpoint.Clear()
 	if t.watchAddr > 0 {
 		t.CurrentBreakpoint.Breakpoint = t.p.Breakpoints().M[t.watchAddr]
 		if t.CurrentBreakpoint.Breakpoint == nil {

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -137,4 +137,9 @@ func (t *nativeThread) Stopped() bool {
 	panic(ErrNativeBackendDisabled)
 }
 
+// SoftExc returns true if this thread received a software exception during the last resume.
+func (t *nativeThread) SoftExc() bool {
+	panic(ErrNativeBackendDisabled)
+}
+
 func initialize(dbp *nativeProcess) error { return nil }

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -341,6 +341,9 @@ func (dbp *nativeProcess) waitForDebugEvent(flags waitForDebugEventFlags) (threa
 
 				if atbp {
 					dbp.os.breakThread = tid
+					if th := dbp.threads[tid]; th != nil {
+						th.os.setbp = true
+					}
 					return tid, 0, nil
 				} else {
 					continueStatus = _DBG_CONTINUE
@@ -428,6 +431,10 @@ func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) 
 	}
 
 	dbp.os.running = false
+	for _, th := range dbp.threads {
+		th.os.setbp = false
+	}
+	trapthread.os.setbp = true
 
 	// While the debug event that stopped the target was being propagated
 	// other target threads could generate other debug events.

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -138,3 +138,8 @@ func (t *nativeThread) restoreRegisters(sr proc.Registers) error {
 func (t *nativeThread) withDebugRegisters(f func(*amd64util.DebugRegisters) error) error {
 	return proc.ErrHWBreakUnsupported
 }
+
+// SoftExc returns true if this thread received a software exception during the last resume.
+func (t *nativeThread) SoftExc() bool {
+	return false
+}

--- a/pkg/proc/native/threads_freebsd.go
+++ b/pkg/proc/native/threads_freebsd.go
@@ -125,3 +125,8 @@ func (t *nativeThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
 func (t *nativeThread) withDebugRegisters(f func(*amd64util.DebugRegisters) error) error {
 	return proc.ErrHWBreakUnsupported
 }
+
+// SoftExc returns true if this thread received a software exception during the last resume.
+func (t *nativeThread) SoftExc() bool {
+	return false
+}

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -115,3 +115,8 @@ func (t *nativeThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
 	}
 	return
 }
+
+// SoftExc returns true if this thread received a software exception during the last resume.
+func (t *nativeThread) SoftExc() bool {
+	return t.os.setbp
+}

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -22,6 +22,7 @@ type osSpecificDetails struct {
 	hThread            syscall.Handle
 	dbgUiRemoteBreakIn bool // whether thread is an auxiliary DbgUiRemoteBreakIn thread created by Windows
 	delayErr           error
+	setbp              bool
 }
 
 func (t *nativeThread) singleStep() error {
@@ -185,4 +186,9 @@ func (t *nativeThread) withDebugRegisters(f func(*amd64util.DebugRegisters) erro
 	}
 
 	return nil
+}
+
+// SoftExc returns true if this thread received a software exception during the last resume.
+func (t *nativeThread) SoftExc() bool {
+	return t.os.setbp
 }

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -30,6 +30,8 @@ type Thread interface {
 	StepInstruction() error
 	// SetCurrentBreakpoint updates the current breakpoint of this thread, if adjustPC is true also checks for breakpoints that were just hit (this should only be passed true after a thread resume)
 	SetCurrentBreakpoint(adjustPC bool) error
+	// SoftExc returns true if this thread received a software exception during the last resume.
+	SoftExc() bool
 	// Common returns the CommonThread structure for this thread
 	Common() *CommonThread
 


### PR DESCRIPTION
This commit improves the handling of hardcoded breakpoints in Delve.

A hardcoded breakpoint is a breakpoint instruction hardcoded in the
text of the program, for example through runtime.Breakpoint.

1. hardcoded breakpoints are now indicated by setting the breakpoint
field on any thread stopped by a hardcoded breakpoint
2. if multiple hardcoded breakpoints are hit during a single stop all
will be notified to the user.

3. a debugger breakpoint with an unmet condition can't hide a hardcoded
breakpoint anymore.
