### PR TITLE
_scripts: un-pin mingw version

### DIFF
--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -9,7 +9,7 @@ Set-MpPreference -DisableRealtimeMonitoring $true
 #Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # Install MinGW.
-choco install -y mingw --version 10.2.0 
+choco install -y mingw
 
 # Install Procdump
 if (-Not(Test-Path "C:\procdump"))


### PR DESCRIPTION
The version of mingw was pinned to 10.2.0 because mingw 11 started
using DWARFv5, which wasn't supported by Go 1.17. We are now testing
only 1.18 and 1.19 and both support DWARFv5 correctly.
