### PR TITLE
proc: change UserCurrent to exclude internal and runtime/internal

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -497,7 +497,7 @@ func (g *G) UserCurrent() Location {
 		frame := it.Frame()
 		if frame.Call.Fn != nil {
 			name := frame.Call.Fn.Name
-			if strings.Contains(name, ".") && (!strings.HasPrefix(name, "runtime.") || frame.Call.Fn.exportedRuntime()) {
+			if strings.Contains(name, ".") && (!strings.HasPrefix(name, "runtime.") || frame.Call.Fn.exportedRuntime()) && !strings.HasPrefix(name, "internal/") && !strings.HasPrefix(name, "runtime/internal") {
 				return frame.Call
 			}
 		}


### PR DESCRIPTION
packages

Changes UserCurrent to exclude frames stopped inside the 'internal' and
'runtime/internal' packages of the standard library.

Before this change a goroutine blocked accepting or reading from a
socket would be reported as having a user current frame of:

internal/poll.runtime_pollWait

After this change accepting goroutines will be reported with a user
current frame of:

net.(*netFD).accept

and reading goroutines as:

net.(*netFD).read
