### PR TITLE
proc: fix crash trying to open separate debug info

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1209,7 +1209,7 @@ func (bi *BinaryInfo) openSeparateDebugInfo(image *Image, exe *elf.File, debugIn
 	var err error
 	for _, dir := range debugInfoDirectories {
 		var potentialDebugFilePath string
-		if strings.Contains(dir, "build-id") {
+		if strings.Contains(dir, "build-id") && len(bi.BuildID) > 2 {
 			potentialDebugFilePath = fmt.Sprintf("%s/%s/%s.debug", dir, bi.BuildID[:2], bi.BuildID[2:])
 		} else if strings.HasPrefix(image.Path, "/proc") {
 			path, err := filepath.EvalSymlinks(image.Path)


### PR DESCRIPTION
If debugInfoDirectories is set, the executable does not have debug info
and build-id is not set we should not crash.
