### PR TITLE
proc: fix path to separate debug info

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1243,7 +1243,7 @@ func (bi *BinaryInfo) openSeparateDebugInfo(image *Image, exe *elf.File, debugIn
 	if debugFilePath == "" && len(bi.BuildID) > 2 {
 		// Build ID method: look for a file named .build-id/nn/nnnnnnnn.debug in
 		// every debug info directory.
-		find(nil, fmt.Sprintf(".build-id/%s/%s.debug", bi.BuildID[:2], bi.BuildID[2:]))
+		find(nil, fmt.Sprintf("%s/%s.debug", bi.BuildID[:2], bi.BuildID[2:]))
 	}
 
 	if debugFilePath == "" {


### PR DESCRIPTION
An incorrect path to separate files with debug information is generated:
/usr/lib/debug/.build-id/.build-id/%s/%s.debug -> /usr/lib/debug/.build-id/%s/%s.debug