### PR TITLE
cmd/dlv,proc: misc improvements to trace subcommand

### DIFF
--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -26,7 +26,7 @@ dlv trace [package] regexp [flags]
   -h, --help            help for trace
       --output string   Output path for the binary. (default "debug")
   -p, --pid int         Pid to attach to.
-  -s, --stack int       Show stack trace with given depth. (Ignored with -ebpf)
+  -s, --stack int       Show stack trace with given depth. (Ignored with --ebpf)
   -t, --test            Trace a test binary.
 ```
 

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -305,7 +305,7 @@ only see the output of the trace operations you can redirect stdout.`,
 	traceCommand.Flags().StringVarP(&traceExecFile, "exec", "e", "", "Binary file to exec and trace.")
 	traceCommand.Flags().BoolVarP(&traceTestBinary, "test", "t", false, "Trace a test binary.")
 	traceCommand.Flags().BoolVarP(&traceUseEBPF, "ebpf", "", false, "Trace using eBPF (experimental).")
-	traceCommand.Flags().IntVarP(&traceStackDepth, "stack", "s", 0, "Show stack trace with given depth. (Ignored with -ebpf)")
+	traceCommand.Flags().IntVarP(&traceStackDepth, "stack", "s", 0, "Show stack trace with given depth. (Ignored with --ebpf)")
 	traceCommand.Flags().String("output", "debug", "Output path for the binary.")
 	rootCommand.AddCommand(traceCommand)
 
@@ -586,7 +586,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 		var debugname string
 		if traceAttachPid == 0 {
 			if dlvArgsLen >= 2 && traceExecFile != "" {
-				fmt.Fprintln(os.Stderr, "Cannot specify package when using exec.")
+				fmt.Fprintln(os.Stderr, "Cannot specify package when using --exec.")
 				return 1
 			}
 
@@ -628,16 +628,20 @@ func traceCmd(cmd *cobra.Command, args []string) {
 			return 1
 		}
 		client := rpc2.NewClientFromConn(clientConn)
+		defer client.Detach(true)
 		funcs, err := client.ListFunctions(regexp)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 1
 		}
+		success := false
 		for i := range funcs {
 			if traceUseEBPF {
 				err := client.CreateEBPFTracepoint(funcs[i])
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "unable to set tracepoint on function %s: %#v\n", funcs[i], err)
+				} else {
+					success = true
 				}
 			} else {
 				// Fall back to breakpoint based tracing if we get an error.
@@ -650,10 +654,14 @@ func traceCmd(cmd *cobra.Command, args []string) {
 				})
 				if err != nil && !isBreakpointExistsErr(err) {
 					fmt.Fprintf(os.Stderr, "unable to set tracepoint on function %s: %#v\n", funcs[i], err)
+					continue
+				} else {
+					success = true
 				}
 				addrs, err := client.FunctionReturnLocations(funcs[i])
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "unable to set tracepoint on function %s: %#v\n", funcs[i], err)
+					continue
 				}
 				for i := range addrs {
 					_, err = client.CreateBreakpoint(&api.Breakpoint{
@@ -665,9 +673,15 @@ func traceCmd(cmd *cobra.Command, args []string) {
 					})
 					if err != nil && !isBreakpointExistsErr(err) {
 						fmt.Fprintf(os.Stderr, "unable to set tracepoint on function %s: %#v\n", funcs[i], err)
+					} else {
+						success = true
 					}
 				}
 			}
+		}
+		if !success {
+			fmt.Fprintln(os.Stderr, "no breakpoints set")
+			return 1
 		}
 		cmds := terminal.DebugCommands(client)
 		t := terminal.New(client, nil)

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -575,8 +575,7 @@ func (t *Target) setEBPFTracepointOnFunc(fn *Function, goidOffset int64) error {
 	//TODO(aarzilli): inlined calls?
 
 	// Finally, set the uprobe on the function.
-	t.proc.SetUProbe(fn.Name, goidOffset, args)
-	return nil
+	return t.proc.SetUProbe(fn.Name, goidOffset, args)
 }
 
 // SetWatchpoint sets a data breakpoint at addr and stores it in the


### PR DESCRIPTION
1. return an error when SetUProbe fails, while creating ebpf tracepoints
2. if no tracepoint can be set for 'dlv trace' exit early
3. never leave the traced program running
4. fix typo in description of --ebpf flag
