### PR TITLE
proc,_scripts/rtype.go: add rtype annotations for g.atomicstatus

### DIFF
--- a/_scripts/rtype-out.txt
+++ b/_scripts/rtype-out.txt
@@ -27,7 +27,7 @@ type g struct {
 	waitsince int64
 	waitreason waitReason (optional)
 	stack stack
-	atomicstatus anytype
+	atomicstatus uint32|runtime/internal/atomic.Uint32
 }
 
 type gobuf struct {
@@ -56,6 +56,10 @@ type itab struct {
 type moduledata struct {
 	text uintptr
 	types uintptr
+}
+
+type runtime/internal/atomic.Uint32 struct {
+	value uint32
 }
 
 type stack struct {

--- a/_scripts/rtype.go
+++ b/_scripts/rtype.go
@@ -512,20 +512,44 @@ func report() {
 	}
 }
 
-// check parses the runtime package and checks that all the rules retrieved
-// from the 'proc' package pass.
-func check() {
-	pkgs2, err := packages.Load(&packages.Config{Mode: packages.LoadSyntax, Fset: fset}, "runtime")
+func lookupPackage(pkgmap map[string]*packages.Package, name string) *packages.Package {
+	if pkgmap[name] != nil {
+		return pkgmap[name]
+	}
+
+	pkgs, err := packages.Load(&packages.Config{Mode: packages.LoadSyntax, Fset: fset}, name)
 	if err != nil {
 		log.Fatalf("could not load runtime package: %v", err)
 	}
+	packages.Visit(pkgs, func(pkg *packages.Package) bool {
+		if pkgmap[pkg.ID] == nil {
+			pkgmap[pkg.ID] = pkg
+		}
+		return true
+	}, nil)
 
+	return pkgmap[name]
+}
+
+func lookupTypeDef(pkgmap map[string]*packages.Package, typ string) types.Object {
+	dot := strings.Index(typ, ".")
+	if dot < 0 {
+		return lookupPackage(pkgmap, "runtime").Types.Scope().Lookup(typ)
+	}
+
+	return lookupPackage(pkgmap, typ[:dot]).Types.Scope().Lookup(typ[dot+1:])
+}
+
+// check parses the runtime package and checks that all the rules retrieved
+// from the 'proc' package pass.
+func check() {
+	pkgmap := map[string]*packages.Package{}
 	allok := true
 
 	for _, rule := range checkVarTypeRules {
 		//TODO: implement
 		pos := fset.Position(rule.pos)
-		def := pkgs2[0].Types.Scope().Lookup(rule.V)
+		def := lookupPackage(pkgmap, "runtime").Types.Scope().Lookup(rule.V)
 		if def == nil {
 			fmt.Fprintf(os.Stderr, "%s:%d: could not find variable %s\n", pos.Filename, pos.Line, rule.V)
 			allok = false
@@ -547,7 +571,7 @@ func check() {
 		rules := checkFieldTypeRules[S]
 		pos := fset.Position(rules[0].pos)
 
-		def := pkgs2[0].Types.Scope().Lookup(S)
+		def := lookupTypeDef(pkgmap, S)
 		if def == nil {
 			fmt.Fprintf(os.Stderr, "%s:%d: could not find struct %s\n", pos.Filename, pos.Line, S)
 			allok = false
@@ -594,7 +618,7 @@ func check() {
 	for _, C := range Cs {
 		rules := checkConstValRules[C]
 		pos := fset.Position(rules[0].pos)
-		def := pkgs2[0].Types.Scope().Lookup(C)
+		def := lookupPackage(pkgmap, "runtime").Types.Scope().Lookup(C)
 		if def == nil {
 			fmt.Fprintf(os.Stderr, "%s:%d: could not find constant %s\n", pos.Filename, pos.Line, C)
 			allok = false

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -460,9 +460,10 @@ func TestGeneratedDoc(t *testing.T) {
 	checkAutogenDoc(t, "pkg/terminal/starbind/starlark_mapping.go", "'go generate' inside pkg/terminal/starbind", runScript("_scripts/gen-starlark-bindings.go", "go", "-"))
 	checkAutogenDoc(t, "Documentation/cli/starlark.md", "'go generate' inside pkg/terminal/starbind", runScript("_scripts/gen-starlark-bindings.go", "doc/dummy", "Documentation/cli/starlark.md"))
 	checkAutogenDoc(t, "Documentation/backend_test_health.md", "go run _scripts/gen-backend_test_health.go", runScript("_scripts/gen-backend_test_health.go", "-"))
-	checkAutogenDoc(t, "_scripts/rtype-out.txt", "go run _scripts/rtype.go report _scripts/rtype-out.txt", runScript("_scripts/rtype.go", "report"))
-
-	runScript("_scripts/rtype.go", "check")
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) {
+		checkAutogenDoc(t, "_scripts/rtype-out.txt", "go run _scripts/rtype.go report _scripts/rtype-out.txt", runScript("_scripts/rtype.go", "report"))
+		runScript("_scripts/rtype.go", "check")
+	}
 }
 
 func TestExitInInit(t *testing.T) {

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -919,11 +919,12 @@ func (v *Variable) parseG() (*G, error) {
 	}
 
 	status := uint64(0)
-	if atomicStatus := v.loadFieldNamed("atomicstatus"); atomicStatus != nil {
+	if atomicStatus := v.loadFieldNamed("atomicstatus"); /* +rtype uint32|runtime/internal/atomic.Uint32 */ atomicStatus != nil {
 		if constant.Val(atomicStatus.Value) != nil {
 			status, _ = constant.Uint64Val(atomicStatus.Value)
 		} else {
-			vv := atomicStatus.fieldVariable("value")
+			atomicStatus := atomicStatus              // +rtype runtime/internal/atomic.Uint32
+			vv := atomicStatus.fieldVariable("value") // +rtype uint32
 			if vv == nil {
 				unreadable = true
 			} else {


### PR DESCRIPTION
Adds some rtype annotations for g.atomicstatus and update
_scripts/rtype.go to handle types outside of the runtime package.
