### PR TITLE
_scripts: fix CI on go1.19/linux/386

### DIFF
--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -445,13 +445,17 @@ func testCmdIntl(testSet, testRegex, testBackend, testBuildMode string) {
 		buildModeFlag = "-test-buildmode=" + testBuildMode
 	}
 
+	env := []string{}
+	if os.Getenv("CI") != "" {
+		env = os.Environ()
+	}
+
 	if len(testPackages) > 3 {
-		env := []string{}
 		executeq(env, "go", "test", testFlags(), buildFlags(), testPackages, backendFlag, buildModeFlag)
 	} else if testRegex != "" {
-		execute("go", "test", testFlags(), buildFlags(), testPackages, "-run="+testRegex, backendFlag, buildModeFlag)
+		executeq(env, "go", "test", testFlags(), buildFlags(), testPackages, "-run="+testRegex, backendFlag, buildModeFlag)
 	} else {
-		execute("go", "test", testFlags(), buildFlags(), testPackages, backendFlag, buildModeFlag)
+		executeq(env, "go", "test", testFlags(), buildFlags(), testPackages, backendFlag, buildModeFlag)
 	}
 }
 

--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -57,6 +57,13 @@ elif [ ${version:4:2} -gt 17 ]; then
 	export GOFLAGS=-buildvcs=false
 fi
 
+if [ "$arch" = "386" ]; then
+	ver=$(go version)
+	if [ "$ver" = "go version go1.19 linux/386" ]; then
+		export CGO_CFLAGS='-g -O0 -fno-stack-protector'
+	fi
+fi
+
 set +e
 make test
 x=$?

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -111,8 +111,13 @@ func TestBuild(t *testing.T) {
 
 	scan := bufio.NewScanner(stderr)
 	// wait for the debugger to start
-	scan.Scan()
-	t.Log(scan.Text())
+	for scan.Scan() {
+		text := scan.Text()
+		t.Log(text)
+		if strings.Contains(text, "API server pid = ") {
+			break
+		}
+	}
 	go func() {
 		for scan.Scan() {
 			t.Log(scan.Text())

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -93,7 +93,9 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	}
 
 	if flags&EnableCGOOptimization == 0 {
-		os.Setenv("CGO_CFLAGS", "-O0 -g")
+		if os.Getenv("CI") == "" || os.Getenv("CGO_CFLAGS") == "" {
+			os.Setenv("CGO_CFLAGS", "-O0 -g")
+		}
 	}
 
 	fixturesDir := FindFixturesDir()
@@ -163,6 +165,9 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 
 	cmd := exec.Command("go", buildFlags...)
 	cmd.Dir = dir
+	if os.Getenv("CI") != "" {
+		cmd.Env = os.Environ()
+	}
 
 	// Build the test binary
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
Go 1.19 is broken on linux/386 with some C compilers, this is a
workaround for our build script. See:

https://github.com/golang/go/issues/52919

Also fix TestBuild if the first message reported by delve is not the
message that indicates the server is listening.
