### PR TITLE
dwarf/op,proc: output register name when printing location exprs

### DIFF
--- a/pkg/dwarf/op/op_test.go
+++ b/pkg/dwarf/op/op_test.go
@@ -13,7 +13,7 @@ func assertExprResult(t *testing.T, expected int64, instructions []byte) {
 	}
 	if actual != expected {
 		buf := new(strings.Builder)
-		PrettyPrint(buf, instructions)
+		PrettyPrint(buf, instructions, nil)
 		t.Errorf("actual %d != expected %d (in %s)", actual, expected, buf.String())
 	}
 }

--- a/pkg/dwarf/regnum/i386.go
+++ b/pkg/dwarf/regnum/i386.go
@@ -93,8 +93,8 @@ func I386MaxRegNum() int {
 	return max
 }
 
-func I386ToName(num int) string {
-	name, ok := i386DwarfToName[num]
+func I386ToName(num uint64) string {
+	name, ok := i386DwarfToName[int(num)]
 	if ok {
 		return name
 	}

--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -40,6 +40,7 @@ func AMD64Arch(goos string) *Arch {
 		ContextRegNum:                    regnum.AMD64_Rdx,
 		asmRegisters:                     amd64AsmRegisters,
 		RegisterNameToDwarf:              nameToDwarfFunc(regnum.AMD64NameToDwarf),
+		RegnumToString:                   regnum.AMD64ToName,
 		debugCallMinStackSize:            256,
 		maxRegArgBytes:                   9*8 + 15*8,
 	}

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -49,6 +49,7 @@ type Arch struct {
 	// inhibitStepInto returns whether StepBreakpoint can be set at pc.
 	inhibitStepInto     func(bi *BinaryInfo, pc uint64) bool
 	RegisterNameToDwarf func(s string) (int, bool)
+	RegnumToString      func(uint64) string
 	// debugCallMinStackSize is the minimum stack size for call injection on this architecture.
 	debugCallMinStackSize uint64
 	// maxRegArgBytes is extra padding for ABI1 call injections, equivalent to

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -40,6 +40,7 @@ func ARM64Arch(goos string) *Arch {
 		LRRegNum:                         regnum.ARM64_LR,
 		asmRegisters:                     arm64AsmRegisters,
 		RegisterNameToDwarf:              nameToDwarfFunc(regnum.ARM64NameToDwarf),
+		RegnumToString:                   regnum.ARM64ToName,
 		debugCallMinStackSize:            288,
 		maxRegArgBytes:                   16*8 + 16*8, // 16 int argument registers plus 16 float argument registers
 	}

--- a/pkg/proc/i386_arch.go
+++ b/pkg/proc/i386_arch.go
@@ -36,6 +36,7 @@ func I386Arch(goos string) *Arch {
 		SPRegNum:                         regnum.I386_Esp,
 		asmRegisters:                     i386AsmRegisters,
 		RegisterNameToDwarf:              nameToDwarfFunc(regnum.I386NameToDwarf),
+		RegnumToString:                   regnum.I386ToName,
 	}
 }
 
@@ -208,7 +209,7 @@ func i386AddrAndStackRegsToDwarfRegisters(staticBase, pc, sp, bp, lr uint64) op.
 }
 
 func i386DwarfRegisterToString(j int, reg *op.DwarfRegister) (name string, floatingPoint bool, repr string) {
-	name = regnum.I386ToName(j)
+	name = regnum.I386ToName(uint64(j))
 
 	if reg == nil {
 		return name, false, ""

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -510,7 +510,7 @@ func (t *Target) newCompositeMemory(mem MemoryReadWriter, regs op.DwarfRegisters
 		// this combination is guaranteed to be unique between resumes.
 		buf := new(strings.Builder)
 		fmt.Fprintf(buf, "%#x ", regs.CFA)
-		op.PrettyPrint(buf, descr.instr)
+		op.PrettyPrint(buf, descr.instr, t.BinInfo().Arch.RegnumToString)
 		key = buf.String()
 
 		if cmem := t.fakeMemoryRegistryMap[key]; cmem != nil {


### PR DESCRIPTION
Output the architecture specific register name when printing location
expression after DW_OP_regN and DW_OP_bregN operators.
