### PR TITLE
proc/native: fix Ctrl-C handling on non-headless instances on windows

### DIFF
--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -38,6 +38,11 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ strin
 		return nil, err
 	}
 
+	creationFlags := uint32(_DEBUG_ONLY_THIS_PROCESS)
+	if flags&proc.LaunchForeground == 0 {
+		creationFlags |= syscall.CREATE_NEW_PROCESS_GROUP
+	}
+
 	var p *os.Process
 	dbp := newProcess(0)
 	dbp.execPtraceFunc(func() {
@@ -45,7 +50,7 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ strin
 			Dir:   wd,
 			Files: []*os.File{stdin, stdout, stderr},
 			Sys: &syscall.SysProcAttr{
-				CreationFlags: _DEBUG_ONLY_THIS_PROCESS,
+				CreationFlags: creationFlags,
 			},
 			Env: env,
 		}


### PR DESCRIPTION
In non-headless instances Ctrl-C should pause the process, not
terminate it. To make this work on Windows we have to pass the
syscall.CREATE_NEW_PROCESS_GROUP flag to os.StartProcess.
