### PR TITLE
proc: move resume notify and manual stop handling to Target

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -415,7 +415,7 @@ func (p *process) ClearInternalBreakpoints() error {
 
 // ContinueOnce will always return an error because you
 // cannot control execution of a core file.
-func (p *process) ContinueOnce() (proc.Thread, proc.StopReason, error) {
+func (p *process) ContinueOnce(cctx *proc.ContinueOnceContext) (proc.Thread, proc.StopReason, error) {
 	return nil, proc.StopUnknown, ErrContinueCore
 }
 
@@ -427,7 +427,7 @@ func (p *process) StepInstruction() error {
 
 // RequestManualStop will return nil and have no effect
 // as you cannot control execution of a core file.
-func (p *process) RequestManualStop() error {
+func (p *process) RequestManualStop(cctx *proc.ContinueOnceContext) error {
 	return nil
 }
 

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -61,7 +61,7 @@ func (dbp *nativeProcess) trapWait(pid int) (*nativeThread, error) {
 	panic(ErrNativeBackendDisabled)
 }
 
-func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
+func (dbp *nativeProcess) stop(cctx *proc.ContinueOnceContext, trapthread *nativeThread) (*nativeThread, error) {
 	panic(ErrNativeBackendDisabled)
 }
 

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -121,7 +121,7 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ strin
 	if err != nil {
 		return nil, err
 	}
-	if _, err := dbp.stop(nil); err != nil {
+	if _, err := dbp.stop(nil, nil); err != nil {
 		return nil, err
 	}
 
@@ -318,9 +318,7 @@ func (dbp *nativeProcess) trapWait(pid int) (*nativeThread, error) {
 			return nil, proc.ErrProcessExited{Pid: dbp.pid, Status: status.ExitStatus()}
 
 		case C.MACH_RCV_INTERRUPTED:
-			dbp.stopMu.Lock()
 			halt := dbp.os.halt
-			dbp.stopMu.Unlock()
 			if !halt {
 				// Call trapWait again, it seems
 				// MACH_RCV_INTERRUPTED is emitted before
@@ -349,9 +347,7 @@ func (dbp *nativeProcess) trapWait(pid int) (*nativeThread, error) {
 		dbp.updateThreadList()
 		th, ok := dbp.threads[int(port)]
 		if !ok {
-			dbp.stopMu.Lock()
 			halt := dbp.os.halt
-			dbp.stopMu.Unlock()
 			if halt {
 				dbp.os.halt = false
 				return th, nil
@@ -433,7 +429,7 @@ func (dbp *nativeProcess) resume() error {
 }
 
 // stop stops all running threads and sets breakpoints
-func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
+func (dbp *nativeProcess) stop(cctx *proc.ContinueOnceContext, trapthread *nativeThread) (*nativeThread, error) {
 	if dbp.exited {
 		return nil, proc.ErrProcessExited{Pid: dbp.pid}
 	}

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -350,7 +350,7 @@ func (dbp *nativeProcess) resume() error {
 
 // Used by ContinueOnce
 // stop stops all running threads and sets breakpoints
-func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
+func (dbp *nativeProcess) stop(cctx *proc.ContinueOnceContext, trapthread *nativeThread) (*nativeThread, error) {
 	if dbp.exited {
 		return nil, proc.ErrProcessExited{Pid: dbp.pid}
 	}

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -425,7 +425,7 @@ func (dbp *nativeProcess) resume() error {
 }
 
 // stop stops all running threads threads and sets breakpoints
-func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
+func (dbp *nativeProcess) stop(cctx *proc.ContinueOnceContext, trapthread *nativeThread) (*nativeThread, error) {
 	if dbp.exited {
 		return nil, proc.ErrProcessExited{Pid: dbp.pid}
 	}

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -56,11 +56,11 @@ func (dbp *Target) Continue() error {
 	}
 	dbp.Breakpoints().WatchOutOfScope = nil
 	dbp.clearHardcodedBreakpoints()
-	dbp.CheckAndClearManualStopRequest()
+	dbp.cctx.CheckAndClearManualStopRequest()
 	defer func() {
 		// Make sure we clear internal breakpoints if we simultaneously receive a
 		// manual stop request and hit a breakpoint.
-		if dbp.CheckAndClearManualStopRequest() {
+		if dbp.cctx.CheckAndClearManualStopRequest() {
 			dbp.StopReason = StopManual
 			dbp.clearHardcodedBreakpoints()
 			if dbp.KeepSteppingBreakpoints&HaltKeepsSteppingBreakpoints == 0 {
@@ -69,7 +69,7 @@ func (dbp *Target) Continue() error {
 		}
 	}()
 	for {
-		if dbp.CheckAndClearManualStopRequest() {
+		if dbp.cctx.CheckAndClearManualStopRequest() {
 			dbp.StopReason = StopManual
 			dbp.clearHardcodedBreakpoints()
 			if dbp.KeepSteppingBreakpoints&HaltKeepsSteppingBreakpoints == 0 {
@@ -78,7 +78,7 @@ func (dbp *Target) Continue() error {
 			return nil
 		}
 		dbp.ClearCaches()
-		trapthread, stopReason, contOnceErr := dbp.proc.ContinueOnce()
+		trapthread, stopReason, contOnceErr := dbp.proc.ContinueOnce(dbp.cctx)
 		dbp.StopReason = stopReason
 
 		threads := dbp.ThreadList()


### PR DESCRIPTION
Moves handling of ResumeNotify and manualStopRequested to Target instead of the backends

Updates #2551
