### PR TITLE
service/debugger: Assume current dir for exec

### DIFF
--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -25,10 +25,7 @@ func (os *osProcessDetails) Close() {}
 
 // Launch creates and begins debugging a new process.
 func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ string, redirects [3]string) (*proc.Target, error) {
-	argv0Go, err := filepath.Abs(cmd[0])
-	if err != nil {
-		return nil, err
-	}
+	argv0Go := cmd[0]
 
 	env := proc.DisableAsyncPreemptEnv()
 

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -3,7 +3,6 @@ package native
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"syscall"
 	"unsafe"
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -11,6 +11,7 @@ import (
 	"go/token"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -2273,11 +2274,9 @@ func verifyBinaryFormat(exePath string) (string, error) {
 	}
 	defer f.Close()
 
-	fi, err := f.Stat()
+	// Ensure the file is executable
+	_, err = exec.LookPath(fullpath)
 	if err != nil {
-		return "", err
-	}
-	if (fi.Mode() & 0111) == 0 {
 		return "", api.ErrNotExecutable
 	}
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -260,12 +260,11 @@ func (d *Debugger) Launch(processArgs []string, wd string) (*proc.Target, error)
 
 	_, err := exec.LookPath(processArgs[0])
 	if err != nil {
-		if wd == "." {
-			if cwd, err := os.Getwd(); err == nil {
-				wd = cwd
-			}
+		fullpath, err := filepath.Abs(processArgs[0])
+		if err != nil {
+			return nil, err
 		}
-		processArgs[0] = filepath.Join(wd, processArgs[0])
+		processArgs[0] = fullpath
 	}
 
 	switch d.config.Backend {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2274,10 +2274,15 @@ func verifyBinaryFormat(exePath string) (string, error) {
 	}
 	defer f.Close()
 
-	// Ensure the file is executable
-	_, err = exec.LookPath(fullpath)
-	if err != nil {
-		return "", api.ErrNotExecutable
+	// Skip this check on Windows.
+	// TODO(derekparker) exec.LookPath looks for valid Windows extensions.
+	// We don't create our binaries with valid extensions, even though we should.
+	// Skip this check for now.
+	if runtime.GOOS != "windows" {
+		_, err = exec.LookPath(fullpath)
+		if err != nil {
+			return "", api.ErrNotExecutable
+		}
 	}
 
 	// check that the binary format is what we expect for the host system

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2262,7 +2262,6 @@ func noDebugErrorWarning(err error) error {
 }
 
 func verifyBinaryFormat(exePath string) (string, error) {
-	// Get the full path of the executable to launch.
 	fullpath, err := filepath.Abs(exePath)
 	if err != nil {
 		return "", err

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -246,12 +246,15 @@ func (d *Debugger) TargetGoVersion() string {
 
 // Launch will start a process with the given args and working directory.
 func (d *Debugger) Launch(processArgs []string, wd string) (*proc.Target, error) {
-	fullpath, err := exec.LookPath(processArgs[0])
+	// Get the full path of the executable to launch.
+	fullpath, err := filepath.Abs(processArgs[0])
 	if err != nil {
-		fullpath, err = filepath.Abs(processArgs[0])
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
+	// Ensure it is a proper executable.
+	fullpath, err = exec.LookPath(fullpath)
+	if err != nil {
+		return nil, err
 	}
 	processArgs[0] = fullpath
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -11,7 +11,6 @@ import (
 	"go/token"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2274,20 +2274,12 @@ func verifyBinaryFormat(exePath string) (string, error) {
 	}
 	defer f.Close()
 
-	switch runtime.GOOS {
-	case "windows":
-		// Make sure the binary exists and is an executable file
-		if _, err := exec.LookPath(fullpath); err != nil {
-			return "", err
-		}
-	default:
-		fi, err := f.Stat()
-		if err != nil {
-			return "", err
-		}
-		if (fi.Mode() & 0111) == 0 {
-			return "", api.ErrNotExecutable
-		}
+	fi, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	if (fi.Mode() & 0111) == 0 {
+		return "", api.ErrNotExecutable
 	}
 
 	// check that the binary format is what we expect for the host system

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -258,6 +258,16 @@ func (d *Debugger) Launch(processArgs []string, wd string) (*proc.Target, error)
 		launchFlags |= proc.LaunchDisableASLR
 	}
 
+	_, err := exec.LookPath(processArgs[0])
+	if err != nil {
+		if wd == "." {
+			if cwd, err := os.Getwd(); err == nil {
+				wd = cwd
+			}
+		}
+		processArgs[0] = filepath.Join(wd, processArgs[0])
+	}
+
 	switch d.config.Backend {
 	case "native":
 		return native.Launch(processArgs, wd, launchFlags, d.config.DebugInfoDirectories, d.config.TTY, d.config.Redirects)

--- a/service/debugger/debugger_test.go
+++ b/service/debugger/debugger_test.go
@@ -75,18 +75,21 @@ func TestDebugger_LaunchCurrentDir(t *testing.T) {
 	testDir := filepath.Join(fixturesDir, "buildtest")
 	debugname := "debug"
 	exepath := filepath.Join(testDir, debugname)
-	defer os.Remove(exepath)
+	originalPath, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(originalPath)
+	defer func() {
+		if err := os.Remove(exepath); err != nil {
+			t.Fatalf("error removing executable %v", err)
+		}
+	}()
 	if err := gobuild.GoBuild(debugname, []string{testDir}, fmt.Sprintf("-o %s", exepath)); err != nil {
 		t.Fatalf("go build error %v", err)
 	}
 
-	testExec, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	originalPath := filepath.Dir(testExec)
 	os.Chdir(testDir)
-	defer os.Chdir(originalPath)
 
 	d := new(Debugger)
 	d.config = &Config{}


### PR DESCRIPTION
This patch modifies the behavior of the exec subcommand such that you don't necessarily have to write the "./" prefix when trying to debug a precompiled binary in your working directory.

For example (given foo.test in working dir), before this change:

dlv exec foo.test

Would result in an error, forcing the user to type:

dlv exec ./foo.test

This just makes things a bit more convenient.