### PR TITLE
bininfo: Strip whitespace from debuginfod-find output

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1241,7 +1241,7 @@ func (bi *BinaryInfo) openSeparateDebugInfo(image *Image, exe *elf.File, debugIn
 			if err != nil {
 				return nil, nil, ErrNoDebugInfoFound
 			}
-			debugFilePath = string(out)
+			debugFilePath = strings.TrimSpace(string(out))
 		} else {
 			return nil, nil, ErrNoDebugInfoFound
 		}


### PR DESCRIPTION
Signed-off-by: Morten Linderud <morten@linderud.pw>