### PR TITLE
Fix StepInstruction on 1 byte instruction with a software breakpoint

### DIFF
--- a/_fixtures/break/break_amd64.s
+++ b/_fixtures/break/break_amd64.s
@@ -1,0 +1,5 @@
+#include "textflag.h"
+
+TEXT ·asmBrk(SB),0,$0-0
+	BYTE	$0xcc
+	RET

--- a/_fixtures/break/main.go
+++ b/_fixtures/break/main.go
@@ -1,0 +1,7 @@
+package main
+
+func asmBrk()
+
+func main() {
+	asmBrk()
+}

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -433,7 +433,7 @@ func (grp *TargetGroup) StepInstruction() (err error) {
 		return err
 	}
 	thread.Breakpoint().Clear()
-	err = thread.SetCurrentBreakpoint(true)
+	err = thread.SetCurrentBreakpoint(false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For architectures that `BreakInstrMovesPC() == true`, `StepInstruction` does not move forward the PC when the PC is on an instruction with the same size as the breakpoint (1 byte for amd64) and there is a software breakpoint active on that instruction.

This happens because `StepInstruction` calls `SetCurrentBreakpoint(true)` after advancing the PC, which sees a breakpoint and moves the PC 1 instruction backwards, ending at the same original point. This bug is difficult to trigger becase the breakpoint instruction is small, just one byte.

This PR changes `StepInstruction` to call `SetCurrentBreakpoint(false)` instead.

I've found this while working on #3063, where this issue is hit more times because all instructions have the same length.

@aarzilli @derekparker 