### PR TITLE
proc: fixes concerning call injection on freebsd and rr

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ env:
   GOFLAGS: -mod=vendor
 
 freebsd_instance:
-  image: freebsd-11-3-stable-amd64-v20200402
+  image_family: freebsd-12-3
 
 test_task:
   install_script: pkg install -y go gcc git

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -268,7 +268,7 @@ func (t *Target) Valid() (bool, error) {
 // Currently only non-recorded processes running on AMD64 support
 // function calls.
 func (t *Target) SupportsFunctionCalls() bool {
-	return t.Process.BinInfo().Arch.Name == "amd64" || t.Process.BinInfo().Arch.Name == "arm64"
+	return (t.Process.BinInfo().Arch.Name == "amd64" && t.Process.BinInfo().GOOS != "freebsd") || t.Process.BinInfo().Arch.Name == "arm64"
 }
 
 // ClearCaches clears internal caches that should not survive a restart.

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -325,6 +325,10 @@ func MustSupportFunctionCalls(t *testing.T, testBackend string) {
 		t.Skip("this backend does not support function calls")
 	}
 
+	if runtime.GOOS == "freebsd" {
+		t.Skip("freebsd backend has problems with changing and restoring XMM registers")
+	}
+
 	if runtime.GOOS == "darwin" && os.Getenv("TRAVIS") == "true" && runtime.GOARCH == "amd64" {
 		t.Skip("function call injection tests are failing on macOS on Travis-CI (see #1802)")
 	}

--- a/service/test/variables_test.go
+++ b/service/test/variables_test.go
@@ -1340,6 +1340,11 @@ func TestCallFunction(t *testing.T) {
 
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) {
 			for _, tc := range testcases117 {
+				if strings.Contains(tc.expr, "floatsum") && testBackend == "rr" {
+					// Can not set floating point registers with RR.
+					// See: https://github.com/rr-debugger/rr/issues/3208
+					continue
+				}
 				testCallFunction(t, p, tc)
 			}
 		}


### PR DESCRIPTION
On FreeBSD it seems we have problems restoring and setting floating
point registers, since at least restoring is necessary for call
injection to function properly fully disable call injection on FreeBSD.

On rr the same problem exists, however due to the fact that we are
acting on a recording and ending a diversion will restore register
values anyway simply disable the floatsum test.

See also: https://github.com/rr-debugger/rr/issues/3208

Updates #3001
