### PR TITLE
proc: fix prettyprint for register components with large values

### DIFF
--- a/_fixtures/xmm0print/main.go
+++ b/_fixtures/xmm0print/main.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+//go:noescape
+func VPSLLQ36(src, dst *[4]uint64)
+
+func main() {
+	src := [4]uint64{0: 0x38180a06, 1: 0x38180a06, 2: 0x18080200, 3: 0x18080200}
+	dst := [4]uint64{}
+	VPSLLQ36(&src, &dst)
+
+	for _, qword := range dst {
+		fmt.Printf("%064b\n", qword)
+	}
+}

--- a/_fixtures/xmm0print/main.s
+++ b/_fixtures/xmm0print/main.s
@@ -1,0 +1,9 @@
+#include "textflag.h"
+
+TEXT ·VPSLLQ36(SB), NOSPLIT, $0-16
+    MOVQ src+0(FP), AX
+    MOVQ dst+8(FP), BX
+    VMOVDQU (AX), Y0
+    VPSLLQ $36, Y0, Y0
+    VMOVDQU Y0, (BX)
+    RET

--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -73,7 +73,7 @@ Write-Host $env:GOPATH
 go version
 go env
 go run _scripts/make.go test
-x = $LastExitCode
+$x = $LastExitCode
 if ($version -ne "gotip") {
 	Exit $x
 }

--- a/pkg/proc/native/registers_windows_amd64.go
+++ b/pkg/proc/native/registers_windows_amd64.go
@@ -80,7 +80,7 @@ func (thread *nativeThread) SetReg(regNum uint64, reg *op.DwarfRegister) error {
 		}
 		*p = reg.Uint64Val
 	} else if regNum == regnum.AMD64_Rflags {
-		context.Eflags = uint32(reg.Uint64Val)
+		context.EFlags = uint32(reg.Uint64Val)
 	} else {
 		if regNum < regnum.AMD64_XMM0 || regNum > regnum.AMD64_XMM0+15 {
 			return fmt.Errorf("can not set register %s", regnum.AMD64ToName(regNum))

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -740,11 +740,16 @@ func resolveTypedef(typ godwarf.Type) godwarf.Type {
 	}
 }
 
+var constantMaxInt64 = constant.MakeInt64(1<<63 - 1)
+
 func newConstant(val constant.Value, mem MemoryReadWriter) *Variable {
 	v := &Variable{Value: val, mem: mem, loaded: true}
 	switch val.Kind() {
 	case constant.Int:
 		v.Kind = reflect.Int
+		if constant.Sign(val) >= 0 && constant.Compare(val, token.GTR, constantMaxInt64) {
+			v.Kind = reflect.Uint64
+		}
 	case constant.Float:
 		v.Kind = reflect.Float64
 	case constant.Bool:
@@ -2278,37 +2283,47 @@ func (v *Variable) registerVariableTypeConv(newtyp string) (*Variable, error) {
 		switch newtyp {
 		case "int8":
 			child = newConstant(constant.MakeInt64(int64(int8(v.reg.Bytes[i]))), v.mem)
+			child.Kind = reflect.Int8
 			n = 1
 		case "int16":
 			child = newConstant(constant.MakeInt64(int64(int16(binary.LittleEndian.Uint16(v.reg.Bytes[i:])))), v.mem)
+			child.Kind = reflect.Int16
 			n = 2
 		case "int32":
 			child = newConstant(constant.MakeInt64(int64(int32(binary.LittleEndian.Uint32(v.reg.Bytes[i:])))), v.mem)
+			child.Kind = reflect.Int32
 			n = 4
 		case "int64":
 			child = newConstant(constant.MakeInt64(int64(binary.LittleEndian.Uint64(v.reg.Bytes[i:]))), v.mem)
+			child.Kind = reflect.Int64
 			n = 8
 		case "uint8":
 			child = newConstant(constant.MakeUint64(uint64(v.reg.Bytes[i])), v.mem)
+			child.Kind = reflect.Uint8
 			n = 1
 		case "uint16":
 			child = newConstant(constant.MakeUint64(uint64(binary.LittleEndian.Uint16(v.reg.Bytes[i:]))), v.mem)
+			child.Kind = reflect.Uint16
 			n = 2
 		case "uint32":
 			child = newConstant(constant.MakeUint64(uint64(binary.LittleEndian.Uint32(v.reg.Bytes[i:]))), v.mem)
+			child.Kind = reflect.Uint32
 			n = 4
 		case "uint64":
 			child = newConstant(constant.MakeUint64(uint64(binary.LittleEndian.Uint64(v.reg.Bytes[i:]))), v.mem)
+			child.Kind = reflect.Uint64
 			n = 8
 		case "float32":
 			a := binary.LittleEndian.Uint32(v.reg.Bytes[i:])
 			x := *(*float32)(unsafe.Pointer(&a))
 			child = newConstant(constant.MakeFloat64(float64(x)), v.mem)
+			child.Kind = reflect.Float32
 			n = 4
 		case "float64":
 			a := binary.LittleEndian.Uint64(v.reg.Bytes[i:])
 			x := *(*float64)(unsafe.Pointer(&a))
 			child = newConstant(constant.MakeFloat64(x), v.mem)
+			child.Kind = reflect.Float64
 			n = 8
 		default:
 			if n == 0 {


### PR DESCRIPTION
Fix pretty printing for CPU register components (created with the
XMM0.uintN syntax) while using format strings
Also fixes printing large literal constants with format strings.

Fixes #3020
