### PR TITLE
proc,service/debugger: introduce TargetGroup abstraction

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -633,7 +633,7 @@ func (t *Target) SetWatchpoint(logicalID int, scope *EvalScope, expr string, wty
 
 func (t *Target) setBreakpointInternal(logicalID int, addr uint64, kind BreakpointKind, wtype WatchType, cond ast.Expr) (*Breakpoint, error) {
 	if valid, err := t.Valid(); !valid {
-		recorded, _ := t.Recorded()
+		recorded, _ := t.recman.Recorded()
 		if !recorded {
 			return nil, err
 		}
@@ -738,7 +738,7 @@ func (bp *Breakpoint) canOverlap(kind BreakpointKind) bool {
 // ClearBreakpoint clears the breakpoint at addr.
 func (t *Target) ClearBreakpoint(addr uint64) error {
 	if valid, err := t.Valid(); !valid {
-		recorded, _ := t.Recorded()
+		recorded, _ := t.recman.Recorded()
 		if !recorded {
 			return err
 		}

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -227,7 +227,9 @@ func OpenCore(corePath, exePath string, debugInfoDirs []string) (*proc.Target, e
 		DebugInfoDirs:       debugInfoDirs,
 		DisableAsyncPreempt: false,
 		StopReason:          proc.StopAttached,
-		CanDump:             false})
+		CanDump:             false,
+		ContinueOnce:        continueOnce,
+	})
 }
 
 // BinInfo will return the binary info.
@@ -417,9 +419,7 @@ func (p *process) ClearInternalBreakpoints() error {
 	return nil
 }
 
-// ContinueOnce will always return an error because you
-// cannot control execution of a core file.
-func (p *process) ContinueOnce(cctx *proc.ContinueOnceContext) (proc.Thread, proc.StopReason, error) {
+func continueOnce(procs []proc.ProcessInternal, cctx *proc.ContinueOnceContext) (proc.Thread, proc.StopReason, error) {
 	return nil, proc.StopUnknown, ErrContinueCore
 }
 

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -256,8 +256,9 @@ func TestCore(t *testing.T) {
 		t.Skip("disabled on linux, Github Actions, with PIE buildmode")
 	}
 	p := withCoreFile(t, "panic", "")
+	grp := proc.NewGroup(p)
 
-	recorded, _ := p.Recorded()
+	recorded, _ := grp.Recorded()
 	if !recorded {
 		t.Fatalf("expecting recorded to be true")
 	}

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -146,7 +146,8 @@ func (callCtx *callContext) doReturn(ret *Variable, err error) {
 // EvalExpressionWithCalls is like EvalExpression but allows function calls in 'expr'.
 // Because this can only be done in the current goroutine, unlike
 // EvalExpression, EvalExpressionWithCalls is not a method of EvalScope.
-func EvalExpressionWithCalls(t *Target, g *G, expr string, retLoadCfg LoadConfig, checkEscape bool) error {
+func EvalExpressionWithCalls(grp *TargetGroup, g *G, expr string, retLoadCfg LoadConfig, checkEscape bool) error {
+	t := grp.Selected
 	bi := t.BinInfo()
 	if !t.SupportsFunctionCalls() {
 		return errFuncCallUnsupportedBackend
@@ -201,7 +202,7 @@ func EvalExpressionWithCalls(t *Target, g *G, expr string, retLoadCfg LoadConfig
 
 	contReq, ok := <-continueRequest
 	if contReq.cont {
-		return t.Continue()
+		return grp.Continue()
 	}
 
 	return finishEvalExpressionWithCalls(t, g, contReq, ok)

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -709,7 +709,9 @@ func (p *gdbProcess) initialize(path string, debugInfoDirs []string, stopReason 
 		DebugInfoDirs:       debugInfoDirs,
 		DisableAsyncPreempt: runtime.GOOS == "darwin",
 		StopReason:          stopReason,
-		CanDump:             runtime.GOOS == "darwin"})
+		CanDump:             runtime.GOOS == "darwin",
+		ContinueOnce:        continueOnce,
+	})
 	if err != nil {
 		p.Detach(true)
 		return nil, err
@@ -799,9 +801,11 @@ const (
 	debugServerTargetExcBreakpoint     = 0x96
 )
 
-// ContinueOnce will continue execution of the process until
-// a breakpoint is hit or signal is received.
-func (p *gdbProcess) ContinueOnce(cctx *proc.ContinueOnceContext) (proc.Thread, proc.StopReason, error) {
+func continueOnce(procs []proc.ProcessInternal, cctx *proc.ContinueOnceContext) (proc.Thread, proc.StopReason, error) {
+	if len(procs) != 1 {
+		panic("not implemented")
+	}
+	p := procs[0].(*gdbProcess)
 	if p.exited {
 		return nil, proc.StopExited, proc.ErrProcessExited{Pid: p.conn.pid}
 	}

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -38,7 +38,6 @@ type ProcessInternal interface {
 	// ErrProcessExited or ErrProcessDetached).
 	Valid() (bool, error)
 	Detach(bool) error
-	ContinueOnce(*ContinueOnceContext) (trapthread Thread, stopReason StopReason, err error)
 
 	// RequestManualStop attempts to stop all the process' threads.
 	RequestManualStop(cctx *ContinueOnceContext) error

--- a/pkg/proc/proc_export_test.go
+++ b/pkg/proc/proc_export_test.go
@@ -1,0 +1,42 @@
+package proc
+
+// Wrapper functions so that most tests proc_test.go don't need to worry
+// about TargetGroup when they just need to resume a single process.
+
+func newGroupTransient(tgt *Target) *TargetGroup {
+	grp := NewGroup(tgt)
+	tgt.partOfGroup = false
+	return grp
+}
+
+func (tgt *Target) Detach(kill bool) error {
+	return tgt.detach(kill)
+}
+
+func (tgt *Target) Continue() error {
+	return newGroupTransient(tgt).Continue()
+}
+
+func (tgt *Target) Next() error {
+	return newGroupTransient(tgt).Next()
+}
+
+func (tgt *Target) Step() error {
+	return newGroupTransient(tgt).Step()
+}
+
+func (tgt *Target) StepOut() error {
+	return newGroupTransient(tgt).StepOut()
+}
+
+func (tgt *Target) ChangeDirection(dir Direction) error {
+	return tgt.recman.ChangeDirection(dir)
+}
+
+func (tgt *Target) StepInstruction() error {
+	return newGroupTransient(tgt).StepInstruction()
+}
+
+func (tgt *Target) Recorded() (bool, string) {
+	return tgt.recman.Recorded()
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -272,16 +272,17 @@ func findFileLocation(p *proc.Target, t *testing.T, file string, lineno int) uin
 func TestHalt(t *testing.T) {
 	stopChan := make(chan interface{}, 1)
 	withTestProcess("loopprog", t, func(p *proc.Target, fixture protest.Fixture) {
+		grp := proc.NewGroup(p)
 		setFunctionBreakpoint(p, t, "main.loop")
-		assertNoError(p.Continue(), t, "Continue")
+		assertNoError(grp.Continue(), t, "Continue")
 		resumeChan := make(chan struct{}, 1)
 		go func() {
 			<-resumeChan
 			time.Sleep(100 * time.Millisecond)
-			stopChan <- p.RequestManualStop()
+			stopChan <- grp.RequestManualStop()
 		}()
-		p.ResumeNotify(resumeChan)
-		assertNoError(p.Continue(), t, "Continue")
+		grp.ResumeNotify(resumeChan)
+		assertNoError(grp.Continue(), t, "Continue")
 		retVal := <-stopChan
 
 		if err, ok := retVal.(error); ok && err != nil {
@@ -2064,6 +2065,7 @@ func TestCmdLineArgs(t *testing.T) {
 func TestIssue462(t *testing.T) {
 	skipOn(t, "broken", "windows") // Stacktrace of Goroutine 0 fails with an error
 	withTestProcess("testnextnethttp", t, func(p *proc.Target, fixture protest.Fixture) {
+		grp := proc.NewGroup(p)
 		go func() {
 			// Wait for program to start listening.
 			for {
@@ -2075,10 +2077,10 @@ func TestIssue462(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 			}
 
-			p.RequestManualStop()
+			grp.RequestManualStop()
 		}()
 
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(grp.Continue(), t, "Continue()")
 		_, err := proc.ThreadStacktrace(p.CurrentThread(), 40)
 		assertNoError(err, t, "Stacktrace()")
 	})
@@ -2638,22 +2640,23 @@ func TestNextBreakpoint(t *testing.T) {
 func TestNextBreakpointKeepsSteppingBreakpoints(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("testnextprog", t, func(p *proc.Target, fixture protest.Fixture) {
-		p.KeepSteppingBreakpoints = proc.TracepointKeepsSteppingBreakpoints
+		grp := proc.NewGroup(p)
+		grp.KeepSteppingBreakpoints = proc.TracepointKeepsSteppingBreakpoints
 		bp := setFileBreakpoint(p, t, fixture.Source, 34)
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(grp.Continue(), t, "Continue()")
 		p.ClearBreakpoint(bp.Addr)
 
 		// Next should be interrupted by a tracepoint on the same goroutine.
 		bp = setFileBreakpoint(p, t, fixture.Source, 14)
 		bp.Logical.Tracepoint = true
-		assertNoError(p.Next(), t, "Next()")
+		assertNoError(grp.Next(), t, "Next()")
 		assertLineNumber(p, t, 14, "wrong line number")
 		if !p.Breakpoints().HasSteppingBreakpoints() {
 			t.Fatal("does not have internal breakpoints after hitting tracepoint on same goroutine")
 		}
 
 		// Continue to complete next.
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(grp.Continue(), t, "Continue()")
 		assertLineNumber(p, t, 35, "wrong line number")
 		if p.Breakpoints().HasSteppingBreakpoints() {
 			t.Fatal("has internal breakpoints after completing next")
@@ -3713,17 +3716,18 @@ func TestIssue1101(t *testing.T) {
 
 func TestIssue1145(t *testing.T) {
 	withTestProcess("sleep", t, func(p *proc.Target, fixture protest.Fixture) {
+		grp := proc.NewGroup(p)
 		setFileBreakpoint(p, t, fixture.Source, 18)
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(grp.Continue(), t, "Continue()")
 		resumeChan := make(chan struct{}, 1)
-		p.ResumeNotify(resumeChan)
+		grp.ResumeNotify(resumeChan)
 		go func() {
 			<-resumeChan
 			time.Sleep(100 * time.Millisecond)
-			p.RequestManualStop()
+			grp.RequestManualStop()
 		}()
 
-		assertNoError(p.Next(), t, "Next()")
+		assertNoError(grp.Next(), t, "Next()")
 		if p.Breakpoints().HasSteppingBreakpoints() {
 			t.Fatal("has internal breakpoints after manual stop request")
 		}
@@ -3732,18 +3736,19 @@ func TestIssue1145(t *testing.T) {
 
 func TestHaltKeepsSteppingBreakpoints(t *testing.T) {
 	withTestProcess("sleep", t, func(p *proc.Target, fixture protest.Fixture) {
-		p.KeepSteppingBreakpoints = proc.HaltKeepsSteppingBreakpoints
+		grp := proc.NewGroup(p)
+		grp.KeepSteppingBreakpoints = proc.HaltKeepsSteppingBreakpoints
 		setFileBreakpoint(p, t, fixture.Source, 18)
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(grp.Continue(), t, "Continue()")
 		resumeChan := make(chan struct{}, 1)
-		p.ResumeNotify(resumeChan)
+		grp.ResumeNotify(resumeChan)
 		go func() {
 			<-resumeChan
 			time.Sleep(100 * time.Millisecond)
-			p.RequestManualStop()
+			grp.RequestManualStop()
 		}()
 
-		assertNoError(p.Next(), t, "Next()")
+		assertNoError(grp.Next(), t, "Next()")
 		if !p.Breakpoints().HasSteppingBreakpoints() {
 			t.Fatal("does not have internal breakpoints after manual stop request")
 		}
@@ -4346,11 +4351,12 @@ func TestIssue1374(t *testing.T) {
 	// Continue did not work when stopped at a breakpoint immediately after calling CallFunction.
 	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestProcess("issue1374", t, func(p *proc.Target, fixture protest.Fixture) {
+		grp := proc.NewGroup(p)
 		setFileBreakpoint(p, t, fixture.Source, 7)
-		assertNoError(p.Continue(), t, "First Continue")
+		assertNoError(grp.Continue(), t, "First Continue")
 		assertLineNumber(p, t, 7, "Did not continue to correct location (first continue),")
-		assertNoError(proc.EvalExpressionWithCalls(p, p.SelectedGoroutine(), "getNum()", normalLoadConfig, true), t, "Call")
-		err := p.Continue()
+		assertNoError(proc.EvalExpressionWithCalls(grp, p.SelectedGoroutine(), "getNum()", normalLoadConfig, true), t, "Call")
+		err := grp.Continue()
 		if _, isexited := err.(proc.ErrProcessExited); !isexited {
 			regs, _ := p.CurrentThread().Registers()
 			f, l, _ := p.BinInfo().PCToLine(regs.PC())
@@ -4577,14 +4583,15 @@ func TestCallConcurrent(t *testing.T) {
 	skipOn(t, "broken", "freebsd")
 	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
+		grp := proc.NewGroup(p)
 		bp := setFileBreakpoint(p, t, fixture.Source, 24)
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(grp.Continue(), t, "Continue()")
 		//_, err := p.ClearBreakpoint(bp.Addr)
 		//assertNoError(err, t, "ClearBreakpoint() returned an error")
 
 		gid1 := p.SelectedGoroutine().ID
 		t.Logf("starting injection in %d / %d", p.SelectedGoroutine().ID, p.CurrentThread().ThreadID())
-		assertNoError(proc.EvalExpressionWithCalls(p, p.SelectedGoroutine(), "Foo(10, 1)", normalLoadConfig, false), t, "EvalExpressionWithCalls()")
+		assertNoError(proc.EvalExpressionWithCalls(grp, p.SelectedGoroutine(), "Foo(10, 1)", normalLoadConfig, false), t, "EvalExpressionWithCalls()")
 
 		returned := testCallConcurrentCheckReturns(p, t, gid1, -1)
 
@@ -4599,7 +4606,7 @@ func TestCallConcurrent(t *testing.T) {
 
 		gid2 := p.SelectedGoroutine().ID
 		t.Logf("starting second injection in %d / %d", p.SelectedGoroutine().ID, p.CurrentThread().ThreadID())
-		assertNoError(proc.EvalExpressionWithCalls(p, p.SelectedGoroutine(), "Foo(10, 2)", normalLoadConfig, false), t, "EvalExpressioniWithCalls")
+		assertNoError(proc.EvalExpressionWithCalls(grp, p.SelectedGoroutine(), "Foo(10, 2)", normalLoadConfig, false), t, "EvalExpressioniWithCalls")
 
 		for {
 			returned += testCallConcurrentCheckReturns(p, t, gid1, gid2)
@@ -4607,10 +4614,10 @@ func TestCallConcurrent(t *testing.T) {
 				break
 			}
 			t.Logf("Continuing... %d", returned)
-			assertNoError(p.Continue(), t, "Continue()")
+			assertNoError(grp.Continue(), t, "Continue()")
 		}
 
-		p.Continue()
+		grp.Continue()
 	})
 }
 
@@ -4964,8 +4971,9 @@ func TestIssue1925(t *testing.T) {
 	// altering the state of the target process.
 	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestProcess("testvariables2", t, func(p *proc.Target, fixture protest.Fixture) {
-		assertNoError(p.Continue(), t, "Continue()")
-		assertNoError(proc.EvalExpressionWithCalls(p, p.SelectedGoroutine(), "afunc(2)", normalLoadConfig, true), t, "Call")
+		grp := proc.NewGroup(p)
+		assertNoError(grp.Continue(), t, "Continue()")
+		assertNoError(proc.EvalExpressionWithCalls(grp, p.SelectedGoroutine(), "afunc(2)", normalLoadConfig, true), t, "Call")
 		t.Logf("%v\n", p.SelectedGoroutine().CurrentLoc)
 		if loc := p.SelectedGoroutine().CurrentLoc; loc.File != fixture.Source {
 			t.Errorf("wrong location for selected goroutine after call: %s:%d", loc.File, loc.Line)
@@ -5059,31 +5067,32 @@ func TestStepoutOneliner(t *testing.T) {
 func TestRequestManualStopWhileStopped(t *testing.T) {
 	// Requesting a manual stop while stopped shouldn't cause problems (issue #2138).
 	withTestProcess("issue2138", t, func(p *proc.Target, fixture protest.Fixture) {
+		grp := proc.NewGroup(p)
 		resumed := make(chan struct{})
 		setFileBreakpoint(p, t, fixture.Source, 8)
-		assertNoError(p.Continue(), t, "Continue() 1")
-		p.ResumeNotify(resumed)
+		assertNoError(grp.Continue(), t, "Continue() 1")
+		grp.ResumeNotify(resumed)
 		go func() {
 			<-resumed
 			time.Sleep(1 * time.Second)
-			p.RequestManualStop()
+			grp.RequestManualStop()
 		}()
 		t.Logf("at time.Sleep call")
-		assertNoError(p.Continue(), t, "Continue() 2")
+		assertNoError(grp.Continue(), t, "Continue() 2")
 		t.Logf("manually stopped")
-		p.RequestManualStop()
-		p.RequestManualStop()
-		p.RequestManualStop()
+		grp.RequestManualStop()
+		grp.RequestManualStop()
+		grp.RequestManualStop()
 
 		resumed = make(chan struct{})
-		p.ResumeNotify(resumed)
+		grp.ResumeNotify(resumed)
 		go func() {
 			<-resumed
 			time.Sleep(1 * time.Second)
-			p.RequestManualStop()
+			grp.RequestManualStop()
 		}()
 		t.Logf("resuming sleep")
-		assertNoError(p.Continue(), t, "Continue() 3")
+		assertNoError(grp.Continue(), t, "Continue() 3")
 		t.Logf("done")
 	})
 }
@@ -5546,9 +5555,10 @@ func TestWatchpointCounts(t *testing.T) {
 func TestManualStopWhileStopped(t *testing.T) {
 	// Checks that RequestManualStop sent to a stopped thread does not cause the target process to die.
 	withTestProcess("loopprog", t, func(p *proc.Target, fixture protest.Fixture) {
+		grp := proc.NewGroup(p)
 		asyncCont := func(done chan struct{}) {
 			defer close(done)
-			err := p.Continue()
+			err := grp.Continue()
 			t.Logf("%v\n", err)
 			if err != nil {
 				panic(err)
@@ -5571,9 +5581,9 @@ func TestManualStopWhileStopped(t *testing.T) {
 			done := make(chan struct{})
 			go asyncCont(done)
 			time.Sleep(1 * time.Second)
-			p.RequestManualStop()
+			grp.RequestManualStop()
 			time.Sleep(1 * time.Second)
-			p.RequestManualStop()
+			grp.RequestManualStop()
 			time.Sleep(1 * time.Second)
 			<-done
 		}
@@ -5581,11 +5591,11 @@ func TestManualStopWhileStopped(t *testing.T) {
 			t.Logf("Continue %d (fast)", i)
 			rch := make(chan struct{})
 			done := make(chan struct{})
-			p.ResumeNotify(rch)
+			grp.ResumeNotify(rch)
 			go asyncCont(done)
 			<-rch
-			p.RequestManualStop()
-			p.RequestManualStop()
+			grp.RequestManualStop()
+			grp.RequestManualStop()
 			<-done
 		}
 	})
@@ -5865,6 +5875,8 @@ func TestCallInjectionFlagCorruption(t *testing.T) {
 	withTestProcessArgs("badflags", t, ".", []string{"0"}, 0, func(p *proc.Target, fixture protest.Fixture) {
 		mainfn := p.BinInfo().LookupFunc["main.main"]
 
+		grp := proc.NewGroup(p)
+
 		// Find JNZ instruction on line :14
 		var addr uint64
 		text, err := proc.Disassemble(p.Memory(), nil, p.Breakpoints(), p.BinInfo(), mainfn.Entry, mainfn.End)
@@ -5886,7 +5898,7 @@ func TestCallInjectionFlagCorruption(t *testing.T) {
 		assertNoError(err, t, "SetBreakpoint")
 
 		// Continue to breakpoint
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(grp.Continue(), t, "Continue()")
 		assertLineNumber(p, t, 14, "expected line :14")
 
 		// Save RFLAGS register
@@ -5894,7 +5906,7 @@ func TestCallInjectionFlagCorruption(t *testing.T) {
 		t.Logf("rflags before = %#x", rflagsBeforeCall)
 
 		// Inject call to main.g()
-		assertNoError(proc.EvalExpressionWithCalls(p, p.SelectedGoroutine(), "g()", normalLoadConfig, true), t, "Call")
+		assertNoError(proc.EvalExpressionWithCalls(grp, p.SelectedGoroutine(), "g()", normalLoadConfig, true), t, "Call")
 
 		// Check RFLAGS register after the call
 		rflagsAfterCall := p.BinInfo().Arch.RegistersToDwarfRegisters(0, getRegisters(p, t)).Uint64Val(regnum.AMD64_Rflags)
@@ -5905,7 +5917,7 @@ func TestCallInjectionFlagCorruption(t *testing.T) {
 		}
 
 		// Single step and check where we end up
-		assertNoError(p.Step(), t, "Step()")
+		assertNoError(grp.Step(), t, "Step()")
 		assertLineNumber(p, t, 17, "expected line :17") // since we passed "0" as argument we should be going into the false branch at line :17
 	})
 }

--- a/pkg/proc/stackwatch.go
+++ b/pkg/proc/stackwatch.go
@@ -72,7 +72,7 @@ func (t *Target) setStackWatchBreakpoints(scope *EvalScope, watchpoint *Breakpoi
 	retbreaklet.watchpoint = watchpoint
 	retbreaklet.callback = woos
 
-	if recorded, _ := t.Recorded(); recorded && retframe.Current.Fn != nil {
+	if recorded, _ := t.recman.Recorded(); recorded && retframe.Current.Fn != nil {
 		// Must also set a breakpoint on the call instruction immediately
 		// preceding retframe.Current.PC, because the watchpoint could also go out
 		// of scope while we are running backwards.

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -36,10 +36,10 @@ const (
 // Target represents the process being debugged.
 type Target struct {
 	Process
-	RecordingManipulation
 
-	proc   ProcessInternal
-	recman RecordingManipulationInternal
+	proc         ProcessInternal
+	recman       RecordingManipulationInternal
+	continueOnce ContinueOnceFunc
 
 	pid int
 
@@ -50,10 +50,6 @@ type Target struct {
 
 	// CanDump is true if core dumping is supported.
 	CanDump bool
-
-	// KeepSteppingBreakpoints determines whether certain stop reasons (e.g. manual halts)
-	// will keep the stepping breakpoints instead of clearing them.
-	KeepSteppingBreakpoints KeepSteppingBreakpoints
 
 	// currentThread is the thread that will be used by next/step/stepout and to evaluate variables if no goroutine is selected.
 	currentThread Thread
@@ -84,7 +80,7 @@ type Target struct {
 	fakeMemoryRegistry    []*compositeMemory
 	fakeMemoryRegistryMap map[string]*compositeMemory
 
-	cctx *ContinueOnceContext
+	partOfGroup bool
 }
 
 type KeepSteppingBreakpoints uint8
@@ -151,6 +147,8 @@ const (
 	StopWatchpoint                     // The target process hit one or more watchpoints
 )
 
+type ContinueOnceFunc func([]ProcessInternal, *ContinueOnceContext) (trapthread Thread, stopReason StopReason, err error)
+
 // NewTargetConfig contains the configuration for a new Target object,
 type NewTargetConfig struct {
 	Path                string     // path of the main executable
@@ -158,6 +156,7 @@ type NewTargetConfig struct {
 	DisableAsyncPreempt bool       // Go 1.14 asynchronous preemption should be disabled
 	StopReason          StopReason // Initial stop reason
 	CanDump             bool       // Can create core dumps (must implement ProcessInternal.MemoryMap)
+	ContinueOnce        ContinueOnceFunc
 }
 
 // DisableAsyncPreemptEnv returns a process environment (like os.Environ)
@@ -200,7 +199,7 @@ func NewTarget(p ProcessInternal, pid int, currentThread Thread, cfg NewTargetCo
 		currentThread: currentThread,
 		CanDump:       cfg.CanDump,
 		pid:           pid,
-		cctx:          &ContinueOnceContext{},
+		continueOnce:  cfg.ContinueOnce,
 	}
 
 	if recman, ok := p.(RecordingManipulationInternal); ok {
@@ -208,7 +207,6 @@ func NewTarget(p ProcessInternal, pid int, currentThread Thread, cfg NewTargetCo
 	} else {
 		t.recman = &dummyRecordingManipulation{}
 	}
-	t.RecordingManipulation = t.recman
 
 	g, _ := GetG(currentThread)
 	t.selectedGoroutine = g
@@ -281,12 +279,18 @@ func (t *Target) ClearCaches() {
 	}
 }
 
-// Restart will start the process over from the location specified by the "from" locspec.
+// Restart will start the process group over from the location specified by the "from" locspec.
 // This is only useful for recorded targets.
 // Restarting of a normal process happens at a higher level (debugger.Restart).
-func (t *Target) Restart(from string) error {
-	t.ClearCaches()
-	currentThread, err := t.recman.Restart(t.cctx, from)
+func (grp *TargetGroup) Restart(from string) error {
+	if len(grp.targets) != 1 {
+		panic("multiple targets not implemented")
+	}
+	for _, t := range grp.targets {
+		t.ClearCaches()
+	}
+	t := grp.Selected
+	currentThread, err := t.recman.Restart(grp.cctx, from)
 	if err != nil {
 		return err
 	}
@@ -333,11 +337,11 @@ func (p *Target) SwitchThread(tid int) error {
 	return fmt.Errorf("thread %d does not exist", tid)
 }
 
-// Detach will detach the target from the underylying process.
+// detach will detach the target from the underylying process.
 // This means the debugger will no longer receive events from the process
 // we were previously debugging.
 // If kill is true then the process will be killed when we detach.
-func (t *Target) Detach(kill bool) error {
+func (t *Target) detach(kill bool) error {
 	if !kill {
 		if t.asyncPreemptChanged {
 			setAsyncPreemptOff(t, t.asyncPreemptOff)
@@ -475,17 +479,17 @@ func (t *Target) GetBufferedTracepoints() []*UProbeTraceResult {
 }
 
 // ResumeNotify specifies a channel that will be closed the next time
-// Continue finishes resuming the target.
-func (t *Target) ResumeNotify(ch chan<- struct{}) {
+// Continue finishes resuming the targets.
+func (t *TargetGroup) ResumeNotify(ch chan<- struct{}) {
 	t.cctx.ResumeChan = ch
 }
 
-// RequestManualStop attempts to stop all the process' threads.
-func (t *Target) RequestManualStop() error {
+// RequestManualStop attempts to stop all the processes' threads.
+func (t *TargetGroup) RequestManualStop() error {
 	t.cctx.StopMu.Lock()
 	defer t.cctx.StopMu.Unlock()
 	t.cctx.manualStopRequested = true
-	return t.proc.RequestManualStop(t.cctx)
+	return t.Selected.proc.RequestManualStop(t.cctx)
 }
 
 const (

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -1,0 +1,123 @@
+package proc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TargetGroup reperesents a group of target processes being debugged that
+// will be resumed and stopped simultaneously.
+// New targets are automatically added to the group if exec catching is
+// enabled and the backend supports it, otherwise the group will always
+// contain a single target process.
+type TargetGroup struct {
+	targets  []*Target
+	Selected *Target
+
+	RecordingManipulation
+	recman RecordingManipulationInternal
+
+	// KeepSteppingBreakpoints determines whether certain stop reasons (e.g. manual halts)
+	// will keep the stepping breakpoints instead of clearing them.
+	KeepSteppingBreakpoints KeepSteppingBreakpoints
+
+	LogicalBreakpoints map[int]*LogicalBreakpoint
+
+	continueOnce ContinueOnceFunc
+	cctx         *ContinueOnceContext
+}
+
+// NewGroup creates a TargetGroup containing the specified Target.
+func NewGroup(t *Target) *TargetGroup {
+	if t.partOfGroup {
+		panic("internal error: target is already part of a group")
+	}
+	t.partOfGroup = true
+	return &TargetGroup{
+		RecordingManipulation: t.recman,
+		targets:               []*Target{t},
+		Selected:              t,
+		cctx:                  &ContinueOnceContext{},
+		recman:                t.recman,
+		LogicalBreakpoints:    t.Breakpoints().Logical,
+		continueOnce:          t.continueOnce,
+	}
+}
+
+// Targets returns a slice of targets in the group.
+func (grp *TargetGroup) Targets() []*Target {
+	return grp.targets
+}
+
+// Valid returns true if any target in the target group is valid.
+func (grp *TargetGroup) Valid() (bool, error) {
+	var err0 error
+	for _, t := range grp.targets {
+		ok, err := t.Valid()
+		if ok {
+			return true, nil
+		}
+		err0 = err
+	}
+	return false, err0
+}
+
+// Detach detaches all targets in the group.
+func (grp *TargetGroup) Detach(kill bool) error {
+	var errs []string
+	for _, t := range grp.targets {
+		isvalid, _ := t.Valid()
+		if !isvalid {
+			continue
+		}
+		err := t.detach(kill)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("could not detach process %d: %v", t.Pid(), err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+// HasSteppingBreakpoints returns true if any of the targets has stepping breakpoints set.
+func (grp *TargetGroup) HasSteppingBreakpoints() bool {
+	for _, t := range grp.targets {
+		if t.Breakpoints().HasSteppingBreakpoints() {
+			return true
+		}
+	}
+	return false
+}
+
+// ClearSteppingBreakpoints removes all stepping breakpoints.
+func (grp *TargetGroup) ClearSteppingBreakpoints() error {
+	for _, t := range grp.targets {
+		if t.Breakpoints().HasSteppingBreakpoints() {
+			return t.ClearSteppingBreakpoints()
+		}
+	}
+	return nil
+}
+
+// ThreadList returns a list of all threads in all target processes.
+func (grp *TargetGroup) ThreadList() []Thread {
+	r := []Thread{}
+	for _, t := range grp.targets {
+		r = append(r, t.ThreadList()...)
+	}
+	return r
+}
+
+// TargetForThread returns the target containing the given thread.
+func (grp *TargetGroup) TargetForThread(thread Thread) *Target {
+	for _, t := range grp.targets {
+		for _, th := range t.ThreadList() {
+			if th == thread {
+				return t
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1232,44 +1232,45 @@ func TestCallFunction(t *testing.T) {
 	}
 
 	withTestProcessArgs("fncall", t, ".", nil, protest.AllNonOptimized, func(p *proc.Target, fixture protest.Fixture) {
+		grp := proc.NewGroup(p)
 		testCallFunctionSetBreakpoint(t, p, fixture)
 
-		assertNoError(p.Continue(), t, "Continue()")
+		assertNoError(grp.Continue(), t, "Continue()")
 		for _, tc := range testcases {
-			testCallFunction(t, p, tc)
+			testCallFunction(t, grp, p, tc)
 		}
 
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 12) {
 			for _, tc := range testcases112 {
-				testCallFunction(t, p, tc)
+				testCallFunction(t, grp, p, tc)
 			}
 			if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 14) {
 				for _, tc := range testcasesBefore114After112 {
-					testCallFunction(t, p, tc)
+					testCallFunction(t, grp, p, tc)
 				}
 			}
 		}
 
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 13) {
 			for _, tc := range testcases113 {
-				testCallFunction(t, p, tc)
+				testCallFunction(t, grp, p, tc)
 			}
 		}
 
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 14) {
 			for _, tc := range testcases114 {
-				testCallFunction(t, p, tc)
+				testCallFunction(t, grp, p, tc)
 			}
 		}
 
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) {
 			for _, tc := range testcases117 {
-				testCallFunction(t, p, tc)
+				testCallFunction(t, grp, p, tc)
 			}
 		}
 
 		// LEAVE THIS AS THE LAST ITEM, IT BREAKS THE TARGET PROCESS!!!
-		testCallFunction(t, p, testCaseCallFunction{"-unsafe escapeArg(&a2)", nil, nil})
+		testCallFunction(t, grp, p, testCaseCallFunction{"-unsafe escapeArg(&a2)", nil, nil})
 	})
 }
 
@@ -1284,7 +1285,7 @@ func testCallFunctionSetBreakpoint(t *testing.T, p *proc.Target, fixture protest
 	}
 }
 
-func testCallFunction(t *testing.T, p *proc.Target, tc testCaseCallFunction) {
+func testCallFunction(t *testing.T, grp *proc.TargetGroup, p *proc.Target, tc testCaseCallFunction) {
 	const unsafePrefix = "-unsafe "
 
 	var callExpr, varExpr string
@@ -1302,7 +1303,7 @@ func testCallFunction(t *testing.T, p *proc.Target, tc testCaseCallFunction) {
 		checkEscape = false
 	}
 	t.Logf("call %q", tc.expr)
-	err := proc.EvalExpressionWithCalls(p, p.SelectedGoroutine(), callExpr, pnormalLoadConfig, checkEscape)
+	err := proc.EvalExpressionWithCalls(grp, p.SelectedGoroutine(), callExpr, pnormalLoadConfig, checkEscape)
 	if tc.err != nil {
 		t.Logf("\terr = %v\n", err)
 		if err == nil {

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1558,7 +1558,7 @@ func (s *Session) onConfigurationDoneRequest(request *dap.ConfigurationDoneReque
 		}
 		s.send(e)
 	}
-	s.debugger.Target().KeepSteppingBreakpoints = proc.HaltKeepsSteppingBreakpoints | proc.TracepointKeepsSteppingBreakpoints
+	s.debugger.TargetGroup().KeepSteppingBreakpoints = proc.HaltKeepsSteppingBreakpoints | proc.TracepointKeepsSteppingBreakpoints
 
 	s.logToConsole("Type 'dlv help' for list of commands.")
 	s.send(&dap.ConfigurationDoneResponse{Response: *newResponse(request.Request)})

--- a/service/debugger/debugger_darwin.go
+++ b/service/debugger/debugger_darwin.go
@@ -2,14 +2,9 @@ package debugger
 
 import (
 	"fmt"
-	sys "golang.org/x/sys/unix"
 )
 
 func attachErrorMessage(pid int, err error) error {
 	//TODO: mention certificates?
 	return fmt.Errorf("could not attach to pid %d: %s", pid, err)
-}
-
-func stopProcess(pid int) error {
-	return sys.Kill(pid, sys.SIGSTOP)
 }

--- a/service/debugger/debugger_freebsd.go
+++ b/service/debugger/debugger_freebsd.go
@@ -2,13 +2,8 @@ package debugger
 
 import (
 	"fmt"
-	sys "golang.org/x/sys/unix"
 )
 
 func attachErrorMessage(pid int, err error) error {
 	return fmt.Errorf("could not attach to pid %d: %s", pid, err)
-}
-
-func stopProcess(pid int) error {
-	return sys.Kill(pid, sys.SIGSTOP)
 }

--- a/service/debugger/debugger_linux.go
+++ b/service/debugger/debugger_linux.go
@@ -5,8 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"syscall"
-
-	sys "golang.org/x/sys/unix"
 )
 
 //lint:file-ignore ST1005 errors here can be capitalized
@@ -31,8 +29,4 @@ func attachErrorMessage(pid int, err error) error {
 		}
 	}
 	return fallbackerr
-}
-
-func stopProcess(pid int) error {
-	return sys.Kill(pid, sys.SIGSTOP)
 }

--- a/service/debugger/debugger_windows.go
+++ b/service/debugger/debugger_windows.go
@@ -14,13 +14,6 @@ func attachErrorMessage(pid int, err error) error {
 	return fmt.Errorf("could not attach to pid %d: %s", pid, err)
 }
 
-func stopProcess(pid int) error {
-	// We cannot gracefully stop a process on Windows,
-	// so just ignore this request and let `Detach` kill
-	// the process.
-	return nil
-}
-
 func verifyBinaryFormat(exePath string) error {
 	f, err := os.Open(exePath)
 	if err != nil {


### PR DESCRIPTION
Introduces a new TargetGroup abstraction that can be used to manage
multiple related targets.

No actual management of child processes is implemented here, this is
just a refactoring to make it possible to do that in the future.

Updates #2551
