### PR TITLE
service/debugger: allow setting a breakpoint with a specific ID

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -772,13 +772,15 @@ func (d *Debugger) ConvertThreadBreakpoint(thread proc.Thread) *api.Breakpoint {
 func createLogicalBreakpoint(d *Debugger, requestedBp *api.Breakpoint, setbp *proc.SetBreakpoint, suspended bool) (*api.Breakpoint, error) {
 	id := requestedBp.ID
 
-	var lbp *proc.LogicalBreakpoint
 	if id <= 0 {
 		d.breakpointIDCounter++
 		id = d.breakpointIDCounter
-		lbp = &proc.LogicalBreakpoint{LogicalID: id, HitCount: make(map[int64]uint64), Enabled: true}
-		d.target.LogicalBreakpoints[id] = lbp
+	} else {
+		d.breakpointIDCounter = id
 	}
+
+	lbp := &proc.LogicalBreakpoint{LogicalID: id, HitCount: make(map[int64]uint64), Enabled: true}
+	d.target.LogicalBreakpoints[id] = lbp
 
 	err := copyLogicalBreakpointInfo(lbp, requestedBp)
 	if err != nil {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2961,3 +2961,20 @@ func TestPluginSuspendedBreakpoint(t *testing.T) {
 		cont("Continue 4", "plugin2.go", 9)
 	})
 }
+
+func TestClientServer_createBreakpointWithID(t *testing.T) {
+	protest.AllowRecording(t)
+	withTestClient2("continuetestprog", t, func(c service.Client) {
+		bp, err := c.CreateBreakpoint(&api.Breakpoint{ID: 2, FunctionName: "main.main", Line: 1})
+		assertNoError(err, t, "CreateBreakpoint()")
+		if bp.ID != 2 {
+			t.Errorf("wrong ID for breakpoint %d", bp.ID)
+		}
+
+		bp2, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main", Line: 2})
+		assertNoError(err, t, "CreateBreakpoint()")
+		if bp2.ID != 3 {
+			t.Errorf("wrong ID for breakpoint %d", bp2.ID)
+		}
+	})
+}


### PR DESCRIPTION
Before 4c5b111a it was possible for a client to create a breakpoint
with a specific logical ID, restore this ability for backwards
compatibility.
