### PR TITLE
service/dap: limit disassembly range

### DIFF
--- a/_fixtures/cgodisass.go
+++ b/_fixtures/cgodisass.go
@@ -1,0 +1,14 @@
+package main
+
+/*
+int a(int v) {
+	return 0xff + v;
+}
+*/
+import "C"
+import "fmt"
+
+func main() {
+	fmt.Println("aaa")
+	print(C.a(11))
+}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -3151,6 +3151,10 @@ func alignPCs(bi *proc.BinaryInfo, start, end uint64) (uint64, uint64) {
 			return end < fn.Entry
 		})
 		end = bi.Functions[i].Entry
+		const limit = 10 * 1024
+		if end-start > limit {
+			end = start + limit
+		}
 	}
 
 	return start, end


### PR DESCRIPTION
Due to dyanmically loaded libraries there could be aribitrarily large
gaps in the address space, between functions. Limit the memory size we
are willing to disassemble.

Fixes #3040
