### PR TITLE
proc/internal/ebpf: drop dependency on cgo

### DIFF
--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -41,7 +41,7 @@ GOPATH=$(pwd)/go
 export GOPATH
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 go version
-go install honnef.co/go/tools/cmd/staticcheck@2021.1.1 || true
+go install honnef.co/go/tools/cmd/staticcheck@2022.1.2 || true
 
 uname -a
 echo "$PATH"

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1182,10 +1182,6 @@ func TestVersion(t *testing.T) {
 }
 
 func TestStaticcheck(t *testing.T) {
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) {
-		//TODO(aarzilli): remove this before version 1.8.0 is released
-		t.Skip("staticcheck does not currently support Go 1.18")
-	}
 	_, err := exec.LookPath("staticcheck")
 	if err != nil {
 		t.Skip("staticcheck not installed")

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -150,9 +150,7 @@ func disassemble(memrw MemoryReadWriter, regs Registers, breakpoints *Breakpoint
 	for len(mem) > 0 {
 		bp, atbp := breakpoints.M[pc]
 		if atbp {
-			for i := range bp.OriginalData {
-				mem[i] = bp.OriginalData[i]
-			}
+			copy(mem, bp.OriginalData)
 		}
 
 		file, line, fn := bi.PCToLine(pc)

--- a/pkg/proc/internal/ebpf/helpers_disabled.go
+++ b/pkg/proc/internal/ebpf/helpers_disabled.go
@@ -1,5 +1,5 @@
-//go:build !linux || !amd64 || !go1.16 || !cgo
-// +build !linux !amd64 !go1.16 !cgo
+//go:build !linux || !amd64 || !go1.16
+// +build !linux !amd64 !go1.16
 
 package ebpf
 

--- a/pkg/proc/internal/ebpf/helpers_test.go
+++ b/pkg/proc/internal/ebpf/helpers_test.go
@@ -1,0 +1,43 @@
+//go:build linux && amd64 && cgo && go1.16
+// +build linux,amd64,cgo,go1.16
+
+package ebpf
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-delve/delve/pkg/proc/internal/ebpf/testhelper"
+)
+
+func compareStructTypes(t *testing.T, gostructVal, cstructVal interface{}) {
+	gostruct := reflect.ValueOf(gostructVal).Type()
+	cstruct := reflect.ValueOf(cstructVal).Type()
+	if gostruct.NumField() != cstruct.NumField() {
+		t.Errorf("mismatched field number %d %d", gostruct.NumField(), cstruct.NumField())
+		return
+	}
+	for i := 0; i < cstruct.NumField(); i++ {
+		gofield := gostruct.Field(i)
+		cfield := cstruct.Field(i)
+		t.Logf("%d %s %s\n", i, gofield.Name, cfield.Name)
+		if gofield.Name != cfield.Name {
+			t.Errorf("mismatched name for field %s %s", gofield.Name, cfield.Name)
+		}
+		if gofield.Offset != cfield.Offset {
+			t.Errorf("mismatched offset for field %s %s (%d %d)", gofield.Name, cfield.Name, gofield.Offset, cfield.Offset)
+		}
+		if gofield.Type.Size() != cfield.Type.Size() {
+			t.Errorf("mismatched size for field %s %s (%d %d)", gofield.Name, cfield.Name, gofield.Type.Size(), cfield.Type.Size())
+		}
+	}
+}
+
+func TestStructConsistency(t *testing.T) {
+	t.Run("function_parameter_t", func(t *testing.T) {
+		compareStructTypes(t, function_parameter_t{}, testhelper.Function_parameter_t{})
+	})
+	t.Run("function_parameter_list_t", func(t *testing.T) {
+		compareStructTypes(t, function_parameter_list_t{}, testhelper.Function_parameter_list_t{})
+	})
+}

--- a/pkg/proc/internal/ebpf/testhelper/testhelper.go
+++ b/pkg/proc/internal/ebpf/testhelper/testhelper.go
@@ -1,0 +1,13 @@
+//go:build linux && amd64 && cgo && go1.16
+// +build linux,amd64,cgo,go1.16
+
+package testhelper
+
+// #include "../bpf/include/function_vals.bpf.h"
+import "C"
+
+// Function_parameter_t exports function_parameter_t from function_vals.bpf.h
+type Function_parameter_t C.function_parameter_t
+
+// Function_parameter_list_t exports function_parameter_list_t from function_vals.bpf.h
+type Function_parameter_list_t C.function_parameter_list_t


### PR DESCRIPTION
The ebpf implementations uses cgo, but only to access some C struct
definitions. Instead of using cgo simply duplicate the defintion of
those two structs in Go and add a test to check that the duplicate
definitions remain synchronized.

Fixes #2827
