### PR TITLE
proc: make sure logical breakpoints map exists

### DIFF
--- a/_fixtures/test.c
+++ b/_fixtures/test.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main(void) {
+	printf("hello world!");
+}

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -33,6 +33,9 @@ func NewGroup(t *Target) *TargetGroup {
 		panic("internal error: target is already part of a group")
 	}
 	t.partOfGroup = true
+	if t.Breakpoints().Logical == nil {
+		t.Breakpoints().Logical = make(map[int]*LogicalBreakpoint)
+	}
 	return &TargetGroup{
 		RecordingManipulation: t.recman,
 		targets:               []*Target{t},

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -82,6 +82,13 @@ const (
 	LinkDisableDWARF
 )
 
+// TempFile makes a (good enough) random temporary file name
+func TempFile(name string) string {
+	r := make([]byte, 4)
+	rand.Read(r)
+	return filepath.Join(os.TempDir(), fmt.Sprintf("%s.%s", name, hex.EncodeToString(r)))
+}
+
 // BuildFixture will compile the fixture 'name' using the provided build flags.
 func BuildFixture(name string, flags BuildFlags) Fixture {
 	if !runningWithFixtures {
@@ -100,9 +107,6 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 
 	fixturesDir := FindFixturesDir()
 
-	// Make a (good enough) random temporary file name
-	r := make([]byte, 4)
-	rand.Read(r)
 	dir := fixturesDir
 	path := filepath.Join(fixturesDir, name+".go")
 	if name[len(name)-1] == '/' {
@@ -110,7 +114,7 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 		path = ""
 		name = name[:len(name)-1]
 	}
-	tmpfile := filepath.Join(os.TempDir(), fmt.Sprintf("%s.%s", name, hex.EncodeToString(r)))
+	tmpfile := TempFile(name)
 
 	buildFlags := []string{"build"}
 	var ver goversion.GoVersion


### PR DESCRIPTION
The logical breakpoints map was created as a side effect of
createUnrecoveredPanicBreakpoint or createFatalThrowBreakpoint, however
with an executable with incomplete debug info (that must be incomplete
in just the right way) both will fail and the logical breakpoint map
will never be created.

It's unknown how such an executable could be created, one easy way is
to debug a non-go executable.

Fixes #3114
