### PR TITLE
_scripts/test_linux.sh: always return exit code 0 when testing on tip

### DIFF
--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -57,4 +57,12 @@ elif [ ${version:4:2} -gt 17 ]; then
 	export GOFLAGS=-buildvcs=false
 fi
 
+set +e
 make test
+x=$?
+if [ "$version" = "gotip" ]; then
+	exit 0
+else
+	exit $x
+fi
+

--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -73,4 +73,7 @@ Write-Host $env:GOPATH
 go version
 go env
 go run _scripts/make.go test
-Exit $LastExitCode
+x = $LastExitCode
+if ($version -ne "gotip") {
+	Exit $x
+}


### PR DESCRIPTION
Same as what we do for test_mac.sh
