### PR TITLE
Fix example block in cli README

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -201,6 +201,7 @@ With the -clear option a condtion on the breakpoint can removed.
 The '% n' form means we should stop at the breakpoint when the hitcount is a multiple of n.
 
 Examples:
+
 	cond 2 i == 10				breakpoint 2 will stop when variable i equals 10
 	cond name runtime.curg.goid == 5	breakpoint 'name' will stop only on goroutine 5
 	cond -clear 2				the condition on breakpoint 2 will be removed

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -472,6 +472,7 @@ With the -clear option a condtion on the breakpoint can removed.
 The '% n' form means we should stop at the breakpoint when the hitcount is a multiple of n.
 
 Examples:
+
 	cond 2 i == 10				breakpoint 2 will stop when variable i equals 10
 	cond name runtime.curg.goid == 5	breakpoint 'name' will stop only on goroutine 5
 	cond -clear 2				the condition on breakpoint 2 will be removed


### PR DESCRIPTION
This missing blank line breaks the example block, every lines are inlined in a single one.