### PR TITLE
pkg/locspec: support exact match in SubstitutePath

### DIFF
--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -492,6 +492,12 @@ func SubstitutePath(path string, rules [][2]string) string {
 		from := crossPlatformPath(r[0])
 		to := r[1]
 
+		// If we have an exact match, use it directly.
+		if path == from {
+			return to
+		}
+
+		// Otherwise check if it's a directory prefix.
 		if !strings.HasSuffix(from, separator) {
 			from = from + separator
 		}

--- a/pkg/terminal/terminal_test.go
+++ b/pkg/terminal/terminal_test.go
@@ -27,8 +27,10 @@ func platformCases() []tCase {
 		{[]tRule{{"/tmp/path/", "/new/path2/"}}, "/tmp/path/file.go", "/new/path2/file.go"},
 		{[]tRule{{"/tmp/path/", "/new/path2"}}, "/tmp/path/file.go", "/new/path2/file.go"},
 		{[]tRule{{"/tmp/path", "/new/path2/"}}, "/tmp/path/file.go", "/new/path2/file.go"},
-		// Should apply only for directory names
+		// Should apply to directory prefixes
 		{[]tRule{{"/tmp/path", "/new/path2"}}, "/tmp/path-2/file.go", "/tmp/path-2/file.go"},
+		// Should apply to exact matches
+		{[]tRule{{"/tmp/path/file.go", "/new/path2/file2.go"}}, "/tmp/path/file.go", "/new/path2/file2.go"},
 		// First matched rule should be used
 		{[]tRule{
 			{"/tmp/path1", "/new/path1"},
@@ -54,8 +56,10 @@ func platformCases() []tCase {
 		{[]tRule{{`c:\tmp\path\`, `d:\new\path2\`}}, `c:\tmp\path\file.go`, `d:\new\path2\file.go`},
 		{[]tRule{{`c:\tmp\path`, `d:\new\path2\`}}, `c:\tmp\path\file.go`, `d:\new\path2\file.go`},
 		{[]tRule{{`c:\tmp\path\`, `d:\new\path2`}}, `c:\tmp\path\file.go`, `d:\new\path2\file.go`},
-		// Should apply only for directory names
+		// Should apply to directory prefixes
 		{[]tRule{{`c:\tmp\path`, `d:\new\path2`}}, `c:\tmp\path-2\file.go`, `c:\tmp\path-2\file.go`},
+		// Should apply to exact matches
+		{[]tRule{{`c:\tmp\path\file.go`, `d:\new\path2\file2.go`}}, `c:\tmp\path\file.go`, `d:\new\path2\file2.go`},
 		// Should be case-insensitive
 		{[]tRule{{`c:\tmp\path`, `d:\new\path2`}}, `C:\TmP\PaTh\file.go`, `d:\new\path2\file.go`},
 	}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -219,10 +219,8 @@ type launchAttachArgs struct {
 	// responses.
 	HideSystemGoroutines bool `cfgName:"hideSystemGoroutines"`
 	// substitutePathClientToServer indicates rules for converting file paths between client and debugger.
-	// These must be directory paths.
 	substitutePathClientToServer [][2]string `cfgName:"substitutePath"`
 	// substitutePathServerToClient indicates rules for converting file paths between debugger and client.
-	// These must be directory paths.
 	substitutePathServerToClient [][2]string
 }
 


### PR DESCRIPTION
In order to support substituting a single file within
a larger package, and not substituting a directory wholesale,
this commit introduces the ability for SubstitutePath
to replace individual file paths if there is an exact match.

This behavior is backwards-compatible with the previous
configuration.

Fixes #3074
