### PR TITLE
pkg/proc: handle double inlined calls

### DIFF
--- a/_fixtures/doubleinline.go
+++ b/_fixtures/doubleinline.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+)
+
+type Rectangle struct{}
+
+func (r *Rectangle) Height() int {
+	h, _ := strconv.ParseInt("7", 10, 0)
+	return int(h)
+}
+
+func (r *Rectangle) Width() int {
+	return 6
+}
+
+func (r *Rectangle) Area() int { return r.Height() * r.Width() }
+
+func main() {
+	var r Rectangle
+	runtime.Breakpoint()
+	fmt.Println(r.Area())
+}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -2262,6 +2262,10 @@ func (bi *BinaryInfo) loadDebugInfoMapsInlinedCalls(ctxt *loadDebugInfoMapsConte
 
 			fl := fileLine{callfile, int(callline)}
 			bi.inlinedCallLines[fl] = append(bi.inlinedCallLines[fl], lowpc)
+
+			if entry.Children {
+				bi.loadDebugInfoMapsInlinedCalls(ctxt, reader, cu)
+			}
 		}
 		reader.SkipChildren()
 	}


### PR DESCRIPTION
It's possible that an inlined function call also contains an inlined
subroutine. In this case we should also parse the children of
inlined calls to ensure we don't lose this information.