### PR TITLE
bininfo: Log when the file listed in .gnu_debuglink is not found

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1291,6 +1291,9 @@ func (bi *BinaryInfo) openSeparateDebugInfo(image *Image, exe *elf.File, debugIn
 				suffix := filepath.Join(filepath.Dir(exePath)[1:], debugLink)
 				find(nil, suffix)
 			}
+			if debugFilePath == "" {
+				bi.logger.Warnf("gnu_debuglink link %q not found in any debug info directory", debugLink)
+			}
 		}
 
 		if debugFilePath != "" {


### PR DESCRIPTION
If Delve finds a file listed in `.gnu_debuglink` it looks for it, so it can read debug symbols from it.

If it fails to find it, it does not tell the user. If Delve fails to find any debug symbols, the user does not know _why_ Delve failed to find them, since Delve multiple strategies to look for the debug symbols.

This change makes Delve log a message when it looks for a file listed in `.gnu_debuglink`, but fails to find it:
 
```console
# ./dlv --log exec example
2022-11-09T17:39:25Z info layer=debugger attaching to pid 1
2022-11-09T17:39:25Z warning layer=debugger gnu_debuglink link "example.debug.custom.extension" not found in any debug info directory
could not attach to pid 1: could not open debug info - debuggee must not be built with 'go run' or -ldflags='-s -w', which strip debug info
```

Fixes https://github.com/go-delve/delve/issues/3187