### PR TITLE
_scripts: always return exit code 0 when testing on tip

### DIFF
--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -42,4 +42,11 @@ export GOARCH="$ARCH"
 export PATH="$GOROOT/bin:$PATH"
 go version
 
+set +e
 make test
+x=$?
+if [ "$GOVERSION" = "gotip" ]; then
+	exit 0
+else
+	exit $x
+fi


### PR DESCRIPTION
So that we can mute failing tests in TeamCity.
