### PR TITLE
dlv_test: fix TestChildProcessExitWhenNoDebugInfo to test stripped binary

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -295,8 +295,14 @@ func TestChildProcessExitWhenNoDebugInfo(t *testing.T) {
 	fix := protest.BuildFixture("http_server", protest.LinkStrip)
 
 	// dlv exec the binary file and expect error.
-	if _, err := exec.Command(dlvbin, "exec", fix.Path).CombinedOutput(); err == nil {
+	out, err := exec.Command(dlvbin, "exec", "--headless", "--log", fix.Path).CombinedOutput()
+	t.Log(string(out))
+	if err == nil {
 		t.Fatalf("Expected err when launching the binary without debug info, but got nil")
+	}
+	//  Test only for dlv's prefix of the error like "could not launch process: could not open debug info"
+	if !strings.Contains(string(out), "could not launch process") {
+		t.Fatalf("Expected logged error 'could not launch process: ...'")
 	}
 
 	// search the running process named fix.Name


### PR DESCRIPTION
Following up on discussion here: https://github.com/go-delve/delve/pull/2018#issuecomment-1068818622
The test was bailing out early before actually trying to debug a stripped binary at this check:
https://github.com/go-delve/delve/blob/2b97231e305c239bcb746234bf67485dbd3b965f/cmd/dlv/cmds/commands.go#L891-L902

Modified the flags and added logging and more checks to make sure the session exits for the right reasons. 
``` 
$ go test -run ^TestChildProcessExitWhenNoDebugInfo$ -v
=== RUN   TestChildProcessExitWhenNoDebugInfo
    dlv_test.go:272: time="2022-03-29T06:17:06Z" level=warning msg="CGO_CFLAGS already set, Cgo code could be optimized." layer=dlv
        2022-03-29T06:17:06Z info layer=debugger launching process with args: [/tmp/http_server.b8c49b54]
        could not launch process: could not open debug info
...
```