### PR TITLE
_scripts: handle not installed CommandLineTools

### DIFF
--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -271,7 +271,8 @@ func canMacnative() bool {
 
 	typesHeader := "/usr/include/sys/types.h"
 	if major >= 11 || (major == 10 && minor >= 15) {
-		typesHeader = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/types.h"
+		sdkpath := strings.TrimSpace(getoutput("xcrun", "--sdk", "macosx", "--show-sdk-path"))
+		typesHeader = filepath.Join(sdkpath, "usr", "include", "sys", "types.h")
 	}
 	_, err = os.Stat(typesHeader)
 	if err != nil {


### PR DESCRIPTION
Handle not installed `CommandLineTools`.

Currently, when installed `Xcode.app` but not installed `CommandLineTools`, `make install` will not adding `-tags=macnative`
Use `xcurn` macOS built-in command for detect SDK path instead of hardcoded `/Library/Developer/CommandLineTools`.