### PR TITLE
pkg/terminal: add '-clear' option to 'condition' command

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -178,7 +178,8 @@ If called with the linespec argument it will delete all the breakpoints matching
 Set breakpoint condition.
 
 	condition <breakpoint name or id> <boolean expression>.
-	condition -hitcount <breakpoint name or id> <operator> <argument>
+	condition -hitcount <breakpoint name or id> <operator> <argument>.
+	condition -clear <breakpoint name or id>.
 
 Specifies that the breakpoint, tracepoint or watchpoint should break only if the boolean expression is true.
 
@@ -193,12 +194,15 @@ With the -hitcount option a condition on the breakpoint hit count can be set, th
 	condition -hitcount bp == n
 	condition -hitcount bp != n
 	condition -hitcount bp % n
+
+With the -clear option a condtion on the breakpoint can removed.
 	
 The '% n' form means we should stop at the breakpoint when the hitcount is a multiple of n.
 
 Examples:
 	cond 2 i == 10				breakpoint 2 will stop when variable i equals 10
 	cond name runtime.curg.goid == 5	breakpoint 'name' will stop only on goroutine 5
+	cond -clear 2				the condition on breakpoint 2 will be removed
 
 
 Aliases: cond

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -450,7 +450,8 @@ The command 'on x -edit' can be used to edit the list of commands executed when 
 		{aliases: []string{"condition", "cond"}, group: breakCmds, cmdFn: conditionCmd, allowedPrefixes: onPrefix, helpMsg: `Set breakpoint condition.
 
 	condition <breakpoint name or id> <boolean expression>.
-	condition -hitcount <breakpoint name or id> <operator> <argument>
+	condition -hitcount <breakpoint name or id> <operator> <argument>.
+	condition -clear <breakpoint name or id>.
 
 Specifies that the breakpoint, tracepoint or watchpoint should break only if the boolean expression is true.
 
@@ -465,12 +466,15 @@ With the -hitcount option a condition on the breakpoint hit count can be set, th
 	condition -hitcount bp == n
 	condition -hitcount bp != n
 	condition -hitcount bp % n
+
+With the -clear option a condtion on the breakpoint can removed.
 	
 The '% n' form means we should stop at the breakpoint when the hitcount is a multiple of n.
 
 Examples:
 	cond 2 i == 10				breakpoint 2 will stop when variable i equals 10
 	cond name runtime.curg.goid == 5	breakpoint 'name' will stop only on goroutine 5
+	cond -clear 2				the condition on breakpoint 2 will be removed
 `},
 		{aliases: []string{"config"}, cmdFn: configureCmd, helpMsg: `Changes configuration parameters.
 
@@ -2812,6 +2816,15 @@ func conditionCmd(t *Term, ctx callContext, argstr string) error {
 
 		bp.HitCond = args[1]
 
+		return t.client.AmendBreakpoint(bp)
+	}
+
+	if args[0] == "-clear" {
+		bp, err := getBreakpointByIDOrName(t, args[1])
+		if err != nil {
+			return err
+		}
+		bp.Cond = ""
 		return t.client.AmendBreakpoint(bp)
 	}
 

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1183,6 +1183,26 @@ func TestHitCondBreakpoint(t *testing.T) {
 	})
 }
 
+func TestClearCondBreakpoint(t *testing.T) {
+	withTestTerminal("break", t, func(term *FakeTerminal) {
+		term.MustExec("break main.main:4")
+		term.MustExec("condition 1 i%3==2")
+		listIsAt(t, term, "continue", 7, -1, -1)
+		out := term.MustExec("print i")
+		t.Logf("%q", out)
+		if !strings.Contains(out, "2\n") {
+			t.Fatalf("wrong value of i")
+		}
+		term.MustExec("condition -clear 1")
+		listIsAt(t, term, "continue", 7, -1, -1)
+		out = term.MustExec("print i")
+		t.Logf("%q", out)
+		if !strings.Contains(out, "3\n") {
+			t.Fatalf("wrong value of i")
+		}
+	})
+}
+
 func TestBreakpointEditing(t *testing.T) {
 	term := &FakeTerminal{
 		t:    t,


### PR DESCRIPTION
This change adds the 'clearcond' which will clear condtion on a breakpoint.