### PR TITLE
proc/native: fix Windows build

### DIFF
--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -73,7 +73,7 @@ Write-Host $env:GOPATH
 go version
 go env
 go run _scripts/make.go test
-x = $LastExitCode
+$x = $LastExitCode
 if ($version -ne "gotip") {
 	Exit $x
 }

--- a/pkg/proc/native/registers_windows_amd64.go
+++ b/pkg/proc/native/registers_windows_amd64.go
@@ -80,7 +80,7 @@ func (thread *nativeThread) SetReg(regNum uint64, reg *op.DwarfRegister) error {
 		}
 		*p = reg.Uint64Val
 	} else if regNum == regnum.AMD64_Rflags {
-		context.Eflags = uint32(reg.Uint64Val)
+		context.EFlags = uint32(reg.Uint64Val)
 	} else {
 		if regNum < regnum.AMD64_XMM0 || regNum > regnum.AMD64_XMM0+15 {
 			return fmt.Errorf("can not set register %s", regnum.AMD64ToName(regNum))


### PR DESCRIPTION
Commit b53fcbe broke the build on Windows, we didn't notice because 2d9a9d broke the test script.
