### PR TITLE
proc: map access with string literal key should always succeed

### DIFF
--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -794,6 +794,9 @@ func TestEvalExpression(t *testing.T) {
 		// pretty printing special types
 		{"tim1", false, `time.Time(1977-05-25T18:00:00Z)…`, `time.Time(1977-05-25T18:00:00Z)…`, "time.Time", nil},
 		{"tim2", false, `time.Time(2022-06-07T02:03:04-06:00)…`, `time.Time(2022-06-07T02:03:04-06:00)…`, "time.Time", nil},
+
+		// issue #3034 - map access with long string key
+		{`m6["very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"]`, false, `123`, `123`, "int", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())


### PR DESCRIPTION
When doing a map lookup with a string literal we should load as much of
the keys to at least match the length of the string literal, so that
the lookup doesn't fail with the "string too long" error.

Fixes #3034
