### PR TITLE
Two fixes to type cast evaluation

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -739,9 +739,14 @@ func (scope *EvalScope) evalTypeCastOrFuncCall(node *ast.CallExpr) (*Variable, e
 		return v, err
 	}
 
-	fnnode := removeParen(node.Fun)
-	if n, _ := fnnode.(*ast.StarExpr); n != nil {
-		fnnode = removeParen(n.X)
+	fnnode := node.Fun
+	for {
+		fnnode = removeParen(fnnode)
+		n, _ := fnnode.(*ast.StarExpr)
+		if n == nil {
+			break
+		}
+		fnnode = n.X
 	}
 
 	switch n := fnnode.(type) {

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -826,6 +826,9 @@ func TestEvalExpression(t *testing.T) {
 		{`*(*uint)(uintptr(&i1))`, false, `1`, `1`, "uint", nil},
 		{`*(*uint)(unsafe.Pointer(p1))`, false, `1`, `1`, "uint", nil},
 		{`*(*uint)(unsafe.Pointer(&i1))`, false, `1`, `1`, "uint", nil},
+
+		// Conversions to ptr-to-ptr types
+		{`**(**runtime.hmap)(uintptr(&m1))`, false, `…`, `…`, "runtime.hmap", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -820,6 +820,12 @@ func TestEvalExpression(t *testing.T) {
 		{`(*string)(&typedstringvar)`, false, `(*string)(…`, `(*string)(…`, "*string", nil},
 		{`(*main.astruct)(&namedA1)`, false, `(*main.astruct)(…`, `(*main.astruct)(…`, "*main.astruct", nil},
 		{`(*main.astructName2)(&namedA1)`, false, `(*main.astructName2)(…`, `(*main.astructName2)(…`, "*main.astructName2", nil},
+
+		// Conversions to and from uintptr/unsafe.Pointer
+		{`*(*uint)(uintptr(p1))`, false, `1`, `1`, "uint", nil},
+		{`*(*uint)(uintptr(&i1))`, false, `1`, `1`, "uint", nil},
+		{`*(*uint)(unsafe.Pointer(p1))`, false, `1`, `1`, "uint", nil},
+		{`*(*uint)(unsafe.Pointer(&i1))`, false, `1`, `1`, "uint", nil},
 	}
 
 	ver, _ := goversion.Parse(runtime.Version())


### PR DESCRIPTION
### proc: fix type casts to ptr-to-ptr types

Fix type casts to **type.

### proc: allow casts form unsafe.Pointer to any pointer and vice versa

We've allowed doing this with uintptr but we should allow
unsafe.Pointer to be used like Go uses it.
