### PR TITLE
Prefer locspec to linespec

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -105,9 +105,9 @@ If regex is specified only function arguments with a name matching it will be re
 ## break
 Sets a breakpoint.
 
-	break [name] [linespec]
+	break [name] [locspec]
 
-See [Documentation/cli/locspec.md](//github.com/go-delve/delve/tree/master/Documentation/cli/locspec.md) for the syntax of linespec. If linespec is omitted a breakpoint will be set on the current line.
+See [Documentation/cli/locspec.md](//github.com/go-delve/delve/tree/master/Documentation/cli/locspec.md) for the syntax of locspec. If locspec is omitted a breakpoint will be set on the current line.
 
 See also: "help on", "help cond" and "help clear"
 
@@ -170,9 +170,9 @@ Aliases: clearcheck
 ## clearall
 Deletes multiple breakpoints.
 
-	clearall [<linespec>]
+	clearall [<locspec>]
 
-If called with the linespec argument it will delete all the breakpoints matching the linespec. If linespec is omitted all breakpoints are deleted.
+If called with the locspec argument it will delete all the breakpoints matching the locspec. If locspec is omitted all breakpoints are deleted.
 
 
 ## condition
@@ -237,9 +237,9 @@ Defines <alias> as an alias to <command> or removes an alias.
 ## continue
 Run until breakpoint or program termination.
 
-	continue [<linespec>]
+	continue [<locspec>]
 
-Optional linespec argument allows you to continue until a specific location is reached. The program will halt if a breakpoint is hit before reaching the specified location.
+Optional locspec argument allows you to continue until a specific location is reached. The program will halt if a breakpoint is hit before reaching the specified location.
 
 For example:
 
@@ -446,9 +446,9 @@ List loaded dynamic libraries
 ## list
 Show source code.
 
-	[goroutine <n>] [frame <m>] list [<linespec>]
+	[goroutine <n>] [frame <m>] list [<locspec>]
 
-Show source around current point or provided linespec.
+Show source around current point or provided locspec.
 
 For example:
 
@@ -633,9 +633,9 @@ toggle <breakpoint name or id>
 ## trace
 Set tracepoint.
 
-	trace [name] [linespec]
+	trace [name] [locspec]
 
-A tracepoint is a breakpoint that does not stop the execution of the program, instead when the tracepoint is hit a notification is displayed. See [Documentation/cli/locspec.md](//github.com/go-delve/delve/tree/master/Documentation/cli/locspec.md) for the syntax of linespec. If linespec is omitted a tracepoint will be set on the current line.
+A tracepoint is a breakpoint that does not stop the execution of the program, instead when the tracepoint is hit a notification is displayed. See [Documentation/cli/locspec.md](//github.com/go-delve/delve/tree/master/Documentation/cli/locspec.md) for the syntax of locspec. If locspec is omitted a tracepoint will be set on the current line.
 
 See also: "help on", "help cond" and "help clear"
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -122,16 +122,16 @@ func DebugCommands(client service.Client) *Commands {
 Type "help" followed by the name of a command for more information about it.`},
 		{aliases: []string{"break", "b"}, group: breakCmds, cmdFn: breakpoint, helpMsg: `Sets a breakpoint.
 
-	break [name] [linespec]
+	break [name] [locspec]
 
-See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/locspec.md for the syntax of linespec. If linespec is omitted a breakpoint will be set on the current line.
+See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/locspec.md for the syntax of locspec. If locspec is omitted a breakpoint will be set on the current line.
 
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"trace", "t"}, group: breakCmds, cmdFn: tracepoint, allowedPrefixes: onPrefix, helpMsg: `Set tracepoint.
 
-	trace [name] [linespec]
+	trace [name] [locspec]
 
-A tracepoint is a breakpoint that does not stop the execution of the program, instead when the tracepoint is hit a notification is displayed. See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/locspec.md for the syntax of linespec. If linespec is omitted a tracepoint will be set on the current line.
+A tracepoint is a breakpoint that does not stop the execution of the program, instead when the tracepoint is hit a notification is displayed. See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/locspec.md for the syntax of locspec. If locspec is omitted a tracepoint will be set on the current line.
 
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"watch"}, group: breakCmds, cmdFn: watchpoint, helpMsg: `Set watchpoint.
@@ -175,9 +175,9 @@ A list of file redirections can be specified after the new argument list to over
 		{aliases: []string{"rebuild"}, group: runCmds, cmdFn: c.rebuild, allowedPrefixes: revPrefix, helpMsg: "Rebuild the target executable and restarts it. It does not work if the executable was not built by delve."},
 		{aliases: []string{"continue", "c"}, group: runCmds, cmdFn: c.cont, allowedPrefixes: revPrefix, helpMsg: `Run until breakpoint or program termination.
 
-	continue [<linespec>]
+	continue [<locspec>]
 
-Optional linespec argument allows you to continue until a specific location is reached. The program will halt if a breakpoint is hit before reaching the specified location.
+Optional locspec argument allows you to continue until a specific location is reached. The program will halt if a breakpoint is hit before reaching the specified location.
 
 For example:
 
@@ -218,9 +218,9 @@ Current limitations:
 	clear <breakpoint name or id>`},
 		{aliases: []string{"clearall"}, group: breakCmds, cmdFn: clearAll, helpMsg: `Deletes multiple breakpoints.
 
-	clearall [<linespec>]
+	clearall [<locspec>]
 
-If called with the linespec argument it will delete all the breakpoints matching the linespec. If linespec is omitted all breakpoints are deleted.`},
+If called with the locspec argument it will delete all the breakpoints matching the locspec. If locspec is omitted all breakpoints are deleted.`},
 		{aliases: []string{"toggle"}, group: breakCmds, cmdFn: toggle, helpMsg: `Toggles on or off a breakpoint.
 
 toggle <breakpoint name or id>`},
@@ -355,9 +355,9 @@ Argument -a shows more registers. Individual registers can also be displayed by 
 When connected to a headless instance started with the --accept-multiclient, pass -c to resume the execution of the target process before disconnecting.`},
 		{aliases: []string{"list", "ls", "l"}, cmdFn: listCommand, helpMsg: `Show source code.
 
-	[goroutine <n>] [frame <m>] list [<linespec>]
+	[goroutine <n>] [frame <m>] list [<locspec>]
 
-Show source around current point or provided linespec.
+Show source around current point or provided locspec.
 
 For example:
 


### PR DESCRIPTION
Often in the CLI documentation we were to inputs as linespec when in reality we mean locspec which is a
location specifier, not necessarily a line specifier.