### PR TITLE
pkg/dwarf/line: Fix parsing file table for DWARFv5

### DIFF
--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -231,7 +231,7 @@ func (lineInfo *DebugLineInfo) stateMachineFor(basePC, pc uint64) *StateMachine 
 		sm = newStateMachine(lineInfo, lineInfo.Instructions, lineInfo.ptrSize)
 	} else {
 		// Try to use the last state machine that we used for this function, if
-		// there isn't one or it's already past pc try to clone the cached state
+		// there isn't one, or it's already past pc try to clone the cached state
 		// machine stopped at the entry point of the function.
 		// As a last resort start from the start of the debug_line section.
 		sm = lineInfo.lastMachineCache[basePC]
@@ -239,6 +239,7 @@ func (lineInfo *DebugLineInfo) stateMachineFor(basePC, pc uint64) *StateMachine 
 			sm = lineInfo.stateMachineForEntry(basePC)
 			lineInfo.lastMachineCache[basePC] = sm
 		}
+		sm = sm.copy()
 	}
 	return sm
 }

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -239,7 +239,6 @@ func (lineInfo *DebugLineInfo) stateMachineFor(basePC, pc uint64) *StateMachine 
 			sm = lineInfo.stateMachineForEntry(basePC)
 			lineInfo.lastMachineCache[basePC] = sm
 		}
-		sm = sm.copy()
 	}
 	return sm
 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -849,6 +849,18 @@ func TestCGONext(t *testing.T) {
 	})
 }
 
+func TestCGOBreakpointLocation(t *testing.T) {
+	protest.MustHaveCgo(t)
+	protest.AllowRecording(t)
+
+	withTestProcess("cgotest", t, func(p *proc.Target, fixture protest.Fixture) {
+		bp := setFunctionBreakpoint(p, t, "C.foo")
+		if !strings.Contains(bp.File, "cgotest.go") {
+			t.Fatalf("incorrect breakpoint location, expected cgotest.go got %s", bp.File)
+		}
+	})
+}
+
 type loc struct {
 	line int
 	fn   string


### PR DESCRIPTION
As we parse this informatin in the loop we must take care to assemble
things correctly. In this situation when we encounter a file name,
the dir index is -1, then subsequently we get the correct dir index
for that file and can put them together. Previously we were adding the
file and then the directory location to the file list instead of
correctly concatenating them, resulting in an incorrect file list making
indexing into the list return incorrect results later on.