### PR TITLE
:* Improve trace subcommand output

### DIFF
--- a/_fixtures/goroutines-trace.go
+++ b/_fixtures/goroutines-trace.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func callme(i int, s string) int {
+	fmt.Println(s)
+	return i * i
+}
+
+func dostuff(wg *sync.WaitGroup, lbl string) {
+	defer wg.Done()
+	var j int
+	for i := 0; i < 10; i++ {
+		j += callme(i, lbl)
+	}
+	println(lbl, j)
+}
+
+func main() {
+	var wg sync.WaitGroup
+
+	for _, lbl := range []string{"one", "two", "three", "four", "five"} {
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go dostuff(&wg, lbl)
+		}
+	}
+	wg.Wait()
+}

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -685,6 +685,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 		}
 		cmds := terminal.DebugCommands(client)
 		t := terminal.New(client, nil)
+		t.SetTraceNonInteractive()
 		t.RedirectTo(os.Stderr)
 		defer t.Close()
 		if traceUseEBPF {
@@ -724,7 +725,11 @@ func traceCmd(cmd *cobra.Command, args []string) {
 				}
 			}()
 		}
-		cmds.Call("continue", t)
+		err = cmds.Call("continue", t)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
 		return 0
 	}()
 	os.Exit(status)

--- a/pkg/proc/threads.go
+++ b/pkg/proc/threads.go
@@ -2,7 +2,6 @@ package proc
 
 import (
 	"errors"
-
 	"github.com/go-delve/delve/pkg/dwarf/op"
 )
 

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -75,6 +75,8 @@ type Term struct {
 
 	quittingMutex sync.Mutex
 	quitting      bool
+
+	traceNonInteractive bool
 }
 
 type displayEntry struct {
@@ -138,6 +140,14 @@ func New(client service.Client, conf *config.Config) *Term {
 
 	t.starlarkEnv = starbind.New(starlarkContext{t}, t.stdout)
 	return t
+}
+
+func (t *Term) SetTraceNonInteractive() {
+	t.traceNonInteractive = true
+}
+
+func (t *Term) IsTraceNonInteractive() bool {
+	return t.traceNonInteractive
 }
 
 // Close returns the terminal to its previous mode.


### PR DESCRIPTION
This patch improves the output of the trace subcommand by
adding better line breaks, adding goroutine info to the
return statement, and removing unnecessary output.