### PR TITLE
Redirect if internal console

### DIFF
--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -326,7 +326,7 @@ func openRedirects(redirects [3]string, foreground bool) (stdin, stdout, stderr 
 			return dflt
 		}
 		var f *os.File
-		f, err = os.Create(path)
+		f, err = os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0o666)
 		if f != nil {
 			toclose = append(toclose, f)
 		}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -273,11 +273,9 @@ const (
 	maxStringLenInCallRetVars = 1 << 10 // 1024
 )
 
-var (
-	// Max number of goroutines that we will return.
-	// This is a var for testing
-	maxGoroutines = 1 << 10
-)
+// Max number of goroutines that we will return.
+// This is a var for testing
+var maxGoroutines = 1 << 10
 
 // NewServer creates a new DAP Server. It takes an opened Listener
 // via config and assumes its ownership. config.DisconnectChan has to be set;
@@ -805,7 +803,24 @@ func (s *Session) logToConsole(msg string) {
 		Body: dap.OutputEventBody{
 			Output:   msg + "\n",
 			Category: "console",
-		}})
+		},
+	})
+}
+
+type debugConsoleLogger struct {
+	session  *Session
+	category string
+}
+
+func (l *debugConsoleLogger) Write(p []byte) (int, error) {
+	l.session.send(&dap.OutputEvent{
+		Event: *newEvent("output"),
+		Body: dap.OutputEventBody{
+			Output:   string(p),
+			Category: l.category,
+		},
+	})
+	return len(p), nil
 }
 
 func (s *Session) onInitializeRequest(request *dap.InitializeRequest) {
@@ -881,7 +896,7 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 		return
 	}
 
-	var args = defaultLaunchConfig // narrow copy for initializing non-zero default values
+	args := defaultLaunchConfig // narrow copy for initializing non-zero default values
 	if err := unmarshalLaunchAttachArgs(request.Arguments, &args); err != nil {
 		s.sendShowUserErrorResponse(request.Request,
 			FailedToLaunch, "Failed to launch", fmt.Sprintf("invalid debug configuration - %v", err))
@@ -989,7 +1004,8 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 				Body: dap.OutputEventBody{
 					Output:   fmt.Sprintf("Build Error: %s\n%s (%s)\n", cmd, strings.TrimSpace(string(out)), err.Error()),
 					Category: "stderr",
-				}})
+				},
+			})
 			// Users are used to checking the Debug Console for build errors.
 			// No need to bother them with a visible pop-up.
 			s.sendErrorResponse(request.Request, FailedToLaunch, "Failed to launch",
@@ -1028,6 +1044,12 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 	if args.NoDebug {
 		s.mu.Lock()
 		cmd, err := s.newNoDebugProcess(debugbinary, args.Args, s.config.Debugger.WorkingDir)
+		if args.Console == "internalConsole" {
+			cmd.Stdout, cmd.Stderr = &debugConsoleLogger{session: s, category: "stdout"}, &debugConsoleLogger{session: s, category: "stderr"}
+		}
+		if err == nil {
+			err = cmd.Start()
+		}
 		s.mu.Unlock()
 		if err != nil {
 			s.sendShowUserErrorResponse(request.Request, FailedToLaunch, "Failed to launch", err.Error())
@@ -1088,9 +1110,6 @@ func (s *Session) newNoDebugProcess(program string, targetArgs []string, wd stri
 	}
 	cmd := exec.Command(program, targetArgs...)
 	cmd.Stdout, cmd.Stderr, cmd.Stdin, cmd.Dir = os.Stdout, os.Stderr, os.Stdin, wd
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
 	s.noDebugProcess = &process{Cmd: cmd, exited: make(chan struct{})}
 	return cmd, nil
 }
@@ -1571,7 +1590,8 @@ func (s *Session) onConfigurationDoneRequest(request *dap.ConfigurationDoneReque
 func (s *Session) onContinueRequest(request *dap.ContinueRequest, allowNextStateChange chan struct{}) {
 	s.send(&dap.ContinueResponse{
 		Response: *newResponse(request.Request),
-		Body:     dap.ContinueResponseBody{AllThreadsContinued: true}})
+		Body:     dap.ContinueResponseBody{AllThreadsContinued: true},
+	})
 	s.runUntilStopAndNotify(api.Continue, allowNextStateChange)
 }
 
@@ -1635,7 +1655,8 @@ func (s *Session) onThreadsRequest(request *dap.ThreadsRequest) {
 				Body: dap.OutputEventBody{
 					Output:   fmt.Sprintf("Unable to retrieve goroutines: %s\n", err.Error()),
 					Category: "stderr",
-				}})
+				},
+			})
 		}
 		threads = []dap.Thread{{Id: 1, Name: "Dummy"}}
 	} else if len(gs) == 0 {
@@ -2463,7 +2484,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 
 	// Some of the types might be fully or partially not loaded based on LoadConfig.
 	// Those that are fully missing (e.g. due to hitting MaxVariableRecurse), can be reloaded in place.
-	var reloadVariable = func(v *proc.Variable, qualifiedNameOrExpr string) (value string) {
+	reloadVariable := func(v *proc.Variable, qualifiedNameOrExpr string) (value string) {
 		// We might be loading variables from the frame that's not topmost, so use
 		// frame-independent address-based expression, not fully-qualified name as per
 		// https://github.com/go-delve/delve/blob/master/Documentation/api/ClientHowto.md#looking-into-variables.
@@ -3393,6 +3414,7 @@ func newEvent(event string) *dap.Event {
 
 const BetterBadAccessError = `invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation]
 Unable to propagate EXC_BAD_ACCESS signal to target process and panic (see https://github.com/go-delve/delve/issues/852)`
+
 const BetterNextWhileNextingError = `Unable to step while the previous step is interrupted by a breakpoint.
 Use 'Continue' to resume the original step command.`
 

--- a/service/dap/stdio_pipe.go
+++ b/service/dap/stdio_pipe.go
@@ -1,0 +1,13 @@
+//go:build !linux
+// +build !linux
+
+package dap
+
+import (
+	"errors"
+)
+
+func generateStdioTempPipes() (res [2]string, err error) {
+	err = errors.New("Unimplemented")
+	return res, err
+}

--- a/service/dap/stdio_pipe_linux.go
+++ b/service/dap/stdio_pipe_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+// +build linux
+
+package dap
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func generateStdioTempPipes() (res [2]string, err error) {
+	r := make([]byte, 4)
+	if _, err := rand.Read(r); err != nil {
+		return res, err
+	}
+	prefix := filepath.Join(os.TempDir(), hex.EncodeToString(r))
+	stdoutPath := prefix + "stdout"
+	stderrPath := prefix + "stderr"
+	if err := syscall.Mkfifo(stdoutPath, 0o600); err != nil {
+		return res, err
+	}
+	if err := syscall.Mkfifo(stderrPath, 0o600); err != nil {
+		os.Remove(stdoutPath)
+		return res, err
+	}
+
+	res[0] = stdoutPath
+	res[1] = stderrPath
+	return res, nil
+}

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -148,6 +148,12 @@ type LaunchConfig struct {
 	// reference to other environment variables is not supported.
 	Env map[string]*string `json:"env,omitempty"`
 
+	// Console specifies the console the user desired to execute with.
+	// If the user requested `internalConsole` as its terminal, then we
+	// wish to redirect its stdout/stderr as DAP OutputEvents.
+	// By default, we do not redirect if it doesn't exist.
+	Console string `json:"console,omitempty"`
+
 	LaunchAttachCommonConfig
 }
 


### PR DESCRIPTION
**This PR is currently as draft to better improve implementation and pass tests.**
This PR partially implements https://github.com/go-delve/delve/issues/3094, by implementing redirection of `stdout` and `stderr` to the debug console via DAP's `OutputEvent`'s on Linux. 

It partially does so as current debug backend API support receiving a path to a redirected file only, and not a `io.Writer` as an example. It also supports only the `native` backend and not other backends. 

Achieving full support would require adding a generalized API so that we can pass an `io.Writer` to the native backend nicely, but this can be done later on and be discussed more, while Linux support can be easily implemented. 