### PR TITLE
TeamCity,goversion: bump test matrix

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -35,23 +35,23 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2020.2"
 
 val targets = arrayOf(
-        "linux/amd64/1.16",
         "linux/amd64/1.17",
         "linux/amd64/1.18",
+        "linux/amd64/1.19",
         "linux/amd64/tip",
 
-        "linux/386/1.18",
+        "linux/386/1.19",
 
-        "linux/arm64/1.18",
+        "linux/arm64/1.19",
         "linux/arm64/tip",
 
-        "windows/amd64/1.18",
+        "windows/amd64/1.19",
         "windows/amd64/tip",
 
-        "mac/amd64/1.18",
+        "mac/amd64/1.19",
         "mac/amd64/tip",
 
-        "mac/arm64/1.18",
+        "mac/arm64/1.19",
         "mac/arm64/tip"
 )
 

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	MinSupportedVersionOfGoMajor = 1
-	MinSupportedVersionOfGoMinor = 16
+	MinSupportedVersionOfGoMinor = 17
 	MaxSupportedVersionOfGoMajor = 1
 	MaxSupportedVersionOfGoMinor = 19
 	goTooOldErr                  = fmt.Sprintf("Go version %%s is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)


### PR DESCRIPTION
Add Go 1.19 to test matrix, drop 1.16.
