### PR TITLE
proc,service/debugger: track how breakpoints were originally set

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -26,7 +26,7 @@ checkpoint(Where) | Equivalent to API call [Checkpoint](https://godoc.org/github
 clear_breakpoint(Id, Name) | Equivalent to API call [ClearBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ClearBreakpoint)
 clear_checkpoint(ID) | Equivalent to API call [ClearCheckpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ClearCheckpoint)
 raw_command(Name, ThreadID, GoroutineID, ReturnInfoLoadConfig, Expr, UnsafeCall) | Equivalent to API call [Command](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Command)
-create_breakpoint(Breakpoint) | Equivalent to API call [CreateBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.CreateBreakpoint)
+create_breakpoint(Breakpoint, LocExpr, SubstitutePathRules) | Equivalent to API call [CreateBreakpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.CreateBreakpoint)
 create_ebpf_tracepoint(FunctionName) | Equivalent to API call [CreateEBPFTracepoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.CreateEBPFTracepoint)
 create_watchpoint(Scope, Expr, Type) | Equivalent to API call [CreateWatchpoint](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.CreateWatchpoint)
 detach(Kill) | Equivalent to API call [Detach](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.Detach)

--- a/_fixtures/testfnpos1.go
+++ b/_fixtures/testfnpos1.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+func f1() {
+	fmt.Printf("f1\n")
+}
+
+func f2() {
+	fmt.Printf("f2\n")
+}
+
+func main() {
+	f1()
+	f2()
+}

--- a/_fixtures/testfnpos2.go
+++ b/_fixtures/testfnpos2.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+func f2() {
+	fmt.Printf("f2\n")
+}
+
+func f1() {
+	fmt.Printf("f1\n")
+}
+
+func main() {
+	f1()
+	f2()
+}

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -966,6 +966,8 @@ type LogicalBreakpoint struct {
 	Line         int
 	Enabled      bool
 
+	Set SetBreakpoint
+
 	Tracepoint  bool // Tracepoint flag
 	TraceReturn bool
 	Goroutine   bool     // Retrieve goroutine information
@@ -989,4 +991,18 @@ type LogicalBreakpoint struct {
 	Cond ast.Expr
 
 	UserData interface{} // Any additional information about the breakpoint
+}
+
+// SetBreakpoint describes how a breakpoint should be set.
+type SetBreakpoint struct {
+	FunctionName string
+	File         string
+	Line         int
+	Expr         func(*Target) []uint64
+	PidAddrs     []PidAddr
+}
+
+type PidAddr struct {
+	Pid  int
+	Addr uint64
 }

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1763,7 +1763,7 @@ func setBreakpoint(t *Term, ctx callContext, tracepoint bool, argstr string) ([]
 			requestedBp.LoadArgs = &ShortLoadConfig
 		}
 
-		bp, err := t.client.CreateBreakpoint(requestedBp)
+		bp, err := t.client.CreateBreakpointWithExpr(requestedBp, spec, t.substitutePathRules())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -307,11 +307,27 @@ func (env *Env) starlarkPredeclare() starlark.StringDict {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 1 && args[1] != starlark.None {
+			err := unmarshalStarlarkValue(args[1], &rpcArgs.LocExpr, "LocExpr")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
+		if len(args) > 2 && args[2] != starlark.None {
+			err := unmarshalStarlarkValue(args[2], &rpcArgs.SubstitutePathRules, "SubstitutePathRules")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
 			case "Breakpoint":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Breakpoint, "Breakpoint")
+			case "LocExpr":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.LocExpr, "LocExpr")
+			case "SubstitutePathRules":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.SubstitutePathRules, "SubstitutePathRules")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}

--- a/service/client.go
+++ b/service/client.go
@@ -69,6 +69,8 @@ type Client interface {
 	GetBreakpointByName(name string) (*api.Breakpoint, error)
 	// CreateBreakpoint creates a new breakpoint.
 	CreateBreakpoint(*api.Breakpoint) (*api.Breakpoint, error)
+	// CreateBreakpointWithExpr creates a new breakpoint and sets an expression to restore it after it is disabled.
+	CreateBreakpointWithExpr(*api.Breakpoint, string, [][2]string) (*api.Breakpoint, error)
 	// CreateWatchpoint creates a new watchpoint.
 	CreateWatchpoint(api.EvalScope, string, api.WatchType) (*api.Breakpoint, error)
 	// ListBreakpoints gets all breakpoints.

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1381,7 +1381,7 @@ func (s *Session) setBreakpoints(prefix string, totalBps int, metadataFunc func(
 				err = setLogMessage(bp, want.logMessage)
 				if err == nil {
 					// Create new breakpoints.
-					got, err = s.debugger.CreateBreakpoint(bp)
+					got, err = s.debugger.CreateBreakpoint(bp, "", nil)
 				}
 			}
 		}

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -106,7 +106,7 @@ func (s *RPCServer) CreateBreakpoint(bp, newBreakpoint *api.Breakpoint) error {
 	if err := api.ValidBreakpointName(bp.Name); err != nil {
 		return err
 	}
-	createdbp, err := s.debugger.CreateBreakpoint(bp)
+	createdbp, err := s.debugger.CreateBreakpoint(bp, "", nil)
 	if err != nil {
 		return err
 	}

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -245,7 +245,16 @@ func (c *RPCClient) GetBreakpointByName(name string) (*api.Breakpoint, error) {
 // https://pkg.go.dev/github.com/go-delve/delve/service/debugger#Debugger.CreateBreakpoint
 func (c *RPCClient) CreateBreakpoint(breakPoint *api.Breakpoint) (*api.Breakpoint, error) {
 	var out CreateBreakpointOut
-	err := c.call("CreateBreakpoint", CreateBreakpointIn{*breakPoint}, &out)
+	err := c.call("CreateBreakpoint", CreateBreakpointIn{*breakPoint, "", nil}, &out)
+	return &out.Breakpoint, err
+}
+
+// CreateBreakpointWithExpr is like CreateBreakpoint but will also set a
+// location expression to be used to restore the breakpoint after it is
+// disabled.
+func (c *RPCClient) CreateBreakpointWithExpr(breakPoint *api.Breakpoint, locExpr string, substitutePathRules [][2]string) (*api.Breakpoint, error) {
+	var out CreateBreakpointOut
+	err := c.call("CreateBreakpoint", CreateBreakpointIn{*breakPoint, locExpr, substitutePathRules}, &out)
 	return &out.Breakpoint, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -242,6 +242,9 @@ func (s *RPCServer) ListBreakpoints(arg ListBreakpointsIn, out *ListBreakpointsO
 
 type CreateBreakpointIn struct {
 	Breakpoint api.Breakpoint
+
+	LocExpr             string
+	SubstitutePathRules [][2]string
 }
 
 type CreateBreakpointOut struct {
@@ -256,7 +259,7 @@ func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpoi
 	if err := api.ValidBreakpointName(arg.Breakpoint.Name); err != nil {
 		return err
 	}
-	createdbp, err := s.debugger.CreateBreakpoint(&arg.Breakpoint)
+	createdbp, err := s.debugger.CreateBreakpoint(&arg.Breakpoint, arg.LocExpr, arg.SubstitutePathRules)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds field to breakpoint struct to track how a breakpoint was
originally set, moves the logic for disabling and enabling a breakpoint
to proc.

This will allow creating suspended breakpoints that are automatically
enabled when a plugin is loaded. When follow exec mode is implemented
it will also be possible to automatically enable breakpoints (whether
or not they were suspended) on new child processes, as they are
spawned.

It also improves breakpoint restore after a restart, before this after
a restart breakpoints would be re-enabled using their file:line
position, for breakpoints set using a function name or a location
expression this could be the wrong location after a recompile.

Updates #1653
Updates #2551
