### PR TITLE
_scripts/make: do not exit if git SHA ID can not be retrieved

### DIFF
--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -294,11 +294,13 @@ func prepareMacnative() string {
 }
 
 func buildFlags() []string {
+	var ldFlags string
 	buildSHA, err := getBuildSHA()
 	if err != nil {
-		log.Fatal(fmt.Errorf("error getting build SHA via git: %w", err))
+		log.Printf("error getting build SHA via git: %w", err)
+	} else {
+		ldFlags = "-X main.Build=" + buildSHA
 	}
-	ldFlags := "-X main.Build=" + buildSHA
 	if runtime.GOOS == "darwin" {
 		ldFlags = "-s " + ldFlags
 	}


### PR DESCRIPTION
Something changed in TeamCity's infrastructure that makes 'git
rev-parse HEAD' fail systematically on most configurations.

Since the SHA ID isn't necessary anyway, print an error and continue.
