### PR TITLE
Implement source listing from debuginfo

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -20,7 +20,7 @@ Function | API Call
 amend_breakpoint(Breakpoint) | Equivalent to API call [AmendBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.AmendBreakpoint)
 ancestors(GoroutineID, NumAncestors, Depth) | Equivalent to API call [Ancestors](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Ancestors)
 attached_to_existing_process() | Equivalent to API call [AttachedToExistingProcess](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.AttachedToExistingProcess)
-build_i_d() | Equivalent to API call [BuildID](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.BuildID)
+build_id() | Equivalent to API call [BuildID](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.BuildID)
 cancel_next() | Equivalent to API call [CancelNext](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.CancelNext)
 checkpoint(Where) | Equivalent to API call [Checkpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Checkpoint)
 clear_breakpoint(Id, Name) | Equivalent to API call [ClearBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ClearBreakpoint)

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -20,6 +20,7 @@ Function | API Call
 amend_breakpoint(Breakpoint) | Equivalent to API call [AmendBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.AmendBreakpoint)
 ancestors(GoroutineID, NumAncestors, Depth) | Equivalent to API call [Ancestors](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Ancestors)
 attached_to_existing_process() | Equivalent to API call [AttachedToExistingProcess](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.AttachedToExistingProcess)
+build_i_d() | Equivalent to API call [BuildID](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.BuildID)
 cancel_next() | Equivalent to API call [CancelNext](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.CancelNext)
 checkpoint(Where) | Equivalent to API call [Checkpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Checkpoint)
 clear_breakpoint(Id, Name) | Equivalent to API call [ClearBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ClearBreakpoint)

--- a/_scripts/gen-starlark-bindings.go
+++ b/_scripts/gen-starlark-bindings.go
@@ -111,6 +111,8 @@ func processServerMethods(serverMethods []*types.Func) []binding {
 			name = "set_expr"
 		case "command":
 			name = "raw_command"
+		case "build_i_d":
+			name = "build_id"
 		case "create_e_b_p_f_tracepoint":
 			name = "create_ebpf_tracepoint"
 		default:

--- a/pkg/proc/debuginfod/debuginfod.go
+++ b/pkg/proc/debuginfod/debuginfod.go
@@ -1,0 +1,28 @@
+package debuginfod
+
+import (
+	"os/exec"
+	"strings"
+)
+
+const debuginfodFind = "debuginfod-find"
+
+func execFind(args ...string) (string, error) {
+	if _, err := exec.LookPath(debuginfodFind); err != nil {
+		return "", err
+	}
+	cmd := exec.Command(debuginfodFind, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), err
+}
+
+func GetSource(buildid, filename string) (string, error) {
+	return execFind("source", buildid, filename)
+}
+
+func GetDebuginfo(buildid string) (string, error) {
+	return execFind("debuginfo", buildid)
+}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2679,10 +2679,10 @@ func printfile(t *Term, filename string, line int, showArrow bool) error {
 
 	var file *os.File
 	path := t.substitutePath(filename)
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		path, err = debuginfod.GetSource(t.client.BuildID(), filename)
-		if err != nil {
-			return fmt.Errorf("couldn't find debuginfod sources")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		foundPath, err := debuginfod.GetSource(t.client.BuildID(), filename)
+		if err == nil {
+			path = foundPath
 		}
 	}
 	file, err := os.OpenFile(path, 0, os.ModePerm)

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -100,7 +100,7 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 		}
 		return env.interfaceToStarlarkValue(rpcRet), nil
 	})
-	r["build_i_d"] = starlark.NewBuiltin("build_i_d", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	r["build_id"] = starlark.NewBuiltin("build_id", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		if err := isCancelled(thread); err != nil {
 			return starlark.None, decorateError(thread, err)
 		}

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -100,6 +100,18 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 		}
 		return env.interfaceToStarlarkValue(rpcRet), nil
 	})
+	r["build_i_d"] = starlark.NewBuiltin("build_i_d", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		if err := isCancelled(thread); err != nil {
+			return starlark.None, decorateError(thread, err)
+		}
+		var rpcArgs rpc2.BuildIDIn
+		var rpcRet rpc2.BuildIDOut
+		err := env.ctx.Client().CallAPI("BuildID", &rpcArgs, &rpcRet)
+		if err != nil {
+			return starlark.None, err
+		}
+		return env.interfaceToStarlarkValue(rpcRet), nil
+	})
 	r["cancel_next"] = starlark.NewBuiltin("cancel_next", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		if err := isCancelled(thread); err != nil {
 			return starlark.None, decorateError(thread, err)

--- a/service/client.go
+++ b/service/client.go
@@ -12,6 +12,9 @@ type Client interface {
 	// Returns the pid of the process we are debugging.
 	ProcessPid() int
 
+	// Returns the BuildID of the process' executable we are debugging.
+	BuildID() string
+
 	// LastModified returns the time that the process' executable was modified.
 	LastModified() time.Time
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2199,6 +2199,10 @@ func (d *Debugger) Target() *proc.Target {
 	return d.target
 }
 
+func (d *Debugger) BuildID() string {
+	return d.target.BinInfo().BuildID
+}
+
 func (d *Debugger) GetBufferedTracepoints() []api.TracepointResult {
 	traces := d.target.GetBufferedTracepoints()
 	if traces == nil {

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -48,6 +48,12 @@ func (c *RPCClient) ProcessPid() int {
 	return out.Pid
 }
 
+func (c *RPCClient) BuildID() string {
+	out := new(BuildIDOut)
+	c.call("BuildID", BuildIDIn{}, out)
+	return out.BuildID
+}
+
 func (c *RPCClient) LastModified() time.Time {
 	out := new(LastModifiedOut)
 	c.call("LastModified", LastModifiedIn{}, out)

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -1011,3 +1011,15 @@ func (s *RPCServer) CreateWatchpoint(arg CreateWatchpointIn, out *CreateWatchpoi
 	out.Breakpoint, err = s.debugger.CreateWatchpoint(arg.Scope.GoroutineID, arg.Scope.Frame, arg.Scope.DeferredCall, arg.Expr, arg.Type)
 	return err
 }
+
+type BuildIDIn struct {
+}
+
+type BuildIDOut struct {
+	BuildID string
+}
+
+func (s *RPCServer) BuildID(arg BuildIDIn, out *BuildIDOut) error {
+	out.BuildID = s.debugger.BuildID()
+	return nil
+}


### PR DESCRIPTION
This pull-request does  a few things.

We implement a BuilID call in the RPC so the client can figure out which binary it's working on.

We implement support for fetching file listing through `debuginfod-find` if they are not present locally.

Then lastly we try to remove a bit of the duplicated code around dealing with `debuginfod-find`.

I'm not sure how much testing you want around this, or if new package belongs under `pkg/proc/debuginfod`. Feel free to nitpick and I'll try fix up all the issues around this patch :)