### PR TITLE
Documentation: improve wording for "rewind" command (#2870)

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -16,7 +16,7 @@ Command | Description
 [rebuild](#rebuild) | Rebuild the target executable and restarts it. It does not work if the executable was not built by delve.
 [restart](#restart) | Restart process.
 [rev](#rev) | Reverses the execution of the target program for the command specified.
-[rewind](#rewind) | Run backwards until breakpoint or program termination.
+[rewind](#rewind) | Run backwards until breakpoint or start of recorded history.
 [step](#step) | Single step through program.
 [step-instruction](#step-instruction) | Single step a single cpu instruction.
 [stepout](#stepout) | Step out of the current function.
@@ -545,7 +545,7 @@ Currently, only the rev step-instruction command is supported.
 
 
 ## rewind
-Run backwards until breakpoint or program termination.
+Run backwards until breakpoint or start of recorded history.
 
 Aliases: rw
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -554,7 +554,7 @@ The core dump is always written in ELF, even on systems (windows, macOS) where t
 				aliases: []string{"rewind", "rw"},
 				group:   runCmds,
 				cmdFn:   c.rewind,
-				helpMsg: "Run backwards until breakpoint or program termination.",
+				helpMsg: "Run backwards until breakpoint or start of recorded history.",
 			},
 			command{
 				aliases: []string{"check", "checkpoint"},


### PR DESCRIPTION
Fixes #2870 (Documentation for "rewind" command is misleading)