### PR TITLE
Add auto-complete for local variables

### DIFF
--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -460,7 +460,7 @@ func (t *Term) handleExit() (int, error) {
 	return 0, nil
 }
 
-// loadConfig returns an api.LoadConfig with the parameterss specified in
+// loadConfig returns an api.LoadConfig with the parameters specified in
 // the configuration file.
 func (t *Term) loadConfig() api.LoadConfig {
 	r := api.LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -246,7 +246,7 @@ func (t *Term) Run() (int, error) {
 		case "print", "whatis":
 			localVars, err := t.client.ListLocalVariables(
 				api.EvalScope{GoroutineID: -1, Frame: t.cmds.frame, DeferredCall: 0},
-				t.loadConfig(),
+				api.LoadConfig{},
 			)
 			if err != nil {
 				fmt.Printf("Unable to get local variables: %v.", err)


### PR DESCRIPTION
Add auto-complete for local variables when using `print` or `whatis` commands.