### PR TITLE
Add type to simple expression evaluation in DAP's `evaluateRequest`

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2694,7 +2694,7 @@ func (s *Session) onEvaluateRequest(request *dap.EvaluateRequest) {
 			opts |= showFullValue
 		}
 		exprVal, exprRef := s.convertVariableWithOpts(exprVar, fmt.Sprintf("(%s)", request.Arguments.Expression), opts)
-		response.Body = dap.EvaluateResponseBody{Result: exprVal, VariablesReference: exprRef, IndexedVariables: getIndexedVariableCount(exprVar), NamedVariables: getNamedVariableCount(exprVar)}
+		response.Body = dap.EvaluateResponseBody{Result: exprVal, Type: s.getTypeIfSupported(exprVar), VariablesReference: exprRef, IndexedVariables: getIndexedVariableCount(exprVar), NamedVariables: getNamedVariableCount(exprVar)}
 	}
 	s.send(response)
 }


### PR DESCRIPTION
Solve https://github.com/go-delve/delve/issues/3170 for `evaluateExpression` so that the type of the evaluation is returned upon evaluating an expression. Implemented so when there's an actual evaluated variable with a type with a variable reference, which is the either a `call` expression or a plain expression. 