### PR TITLE
Add Debugger to UIs list in EditorIntegration

### DIFF
--- a/Documentation/EditorIntegration.md
+++ b/Documentation/EditorIntegration.md
@@ -35,3 +35,4 @@ The following editor plugins for delve are available:
 The following alternative UIs for delve are available:
 
 * [Gdlv](https://github.com/aarzilli/gdlv)
+* [Debugger](https://github.com/emad-elsaid/debugger)


### PR DESCRIPTION
Added Debugger to the list of UIs as suggested [here](https://github.com/go-delve/delve/discussions/3126#discussioncomment-3491801)