### PR TITLE
Improve coverage of rr backend by allowing recording (#2932)

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -349,6 +349,7 @@ func TestBreakpointInSeparateGoRoutine(t *testing.T) {
 }
 
 func TestBreakpointWithNonExistantFunction(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("testprog", t, func(p *proc.Target, fixture protest.Fixture) {
 		_, err := p.SetBreakpoint(0, 0, proc.UserBreakpoint, nil)
 		if err == nil {
@@ -358,6 +359,7 @@ func TestBreakpointWithNonExistantFunction(t *testing.T) {
 }
 
 func TestClearBreakpointBreakpoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("testprog", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFunctionBreakpoint(p, t, "main.sleepytime")
 
@@ -1061,6 +1063,7 @@ func testGSupportFunc(name string, t *testing.T, p *proc.Target, fixture protest
 }
 
 func TestGetG(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("testprog", t, func(p *proc.Target, fixture protest.Fixture) {
 		testGSupportFunc("nocgo", t, p, fixture)
 	})
@@ -1359,6 +1362,7 @@ func TestThreadFrameEvaluation(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
 		t.SkipNow()
 	}
+	protest.AllowRecording(t)
 	withTestProcess("testdeadlock", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 
@@ -1765,6 +1769,7 @@ func TestCondBreakpointError(t *testing.T) {
 }
 
 func TestHitCondBreakpointEQ(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("break", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 7)
 		bp.UserBreaklet().HitCond = &struct {
@@ -2005,6 +2010,7 @@ func TestIssue149(t *testing.T) {
 		return
 	}
 	// setting breakpoint on break statement
+	protest.AllowRecording(t)
 	withTestProcess("break", t, func(p *proc.Target, fixture protest.Fixture) {
 		findFileLocation(p, t, fixture.Source, 8)
 	})
@@ -2046,6 +2052,7 @@ func TestCmdLineArgs(t *testing.T) {
 		}
 	}
 
+	protest.AllowRecording(t)
 	// make sure multiple arguments (including one with spaces) are passed to the binary correctly
 	withTestProcessArgs("testargs", t, ".", []string{"test"}, 0, expectSuccess)
 	withTestProcessArgs("testargs", t, ".", []string{"-test"}, 0, expectPanic)
@@ -2245,6 +2252,7 @@ func TestIssue573(t *testing.T) {
 }
 
 func TestTestvariables2Prologue(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("testvariables2", t, func(p *proc.Target, fixture protest.Fixture) {
 		addrEntry := p.BinInfo().LookupFunc["main.main"].Entry
 		addrPrologue := findFunctionLocation(p, t, "main.main")
@@ -3064,6 +3072,7 @@ func TestIssue877(t *testing.T) {
 	}
 	const envval = "/usr/local/lib"
 	os.Setenv("DYLD_LIBRARY_PATH", envval)
+	protest.AllowRecording(t)
 	withTestProcess("issue877", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 		v := evalVariable(p, t, "dyldenv")
@@ -3261,6 +3270,7 @@ func TestAttachStripped(t *testing.T) {
 func TestIssue844(t *testing.T) {
 	// Conditional breakpoints should not prevent next from working if their
 	// condition isn't met.
+	protest.AllowRecording(t)
 	withTestProcess("nextcond", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 9)
 		condbp := setFileBreakpoint(p, t, fixture.Source, 10)
@@ -3485,6 +3495,7 @@ func TestCgoSources(t *testing.T) {
 
 	protest.MustHaveCgo(t)
 
+	protest.AllowRecording(t)
 	withTestProcess("cgostacktest/", t, func(p *proc.Target, fixture protest.Fixture) {
 		sources := p.BinInfo().Sources
 		for _, needle := range []string{"main.go", "hello.c"} {
@@ -3504,6 +3515,7 @@ func TestCgoSources(t *testing.T) {
 
 func TestSystemstackStacktrace(t *testing.T) {
 	// check that we can follow a stack switch initiated by runtime.systemstack()
+	protest.AllowRecording(t)
 	withTestProcess("panic", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "runtime.startpanic_m")
 		assertNoError(p.Continue(), t, "first continue")
@@ -3559,6 +3571,7 @@ func TestIssue1034(t *testing.T) {
 
 	// The external linker on macOS produces an abbrev for DW_TAG_subprogram
 	// without the "has children" flag, we should support this.
+	protest.AllowRecording(t)
 	withTestProcess("cgostacktest/", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -3579,6 +3592,7 @@ func TestIssue1008(t *testing.T) {
 
 	// The external linker on macOS inserts "end of sequence" extended opcodes
 	// in debug_line. which we should support correctly.
+	protest.AllowRecording(t)
 	withTestProcess("cgostacktest/", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -3624,6 +3638,7 @@ func TestDeclLine(t *testing.T) {
 		t.Skip("go 1.9 and prior versions do not emit DW_AT_decl_line")
 	}
 
+	protest.AllowRecording(t)
 	withTestProcess("decllinetest", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 8)
 		setFileBreakpoint(p, t, fixture.Source, 9)
@@ -3657,6 +3672,7 @@ func TestDeclLine(t *testing.T) {
 }
 
 func TestIssue1137(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("dotpackagesiface", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 		v := evalVariable(p, t, "iface")
@@ -3760,6 +3776,7 @@ func TestDisassembleGlobalVars(t *testing.T) {
 	if runtime.GOARCH == "386" && runtime.GOOS == "linux" && buildMode == "pie" {
 		t.Skip("On 386 linux when pie, symLookup can't look up global variables")
 	}
+	protest.AllowRecording(t)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
 		mainfn := p.BinInfo().LookupFunc["main.main"]
 		regs, _ := p.CurrentThread().Registers()
@@ -3802,6 +3819,7 @@ func TestAllPCsForFileLines(t *testing.T) {
 		// Versions of go before 1.10 do not have DWARF information for inlined calls
 		t.Skip("inlining not supported")
 	}
+	protest.AllowRecording(t)
 	withTestProcessArgs("testinline", t, ".", []string{}, protest.EnableInlining, func(p *proc.Target, fixture protest.Fixture) {
 		l2pcs := p.BinInfo().AllPCsForFileLines(fixture.Source, []int{7, 20})
 		if len(l2pcs) != 2 {
@@ -3866,6 +3884,7 @@ func TestInlinedStacktraceAndVariables(t *testing.T) {
 		},
 	}
 
+	protest.AllowRecording(t)
 	withTestProcessArgs("testinline", t, ".", []string{}, protest.EnableInlining, func(p *proc.Target, fixture protest.Fixture) {
 		pcs, err := proc.FindFileLocation(p, fixture.Source, 7)
 		assertNoError(err, t, "LineToPC")
@@ -3995,6 +4014,7 @@ func TestInlineFunctionList(t *testing.T) {
 		// Versions of go before 1.10 do not have DWARF information for inlined calls
 		t.Skip("inlining not supported")
 	}
+	protest.AllowRecording(t)
 	withTestProcessArgs("testinline", t, ".", []string{}, protest.EnableInlining|protest.EnableOptimization, func(p *proc.Target, fixture protest.Fixture) {
 		var found bool
 		for _, fn := range p.BinInfo().Functions {
@@ -4015,6 +4035,7 @@ func TestInlineBreakpoint(t *testing.T) {
 		// Versions of go before 1.10 do not have DWARF information for inlined calls
 		t.Skip("inlining not supported")
 	}
+	protest.AllowRecording(t)
 	withTestProcessArgs("testinline", t, ".", []string{}, protest.EnableInlining|protest.EnableOptimization, func(p *proc.Target, fixture protest.Fixture) {
 		pcs, err := proc.FindFileLocation(p, fixture.Source, 17)
 		if err != nil {
@@ -4043,6 +4064,7 @@ func TestDoubleInlineBreakpoint(t *testing.T) {
 		// Versions of go before 1.10 do not have DWARF information for inlined calls
 		t.Skip("inlining not supported")
 	}
+	protest.AllowRecording(t)
 	withTestProcessArgs("doubleinline", t, ".", []string{}, protest.EnableInlining|protest.EnableOptimization, func(p *proc.Target, fixture protest.Fixture) {
 		fns, err := p.BinInfo().FindFunction("main.(*Rectangle).Height")
 		if err != nil {
@@ -4135,6 +4157,7 @@ func TestStepOutReturn(t *testing.T) {
 	if ver.Major >= 0 && !ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 10, Rev: -1}) {
 		t.Skip("return variables aren't marked on 1.9 or earlier")
 	}
+	protest.AllowRecording(t)
 	withTestProcess("stepoutret", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.stepout")
 		assertNoError(p.Continue(), t, "Continue")
@@ -4183,6 +4206,7 @@ func TestStepOutReturn(t *testing.T) {
 }
 
 func TestOptimizationCheck(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("continuetestprog", t, func(p *proc.Target, fixture protest.Fixture) {
 		fn := p.BinInfo().LookupFunc["main.main"]
 		if fn.Optimized() {
@@ -4203,6 +4227,7 @@ func TestOptimizationCheck(t *testing.T) {
 func TestIssue1264(t *testing.T) {
 	// It should be possible to set a breakpoint condition that consists only
 	// of evaluating a single boolean variable.
+	protest.AllowRecording(t)
 	withTestProcess("issue1264", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 8)
 		bp.UserBreaklet().Cond = &ast.Ident{Name: "equalsTwo"}
@@ -4275,6 +4300,7 @@ func TestNextUnknownInstr(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 10) {
 		t.Skip("versions of Go before 1.10 can't assemble the instruction VPUNPCKLWD")
 	}
+	protest.AllowRecording(t)
 	withTestProcess("nodisasm/", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.asmFunc")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -4378,6 +4404,7 @@ func TestIssue1432(t *testing.T) {
 }
 
 func TestGoroutinesInfoLimit(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 37)
 		assertNoError(p.Continue(), t, "Continue()")
@@ -4407,6 +4434,7 @@ func TestGoroutinesInfoLimit(t *testing.T) {
 }
 
 func TestIssue1469(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("issue1469", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 13)
 		assertNoError(p.Continue(), t, "Continue()")
@@ -4444,6 +4472,7 @@ func TestDeadlockBreakpoint(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
 		deadlockBp = proc.UnrecoveredPanic
 	}
+	protest.AllowRecording(t)
 	withTestProcess("testdeadlock", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 
@@ -4517,6 +4546,7 @@ func TestAncestors(t *testing.T) {
 	savedGodebug := os.Getenv("GODEBUG")
 	os.Setenv("GODEBUG", "tracebackancestors=100")
 	defer os.Setenv("GODEBUG", savedGodebug)
+	protest.AllowRecording(t)
 	withTestProcess("testnextprog", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.testgoroutine")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -4634,6 +4664,7 @@ func TestPluginStepping(t *testing.T) {
 func TestIssue1601(t *testing.T) {
 	protest.MustHaveCgo(t)
 	//Tests that recursive types involving C qualifiers and typedefs are parsed correctly
+	protest.AllowRecording(t)
 	withTestProcess("issue1601", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue")
 		evalVariable(p, t, "C.globalq")
@@ -4643,6 +4674,7 @@ func TestIssue1601(t *testing.T) {
 func TestIssue1615(t *testing.T) {
 	// A breakpoint condition that tests for string equality with a constant string shouldn't fail with 'string too long for comparison' error
 
+	protest.AllowRecording(t)
 	withTestProcess("issue1615", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 19)
 		bp.UserBreaklet().Cond = &ast.BinaryExpr{
@@ -4663,6 +4695,7 @@ func TestCgoStacktrace2(t *testing.T) {
 	protest.MustHaveCgo(t)
 	// If a panic happens during cgo execution the stacktrace should show the C
 	// function that caused the problem.
+	protest.AllowRecording(t)
 	withTestProcess("cgosigsegvstack", t, func(p *proc.Target, fixture protest.Fixture) {
 		p.Continue()
 		frames, err := proc.ThreadStacktrace(p.CurrentThread(), 100)
@@ -4677,6 +4710,7 @@ func TestCgoStacktrace2(t *testing.T) {
 
 func TestIssue1656(t *testing.T) {
 	skipUnlessOn(t, "amd64 only", "amd64")
+	protest.AllowRecording(t)
 	withTestProcess("issue1656/", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, filepath.ToSlash(filepath.Join(fixture.BuildDir, "main.s")), 5)
 		assertNoError(p.Continue(), t, "Continue()")
@@ -4695,6 +4729,7 @@ func TestBreakpointConfusionOnResume(t *testing.T) {
 	// stopped at.
 	// This test checks for a regression introduced when fixing Issue #1656
 	skipUnlessOn(t, "amd64 only", "amd64")
+	protest.AllowRecording(t)
 	withTestProcess("nopbreakpoint/", t, func(p *proc.Target, fixture protest.Fixture) {
 		maindots := filepath.ToSlash(filepath.Join(fixture.BuildDir, "main.s"))
 		maindotgo := filepath.ToSlash(filepath.Join(fixture.BuildDir, "main.go"))
@@ -4712,6 +4747,7 @@ func TestBreakpointConfusionOnResume(t *testing.T) {
 }
 
 func TestIssue1736(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("testvariables2", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 		ch1BufVar := evalVariable(p, t, "*(ch1.buf)")
@@ -4727,12 +4763,14 @@ func TestIssue1736(t *testing.T) {
 func TestIssue1817(t *testing.T) {
 	// Setting a breakpoint on a line that doesn't have any PC addresses marked
 	// is_stmt should work.
+	protest.AllowRecording(t)
 	withTestProcess("issue1817", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 16)
 	})
 }
 
 func TestListPackagesBuildInfo(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("pkgrenames", t, func(p *proc.Target, fixture protest.Fixture) {
 		pkgs := p.BinInfo().ListPackagesBuildInfo(true)
 		t.Logf("returned %d", len(pkgs))
@@ -5092,6 +5130,7 @@ func TestStepOutPreservesGoroutine(t *testing.T) {
 	// Checks that StepOut preserves the currently selected goroutine.
 	skipOn(t, "broken", "freebsd")
 	rand.Seed(time.Now().Unix())
+	protest.AllowRecording(t)
 	withTestProcess("issue2113", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 
@@ -5429,6 +5468,7 @@ func TestVariablesWithExternalLinking(t *testing.T) {
 	// See:
 	//  https://github.com/golang/go/issues/25841
 	//  https://github.com/go-delve/delve/issues/2346
+	protest.AllowRecording(t)
 	withTestProcessArgs("testvariables2", t, ".", []string{}, protest.BuildModeExternalLinker, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 		str1Var := evalVariable(p, t, "str1")
@@ -5593,6 +5633,7 @@ func TestManualStopWhileStopped(t *testing.T) {
 
 func TestDwrapStartLocation(t *testing.T) {
 	// Tests that the start location of a goroutine is unwrapped in Go 1.17 and later.
+	protest.AllowRecording(t)
 	withTestProcess("goroutinestackprog", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.stacktraceme")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -5752,6 +5793,7 @@ func TestWatchpointStackBackwardsOutOfScope(t *testing.T) {
 func TestSetOnFunctions(t *testing.T) {
 	// The set command between function variables should fail with an error
 	// Issue #2691
+	protest.AllowRecording(t)
 	withTestProcess("goroutinestackprog", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -5819,6 +5861,7 @@ func TestNilPtrDerefInBreakInstr(t *testing.T) {
 		t.Fatalf("assembly file for %s not provided", runtime.GOARCH)
 	}
 
+	protest.AllowRecording(t)
 	withTestProcess("asmnilptr/", t, func(p *proc.Target, fixture protest.Fixture) {
 		f := filepath.Join(fixture.BuildDir, asmfile)
 		f = strings.Replace(f, "\\", "/", -1)

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -23,6 +23,7 @@ func TestScopeWithEscapedVariable(t *testing.T) {
 		return
 	}
 
+	protest.AllowRecording(t)
 	withTestProcess("scopeescapevareval", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue")
 
@@ -72,6 +73,7 @@ func TestScope(t *testing.T) {
 
 	scopeChecks := getScopeChecks(scopetestPath, t)
 
+	protest.AllowRecording(t)
 	withTestProcess("scopetest", t, func(p *proc.Target, fixture protest.Fixture) {
 		for i := range scopeChecks {
 			setFileBreakpoint(p, t, fixture.Source, scopeChecks[i].line)

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -291,6 +291,7 @@ func TestTraceOnNonFunctionEntry(t *testing.T) {
 }
 
 func TestExitStatus(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
 		term.Exec("continue")
 		status, err := term.handleExit()
@@ -812,6 +813,7 @@ func TestConfig(t *testing.T) {
 func TestIssue1090(t *testing.T) {
 	// Exit while executing 'next' should report the "Process exited" error
 	// message instead of crashing.
+	test.AllowRecording(t)
 	withTestTerminal("math", t, func(term *FakeTerminal) {
 		term.MustExec("break main.main")
 		term.MustExec("continue")
@@ -825,6 +827,7 @@ func TestIssue1090(t *testing.T) {
 }
 
 func TestPrintContextParkedGoroutine(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("goroutinestackprog", t, func(term *FakeTerminal) {
 		term.MustExec("break stacktraceme")
 		term.MustExec("continue")
@@ -864,6 +867,7 @@ func TestStepOutReturn(t *testing.T) {
 	if ver.Major >= 0 && !ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 10, Rev: -1}) {
 		t.Skip("return variables aren't marked on 1.9 or earlier")
 	}
+	test.AllowRecording(t)
 	withTestTerminal("stepoutret", t, func(term *FakeTerminal) {
 		term.MustExec("break main.stepout")
 		term.MustExec("continue")
@@ -876,6 +880,7 @@ func TestStepOutReturn(t *testing.T) {
 }
 
 func TestOptimizationCheck(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
 		term.MustExec("break main.main")
 		out := term.MustExec("continue")
@@ -899,6 +904,7 @@ func TestOptimizationCheck(t *testing.T) {
 
 func TestTruncateStacktrace(t *testing.T) {
 	const stacktraceTruncatedMessage = "(truncated)"
+	test.AllowRecording(t)
 	withTestTerminal("stacktraceprog", t, func(term *FakeTerminal) {
 		term.MustExec("break main.stacktraceme")
 		term.MustExec("continue")
@@ -918,6 +924,7 @@ func TestTruncateStacktrace(t *testing.T) {
 func TestIssue1493(t *testing.T) {
 	// The 'regs' command without the '-a' option should only return
 	// general purpose registers.
+	test.AllowRecording(t)
 	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
 		r := term.MustExec("regs")
 		nr := len(strings.Split(r, "\n"))
@@ -1049,6 +1056,7 @@ func TestExamineMemoryCmd(t *testing.T) {
 }
 
 func TestPrintOnTracepoint(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("increment", t, func(term *FakeTerminal) {
 		term.MustExec("trace main.Increment")
 		term.MustExec("on 1 print y+1")
@@ -1115,6 +1123,7 @@ func TestParseNewArgv(t *testing.T) {
 }
 
 func TestContinueUntil(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
 		if runtime.GOARCH != "386" {
 			listIsAt(t, term, "continue main.main", 16, -1, -1)
@@ -1126,6 +1135,7 @@ func TestContinueUntil(t *testing.T) {
 }
 
 func TestContinueUntilExistingBreakpoint(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("continuetestprog", t, func(term *FakeTerminal) {
 		term.MustExec("break main.main")
 		if runtime.GOARCH != "386" {
@@ -1148,6 +1158,7 @@ func TestPrintFormat(t *testing.T) {
 }
 
 func TestHitCondBreakpoint(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("break", t, func(term *FakeTerminal) {
 		term.MustExec("break bp1 main.main:4")
 		term.MustExec("condition -hitcount bp1 > 2")
@@ -1161,6 +1172,7 @@ func TestHitCondBreakpoint(t *testing.T) {
 }
 
 func TestClearCondBreakpoint(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("break", t, func(term *FakeTerminal) {
 		term.MustExec("break main.main:4")
 		term.MustExec("condition 1 i%3==2")
@@ -1268,6 +1280,7 @@ func TestBreakpointEditing(t *testing.T) {
 }
 
 func TestTranscript(t *testing.T) {
+	test.AllowRecording(t)
 	withTestTerminal("math", t, func(term *FakeTerminal) {
 		term.MustExec("break main.main")
 		out := term.MustExec("continue")

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -104,6 +104,7 @@ func Test1Restart_afterExit(t *testing.T) {
 }
 
 func Test1Restart_breakpointPreservation(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("continuetestprog", t, func(c *rpc1.RPCClient) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1, Name: "firstbreakpoint", Tracepoint: true})
 		assertNoError(err, t, "CreateBreakpoint()")
@@ -160,6 +161,7 @@ func Test1Restart_duringStop(t *testing.T) {
 }
 
 func Test1ClientServer_exit(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("continuetestprog", t, func(c *rpc1.RPCClient) {
 		state, err := c.GetState()
 		if err != nil {
@@ -183,6 +185,7 @@ func Test1ClientServer_exit(t *testing.T) {
 }
 
 func Test1ClientServer_step(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testprog", t, func(c *rpc1.RPCClient) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.helloworld", Line: -1})
 		if err != nil {
@@ -206,6 +209,7 @@ func Test1ClientServer_step(t *testing.T) {
 }
 
 func testnext(testcases []nextTest, initialLocation string, t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testnextprog", t, func(c *rpc1.RPCClient) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: initialLocation, Line: -1})
 		if err != nil {
@@ -297,6 +301,7 @@ func Test1NextFunctionReturn(t *testing.T) {
 }
 
 func Test1ClientServer_breakpointInMainThread(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testprog", t, func(c *rpc1.RPCClient) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.helloworld", Line: 1})
 		if err != nil {
@@ -318,6 +323,7 @@ func Test1ClientServer_breakpointInMainThread(t *testing.T) {
 }
 
 func Test1ClientServer_breakpointInSeparateGoroutine(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testthreads", t, func(c *rpc1.RPCClient) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.anotherthread", Line: 1})
 		if err != nil {
@@ -337,6 +343,7 @@ func Test1ClientServer_breakpointInSeparateGoroutine(t *testing.T) {
 }
 
 func Test1ClientServer_breakAtNonexistentPoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testprog", t, func(c *rpc1.RPCClient) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "nowhere", Line: 1})
 		if err == nil {
@@ -346,6 +353,7 @@ func Test1ClientServer_breakAtNonexistentPoint(t *testing.T) {
 }
 
 func Test1ClientServer_clearBreakpoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testprog", t, func(c *rpc1.RPCClient) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sleepytime", Line: 1})
 		if err != nil {
@@ -372,6 +380,7 @@ func Test1ClientServer_clearBreakpoint(t *testing.T) {
 }
 
 func Test1ClientServer_switchThread(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testnextprog", t, func(c *rpc1.RPCClient) {
 		// With invalid thread id
 		_, err := c.SwitchThread(-1)
@@ -415,6 +424,7 @@ func Test1ClientServer_switchThread(t *testing.T) {
 }
 
 func Test1ClientServer_infoLocals(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testnextprog", t, func(c *rpc1.RPCClient) {
 		fp := testProgPath(t, "testnextprog")
 		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 24})
@@ -436,6 +446,7 @@ func Test1ClientServer_infoLocals(t *testing.T) {
 }
 
 func Test1ClientServer_infoArgs(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testnextprog", t, func(c *rpc1.RPCClient) {
 		fp := testProgPath(t, "testnextprog")
 		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 47})
@@ -464,6 +475,7 @@ func Test1ClientServer_infoArgs(t *testing.T) {
 }
 
 func Test1ClientServer_traceContinue(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("integrationprog", t, func(c *rpc1.RPCClient) {
 		fp := testProgPath(t, "integrationprog")
 		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 15, Tracepoint: true, Goroutine: true, Stacktrace: 5, Variables: []string{"i"}})
@@ -521,6 +533,7 @@ func Test1ClientServer_traceContinue(t *testing.T) {
 }
 
 func Test1ClientServer_traceContinue2(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("integrationprog", t, func(c *rpc1.RPCClient) {
 		bp1, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1, Tracepoint: true})
 		if err != nil {
@@ -564,6 +577,7 @@ func Test1ClientServer_traceContinue2(t *testing.T) {
 }
 
 func Test1ClientServer_FindLocations(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("locationsprog", t, func(c *rpc1.RPCClient) {
 		someFunctionCallAddr := findLocationHelper(t, c, "locationsprog.go:26", false, 1, 0)[0]
 		someFunctionLine1 := findLocationHelper(t, c, "locationsprog.go:27", false, 1, 0)[0]
@@ -725,6 +739,7 @@ func Test1ClientServer_FullStacktrace(t *testing.T) {
 		lenient = true
 	}
 
+	protest.AllowRecording(t)
 	withTestClient1("goroutinestackprog", t, func(c *rpc1.RPCClient) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.stacktraceme", Line: -1})
 		assertNoError(err, t, "CreateBreakpoint()")
@@ -972,6 +987,7 @@ func Test1Disasm(t *testing.T) {
 }
 
 func Test1NegativeStackDepthBug(t *testing.T) {
+	protest.AllowRecording(t)
 	// After the target process has terminated should return an error but not crash
 	withTestClient1("continuetestprog", t, func(c *rpc1.RPCClient) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sayhi", Line: -1})
@@ -988,6 +1004,7 @@ func Test1ClientServer_CondBreakpoint(t *testing.T) {
 	if runtime.GOOS == "freebsd" {
 		t.Skip("test is not valid on FreeBSD")
 	}
+	protest.AllowRecording(t)
 	withTestClient1("parallel_next", t, func(c *rpc1.RPCClient) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sayhi", Line: 1})
 		assertNoError(err, t, "CreateBreakpoint()")
@@ -1035,6 +1052,7 @@ func Test1Issue419(t *testing.T) {
 }
 
 func Test1TypesCommand(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("testvariables2", t, func(c *rpc1.RPCClient) {
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
@@ -1061,6 +1079,7 @@ func Test1TypesCommand(t *testing.T) {
 }
 
 func Test1Issue406(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient1("issue406", t, func(c *rpc1.RPCClient) {
 		locs, err := c.FindLocation(api.EvalScope{GoroutineID: -1}, "issue406.go:146")
 		assertNoError(err, t, "FindLocation()")

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -473,6 +473,7 @@ func TestClientServer_breakpointInSeparateGoroutine(t *testing.T) {
 }
 
 func TestClientServer_breakAtNonexistentPoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("testprog", t, func(c service.Client) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "nowhere", Line: 1})
 		if err == nil {
@@ -482,6 +483,7 @@ func TestClientServer_breakAtNonexistentPoint(t *testing.T) {
 }
 
 func TestClientServer_clearBreakpoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("testprog", t, func(c service.Client) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sleepytime", Line: 1})
 		if err != nil {
@@ -508,6 +510,7 @@ func TestClientServer_clearBreakpoint(t *testing.T) {
 }
 
 func TestClientServer_toggleBreakpoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("testtoggle", t, func(c service.Client) {
 		toggle := func(bp *api.Breakpoint) {
 			t.Helper()
@@ -581,6 +584,7 @@ func TestClientServer_toggleBreakpoint(t *testing.T) {
 }
 
 func TestClientServer_toggleAmendedBreakpoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("testtoggle", t, func(c service.Client) {
 		toggle := func(bp *api.Breakpoint) {
 			dbp, err := c.ToggleBreakpoint(bp.ID)
@@ -616,6 +620,7 @@ func TestClientServer_toggleAmendedBreakpoint(t *testing.T) {
 }
 
 func TestClientServer_disableHitCondLSSBreakpoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("break", t, func(c service.Client) {
 		fp := testProgPath(t, "break")
 		hitCondBp, err := c.CreateBreakpoint(&api.Breakpoint{
@@ -688,6 +693,7 @@ func TestClientServer_disableHitCondLSSBreakpoint(t *testing.T) {
 }
 
 func TestClientServer_disableHitEQLCondBreakpoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("break", t, func(c service.Client) {
 		fp := testProgPath(t, "break")
 		hitCondBp, err := c.CreateBreakpoint(&api.Breakpoint{
@@ -943,6 +949,7 @@ func TestClientServer_traceContinue2(t *testing.T) {
 }
 
 func TestClientServer_FindLocations(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("locationsprog", t, func(c service.Client) {
 		someFunctionCallAddr := findLocationHelper(t, c, "locationsprog.go:26", false, 1, 0)[0]
 		someFunctionLine1 := findLocationHelper(t, c, "locationsprog.go:27", false, 1, 0)[0]
@@ -1147,6 +1154,7 @@ func TestClientServer_FindLocationsAddr(t *testing.T) {
 }
 
 func TestClientServer_FindLocationsExactMatch(t *testing.T) {
+	protest.AllowRecording(t)
 	// if an expression matches multiple functions but one of them is an exact
 	// match it should be used anyway.
 	// In this example "math/rand.Intn" would normally match "math/rand.Intn"
@@ -1552,6 +1560,7 @@ func TestSkipPrologue(t *testing.T) {
 }
 
 func TestSkipPrologue2(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("callme", t, func(c service.Client) {
 		callme := findLocationHelper(t, c, "main.callme", false, 1, 0)[0]
 		callmeZ := uint64(clientEvalVariable(t, c, "main.callme").Addr)
@@ -1682,6 +1691,7 @@ func TestClientServer_Issue528(t *testing.T) {
 		return
 	}
 
+	protest.AllowRecording(t)
 	withTestClient2("issue528", t, func(c service.Client) {
 		findLocationHelper(t, c, "State.Close", false, 1, 0)
 	})
@@ -1994,6 +2004,7 @@ func TestClientServer_StepOutReturn(t *testing.T) {
 	if ver.Major >= 0 && !ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 10, Rev: -1}) {
 		t.Skip("return variables aren't marked on 1.9 or earlier")
 	}
+	protest.AllowRecording(t)
 	withTestClient2("stepoutret", t, func(c service.Client) {
 		c.SetReturnValuesLoadConfig(&normalLoadConfig)
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.stepout", Line: -1})
@@ -2235,6 +2246,7 @@ func TestAncestors(t *testing.T) {
 	savedGodebug := os.Getenv("GODEBUG")
 	os.Setenv("GODEBUG", "tracebackancestors=100")
 	defer os.Setenv("GODEBUG", savedGodebug)
+	protest.AllowRecording(t)
 	withTestClient2("testnextprog", t, func(c service.Client) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.testgoroutine", Line: -1})
 		assertNoError(err, t, "CreateBreakpoin")
@@ -2289,6 +2301,7 @@ func TestUnknownMethodCall(t *testing.T) {
 }
 
 func TestIssue1703(t *testing.T) {
+	protest.AllowRecording(t)
 	// Calling Disassemble when there is no current goroutine should work.
 	withTestClient2("testnextprog", t, func(c service.Client) {
 		locs, err := c.FindLocation(api.EvalScope{GoroutineID: -1}, "main.main", true, nil)
@@ -2354,6 +2367,7 @@ func TestRerecord(t *testing.T) {
 func TestIssue1787(t *testing.T) {
 	// Calling FunctionReturnLocations without a selected goroutine should
 	// work.
+	protest.AllowRecording(t)
 	withTestClient2("testnextprog", t, func(c service.Client) {
 		if c, _ := c.(*rpc2.RPCClient); c != nil {
 			c.FunctionReturnLocations("main.main")
@@ -2362,6 +2376,7 @@ func TestIssue1787(t *testing.T) {
 }
 
 func TestDoubleCreateBreakpoint(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestClient2("testnextprog", t, func(c service.Client) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1, Name: "firstbreakpoint", Tracepoint: true})
 		assertNoError(err, t, "CreateBreakpoint 1")
@@ -2420,6 +2435,7 @@ func TestClearLogicalBreakpoint(t *testing.T) {
 	// Clearing a logical breakpoint should clear all associated physical
 	// breakpoints.
 	// Issue #1955.
+	protest.AllowRecording(t)
 	withTestClient2Extended("testinline", t, protest.EnableInlining, [3]string{}, func(c service.Client, fixture protest.Fixture) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.inlineThis"})
 		assertNoError(err, t, "CreateBreakpoint()")
@@ -2478,6 +2494,7 @@ func TestIssue2162(t *testing.T) {
 	if buildMode == "pie" || runtime.GOOS == "windows" {
 		t.Skip("skip it for stepping into one place where no source for pc when on pie mode or windows")
 	}
+	protest.AllowRecording(t)
 	withTestClient2("issue2162", t, func(c service.Client) {
 		state, err := c.GetState()
 		assertNoError(err, t, "GetState()")
@@ -2563,6 +2580,7 @@ func assertNoDuplicateBreakpoints(t *testing.T, c service.Client) {
 
 func TestToggleBreakpointRestart(t *testing.T) {
 	// Checks that breakpoints IDs do not overlap after Restart if there are disabled breakpoints.
+	protest.AllowRecording(t)
 	withTestClient2("testtoggle", t, func(c service.Client) {
 		bp1, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 1, Name: "firstbreakpoint"})
 		assertNoError(err, t, "CreateBreakpoint 1")
@@ -2639,6 +2657,7 @@ func TestGoroutinesGrouping(t *testing.T) {
 func TestLongStringArg(t *testing.T) {
 	// Test the ability to load more elements of a string argument, this could
 	// be broken if registerized variables are not handled correctly.
+	protest.AllowRecording(t)
 	withTestClient2("morestringarg", t, func(c service.Client) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.f"})
 		assertNoError(err, t, "CreateBreakpoint")

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1129,6 +1129,7 @@ func TestConstants(t *testing.T) {
 		// Not supported on 1.9 or earlier
 		t.Skip("constants added in go 1.10")
 	}
+	protest.AllowRecording(t)
 	withTestProcess("consts", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue")
 		for _, testcase := range testcases {
@@ -1158,6 +1159,7 @@ func setFunctionBreakpoint(p *proc.Target, t testing.TB, fname string) *proc.Bre
 }
 
 func TestIssue1075(t *testing.T) {
+	protest.AllowRecording(t)
 	withTestProcess("clientdo", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "net/http.(*Client).Do")
 		assertNoError(p.Continue(), t, "Continue()")
@@ -1429,6 +1431,7 @@ func testCallFunction(t *testing.T, p *proc.Target, tc testCaseCallFunction) {
 
 func TestIssue1531(t *testing.T) {
 	// Go 1.12 introduced a change to the map representation where empty cells can be marked with 1 instead of just 0.
+	protest.AllowRecording(t)
 	withTestProcess("issue1531", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 


### PR DESCRIPTION
This pull request improves the test coverage of the `rr` backend by allowing recording in test cases that were formerly skipped in the `rr` backend.

Fixes #2932 (Test suite could have better coverage of the rr backend)

As noted in #2932,

1. There may be other test cases that could be made to pass in the `rr` backend with extra work. This pull request only enables test cases that can be made to pass by the trivial addition of an `AllowRecording` call, for simplicity and ease of review.

2. From a test suite maintenance point of view, it would be better to reverse the coverage policy, so that tests run under the `rr` backend by default, with a function `DisallowRecording()` to disable the tests that don't pass in this mode. This would avoid the risk of adding a test and accidentally forgetting to enable it in the `rr` backend. However, that would be a substantially more radical change than the one implemented here.