### PR TITLE
service/dap: Add support for empty string in substitutePath

### DIFF
--- a/pkg/config/split.go
+++ b/pkg/config/split.go
@@ -41,6 +41,7 @@ func SplitQuotedFields(in string, quote rune) []string {
 			} else if unicode.IsSpace(ch) {
 				r = append(r, buf.String())
 				buf.Reset()
+				state = inSpace
 			} else {
 				buf.WriteRune(ch)
 			}

--- a/pkg/config/split.go
+++ b/pkg/config/split.go
@@ -60,7 +60,7 @@ func SplitQuotedFields(in string, quote rune) []string {
 		}
 	}
 
-	if buf.Len() != 0 {
+	if state == inField || buf.Len() != 0 {
 		r = append(r, buf.String())
 	}
 

--- a/pkg/config/split_test.go
+++ b/pkg/config/split_test.go
@@ -21,18 +21,52 @@ func TestSplitQuotedFields(t *testing.T) {
 }
 
 func TestSplitDoubleQuotedFields(t *testing.T) {
-	in := `field"A" "fieldB" fie"l'd"C "field\"D" "yet another field" "" `
-	tgt := []string{"fieldA", "fieldB", "fiel'dC", "field\"D", "yet another field", "", ""}
-	out := SplitQuotedFields(in, '"')
-
-	if len(tgt) != len(out) {
-		t.Fatalf("expected %#v, got %#v (len mismatch)", tgt, out)
+	tests := []struct {
+		name     string
+		in       string
+		expected []string
+	}{
+		{
+			name:     "generic test case",
+			in:       `field"A" "fieldB" fie"l'd"C "field\"D" "yet another field"`,
+			expected: []string{"fieldA", "fieldB", "fiel'dC", "field\"D", "yet another field"},
+		},
+		{
+			name:     "with empty string in the end",
+			in:       `field"A" "" `,
+			expected: []string{"fieldA", ""},
+		},
+		{
+			name:     "with empty string at the beginning",
+			in:       ` "" field"A"`,
+			expected: []string{"", "fieldA"},
+		},
+		{
+			name:     "lots of spaces",
+			in:       `    field"A"   `,
+			expected: []string{"fieldA"},
+		},
+		{
+			name:     "only empty string",
+			in:       ` "" "" "" """" "" `,
+			expected: []string{"", "", "", "", ""},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := tt.in
+			tgt := tt.expected
+			out := SplitQuotedFields(in, '"')
+			if len(tgt) != len(out) {
+				t.Fatalf("expected %#v, got %#v (len mismatch)", tgt, out)
+			}
 
-	for i := range tgt {
-		if tgt[i] != out[i] {
-			t.Fatalf(" expected %#v, got %#v (mismatch at %d)", tgt, out, i)
-		}
+			for i := range tgt {
+				if tgt[i] != out[i] {
+					t.Fatalf(" expected %#v, got %#v (mismatch at %d)", tgt, out, i)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/config/split_test.go
+++ b/pkg/config/split_test.go
@@ -21,8 +21,8 @@ func TestSplitQuotedFields(t *testing.T) {
 }
 
 func TestSplitDoubleQuotedFields(t *testing.T) {
-	in := `field"A" "fieldB" fie"l'd"C "field\"D" "yet another field"`
-	tgt := []string{"fieldA", "fieldB", "fiel'dC", "field\"D", "yet another field"}
+	in := `field"A" "fieldB" fie"l'd"C "field\"D" "yet another field" "" `
+	tgt := []string{"fieldA", "fieldB", "fiel'dC", "field\"D", "yet another field", "", ""}
 	out := SplitQuotedFields(in, '"')
 
 	if len(tgt) != len(out) {

--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -498,13 +498,19 @@ func SubstitutePath(path string, rules [][2]string) string {
 		}
 
 		// Otherwise check if it's a directory prefix.
-		if !strings.HasSuffix(from, separator) {
+		if from != "" && !strings.HasSuffix(from, separator) {
 			from = from + separator
 		}
-		if !strings.HasSuffix(to, separator) {
+		if to != "" && !strings.HasSuffix(to, separator) {
 			to = to + separator
 		}
-		if strings.HasPrefix(path, from) {
+
+		//  If 'from' is a empty string and path is not absolute, prepende 'to'.
+		if from == "" && !filepath.IsAbs(path) {
+			return strings.Replace(path, from, to, 1)
+		}
+
+		if from != "" && strings.HasPrefix(path, from) {
 			return strings.Replace(path, from, to, 1)
 		}
 	}

--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -505,7 +505,7 @@ func SubstitutePath(path string, rules [][2]string) string {
 			to = to + separator
 		}
 
-		//  If 'from' is a empty string and path is not absolute, prepende 'to'.
+		// Expand relative paths with the specified prefix
 		if from == "" && !filepath.IsAbs(path) {
 			return strings.Replace(path, from, to, 1)
 		}

--- a/service/dap/config_test.go
+++ b/service/dap/config_test.go
@@ -95,6 +95,74 @@ func TestConfigureSetSubstitutePath(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "add rule from empty string",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{},
+					substitutePathServerToClient: [][2]string{},
+				},
+				rest: `"" /path/to/client/dir`,
+			},
+			wantRules: [][2]string{{"", "/path/to/client/dir"}},
+			wantErr:   false,
+		},
+		{
+			name: "add rule to empty string",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{},
+					substitutePathServerToClient: [][2]string{},
+				},
+				rest: `/path/to/client/dir ""`,
+			},
+			wantRules: [][2]string{{"/path/to/client/dir", ""}},
+			wantErr:   false,
+		},
+		{
+			name: "add rule from empty string(multiple)",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{
+						{"/path/to/client/dir/a", "/path/to/server/dir/a"},
+						{"/path/to/client/dir/b", "/path/to/server/dir/b"},
+					},
+					substitutePathServerToClient: [][2]string{
+						{"/path/to/server/dir/a", "/path/to/client/dir/a"},
+						{"/path/to/server/dir/b", "/path/to/client/dir/b"},
+					},
+				},
+				rest: `"" /path/to/client/dir/c`,
+			},
+			wantRules: [][2]string{
+				{"/path/to/client/dir/a", "/path/to/server/dir/a"},
+				{"/path/to/client/dir/b", "/path/to/server/dir/b"},
+				{"", "/path/to/client/dir/c"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "add rule to empty string(multiple)",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{
+						{"/path/to/client/dir/a", "/path/to/server/dir/a"},
+						{"/path/to/client/dir/b", "/path/to/server/dir/b"},
+					},
+					substitutePathServerToClient: [][2]string{
+						{"/path/to/server/dir/a", "/path/to/client/dir/a"},
+						{"/path/to/server/dir/b", "/path/to/client/dir/b"},
+					},
+				},
+				rest: `/path/to/client/dir/c ""`,
+			},
+			wantRules: [][2]string{
+				{"/path/to/client/dir/a", "/path/to/server/dir/a"},
+				{"/path/to/client/dir/b", "/path/to/server/dir/b"},
+				{"/path/to/client/dir/c", ""},
+			},
+			wantErr: false,
+		},
 		// Test modify rule.
 		{
 			name: "modify rule",
@@ -106,6 +174,30 @@ func TestConfigureSetSubstitutePath(t *testing.T) {
 				rest: "/path/to/client/dir /new/path/to/server/dir",
 			},
 			wantRules: [][2]string{{"/path/to/client/dir", "/new/path/to/server/dir"}},
+			wantErr:   false,
+		},
+		{
+			name: "modify rule with from as empty string",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{{"", "/path/to/server/dir"}},
+					substitutePathServerToClient: [][2]string{{"/path/to/server/dir", ""}},
+				},
+				rest: `"" /new/path/to/server/dir`,
+			},
+			wantRules: [][2]string{{"", "/new/path/to/server/dir"}},
+			wantErr:   false,
+		},
+		{
+			name: "modify rule with to as empty string",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{{"/path/to/client/dir", ""}},
+					substitutePathServerToClient: [][2]string{{"", "/path/to/client/dir"}},
+				},
+				rest: `/path/to/client/dir ""`,
+			},
+			wantRules: [][2]string{{"/path/to/client/dir", ""}},
 			wantErr:   false,
 		},
 		{
@@ -132,6 +224,54 @@ func TestConfigureSetSubstitutePath(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "modify rule with from as empty string(multiple)",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{
+						{"/path/to/client/dir/a", "/path/to/server/dir/a"},
+						{"", "/path/to/server/dir/b"},
+						{"/path/to/client/dir/c", "/path/to/server/dir/b"},
+					},
+					substitutePathServerToClient: [][2]string{
+						{"/path/to/server/dir/a", "/path/to/client/dir/a"},
+						{"/path/to/server/dir/b", ""},
+						{"/path/to/server/dir/b", "/path/to/client/dir/c"},
+					},
+				},
+				rest: `"" /new/path`,
+			},
+			wantRules: [][2]string{
+				{"/path/to/client/dir/a", "/path/to/server/dir/a"},
+				{"", "/new/path"},
+				{"/path/to/client/dir/c", "/path/to/server/dir/b"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "modify rule with to as empty string(multiple)",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{
+						{"/path/to/client/dir/a", "/path/to/server/dir/a"},
+						{"/path/to/client/dir/b", "/path/to/server/dir/b"},
+						{"/path/to/client/dir/c", "/path/to/server/dir/b"},
+					},
+					substitutePathServerToClient: [][2]string{
+						{"/path/to/server/dir/a", "/path/to/client/dir/a"},
+						{"/path/to/server/dir/b", "/path/to/client/dir/b"},
+						{"/path/to/server/dir/b", "/path/to/client/dir/c"},
+					},
+				},
+				rest: `/path/to/client/dir/b ""`,
+			},
+			wantRules: [][2]string{
+				{"/path/to/client/dir/a", "/path/to/server/dir/a"},
+				{"/path/to/client/dir/b", ""},
+				{"/path/to/client/dir/c", "/path/to/server/dir/b"},
+			},
+			wantErr: false,
+		},
 		// Test delete rule.
 		{
 			name: "delete rule",
@@ -141,6 +281,18 @@ func TestConfigureSetSubstitutePath(t *testing.T) {
 					substitutePathServerToClient: [][2]string{{"/path/to/server/dir", "/path/to/client/dir"}},
 				},
 				rest: "/path/to/client/dir",
+			},
+			wantRules: [][2]string{},
+			wantErr:   false,
+		},
+		{
+			name: "delete rule, empty string",
+			args: args{
+				args: &launchAttachArgs{
+					substitutePathClientToServer: [][2]string{{"", "/path/to/server/dir"}},
+					substitutePathServerToClient: [][2]string{{"/path/to/server/dir", ""}},
+				},
+				rest: `""`,
 			},
 			wantRules: [][2]string{},
 			wantErr:   false,

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -189,7 +189,8 @@ type LaunchAttachCommonConfig struct {
 }
 
 // SubstitutePath defines a mapping from a local path to the remote path.
-// Both 'from' and 'to' must be specified and non-null.
+// Both 'from' and 'to' must be specified and non-null but it can be empty string.
+// Mapping with 'to' as empty string can be used to expand relative paths.
 type SubstitutePath struct {
 	// The local path to be replaced when passing paths to the debugger.
 	From string `json:"from,omitempty"`

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -189,8 +189,9 @@ type LaunchAttachCommonConfig struct {
 }
 
 // SubstitutePath defines a mapping from a local path to the remote path.
-// Both 'from' and 'to' must be specified and non-null but it can be empty string.
-// Mapping with 'to' as empty string can be used to expand relative paths.
+// Both 'from' and 'to' must be specified and non-null.
+// Empty values can be used to add or remove absolute path prefixes when mapping.
+// For example, mapping with empy 'to' can be used to work with binaries with trimmed paths.
 type SubstitutePath struct {
 	// The local path to be replaced when passing paths to the debugger.
 	From string `json:"from,omitempty"`

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -189,7 +189,7 @@ type LaunchAttachCommonConfig struct {
 }
 
 // SubstitutePath defines a mapping from a local path to the remote path.
-// Both 'from' and 'to' must be specified and non-empty.
+// Both 'from' and 'to' must be specified and non-null.
 type SubstitutePath struct {
 	// The local path to be replaced when passing paths to the debugger.
 	From string `json:"from,omitempty"`
@@ -199,7 +199,10 @@ type SubstitutePath struct {
 
 func (m *SubstitutePath) UnmarshalJSON(data []byte) error {
 	// use custom unmarshal to check if both from/to are set.
-	type tmpType SubstitutePath
+	type tmpType struct {
+		From *string
+		To   *string
+	}
 	var tmp tmpType
 
 	if err := json.Unmarshal(data, &tmp); err != nil {
@@ -208,10 +211,10 @@ func (m *SubstitutePath) UnmarshalJSON(data []byte) error {
 		}
 		return err
 	}
-	if tmp.From == "" || tmp.To == "" {
+	if tmp.From == nil || tmp.To == nil {
 		return errors.New("'substitutePath' requires both 'from' and 'to' entries")
 	}
-	*m = SubstitutePath(tmp)
+	*m = SubstitutePath{*tmp.From, *tmp.To}
 	return nil
 }
 


### PR DESCRIPTION
This changes adds the support to replace relative paths sources with "" as representing current directory.
For example:
Rule like '{from: "", to: "/my/project"}' will map path "src/my/code.go" into "/my/project/src/my/code.go"
Rule like '{from: "/my/project", to: ""}' will map path "/my/project/src/my/code.go" into "src/my/code.go"

Solves #3082