### PR TITLE
_scripts: fix command to download Go version

### DIFF
--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -31,7 +31,7 @@ if [ "$version" = "gotip" ]; then
 	cd -
 else
 	echo Finding latest patch version for $version
-	version=$(curl 'https://go.dev/dl/?mode=json&include=all' | jq '.[].version' --raw-output | egrep ^$version'($|\.|beta|rc)' | sort -rV | head -1)
+	version=$(curl 'https://go.dev/dl/?mode=json&include=all' | jq '.[].version' --raw-output | egrep ^$version'($|\.|^beta|^rc)' | sort -rV | head -1)
 	echo "Go $version on $arch"
 	getgo $version
 fi


### PR DESCRIPTION
We should exclude rc/beta versions as we already run tests
against tip, we don't explicitly test RC versions.