### PR TITLE
terminal: add ability to show disassembly instead of source

### DIFF
--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1311,3 +1311,14 @@ func TestTranscript(t *testing.T) {
 		os.Remove(name)
 	})
 }
+
+func TestDisassPosCmd(t *testing.T) {
+	withTestTerminal("testvariables2", t, func(term *FakeTerminal) {
+		term.MustExec("continue")
+		out := term.MustExec("step-instruction")
+		t.Logf("%q\n", out)
+		if !strings.Contains(out, "call $runtime.Breakpoint") && !strings.Contains(out, "CALL runtime.Breakpoint(SB)") {
+			t.Errorf("output doesn't look like disassembly")
+		}
+	})
+}

--- a/pkg/terminal/disasmprint.go
+++ b/pkg/terminal/disasmprint.go
@@ -10,10 +10,10 @@ import (
 	"github.com/go-delve/delve/service/api"
 )
 
-func disasmPrint(dv api.AsmInstructions, out io.Writer) {
+func disasmPrint(dv api.AsmInstructions, out io.Writer, showHeader bool) {
 	bw := bufio.NewWriter(out)
 	defer bw.Flush()
-	if len(dv) > 0 && dv[0].Loc.Function != nil {
+	if len(dv) > 0 && dv[0].Loc.Function != nil && showHeader {
 		fmt.Fprintf(bw, "TEXT %s(SB) %s\n", dv[0].Loc.Function.Name(), dv[0].Loc.File)
 	}
 	tw := tabwriter.NewWriter(bw, 1, 8, 1, '\t', 0)


### PR DESCRIPTION
Adds ability to show current position as disassembly instead of source
listing every time execution stops. Change default to show disassembly
after step-instruction and source listing in every other case.

Fixes #2878
