### PR TITLE
service/dap: show full value when evaluating log messages

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -3692,7 +3692,7 @@ func (msg *logMessage) evaluate(s *Session, goid int64) string {
 			evaluated[i] = fmt.Sprintf("{eval err: %e}", err)
 			continue
 		}
-		evaluated[i] = s.convertVariableToString(exprVar)
+		evaluated[i], _ = s.convertVariableWithOpts(exprVar, "", skipRef|showFullValue)
 	}
 	return fmt.Sprintf(msg.format, evaluated...)
 }


### PR DESCRIPTION
When evaluating variables in a log message, do not truncate the string representation.

Updates golang/vscode-go#2447