### PR TITLE
proc,service: represent logical breakpoints explicitly

### DIFF
--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -128,7 +128,7 @@ func setFileBreakpoint(p *proc.Target, t *testing.T, fixture protest.Fixture, li
 	if len(addrs) != 1 {
 		t.Fatalf("%s:%d: setFileLineBreakpoint(%s, %d): too many results %v", f, l, fixture.Source, lineno, addrs)
 	}
-	bp, err := p.SetBreakpoint(0, addrs[0], proc.UserBreakpoint, nil)
+	bp, err := p.SetBreakpoint(int(addrs[0]), addrs[0], proc.UserBreakpoint, nil)
 	if err != nil {
 		t.Fatalf("%s:%d: SetBreakpoint: %v", f, l, err)
 	}
@@ -164,18 +164,18 @@ func TestReverseBreakpointCounts(t *testing.T) {
 			}
 		}
 
-		t.Logf("TotalHitCount: %d", bp.UserBreaklet().TotalHitCount)
-		if bp.UserBreaklet().TotalHitCount != 200 {
-			t.Fatalf("Wrong TotalHitCount for the breakpoint (%d)", bp.UserBreaklet().TotalHitCount)
+		t.Logf("TotalHitCount: %d", bp.Logical.TotalHitCount)
+		if bp.Logical.TotalHitCount != 200 {
+			t.Fatalf("Wrong TotalHitCount for the breakpoint (%d)", bp.Logical.TotalHitCount)
 		}
 
-		if len(bp.UserBreaklet().HitCount) != 2 {
-			t.Fatalf("Wrong number of goroutines for breakpoint (%d)", len(bp.UserBreaklet().HitCount))
+		if len(bp.Logical.HitCount) != 2 {
+			t.Fatalf("Wrong number of goroutines for breakpoint (%d)", len(bp.Logical.HitCount))
 		}
 
-		for _, v := range bp.UserBreaklet().HitCount {
+		for _, v := range bp.Logical.HitCount {
 			if v != 100 {
-				t.Fatalf("Wrong HitCount for breakpoint (%v)", bp.UserBreaklet().HitCount)
+				t.Fatalf("Wrong HitCount for breakpoint (%v)", bp.Logical.HitCount)
 			}
 		}
 	})

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -319,8 +319,8 @@ func TestBreakpoint(t *testing.T) {
 		assertNoError(err, t, "Registers")
 		pc := regs.PC()
 
-		if bp.UserBreaklet().TotalHitCount != 1 {
-			t.Fatalf("Breakpoint should be hit once, got %d\n", bp.UserBreaklet().TotalHitCount)
+		if bp.Logical.TotalHitCount != 1 {
+			t.Fatalf("Breakpoint should be hit once, got %d\n", bp.Logical.TotalHitCount)
 		}
 
 		if pc-1 != bp.Addr && pc != bp.Addr {
@@ -1363,7 +1363,7 @@ func TestThreadFrameEvaluation(t *testing.T) {
 		assertNoError(p.Continue(), t, "Continue()")
 
 		bp := p.CurrentThread().Breakpoint()
-		if bp.Breakpoint == nil || bp.Name != deadlockBp {
+		if bp.Breakpoint == nil || bp.Logical.Name != deadlockBp {
 			t.Fatalf("did not stop at deadlock breakpoint %v", bp)
 		}
 
@@ -1471,18 +1471,18 @@ func TestBreakpointCounts(t *testing.T) {
 			}
 		}
 
-		t.Logf("TotalHitCount: %d", bp.UserBreaklet().TotalHitCount)
-		if bp.UserBreaklet().TotalHitCount != 200 {
-			t.Fatalf("Wrong TotalHitCount for the breakpoint (%d)", bp.UserBreaklet().TotalHitCount)
+		t.Logf("TotalHitCount: %d", bp.Logical.TotalHitCount)
+		if bp.Logical.TotalHitCount != 200 {
+			t.Fatalf("Wrong TotalHitCount for the breakpoint (%d)", bp.Logical.TotalHitCount)
 		}
 
-		if len(bp.UserBreaklet().HitCount) != 2 {
-			t.Fatalf("Wrong number of goroutines for breakpoint (%d)", len(bp.UserBreaklet().HitCount))
+		if len(bp.Logical.HitCount) != 2 {
+			t.Fatalf("Wrong number of goroutines for breakpoint (%d)", len(bp.Logical.HitCount))
 		}
 
-		for _, v := range bp.UserBreaklet().HitCount {
+		for _, v := range bp.Logical.HitCount {
 			if v != 100 {
-				t.Fatalf("Wrong HitCount for breakpoint (%v)", bp.UserBreaklet().HitCount)
+				t.Fatalf("Wrong HitCount for breakpoint (%v)", bp.Logical.HitCount)
 			}
 		}
 	})
@@ -1505,8 +1505,8 @@ func TestHardcodedBreakpointCounts(t *testing.T) {
 				if bp == nil {
 					continue
 				}
-				if bp.Name != proc.HardcodedBreakpoint {
-					t.Fatalf("wrong breakpoint name %s", bp.Name)
+				if bp.Logical.Name != proc.HardcodedBreakpoint {
+					t.Fatalf("wrong breakpoint name %s", bp.Logical.Name)
 				}
 				g, err := proc.GetG(th)
 				assertNoError(err, t, "GetG")
@@ -1576,23 +1576,23 @@ func TestBreakpointCountsWithDetection(t *testing.T) {
 				total += m[i] + 1
 			}
 
-			if uint64(total) != bp.UserBreaklet().TotalHitCount {
-				t.Fatalf("Mismatched total count %d %d\n", total, bp.UserBreaklet().TotalHitCount)
+			if uint64(total) != bp.Logical.TotalHitCount {
+				t.Fatalf("Mismatched total count %d %d\n", total, bp.Logical.TotalHitCount)
 			}
 		}
 
-		t.Logf("TotalHitCount: %d", bp.UserBreaklet().TotalHitCount)
-		if bp.UserBreaklet().TotalHitCount != 200 {
-			t.Fatalf("Wrong TotalHitCount for the breakpoint (%d)", bp.UserBreaklet().TotalHitCount)
+		t.Logf("TotalHitCount: %d", bp.Logical.TotalHitCount)
+		if bp.Logical.TotalHitCount != 200 {
+			t.Fatalf("Wrong TotalHitCount for the breakpoint (%d)", bp.Logical.TotalHitCount)
 		}
 
-		if len(bp.UserBreaklet().HitCount) != 2 {
-			t.Fatalf("Wrong number of goroutines for breakpoint (%d)", len(bp.UserBreaklet().HitCount))
+		if len(bp.Logical.HitCount) != 2 {
+			t.Fatalf("Wrong number of goroutines for breakpoint (%d)", len(bp.Logical.HitCount))
 		}
 
-		for _, v := range bp.UserBreaklet().HitCount {
+		for _, v := range bp.Logical.HitCount {
 			if v != 100 {
-				t.Fatalf("Wrong HitCount for breakpoint (%v)", bp.UserBreaklet().HitCount)
+				t.Fatalf("Wrong HitCount for breakpoint (%v)", bp.Logical.HitCount)
 			}
 		}
 	})
@@ -1767,7 +1767,7 @@ func TestCondBreakpointError(t *testing.T) {
 func TestHitCondBreakpointEQ(t *testing.T) {
 	withTestProcess("break", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 7)
-		bp.UserBreaklet().HitCond = &struct {
+		bp.Logical.HitCond = &struct {
 			Op  token.Token
 			Val int
 		}{token.EQL, 3}
@@ -1791,7 +1791,7 @@ func TestHitCondBreakpointGEQ(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("break", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 7)
-		bp.UserBreaklet().HitCond = &struct {
+		bp.Logical.HitCond = &struct {
 			Op  token.Token
 			Val int
 		}{token.GEQ, 3}
@@ -1814,7 +1814,7 @@ func TestHitCondBreakpointREM(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("break", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 7)
-		bp.UserBreaklet().HitCond = &struct {
+		bp.Logical.HitCond = &struct {
 			Op  token.Token
 			Val int
 		}{token.REM, 2}
@@ -2015,7 +2015,7 @@ func TestPanicBreakpoint(t *testing.T) {
 	withTestProcess("panic", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
 		bp := p.CurrentThread().Breakpoint()
-		if bp.Breakpoint == nil || bp.Name != proc.UnrecoveredPanic {
+		if bp.Breakpoint == nil || bp.Logical.Name != proc.UnrecoveredPanic {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", bp)
 		}
 	})
@@ -2025,7 +2025,7 @@ func TestCmdLineArgs(t *testing.T) {
 	expectSuccess := func(p *proc.Target, fixture protest.Fixture) {
 		err := p.Continue()
 		bp := p.CurrentThread().Breakpoint()
-		if bp.Breakpoint != nil && bp.Name == proc.UnrecoveredPanic {
+		if bp.Breakpoint != nil && bp.Logical.Name == proc.UnrecoveredPanic {
 			t.Fatalf("testing args failed on unrecovered-panic breakpoint: %v", bp)
 		}
 		exit, exited := err.(proc.ErrProcessExited)
@@ -2041,7 +2041,7 @@ func TestCmdLineArgs(t *testing.T) {
 	expectPanic := func(p *proc.Target, fixture protest.Fixture) {
 		p.Continue()
 		bp := p.CurrentThread().Breakpoint()
-		if bp.Breakpoint == nil || bp.Name != proc.UnrecoveredPanic {
+		if bp.Breakpoint == nil || bp.Logical.Name != proc.UnrecoveredPanic {
 			t.Fatalf("not on unrecovered-panic breakpoint: %v", bp)
 		}
 	}
@@ -2475,7 +2475,7 @@ func TestStepConcurrentDirect(t *testing.T) {
 		assertNoError(err, t, "ClearBreakpoint()")
 
 		for _, b := range p.Breakpoints().M {
-			if b.Name == proc.UnrecoveredPanic {
+			if b.Logical.Name == proc.UnrecoveredPanic {
 				err := p.ClearBreakpoint(b.Addr)
 				assertNoError(err, t, "ClearBreakpoint(unrecovered-panic)")
 				break
@@ -2535,7 +2535,7 @@ func TestStepConcurrentPtr(t *testing.T) {
 		setFileBreakpoint(p, t, fixture.Source, 24)
 
 		for _, b := range p.Breakpoints().M {
-			if b.Name == proc.UnrecoveredPanic {
+			if b.Logical.Name == proc.UnrecoveredPanic {
 				err := p.ClearBreakpoint(b.Addr)
 				assertNoError(err, t, "ClearBreakpoint(unrecovered-panic)")
 				break
@@ -2645,7 +2645,7 @@ func TestNextBreakpointKeepsSteppingBreakpoints(t *testing.T) {
 
 		// Next should be interrupted by a tracepoint on the same goroutine.
 		bp = setFileBreakpoint(p, t, fixture.Source, 14)
-		bp.Tracepoint = true
+		bp.Logical.Tracepoint = true
 		assertNoError(p.Next(), t, "Next()")
 		assertLineNumber(p, t, 14, "wrong line number")
 		if !p.Breakpoints().HasSteppingBreakpoints() {
@@ -4448,7 +4448,7 @@ func TestDeadlockBreakpoint(t *testing.T) {
 		assertNoError(p.Continue(), t, "Continue()")
 
 		bp := p.CurrentThread().Breakpoint()
-		if bp.Breakpoint == nil || bp.Name != deadlockBp {
+		if bp.Breakpoint == nil || bp.Logical.Name != deadlockBp {
 			t.Fatalf("did not stop at deadlock breakpoint %v", bp)
 		}
 	})
@@ -5526,18 +5526,18 @@ func TestWatchpointCounts(t *testing.T) {
 			}
 		}
 
-		t.Logf("TotalHitCount: %d", bp.UserBreaklet().TotalHitCount)
-		if bp.UserBreaklet().TotalHitCount != 200 {
-			t.Fatalf("Wrong TotalHitCount for the breakpoint (%d)", bp.UserBreaklet().TotalHitCount)
+		t.Logf("TotalHitCount: %d", bp.Logical.TotalHitCount)
+		if bp.Logical.TotalHitCount != 200 {
+			t.Fatalf("Wrong TotalHitCount for the breakpoint (%d)", bp.Logical.TotalHitCount)
 		}
 
-		if len(bp.UserBreaklet().HitCount) != 2 {
-			t.Fatalf("Wrong number of goroutines for breakpoint (%d)", len(bp.UserBreaklet().HitCount))
+		if len(bp.Logical.HitCount) != 2 {
+			t.Fatalf("Wrong number of goroutines for breakpoint (%d)", len(bp.Logical.HitCount))
 		}
 
-		for _, v := range bp.UserBreaklet().HitCount {
+		for _, v := range bp.Logical.HitCount {
 			if v != 100 {
-				t.Fatalf("Wrong HitCount for breakpoint (%v)", bp.UserBreaklet().HitCount)
+				t.Fatalf("Wrong HitCount for breakpoint (%v)", bp.Logical.HitCount)
 			}
 		}
 	})
@@ -5836,7 +5836,7 @@ func TestNilPtrDerefInBreakInstr(t *testing.T) {
 		if bp != nil {
 			t.Logf("%#v\n", bp.Breakpoint)
 		}
-		if bp == nil || (bp.Name != proc.UnrecoveredPanic) {
+		if bp == nil || (bp.Logical.Name != proc.UnrecoveredPanic) {
 			t.Fatalf("no breakpoint hit or wrong breakpoint hit: %#v", bp)
 		}
 	})

--- a/pkg/proc/stackwatch.go
+++ b/pkg/proc/stackwatch.go
@@ -164,6 +164,7 @@ func watchpointOutOfScope(t *Target, watchpoint *Breakpoint) {
 		log := logflags.DebuggerLogger()
 		log.Errorf("could not clear out-of-scope watchpoint: %v", err)
 	}
+	delete(t.Breakpoints().Logical, watchpoint.LogicalID())
 }
 
 // adjustStackWatchpoint is called when the goroutine of watchpoint resizes

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -398,8 +398,8 @@ func (t *Target) createUnrecoveredPanicBreakpoint() {
 	if err == nil {
 		bp, err := t.SetBreakpoint(unrecoveredPanicID, panicpcs[0], UserBreakpoint, nil)
 		if err == nil {
-			bp.Name = UnrecoveredPanic
-			bp.Variables = []string{"runtime.curg._panic.arg"}
+			bp.Logical.Name = UnrecoveredPanic
+			bp.Logical.Variables = []string{"runtime.curg._panic.arg"}
 		}
 	}
 }
@@ -410,14 +410,14 @@ func (t *Target) createFatalThrowBreakpoint() {
 	if err == nil {
 		bp, err := t.SetBreakpoint(fatalThrowID, fatalpcs[0], UserBreakpoint, nil)
 		if err == nil {
-			bp.Name = FatalThrow
+			bp.Logical.Name = FatalThrow
 		}
 	}
 	fatalpcs, err = FindFunctionLocation(t.Process, "runtime.fatal", 0)
 	if err == nil {
 		bp, err := t.SetBreakpoint(fatalThrowID, fatalpcs[0], UserBreakpoint, nil)
 		if err == nil {
-			bp.Name = FatalThrow
+			bp.Logical.Name = FatalThrow
 		}
 	}
 }

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -171,13 +171,13 @@ func (dbp *Target) Continue() error {
 				return err
 			}
 			if onNextGoroutine &&
-				((!curbp.Tracepoint && !curbp.TraceReturn) || dbp.KeepSteppingBreakpoints&TracepointKeepsSteppingBreakpoints == 0) {
+				(!isTraceOrTraceReturn(curbp.Breakpoint) || dbp.KeepSteppingBreakpoints&TracepointKeepsSteppingBreakpoints == 0) {
 				err := dbp.ClearSteppingBreakpoints()
 				if err != nil {
 					return err
 				}
 			}
-			if curbp.Name == UnrecoveredPanic {
+			if curbp.LogicalID() == unrecoveredPanicID {
 				dbp.ClearSteppingBreakpoints()
 			}
 			if curbp.LogicalID() != hardcodedBreakpointID {
@@ -197,6 +197,13 @@ func (dbp *Target) Continue() error {
 			return conditionErrors(threads)
 		}
 	}
+}
+
+func isTraceOrTraceReturn(bp *Breakpoint) bool {
+	if bp.Logical == nil {
+		return false
+	}
+	return bp.Logical.Tracepoint || bp.Logical.TraceReturn
 }
 
 func conditionErrors(threads []Thread) error {
@@ -1119,7 +1126,8 @@ func (tgt *Target) handleHardcodedBreakpoints(trapthread Thread, threads []Threa
 		hcbp.File = loc.File
 		hcbp.Line = loc.Line
 		hcbp.Addr = loc.PC
-		hcbp.Name = HardcodedBreakpoint
+		hcbp.Logical = &LogicalBreakpoint{}
+		hcbp.Logical.Name = HardcodedBreakpoint
 		hcbp.Breaklets = []*Breaklet{&Breaklet{Kind: UserBreakpoint, LogicalID: hardcodedBreakpointID}}
 		tgt.StopReason = StopHardcodedBreakpoint
 	}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1857,10 +1857,12 @@ func (s *Session) stoppedOnBreakpointGoroutineID(state *api.DebuggerState) (int,
 		return goid, nil
 	}
 	bp := g.Thread.Breakpoint()
-	if bp == nil || bp.Breakpoint == nil {
+	if bp == nil || bp.Breakpoint == nil || bp.Breakpoint.Logical == nil {
 		return goid, nil
 	}
-	return goid, api.ConvertBreakpoint(bp.Breakpoint)
+	abp := api.ConvertLogicalBreakpoint(bp.Breakpoint.Logical)
+	api.ConvertPhysicalBreakpoints(abp, []*proc.Breakpoint{bp.Breakpoint})
+	return goid, abp
 }
 
 // stepUntilStopAndNotify is a wrapper around runUntilStopAndNotify that
@@ -3188,8 +3190,8 @@ func (s *Session) onExceptionInfoRequest(request *dap.ExceptionInfoRequest) {
 	}
 	// Check if this goroutine ID is stopped at a breakpoint.
 	includeStackTrace := true
-	if bpState != nil && bpState.Breakpoint != nil && (bpState.Breakpoint.Name == proc.FatalThrow || bpState.Breakpoint.Name == proc.UnrecoveredPanic) {
-		switch bpState.Breakpoint.Name {
+	if bpState != nil && bpState.Breakpoint != nil && bpState.Breakpoint.Logical != nil && (bpState.Breakpoint.Logical.Name == proc.FatalThrow || bpState.Breakpoint.Logical.Name == proc.UnrecoveredPanic) {
+		switch bpState.Breakpoint.Logical.Name {
 		case proc.FatalThrow:
 			body.ExceptionId = "fatal error"
 			body.Description, err = s.throwReason(goroutineID)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -72,10 +72,6 @@ type Debugger struct {
 	recordMutex   sync.Mutex
 
 	dumpState proc.DumpState
-	// Debugger keeps a map of disabled breakpoints
-	// so lower layers like proc doesn't need to deal
-	// with them
-	disabledBreakpoints map[int]*api.Breakpoint
 
 	breakpointIDCounter int
 }
@@ -208,8 +204,6 @@ func New(config *Config, processArgs []string) (*Debugger, error) {
 			return nil, err
 		}
 	}
-
-	d.disabledBreakpoints = make(map[int]*api.Breakpoint)
 
 	return d, nil
 }
@@ -520,46 +514,24 @@ func (d *Debugger) Restart(rerecord bool, pos string, resetArgs bool, newArgs []
 	}
 
 	discarded := []api.DiscardedBreakpoint{}
-	breakpoints := api.ConvertBreakpoints(d.breakpoints())
+	p.Breakpoints().Logical = d.target.Breakpoints().Logical
 	d.target = p
-	maxID := 0
-	for _, oldBp := range breakpoints {
-		if oldBp.ID < 0 {
+	for _, oldBp := range d.target.Breakpoints().Logical {
+		if oldBp.LogicalID < 0 || !oldBp.Enabled {
 			continue
 		}
-		if oldBp.ID > maxID {
-			maxID = oldBp.ID
-		}
-		if oldBp.WatchExpr != "" {
-			discarded = append(discarded, api.DiscardedBreakpoint{Breakpoint: oldBp, Reason: "can not recreate watchpoints on restart"})
-		} else if len(oldBp.File) > 0 {
-			addrs, err := proc.FindFileLocation(p, oldBp.File, oldBp.Line)
+		if len(oldBp.File) > 0 {
+			oldBp.TotalHitCount = 0
+			oldBp.HitCount = make(map[int]uint64)
+			err := d.createPhysicalBreakpoints(oldBp)
 			if err != nil {
-				discarded = append(discarded, api.DiscardedBreakpoint{Breakpoint: oldBp, Reason: err.Error()})
+				discarded = append(discarded, api.DiscardedBreakpoint{Breakpoint: api.ConvertLogicalBreakpoint(oldBp), Reason: err.Error()})
 				continue
 			}
-			createLogicalBreakpoint(d, addrs, oldBp, oldBp.ID)
 		} else {
-			// Avoid setting a breakpoint based on address when rebuilding
-			if rebuild {
-				discarded = append(discarded, api.DiscardedBreakpoint{Breakpoint: oldBp, Reason: "can not recreate address breakpoints on restart"})
-				continue
-			}
-			newBp, err := p.SetBreakpoint(oldBp.ID, oldBp.Addr, proc.UserBreakpoint, nil)
-			if err != nil {
-				return nil, err
-			}
-			if err := copyBreakpointInfo(newBp, oldBp); err != nil {
-				return nil, err
-			}
+			discarded = append(discarded, api.DiscardedBreakpoint{Breakpoint: api.ConvertLogicalBreakpoint(oldBp), Reason: "can not recreate watchpoint on restart"})
 		}
 	}
-	for _, bp := range d.disabledBreakpoints {
-		if bp.ID > maxID {
-			maxID = bp.ID
-		}
-	}
-	d.breakpointIDCounter = maxID
 	return discarded, nil
 }
 
@@ -609,7 +581,7 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 	}
 
 	for _, thread := range d.target.ThreadList() {
-		th := api.ConvertThread(thread)
+		th := api.ConvertThread(thread, d.ConvertThreadBreakpoint(thread))
 
 		th.CallReturn = thread.Common().CallReturn
 		if retLoadCfg != nil {
@@ -630,7 +602,9 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig) (*api.DebuggerState, error
 
 	state.WatchOutOfScope = make([]*api.Breakpoint, 0, len(d.target.Breakpoints().WatchOutOfScope))
 	for _, bp := range d.target.Breakpoints().WatchOutOfScope {
-		state.WatchOutOfScope = append(state.WatchOutOfScope, api.ConvertBreakpoint(bp))
+		abp := api.ConvertLogicalBreakpoint(bp.Logical)
+		api.ConvertPhysicalBreakpoints(abp, []*proc.Breakpoint{bp})
+		state.WatchOutOfScope = append(state.WatchOutOfScope, abp)
 	}
 
 	return state, nil
@@ -673,7 +647,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 	)
 
 	if requestedBp.Name != "" {
-		if (d.findBreakpointByName(requestedBp.Name) != nil) || (d.findDisabledBreakpointByName(requestedBp.Name) != nil) {
+		if d.findBreakpointByName(requestedBp.Name) != nil {
 			return nil, errors.New("breakpoint name already exists")
 		}
 	}
@@ -714,32 +688,51 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoin
 	return createdBp, nil
 }
 
+func (d *Debugger) convertBreakpoint(lbp *proc.LogicalBreakpoint) *api.Breakpoint {
+	abp := api.ConvertLogicalBreakpoint(lbp)
+	api.ConvertPhysicalBreakpoints(abp, d.findBreakpoint(lbp.LogicalID))
+	return abp
+}
+
+func (d *Debugger) ConvertThreadBreakpoint(thread proc.Thread) *api.Breakpoint {
+	if b := thread.Breakpoint(); b.Active && b.Breakpoint.Logical != nil {
+		return d.convertBreakpoint(b.Breakpoint.Logical)
+	}
+	return nil
+}
+
 // createLogicalBreakpoint creates one physical breakpoint for each address
 // in addrs and associates all of them with the same logical breakpoint.
 func createLogicalBreakpoint(d *Debugger, addrs []uint64, requestedBp *api.Breakpoint, id int) (*api.Breakpoint, error) {
 	p := d.target
 
-	if dbp, ok := d.disabledBreakpoints[requestedBp.ID]; ok {
-		return dbp, proc.BreakpointExistsError{File: dbp.File, Line: dbp.Line, Addr: dbp.Addr}
+	if lbp := p.Breakpoints().Logical[requestedBp.ID]; lbp != nil {
+		abp := d.convertBreakpoint(lbp)
+		return abp, proc.BreakpointExistsError{File: lbp.File, Line: lbp.Line}
+	}
+
+	var lbp *proc.LogicalBreakpoint
+	if id <= 0 {
+		d.breakpointIDCounter++
+		id = d.breakpointIDCounter
+		lbp = &proc.LogicalBreakpoint{LogicalID: id, HitCount: make(map[int]uint64), Enabled: true}
+		p.Breakpoints().Logical[id] = lbp
+	}
+
+	err := copyLogicalBreakpointInfo(lbp, requestedBp)
+	if err != nil {
+		return nil, err
 	}
 
 	bps := make([]*proc.Breakpoint, len(addrs))
-	var err error
 	for i := range addrs {
-		if id <= 0 {
-			d.breakpointIDCounter++
-			id = d.breakpointIDCounter
-		}
 		bps[i], err = p.SetBreakpoint(id, addrs[i], proc.UserBreakpoint, nil)
-		if err != nil {
-			break
-		}
-		err = copyBreakpointInfo(bps[i], requestedBp)
 		if err != nil {
 			break
 		}
 	}
 	if err != nil {
+		delete(p.Breakpoints().Logical, id)
 		if isBreakpointExistsErr(err) {
 			return nil, err
 		}
@@ -755,8 +748,65 @@ func createLogicalBreakpoint(d *Debugger, addrs []uint64, requestedBp *api.Break
 		return nil, err
 	}
 
-	createdBp := api.ConvertBreakpoints(bps)
-	return createdBp[0], nil // we created a single logical breakpoint, the slice here will always have len == 1
+	return d.convertBreakpoint(bps[0].Logical), nil
+}
+
+func (d *Debugger) createPhysicalBreakpoints(lbp *proc.LogicalBreakpoint) error {
+	addrs, err := proc.FindFileLocation(d.target, lbp.File, lbp.Line)
+	if err != nil {
+		return err
+	}
+	bps := make([]*proc.Breakpoint, len(addrs))
+	for i := range addrs {
+		bps[i], err = d.target.SetBreakpoint(lbp.LogicalID, addrs[i], proc.UserBreakpoint, nil)
+		if err != nil {
+			break
+		}
+	}
+	if err != nil {
+		if isBreakpointExistsErr(err) {
+			return err
+		}
+		for _, bp := range bps {
+			if bp == nil {
+				continue
+			}
+			if err1 := d.target.ClearBreakpoint(bp.Addr); err1 != nil {
+				return fmt.Errorf("error while creating breakpoint: %v, additionally the breakpoint could not be properly rolled back: %v", err, err1)
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func (d *Debugger) clearPhysicalBreakpoints(id int) error {
+	var errs []error
+	n := 0
+	for _, bp := range d.target.Breakpoints().M {
+		if bp.LogicalID() == id {
+			n++
+			err := d.target.ClearBreakpoint(bp.Addr)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	if len(errs) > 0 {
+		buf := new(bytes.Buffer)
+		for i, err := range errs {
+			fmt.Fprintf(buf, "%s", err)
+			if i != len(errs)-1 {
+				fmt.Fprintf(buf, ", ")
+			}
+		}
+
+		if len(errs) == n {
+			return fmt.Errorf("unable to clear breakpoint %d: %v", id, buf.String())
+		}
+		return fmt.Errorf("unable to clear breakpoint %d (partial): %s", id, buf.String())
+	}
+	return nil
 }
 
 func isBreakpointExistsErr(err error) bool {
@@ -775,47 +825,32 @@ func (d *Debugger) CreateEBPFTracepoint(fnName string) error {
 // It also enables or disables the breakpoint.
 // We can consume this function to avoid locking a goroutine.
 func (d *Debugger) amendBreakpoint(amend *api.Breakpoint) error {
-	originals := d.findBreakpoint(amend.ID)
-
-	if len(originals) > 0 && originals[0].WatchExpr != "" && amend.Disabled {
-		return errors.New("can not disable watchpoints")
-	}
-
-	_, disabled := d.disabledBreakpoints[amend.ID]
-	if originals == nil && !disabled {
+	original := d.target.Breakpoints().Logical[amend.ID]
+	if original == nil {
 		return fmt.Errorf("no breakpoint with ID %d", amend.ID)
 	}
-	if !amend.Disabled && disabled { // enable the breakpoint
-		bp, err := d.target.SetBreakpoint(amend.ID, amend.Addr, proc.UserBreakpoint, nil)
+	if amend.Disabled && original.Enabled {
+		original.Enabled = false
+		err := copyLogicalBreakpointInfo(original, amend)
 		if err != nil {
 			return err
 		}
-		copyBreakpointInfo(bp, amend)
-		if breaklet := bp.UserBreaklet(); breaklet != nil {
-			breaklet.TotalHitCount = amend.TotalHitCount
-			breaklet.HitCount = map[int]uint64{}
-			for idx := range amend.HitCount {
-				i, err := strconv.Atoi(idx)
-				if err != nil {
-					return fmt.Errorf("can't convert goroutine ID: %w", err)
-				}
-				breaklet.HitCount[i] = amend.HitCount[idx]
-			}
-		}
-		delete(d.disabledBreakpoints, amend.ID)
-	}
-	if amend.Disabled && !disabled { // disable the breakpoint
-		if _, err := d.clearBreakpoint(amend); err != nil {
-			return err
-		}
-		d.disabledBreakpoints[amend.ID] = amend
-	}
-	for _, original := range originals {
-		if err := copyBreakpointInfo(original, amend); err != nil {
-			return err
-		}
+		return d.clearPhysicalBreakpoints(amend.ID)
 	}
 
+	if !amend.Disabled && !original.Enabled {
+		original.Enabled = true
+		copyLogicalBreakpointInfo(original, amend)
+		return d.createPhysicalBreakpoints(original)
+	}
+
+	err := copyLogicalBreakpointInfo(original, amend)
+	if err != nil {
+		return err
+	}
+	for _, bp := range d.findBreakpoint(amend.ID) {
+		bp.UserBreaklet().Cond = original.Cond
+	}
 	return nil
 }
 
@@ -836,37 +871,38 @@ func (d *Debugger) CancelNext() error {
 	return d.target.ClearSteppingBreakpoints()
 }
 
-func copyBreakpointInfo(bp *proc.Breakpoint, requested *api.Breakpoint) (err error) {
-	bp.Name = requested.Name
-	bp.Tracepoint = requested.Tracepoint
-	bp.TraceReturn = requested.TraceReturn
-	bp.Goroutine = requested.Goroutine
-	bp.Stacktrace = requested.Stacktrace
-	bp.Variables = requested.Variables
-	bp.UserData = requested.UserData
-	bp.LoadArgs = api.LoadConfigToProc(requested.LoadArgs)
-	bp.LoadLocals = api.LoadConfigToProc(requested.LoadLocals)
-	breaklet := bp.UserBreaklet()
-	if breaklet != nil {
-		breaklet.Cond = nil
-		if requested.Cond != "" {
-			breaklet.Cond, err = parser.ParseExpr(requested.Cond)
-		}
-		breaklet.HitCond = nil
-		if requested.HitCond != "" {
-			opTok, val, parseErr := parseHitCondition(requested.HitCond)
-			if err == nil {
-				err = parseErr
-			}
-			if parseErr == nil {
-				breaklet.HitCond = &struct {
-					Op  token.Token
-					Val int
-				}{opTok, val}
-			}
+func copyLogicalBreakpointInfo(lbp *proc.LogicalBreakpoint, requested *api.Breakpoint) error {
+	lbp.Name = requested.Name
+	lbp.Tracepoint = requested.Tracepoint
+	lbp.TraceReturn = requested.TraceReturn
+	lbp.Goroutine = requested.Goroutine
+	lbp.Stacktrace = requested.Stacktrace
+	lbp.Variables = requested.Variables
+	lbp.LoadArgs = api.LoadConfigToProc(requested.LoadArgs)
+	lbp.LoadLocals = api.LoadConfigToProc(requested.LoadLocals)
+	lbp.UserData = requested.UserData
+	lbp.Cond = nil
+	if requested.Cond != "" {
+		var err error
+		lbp.Cond, err = parser.ParseExpr(requested.Cond)
+		if err != nil {
+			return err
 		}
 	}
-	return err
+
+	lbp.HitCond = nil
+	if requested.HitCond != "" {
+		opTok, val, err := parseHitCondition(requested.HitCond)
+		if err != nil {
+			return err
+		}
+		lbp.HitCond = &struct {
+			Op  token.Token
+			Val int
+		}{opTok, val}
+	}
+
+	return nil
 }
 
 func parseHitCondition(hitCond string) (token.Token, int, error) {
@@ -919,57 +955,19 @@ func (d *Debugger) ClearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint
 
 // clearBreakpoint clears a breakpoint, we can consume this function to avoid locking a goroutine
 func (d *Debugger) clearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint, error) {
-	if bp, ok := d.disabledBreakpoints[requestedBp.ID]; ok {
-		delete(d.disabledBreakpoints, bp.ID)
-		return bp, nil
+	if requestedBp.ID <= 0 {
+		bp := d.target.Breakpoints().M[requestedBp.Addr]
+		requestedBp.ID = bp.LogicalID()
 	}
 
-	var clearBps []*proc.Breakpoint
+	lbp := d.target.Breakpoints().Logical[requestedBp.ID]
+	clearedBp := d.convertBreakpoint(lbp)
 
-	toclear := func(addr uint64) {
-		bp := d.target.Breakpoints().M[addr]
-		if bp != nil {
-			clearBps = append(clearBps, bp)
-		}
-	}
+	delete(d.target.Breakpoints().Logical, requestedBp.ID)
 
-	clearAddr := true
-	for _, addr := range requestedBp.Addrs {
-		if addr == requestedBp.Addr {
-			clearAddr = false
-		}
-		toclear(addr)
-	}
-	if clearAddr {
-		toclear(requestedBp.Addr)
-	}
-
-	// Breakpoints need to be converted before clearing them or they won't have
-	// an ID anymore.
-	sort.Sort(breakpointsByLogicalID(clearBps))
-	clearedBp := api.ConvertBreakpoints(clearBps)[0]
-
-	var errs []error
-	for _, bp := range clearBps {
-		err := d.target.ClearBreakpoint(bp.Addr)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("address %#x: %v", bp.Addr, err))
-		}
-	}
-
-	if len(errs) > 0 {
-		buf := new(bytes.Buffer)
-		for i, err := range errs {
-			fmt.Fprintf(buf, "%s", err)
-			if i != len(errs)-1 {
-				fmt.Fprintf(buf, ", ")
-			}
-		}
-
-		if len(errs) == len(clearBps) {
-			return nil, fmt.Errorf("unable to clear breakpoint %d: %v", requestedBp.ID, buf.String())
-		}
-		return nil, fmt.Errorf("unable to clear breakpoint %d (partial): %s", requestedBp.ID, buf.String())
+	err := d.clearPhysicalBreakpoints(requestedBp.ID)
+	if err != nil {
+		return nil, err
 	}
 
 	d.log.Infof("cleared breakpoint: %#v", clearedBp)
@@ -1008,46 +1006,36 @@ func (d *Debugger) Breakpoints(all bool) []*api.Breakpoint {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 
-	var bps []*api.Breakpoint
-
-	if !all {
-		bps = api.ConvertBreakpoints(d.breakpoints())
-	} else {
+	abps := []*api.Breakpoint{}
+	if all {
 		for _, bp := range d.target.Breakpoints().M {
-			abp := api.ConvertBreakpoint(bp)
+			var abp *api.Breakpoint
+			if bp.Logical != nil {
+				abp = api.ConvertLogicalBreakpoint(bp.Logical)
+			} else {
+				abp = &api.Breakpoint{}
+			}
+			api.ConvertPhysicalBreakpoints(abp, []*proc.Breakpoint{bp})
 			abp.VerboseDescr = bp.VerboseDescr()
-			bps = append(bps, abp)
+			abps = append(abps, abp)
+		}
+	} else {
+		for _, lbp := range d.target.Breakpoints().Logical {
+			abps = append(abps, d.convertBreakpoint(lbp))
 		}
 	}
-
-	for _, bp := range d.disabledBreakpoints {
-		bps = append(bps, bp)
-	}
-
-	return bps
-}
-
-func (d *Debugger) breakpoints() []*proc.Breakpoint {
-	bps := []*proc.Breakpoint{}
-	for _, bp := range d.target.Breakpoints().M {
-		if bp.IsUser() {
-			bps = append(bps, bp)
-		}
-	}
-	sort.Sort(breakpointsByLogicalID(bps))
-	return bps
+	return abps
 }
 
 // FindBreakpoint returns the breakpoint specified by 'id'.
 func (d *Debugger) FindBreakpoint(id int) *api.Breakpoint {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
-	bps := api.ConvertBreakpoints(d.findBreakpoint(id))
-	bps = append(bps, d.findDisabledBreakpoint(id)...)
-	if len(bps) <= 0 {
+	lbp := d.target.Breakpoints().Logical[id]
+	if lbp == nil {
 		return nil
 	}
-	return bps[0]
+	return d.convertBreakpoint(lbp)
 }
 
 func (d *Debugger) findBreakpoint(id int) []*proc.Breakpoint {
@@ -1060,47 +1048,17 @@ func (d *Debugger) findBreakpoint(id int) []*proc.Breakpoint {
 	return bps
 }
 
-func (d *Debugger) findDisabledBreakpoint(id int) []*api.Breakpoint {
-	var bps []*api.Breakpoint
-	for _, dbp := range d.disabledBreakpoints {
-		if dbp.ID == id {
-			bps = append(bps, dbp)
-		}
-	}
-	return bps
-}
-
 // FindBreakpointByName returns the breakpoint specified by 'name'
 func (d *Debugger) FindBreakpointByName(name string) *api.Breakpoint {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
-
-	bp := d.findBreakpointByName(name)
-	if bp == nil {
-		bp = d.findDisabledBreakpointByName(name)
-	}
-	return bp
+	return d.findBreakpointByName(name)
 }
 
 func (d *Debugger) findBreakpointByName(name string) *api.Breakpoint {
-	var bps []*proc.Breakpoint
-	for _, bp := range d.breakpoints() {
-		if bp.Name == name {
-			bps = append(bps, bp)
-		}
-	}
-	if len(bps) == 0 {
-		return nil
-	}
-	sort.Sort(breakpointsByLogicalID(bps))
-	r := api.ConvertBreakpoints(bps)
-	return r[0] // there can only be one logical breakpoint with the same name
-}
-
-func (d *Debugger) findDisabledBreakpointByName(name string) *api.Breakpoint {
-	for _, dbp := range d.disabledBreakpoints {
-		if dbp.Name == name {
-			return dbp
+	for _, lbp := range d.target.Breakpoints().Logical {
+		if lbp.Name == name {
+			return d.convertBreakpoint(lbp)
 		}
 	}
 	return nil
@@ -1118,9 +1076,9 @@ func (d *Debugger) CreateWatchpoint(goid, frame, deferredCall int, expr string, 
 		return nil, err
 	}
 	if d.findBreakpointByName(expr) == nil {
-		bp.Name = expr
+		bp.Logical.Name = expr
 	}
-	return api.ConvertBreakpoint(bp), nil
+	return d.convertBreakpoint(bp.Logical), nil
 }
 
 // Threads returns the threads of the target process.
@@ -2253,19 +2211,4 @@ func noDebugErrorWarning(err error) error {
 		return fmt.Errorf("%s - %s", err.Error(), NoDebugWarning)
 	}
 	return err
-}
-
-type breakpointsByLogicalID []*proc.Breakpoint
-
-func (v breakpointsByLogicalID) Len() int      { return len(v) }
-func (v breakpointsByLogicalID) Swap(i, j int) { v[i], v[j] = v[j], v[i] }
-
-func (v breakpointsByLogicalID) Less(i, j int) bool {
-	if v[i].LogicalID() == v[j].LogicalID() {
-		if v[i].WatchType != v[j].WatchType {
-			return v[i].WatchType > v[j].WatchType // if a logical breakpoint contains a watchpoint let the watchpoint sort first
-		}
-		return v[i].Addr < v[j].Addr
-	}
-	return v[i].LogicalID() < v[j].LogicalID()
 }

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -155,7 +155,7 @@ func (s *RPCServer) ListThreads(arg interface{}, threads *[]*api.Thread) (err er
 	}
 	s.debugger.LockTarget()
 	defer s.debugger.UnlockTarget()
-	*threads = api.ConvertThreads(pthreads)
+	*threads = api.ConvertThreads(pthreads, s.debugger.ConvertThreadBreakpoint)
 	return nil
 }
 
@@ -169,7 +169,7 @@ func (s *RPCServer) GetThread(id int, thread *api.Thread) error {
 	}
 	s.debugger.LockTarget()
 	defer s.debugger.UnlockTarget()
-	*thread = *api.ConvertThread(t)
+	*thread = *api.ConvertThread(t, s.debugger.ConvertThreadBreakpoint(t))
 	return nil
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -387,7 +387,7 @@ func (s *RPCServer) ListThreads(arg ListThreadsIn, out *ListThreadsOut) (err err
 	}
 	s.debugger.LockTarget()
 	defer s.debugger.UnlockTarget()
-	out.Threads = api.ConvertThreads(threads)
+	out.Threads = api.ConvertThreads(threads, s.debugger.ConvertThreadBreakpoint)
 	return nil
 }
 
@@ -410,7 +410,7 @@ func (s *RPCServer) GetThread(arg GetThreadIn, out *GetThreadOut) error {
 	}
 	s.debugger.LockTarget()
 	defer s.debugger.UnlockTarget()
-	out.Thread = api.ConvertThread(t)
+	out.Thread = api.ConvertThread(t, s.debugger.ConvertThreadBreakpoint(t))
 	return nil
 }
 


### PR DESCRIPTION
Adds a LogicalBreakpoint type to represent logical breakpoints
explicitly. Until now logical breakpoints were constructed implicitly
by grouping physical breakpoints together by their LogicalID.

Having logical breakpoints represented explicitly allows for a simpler
implementation of disabled breakpoints, as well as allowing a simple
implementation of delayed breakpoints (#1653, #2551) and in general of
breakpoints spanning multiple processes if we implement debugging
process trees (#2551).

Updates #1653
Updates #2551
