### PR TITLE
pkg/terminal: Improve error when unable to read history file

### DIFF
--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -292,7 +292,7 @@ func (t *Term) Run() (int, error) {
 		fmt.Printf("Unable to open history file: %v. History will not be saved for this session.", err)
 	}
 	if _, err := t.line.ReadHistory(t.historyFile); err != nil {
-		fmt.Printf("Unable to read history file: %v", err)
+		fmt.Printf("Unable to read history file %s: %v\n", t.historyFile, err)
 	}
 
 	fmt.Println("Type 'help' for list of commands.")

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -292,7 +292,7 @@ func (t *Term) Run() (int, error) {
 		fmt.Printf("Unable to open history file: %v. History will not be saved for this session.", err)
 	}
 	if _, err := t.line.ReadHistory(t.historyFile); err != nil {
-		fmt.Printf("Unable to read history file %s: %v\n", t.historyFile, err)
+		fmt.Printf("Unable to read history file %s: %v\n", fullHistoryFile, err)
 	}
 
 	fmt.Println("Type 'help' for list of commands.")


### PR DESCRIPTION
This patch includes the path to the history file itself so that users can better fix the issue when an error arises.

Fixes #3168