### PR TITLE
go.mod: use pseudo verion for github.com/go-delve/liner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cosiner/argv v0.1.0
 	github.com/creack/pty v1.1.9
 	github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9
-	github.com/go-delve/liner v1.2.2-1
+	github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d
 	github.com/google/go-dap v0.6.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/mattn/go-colorable v0.0.9

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebP
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-delve/liner v1.2.2-1 h1:0hGpZh6vjI6LFTlXuHFCX9PebaluzDzps2owdMrrSuk=
-github.com/go-delve/liner v1.2.2-1/go.mod h1:biJCRbqp51wS+I92HMqn5H8/A0PAhxn2vyOT+JqhiGI=
+github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d h1:pxjSLshkZJGLVm0wv20f/H0oTWiq/egkoJQ2ja6LEvo=
+github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d/go.mod h1:biJCRbqp51wS+I92HMqn5H8/A0PAhxn2vyOT+JqhiGI=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,7 +18,7 @@ github.com/creack/pty
 # github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9
 ## explicit
 github.com/derekparker/trie
-# github.com/go-delve/liner v1.2.2-1
+# github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d
 ## explicit
 github.com/go-delve/liner
 # github.com/google/go-dap v0.6.0


### PR DESCRIPTION
Fixes #3025