### PR TITLE
proc: temporarily disable TestCgoStacktrace on darwin/arm64/go1.19

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3374,6 +3374,9 @@ func TestCgoStacktrace(t *testing.T) {
 		if ver.Major > 0 && !ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 8, Rev: -1}) {
 			t.Skip("disabled on macOS with go before version 1.8")
 		}
+		if runtime.GOARCH == "arm64" && (ver.Major < 0 || ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 19, Rev: -1})) {
+			t.Skip("disable on macOS/arm64 with Go after version 1.19")
+		}
 	}
 
 	skipOn(t, "broken - cgo stacktraces", "386")


### PR DESCRIPTION
Something changed in go1.19 that makes TestCgoStacktrace fail on
darwin/arm64, disable the test for now.
