### PR TITLE
proc: remove import "C" for linux/386 backend

### DIFF
--- a/pkg/proc/native/ptrace_linux_386.go
+++ b/pkg/proc/native/ptrace_linux_386.go
@@ -1,7 +1,5 @@
 package native
 
-import "C"
-
 import (
 	"fmt"
 	"syscall"


### PR DESCRIPTION
It is actually unused.
