### PR TITLE
_scripts: fix camelToDash in gen-starlark-bindings.go

### DIFF
--- a/_scripts/gen-starlark-bindings.go
+++ b/_scripts/gen-starlark-bindings.go
@@ -74,13 +74,17 @@ func fieldsOfStruct(typ types.Type) (fieldNames, fieldTypes []string) {
 func camelToDash(in string) string {
 	out := []rune{}
 	for i, ch := range in {
-		if ch < 'A' || ch > 'Z' {
-			out = append(out, ch)
-			continue
+		isupper := func(i int) bool {
+			ch := in[i]
+			return ch >= 'A' && ch <= 'Z'
 		}
 
-		if i != 0 {
-			out = append(out, '_')
+		if i > 0 && isupper(i) {
+			if !isupper(i - 1) {
+				out = append(out, '_')
+			} else if i+1 < len(in) && !isupper(i+1) {
+				out = append(out, '_')
+			}
 		}
 		out = append(out, unicode.ToLower(ch))
 	}
@@ -111,10 +115,6 @@ func processServerMethods(serverMethods []*types.Func) []binding {
 			name = "set_expr"
 		case "command":
 			name = "raw_command"
-		case "build_i_d":
-			name = "build_id"
-		case "create_e_b_p_f_tracepoint":
-			name = "create_ebpf_tracepoint"
 		default:
 			// remove list_ prefix, it looks better
 			const listPrefix = "list_"


### PR DESCRIPTION
Fix camelToDash so that it handles BuildID and CreateEBPFTracepoint
correctly.
