### PR TITLE
terminal: remove leftover GOPATH references

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -185,7 +185,7 @@ Set breakpoint condition.
 
 Specifies that the breakpoint, tracepoint or watchpoint should break only if the boolean expression is true.
 
-See Documentation/cli/expr.md for a description of supported expressions.
+See [Documentation/cli/expr.md](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md) for a description of supported expressions.
 
 With the -hitcount option a condition on the breakpoint hit count can be set, the following operators are supported
 
@@ -511,7 +511,7 @@ Evaluate an expression.
 
 	[goroutine <n>] [frame <m>] print [%format] <expression>
 
-See Documentation/cli/expr.md for a description of supported expressions.
+See [Documentation/cli/expr.md](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md) for a description of supported expressions.
 
 The optional format argument is a format specifier, like the ones used by the fmt package. For example "print %x v" will print v as an hexadecimal number.
 
@@ -526,7 +526,7 @@ Print contents of CPU registers.
 
 	regs [-a]
 
-Argument -a shows more registers. Individual registers can also be displayed by 'print' and 'display'. See Documentation/cli/expr.md.
+Argument -a shows more registers. Individual registers can also be displayed by 'print' and 'display'. See [Documentation/cli/expr.md.](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md.)
 
 
 ## restart
@@ -569,7 +569,7 @@ Changes the value of a variable.
 
 	[goroutine <n>] [frame <m>] set <variable> = <value>
 
-See Documentation/cli/expr.md for a description of supported expressions. Only numerical variables and pointers can be changed.
+See [Documentation/cli/expr.md](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md) for a description of supported expressions. Only numerical variables and pointers can be changed.
 
 
 ## source

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -124,14 +124,14 @@ Type "help" followed by the name of a command for more information about it.`},
 
 	break [name] [locspec]
 
-See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/locspec.md for the syntax of locspec. If locspec is omitted a breakpoint will be set on the current line.
+See Documentation/cli/locspec.md for the syntax of locspec. If locspec is omitted a breakpoint will be set on the current line.
 
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"trace", "t"}, group: breakCmds, cmdFn: tracepoint, allowedPrefixes: onPrefix, helpMsg: `Set tracepoint.
 
 	trace [name] [locspec]
 
-A tracepoint is a breakpoint that does not stop the execution of the program, instead when the tracepoint is hit a notification is displayed. See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/locspec.md for the syntax of locspec. If locspec is omitted a tracepoint will be set on the current line.
+A tracepoint is a breakpoint that does not stop the execution of the program, instead when the tracepoint is hit a notification is displayed. See Documentation/cli/locspec.md for the syntax of locspec. If locspec is omitted a tracepoint will be set on the current line.
 
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"watch"}, group: breakCmds, cmdFn: watchpoint, helpMsg: `Set watchpoint.
@@ -428,7 +428,7 @@ Executes the specified command (print, args, locals) in the context of the n-th 
 
 	source <path>
 	
-If path ends with the .star extension it will be interpreted as a starlark script. See $GOPATH/src/github.com/go-delve/delve/Documentation/cli/starlark.md for the syntax.
+If path ends with the .star extension it will be interpreted as a starlark script. See Documentation/cli/starlark.md for the syntax.
 
 If path is a single '-' character an interactive starlark interpreter will start instead. Type 'exit' to exit.`},
 		{aliases: []string{"disassemble", "disass"}, cmdFn: disassCommand, helpMsg: `Disassembler.

--- a/pkg/terminal/docgen.go
+++ b/pkg/terminal/docgen.go
@@ -7,12 +7,19 @@ import (
 )
 
 func replaceDocPath(s string) string {
-	const docpath = "$GOPATH/src/github.com/go-delve/delve/"
+	const docpath = "Documentation/"
+
+	i0 := 0
 
 	for {
-		start := strings.Index(s, docpath)
+		start := strings.Index(s[i0:], docpath)
 		if start < 0 {
 			return s
+		}
+		start += i0
+		if start-1 >= 0 && s[start-1] != ' ' {
+			i0 = start + len(docpath) + 1
+			continue
 		}
 		var end int
 		for end = start + len(docpath); end < len(s); end++ {
@@ -21,8 +28,9 @@ func replaceDocPath(s string) string {
 			}
 		}
 
-		text := s[start+len(docpath) : end]
+		text := s[start:end]
 		s = s[:start] + fmt.Sprintf("[%s](//github.com/go-delve/delve/tree/master/%s)", text, text) + s[end:]
+		i0 = end + 1
 	}
 }
 


### PR DESCRIPTION
Remove leftover references to $GOPATH in documentation, change script
that generates markdown documentation to look for substrings that start
with "Documentation/" instead.
