### PR TITLE
terminal/colorize: avoid emitting `Package` as illegal colorTok

### DIFF
--- a/pkg/terminal/colorize/colorize.go
+++ b/pkg/terminal/colorize/colorize.go
@@ -126,7 +126,7 @@ func Print(out io.Writer, path string, reader io.Reader, startLine, endLine, arr
 			emit(tokval.Interface().(token.Token), tokposval.Interface().(token.Pos), token.NoPos)
 		}
 
-		for _, kwname := range []string{"Case", "Begin", "Defer", "Pacakge", "For", "Func", "Go", "Interface", "Map", "Return", "Select", "Struct", "Switch"} {
+		for _, kwname := range []string{"Case", "Begin", "Defer", "For", "Func", "Go", "Interface", "Map", "Return", "Select", "Struct", "Switch"} {
 			kwposval := nval.FieldByName(kwname)
 			if kwposval != (reflect.Value{}) {
 				kwpos, ok := kwposval.Interface().(token.Pos)


### PR DESCRIPTION
we have emitted token.Package, so  we may  avoid  emtting `Package` as illegal colorTok again.

Before there's a typo error here:
"Package" is typed as "Pacakge", if we change it to "Package" and run `dlv debug main.go` and `list main.go:0`, dlv will output "packagepackage main" instead of "package main".

So I think we should remove the `Package` from here.