### PR TITLE
proc: interpret value of DW_AT_inline correctly

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -2069,7 +2069,7 @@ func (bi *BinaryInfo) loadDebugInfoMapsCompileUnit(ctxt *loadDebugInfoMapsContex
 		case dwarf.TagSubprogram:
 			inlined := false
 			if inval, ok := entry.Val(dwarf.AttrInline).(int64); ok {
-				inlined = inval == 1
+				inlined = inval >= 1
 			}
 
 			if inlined {


### PR DESCRIPTION
All values greater than or equal to 1 indicate that the function has
been inlined.
