### PR TITLE
Remove ignored flags from dlv_dap.md

### DIFF
--- a/Documentation/usage/dlv_dap.md
+++ b/Documentation/usage/dlv_dap.md
@@ -40,22 +40,16 @@ dlv dap [flags]
 ### Options inherited from parent commands
 
 ```
-      --accept-multiclient               Allows a headless server to accept multiple client connections via JSON-RPC or DAP.
       --allow-non-terminal-interactive   Allows interactive sessions of Delve that don't have a terminal as stdin, stdout and stderr
       --api-version int                  Selects JSON-RPC API version when headless. New clients should use v2. Can be reset via RPCServer.SetApiVersion. See Documentation/api/json-rpc/README.md. (default 1)
-      --backend string                   Backend selection (see 'dlv help backend'). (default "default")
-      --build-flags string               Build flags, to be passed to the compiler. For example: --build-flags="-tags=integration -mod=vendor -cover -v"
       --check-go-version                 Exits if the version of Go in use is not compatible (too old or too new) with the version of Delve. (default true)
       --disable-aslr                     Disables address space randomization
-      --headless                         Run debug server only, in headless mode. Server will accept both JSON-RPC or DAP client connections.
-      --init string                      Init file, executed by the terminal client.
   -l, --listen string                    Debugging server listen address. (default "127.0.0.1:0")
       --log                              Enable debugging server logging.
       --log-dest string                  Writes logs to the specified file or file descriptor (see 'dlv help log').
       --log-output string                Comma separated list of components that should produce debug output (see 'dlv help log')
       --only-same-user                   Only connections from the same user that started this instance of Delve are allowed to connect. (default true)
   -r, --redirect stringArray             Specifies redirect rules for target process (see 'dlv help redirect')
-      --wd string                        Working directory for running the program.
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
According to https://github.com/go-delve/delve/blob/master/cmd/dlv/cmds/commands.go#L434, many of the flags listed in the docs for `dlv dap` are actually ignored.

I suppose they are technically "inherited from parent commands", but I think it's confusing to list them if they will have no effect.