### PR TITLE
proc: always load eh_frame section from executable

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1367,7 +1367,7 @@ func loadBinaryInfoElf(bi *BinaryInfo, image *Image, path string, addr uint64, w
 	image.debugLineStr = debugLineStrBytes
 
 	wg.Add(3)
-	go bi.parseDebugFrameElf(image, dwarfFile, debugInfoBytes, wg)
+	go bi.parseDebugFrameElf(image, dwarfFile, elfFile, debugInfoBytes, wg)
 	go bi.loadDebugInfoMaps(image, debugInfoBytes, debugLineBytes, wg, nil)
 	go bi.loadSymbolName(image, elfFile, wg)
 	if image.index == 0 {
@@ -1395,11 +1395,11 @@ func (bi *BinaryInfo) loadSymbolName(image *Image, file *elf.File, wg *sync.Wait
 	}
 }
 
-func (bi *BinaryInfo) parseDebugFrameElf(image *Image, exe *elf.File, debugInfoBytes []byte, wg *sync.WaitGroup) {
+func (bi *BinaryInfo) parseDebugFrameElf(image *Image, dwarfFile, exeFile *elf.File, debugInfoBytes []byte, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	debugFrameData, debugFrameErr := godwarf.GetDebugSectionElf(exe, "frame")
-	ehFrameSection := exe.Section(".eh_frame")
+	debugFrameData, debugFrameErr := godwarf.GetDebugSectionElf(dwarfFile, "frame")
+	ehFrameSection := exeFile.Section(".eh_frame")
 	var ehFrameData []byte
 	var ehFrameAddr uint64
 	if ehFrameSection != nil {


### PR DESCRIPTION
Always load eh_frame section from the executable file instead of the
split debug info file. The eh_frame section is meant to be loaded in
memory along with the executable file so it will usually not be present
in a split debug info file (or, if it is present, it will be the wrong
one).
