### PR TITLE
terminal: do not use WaitSince as unix time

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	"github.com/cosiner/argv"
 	"github.com/go-delve/delve/pkg/config"
@@ -1076,7 +1075,7 @@ func (t *Term) formatGoroutine(g *api.Goroutine, fgl api.FormatGoroutineLoc) str
 		}
 		fmt.Fprintf(buf, " [%s", wr)
 		if g.WaitSince > 0 {
-			fmt.Fprintf(buf, " %s", time.Since(time.Unix(0, g.WaitSince)).String())
+			fmt.Fprintf(buf, " %d", g.WaitSince)
 		}
 		fmt.Fprintf(buf, "]")
 	}


### PR DESCRIPTION
g.waitsince is the output of runtime.nanotime and represents a
monotonic clock which can not be converted directly into unix time. A
better fix would be to convert it to a time.Duration by reading the
current value of runtime.nanotime. This is complicated, however,
because on some systems (for example macOS) the current value of
runtime.nanotime can only be read by making a system call.

Updates #3137
