### PR TITLE
proc,service: change FindLocation to work with multiple targets

### DIFF
--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -47,7 +47,8 @@ func NewGroup(t *Target) *TargetGroup {
 	}
 }
 
-// Targets returns a slice of targets in the group.
+// Targets returns a slice of all targets in the group, including the
+// ones that are no longer valid.
 func (grp *TargetGroup) Targets() []*Target {
 	return grp.targets
 }
@@ -60,7 +61,9 @@ func (grp *TargetGroup) Valid() (bool, error) {
 		if ok {
 			return true, nil
 		}
-		err0 = err
+		if err0 == nil {
+			err0 = err
+		}
 	}
 	return false, err0
 }
@@ -123,4 +126,26 @@ func (grp *TargetGroup) TargetForThread(thread Thread) *Target {
 		}
 	}
 	return nil
+}
+
+// ValidTargets iterates through all valid targets in Group.
+type ValidTargets struct {
+	*Target
+	Group *TargetGroup
+	start int
+}
+
+// Next moves to the next valid target, returns false if there aren't more
+// valid targets in the group.
+func (it *ValidTargets) Next() bool {
+	for i := it.start; i < len(it.Group.targets); i++ {
+		if ok, _ := it.Group.targets[i].Valid(); ok {
+			it.Target = it.Group.targets[i]
+			it.start = i + 1
+			return true
+		}
+	}
+	it.start = len(it.Group.targets)
+	it.Target = nil
+	return false
 }

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1758,6 +1758,7 @@ func setBreakpoint(t *Term, ctx callContext, tracepoint bool, argstr string) ([]
 	for _, loc := range locs {
 		requestedBp.Addr = loc.PC
 		requestedBp.Addrs = loc.PCs
+		requestedBp.AddrPid = loc.PCPids
 		if tracepoint {
 			requestedBp.LoadArgs = &ShortLoadConfig
 		}

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -54,7 +54,7 @@ func ConvertLogicalBreakpoint(lbp *proc.LogicalBreakpoint) *Breakpoint {
 }
 
 // ConvertPhysicalBreakpoints adds informations from physical breakpoints to an API breakpoint.
-func ConvertPhysicalBreakpoints(b *Breakpoint, bps []*proc.Breakpoint) {
+func ConvertPhysicalBreakpoints(b *Breakpoint, pids []int, bps []*proc.Breakpoint) {
 	if len(bps) == 0 {
 		return
 	}
@@ -63,8 +63,9 @@ func ConvertPhysicalBreakpoints(b *Breakpoint, bps []*proc.Breakpoint) {
 	b.WatchType = WatchType(bps[0].WatchType)
 
 	lg := false
-	for _, bp := range bps {
+	for i, bp := range bps {
 		b.Addrs = append(b.Addrs, bp.Addr)
+		b.AddrPid = append(b.AddrPid, pids[i])
 		if b.FunctionName != bp.FunctionName && b.FunctionName != "" {
 			if !lg {
 				b.FunctionName = removeTypeParams(b.FunctionName)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -80,6 +80,9 @@ type Breakpoint struct {
 	Addr uint64 `json:"addr"`
 	// Addrs is the list of addresses for this breakpoint.
 	Addrs []uint64 `json:"addrs"`
+	// AddrPid[i] is the PID associated with by Addrs[i], when debugging a
+	// single target process this is optional, otherwise it is mandatory.
+	AddrPid []int `json:"addrpid"`
 	// File is the source file for the breakpoint.
 	File string `json:"file"`
 	// Line is a line in File for the breakpoint.
@@ -192,6 +195,7 @@ type Location struct {
 	Line     int       `json:"line"`
 	Function *Function `json:"function,omitempty"`
 	PCs      []uint64  `json:"pcs,omitempty"`
+	PCPids   []int     `json:"pcpids,omitempty"`
 }
 
 // Stackframe describes one frame in a stack trace.

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1860,7 +1860,7 @@ func (s *Session) stoppedOnBreakpointGoroutineID(state *api.DebuggerState) (int6
 		return goid, nil
 	}
 	abp := api.ConvertLogicalBreakpoint(bp.Breakpoint.Logical)
-	api.ConvertPhysicalBreakpoints(abp, []*proc.Breakpoint{bp.Breakpoint})
+	api.ConvertPhysicalBreakpoints(abp, []int{0}, []*proc.Breakpoint{bp.Breakpoint})
 	return goid, abp
 }
 


### PR DESCRIPTION
Changes FindLocation to support multiple targets and adds an AddrPid
member to api.Breakpoint so that clients can set breakpoints by address
when multiple targets are connected (but at them moment this field is
ignored).

Updates #1653
Updates #2551
