### PR TITLE
pkg/proc: fix arm64 linux cgo stacktrace

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -16,8 +16,6 @@ Tests skipped by each supported backend:
 	* 4 not implemented
 * linux/386/pie skipped = 1
 	* 1 broken
-* linux/arm64 skipped = 1
-	* 1 broken - cgo stacktraces
 * pie skipped = 2
 	* 2 upstream issue - https://github.com/golang/go/issues/29322
 * windows skipped = 5

--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -179,7 +179,6 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 		// switch from the system stack back into the goroutine stack
 		// Since we are going backwards on the stack here we see the transition
 		// as goroutine stack -> system stack.
-
 		if it.top || it.systemstack {
 			return false
 		}
@@ -198,6 +197,7 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 		it.pc = frameOnSystemStack.Ret
 		it.regs = callFrameRegs
 		it.systemstack = true
+
 		return true
 
 	case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/go-delve/delve/pkg/dwarf/frame"
@@ -84,15 +85,15 @@ func arm64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *Binary
 		return &frame.FrameContext{
 			RetAddrReg: regnum.ARM64_PC,
 			Regs: map[uint64]frame.DWRule{
-				regnum.ARM64_PC: frame.DWRule{
+				regnum.ARM64_PC: {
 					Rule:   frame.RuleOffset,
 					Offset: int64(-a.PtrSize()),
 				},
-				regnum.ARM64_BP: frame.DWRule{
+				regnum.ARM64_BP: {
 					Rule:   frame.RuleOffset,
 					Offset: int64(-2 * a.PtrSize()),
 				},
-				regnum.ARM64_SP: frame.DWRule{
+				regnum.ARM64_SP: {
 					Rule:   frame.RuleValOffset,
 					Offset: 0,
 				},
@@ -130,7 +131,7 @@ func arm64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *Binary
 	}
 	if fctxt.Regs[regnum.ARM64_LR].Rule == frame.RuleUndefined {
 		fctxt.Regs[regnum.ARM64_LR] = frame.DWRule{
-			Rule:   frame.RuleFramePointer,
+			Rule:   frame.RuleRegister,
 			Reg:    regnum.ARM64_LR,
 			Offset: 0,
 		}
@@ -142,7 +143,143 @@ func arm64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *Binary
 const arm64cgocallSPOffsetSaveSlot = 0x8
 const prevG0schedSPOffsetSaveSlot = 0x10
 
+func arm64SwitchStackLinux(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
+	if it.frame.Current.Fn == nil {
+		if it.systemstack && it.g != nil && it.top {
+			it.switchToGoroutineStack()
+			return true
+		}
+		return false
+	}
+	switch it.frame.Current.Fn.Name {
+	case "runtime.cgocallback_gofunc", "runtime.cgocallback":
+		// For a detailed description of how this works read the long comment at
+		// the start of $GOROOT/src/runtime/cgocall.go and the source code of
+		// runtime.cgocallback_gofunc in $GOROOT/src/runtime/asm_arm64.s
+		//
+		// When a C function calls back into go it will eventually call into
+		// runtime.cgocallback_gofunc which is the function that does the stack
+		// switch from the system stack back into the goroutine stack
+		// Since we are going backwards on the stack here we see the transition
+		// as goroutine stack -> system stack.
+		if it.top || it.systemstack {
+			return false
+		}
+
+		it.loadG0SchedSP()
+		if it.g0_sched_sp <= 0 {
+			return false
+		}
+		// Entering the system stack.
+		it.regs.Reg(callFrameRegs.SPRegNum).Uint64Val = it.g0_sched_sp
+		// Reads the previous value of g0.sched.sp that runtime.cgocallback_gofunc saved on the stack.
+		it.g0_sched_sp, _ = readUintRaw(it.mem, uint64(it.regs.SP()+prevG0schedSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize()))
+		it.top = false
+		callFrameRegs, ret, retaddr := it.advanceRegs()
+		frameOnSystemStack := it.newStackframe(ret, retaddr)
+		it.pc = frameOnSystemStack.Ret
+		it.regs = callFrameRegs
+		it.systemstack = true
+
+		return true
+
+	case "runtime.asmcgocall":
+		if it.top || !it.systemstack {
+			return false
+		}
+
+		// This function is called by a goroutine to execute a C function and
+		// switches from the goroutine stack to the system stack.
+		// Since we are unwinding the stack from callee to caller we have to switch
+		// from the system stack to the goroutine stack.
+		off, _ := readIntRaw(it.mem, uint64(it.regs.SP()+arm64cgocallSPOffsetSaveSlot),
+			int64(it.bi.Arch.PtrSize()))
+		oldsp := it.regs.SP()
+		newsp := uint64(int64(it.stackhi) - off)
+
+		it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(int64(newsp))
+		// runtime.asmcgocall can also be called from inside the system stack,
+		// in that case no stack switch actually happens
+		if it.regs.SP() == oldsp {
+			return false
+		}
+
+		it.top = false
+		it.systemstack = false
+		// The return value is stored in the LR register which is saved at 24(SP).
+		it.frame.addrret = uint64(int64(it.regs.SP()) + int64(it.bi.Arch.PtrSize()*3))
+		it.frame.Ret, _ = readUintRaw(it.mem, it.frame.addrret, int64(it.bi.Arch.PtrSize()))
+		it.pc = it.frame.Ret
+
+		return true
+
+	case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":
+		// Look for "top of stack" functions.
+		it.atend = true
+		return true
+
+	case "crosscall2":
+		// The offsets get from runtime/cgo/asm_arm64.s:10
+		bpoff := uint64(14)
+		lroff := uint64(15)
+		if producer := it.bi.Producer(); producer != "" && goversion.ProducerAfterOrEqual(producer, 1, 19) {
+			// In Go 1.19 (specifically eee6f9f82) the order registers are saved was changed.
+			bpoff = 22
+			lroff = 23
+		}
+		newbp, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*bpoff), int64(it.bi.Arch.PtrSize()))
+		newlr, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*lroff), int64(it.bi.Arch.PtrSize()))
+		if it.regs.Reg(it.regs.BPRegNum) != nil {
+			it.regs.Reg(it.regs.BPRegNum).Uint64Val = uint64(newbp)
+		} else {
+			reg, _ := it.readRegisterAt(it.regs.BPRegNum, it.regs.SP()+8*bpoff)
+			it.regs.AddReg(it.regs.BPRegNum, reg)
+		}
+		it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(newbp)
+		it.pc = newlr
+		return true
+
+	case "runtime.mstart":
+		// Calls to runtime.systemstack will switch to the systemstack then:
+		// 1. alter the goroutine stack so that it looks like systemstack_switch
+		//    was called
+		// 2. alter the system stack so that it looks like the bottom-most frame
+		//    belongs to runtime.mstart
+		// If we find a runtime.mstart frame on the system stack of a goroutine
+		// parked on runtime.systemstack_switch we assume runtime.systemstack was
+		// called and continue tracing from the parked position.
+
+		if it.top || !it.systemstack || it.g == nil {
+			return false
+		}
+		if fn := it.bi.PCToFunc(it.g.PC); fn == nil || fn.Name != "runtime.systemstack_switch" {
+			return false
+		}
+
+		it.switchToGoroutineStack()
+		return true
+
+	default:
+		if it.systemstack && it.top && it.g != nil && strings.HasPrefix(it.frame.Current.Fn.Name, "runtime.") && it.frame.Current.Fn.Name != "runtime.throw" && it.frame.Current.Fn.Name != "runtime.fatalthrow" {
+			// The runtime switches to the system stack in multiple places.
+			// This usually happens through a call to runtime.systemstack but there
+			// are functions that switch to the system stack manually (for example
+			// runtime.morestack).
+			// Since we are only interested in printing the system stack for cgo
+			// calls we switch directly to the goroutine stack if we detect that the
+			// function at the top of the stack is a runtime function.
+			it.switchToGoroutineStack()
+			return true
+		}
+
+		return false
+	}
+}
+
 func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
+	if runtime.GOOS == "linux" {
+		return arm64SwitchStackLinux(it, callFrameRegs)
+	}
 	if it.frame.Current.Fn == nil && it.systemstack && it.g != nil && it.top {
 		it.switchToGoroutineStack()
 		return true

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -143,7 +143,8 @@ func arm64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *Binary
 const arm64cgocallSPOffsetSaveSlot = 0x8
 const prevG0schedSPOffsetSaveSlot = 0x10
 
-func arm64SwitchStackLinux(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
+func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
+	linux := runtime.GOOS == "linux"
 	if it.frame.Current.Fn == nil {
 		if it.systemstack && it.g != nil && it.top {
 			it.switchToGoroutineStack()
@@ -153,73 +154,76 @@ func arm64SwitchStackLinux(it *stackIterator, callFrameRegs *op.DwarfRegisters) 
 	}
 	switch it.frame.Current.Fn.Name {
 	case "runtime.cgocallback_gofunc", "runtime.cgocallback":
-		// For a detailed description of how this works read the long comment at
-		// the start of $GOROOT/src/runtime/cgocall.go and the source code of
-		// runtime.cgocallback_gofunc in $GOROOT/src/runtime/asm_arm64.s
-		//
-		// When a C function calls back into go it will eventually call into
-		// runtime.cgocallback_gofunc which is the function that does the stack
-		// switch from the system stack back into the goroutine stack
-		// Since we are going backwards on the stack here we see the transition
-		// as goroutine stack -> system stack.
-		if it.top || it.systemstack {
-			return false
-		}
+		if linux {
+			// For a detailed description of how this works read the long comment at
+			// the start of $GOROOT/src/runtime/cgocall.go and the source code of
+			// runtime.cgocallback_gofunc in $GOROOT/src/runtime/asm_arm64.s
+			//
+			// When a C function calls back into go it will eventually call into
+			// runtime.cgocallback_gofunc which is the function that does the stack
+			// switch from the system stack back into the goroutine stack
+			// Since we are going backwards on the stack here we see the transition
+			// as goroutine stack -> system stack.
+			if it.top || it.systemstack {
+				return false
+			}
 
-		it.loadG0SchedSP()
-		if it.g0_sched_sp <= 0 {
-			return false
-		}
-		// Entering the system stack.
-		it.regs.Reg(callFrameRegs.SPRegNum).Uint64Val = it.g0_sched_sp
-		// Reads the previous value of g0.sched.sp that runtime.cgocallback_gofunc saved on the stack.
-		it.g0_sched_sp, _ = readUintRaw(it.mem, uint64(it.regs.SP()+prevG0schedSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize()))
-		it.top = false
-		callFrameRegs, ret, retaddr := it.advanceRegs()
-		frameOnSystemStack := it.newStackframe(ret, retaddr)
-		it.pc = frameOnSystemStack.Ret
-		it.regs = callFrameRegs
-		it.systemstack = true
+			it.loadG0SchedSP()
+			if it.g0_sched_sp <= 0 {
+				return false
+			}
+			// Entering the system stack.
+			it.regs.Reg(callFrameRegs.SPRegNum).Uint64Val = it.g0_sched_sp
+			// Reads the previous value of g0.sched.sp that runtime.cgocallback_gofunc saved on the stack.
+			it.g0_sched_sp, _ = readUintRaw(it.mem, uint64(it.regs.SP()+prevG0schedSPOffsetSaveSlot), int64(it.bi.Arch.PtrSize()))
+			it.top = false
+			callFrameRegs, ret, retaddr := it.advanceRegs()
+			frameOnSystemStack := it.newStackframe(ret, retaddr)
+			it.pc = frameOnSystemStack.Ret
+			it.regs = callFrameRegs
+			it.systemstack = true
 
-		return true
+			return true
+		}
 
 	case "runtime.asmcgocall":
-		if it.top || !it.systemstack {
-			return false
+		if linux {
+			if it.top || !it.systemstack {
+				return false
+			}
+
+			// This function is called by a goroutine to execute a C function and
+			// switches from the goroutine stack to the system stack.
+			// Since we are unwinding the stack from callee to caller we have to switch
+			// from the system stack to the goroutine stack.
+			off, _ := readIntRaw(it.mem, uint64(it.regs.SP()+arm64cgocallSPOffsetSaveSlot),
+				int64(it.bi.Arch.PtrSize()))
+			oldsp := it.regs.SP()
+			newsp := uint64(int64(it.stackhi) - off)
+
+			it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(int64(newsp))
+			// runtime.asmcgocall can also be called from inside the system stack,
+			// in that case no stack switch actually happens
+			if it.regs.SP() == oldsp {
+				return false
+			}
+
+			it.top = false
+			it.systemstack = false
+			// The return value is stored in the LR register which is saved at 24(SP).
+			it.frame.addrret = uint64(int64(it.regs.SP()) + int64(it.bi.Arch.PtrSize()*3))
+			it.frame.Ret, _ = readUintRaw(it.mem, it.frame.addrret, int64(it.bi.Arch.PtrSize()))
+			it.pc = it.frame.Ret
+
+			return true
 		}
-
-		// This function is called by a goroutine to execute a C function and
-		// switches from the goroutine stack to the system stack.
-		// Since we are unwinding the stack from callee to caller we have to switch
-		// from the system stack to the goroutine stack.
-		off, _ := readIntRaw(it.mem, uint64(it.regs.SP()+arm64cgocallSPOffsetSaveSlot),
-			int64(it.bi.Arch.PtrSize()))
-		oldsp := it.regs.SP()
-		newsp := uint64(int64(it.stackhi) - off)
-
-		it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(int64(newsp))
-		// runtime.asmcgocall can also be called from inside the system stack,
-		// in that case no stack switch actually happens
-		if it.regs.SP() == oldsp {
-			return false
-		}
-
-		it.top = false
-		it.systemstack = false
-		// The return value is stored in the LR register which is saved at 24(SP).
-		it.frame.addrret = uint64(int64(it.regs.SP()) + int64(it.bi.Arch.PtrSize()*3))
-		it.frame.Ret, _ = readUintRaw(it.mem, it.frame.addrret, int64(it.bi.Arch.PtrSize()))
-		it.pc = it.frame.Ret
-
-		return true
 
 	case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":
 		// Look for "top of stack" functions.
 		it.atend = true
 		return true
-
 	case "crosscall2":
-		// The offsets get from runtime/cgo/asm_arm64.s:10
+		//The offsets get from runtime/cgo/asm_arm64.s:10
 		bpoff := uint64(14)
 		lroff := uint64(15)
 		if producer := it.bi.Producer(); producer != "" && goversion.ProducerAfterOrEqual(producer, 1, 19) {
@@ -227,6 +231,7 @@ func arm64SwitchStackLinux(it *stackIterator, callFrameRegs *op.DwarfRegisters) 
 			bpoff = 22
 			lroff = 23
 		}
+		newsp, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*24), int64(it.bi.Arch.PtrSize()))
 		newbp, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*bpoff), int64(it.bi.Arch.PtrSize()))
 		newlr, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*lroff), int64(it.bi.Arch.PtrSize()))
 		if it.regs.Reg(it.regs.BPRegNum) != nil {
@@ -235,30 +240,35 @@ func arm64SwitchStackLinux(it *stackIterator, callFrameRegs *op.DwarfRegisters) 
 			reg, _ := it.readRegisterAt(it.regs.BPRegNum, it.regs.SP()+8*bpoff)
 			it.regs.AddReg(it.regs.BPRegNum, reg)
 		}
-		it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(newbp)
+		it.regs.Reg(it.regs.LRRegNum).Uint64Val = uint64(newlr)
+		if linux {
+			it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(newbp)
+		} else {
+			it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(newsp)
+		}
 		it.pc = newlr
 		return true
-
 	case "runtime.mstart":
-		// Calls to runtime.systemstack will switch to the systemstack then:
-		// 1. alter the goroutine stack so that it looks like systemstack_switch
-		//    was called
-		// 2. alter the system stack so that it looks like the bottom-most frame
-		//    belongs to runtime.mstart
-		// If we find a runtime.mstart frame on the system stack of a goroutine
-		// parked on runtime.systemstack_switch we assume runtime.systemstack was
-		// called and continue tracing from the parked position.
+		if linux {
+			// Calls to runtime.systemstack will switch to the systemstack then:
+			// 1. alter the goroutine stack so that it looks like systemstack_switch
+			//    was called
+			// 2. alter the system stack so that it looks like the bottom-most frame
+			//    belongs to runtime.mstart
+			// If we find a runtime.mstart frame on the system stack of a goroutine
+			// parked on runtime.systemstack_switch we assume runtime.systemstack was
+			// called and continue tracing from the parked position.
 
-		if it.top || !it.systemstack || it.g == nil {
-			return false
+			if it.top || !it.systemstack || it.g == nil {
+				return false
+			}
+			if fn := it.bi.PCToFunc(it.g.PC); fn == nil || fn.Name != "runtime.systemstack_switch" {
+				return false
+			}
+
+			it.switchToGoroutineStack()
+			return true
 		}
-		if fn := it.bi.PCToFunc(it.g.PC); fn == nil || fn.Name != "runtime.systemstack_switch" {
-			return false
-		}
-
-		it.switchToGoroutineStack()
-		return true
-
 	default:
 		if it.systemstack && it.top && it.g != nil && strings.HasPrefix(it.frame.Current.Fn.Name, "runtime.") && it.frame.Current.Fn.Name != "runtime.throw" && it.frame.Current.Fn.Name != "runtime.fatalthrow" {
 			// The runtime switches to the system stack in multiple places.
@@ -270,62 +280,6 @@ func arm64SwitchStackLinux(it *stackIterator, callFrameRegs *op.DwarfRegisters) 
 			// function at the top of the stack is a runtime function.
 			it.switchToGoroutineStack()
 			return true
-		}
-
-		return false
-	}
-}
-
-func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
-	if runtime.GOOS == "linux" {
-		return arm64SwitchStackLinux(it, callFrameRegs)
-	}
-	if it.frame.Current.Fn == nil && it.systemstack && it.g != nil && it.top {
-		it.switchToGoroutineStack()
-		return true
-	}
-	if it.frame.Current.Fn != nil {
-		switch it.frame.Current.Fn.Name {
-		case "runtime.asmcgocall", "runtime.cgocallback_gofunc", "runtime.sigpanic", "runtime.cgocallback":
-			//do nothing
-		case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":
-			// Look for "top of stack" functions.
-			it.atend = true
-			return true
-		case "crosscall2":
-			//The offsets get from runtime/cgo/asm_arm64.s:10
-			bpoff := uint64(14)
-			lroff := uint64(15)
-			if producer := it.bi.Producer(); producer != "" && goversion.ProducerAfterOrEqual(producer, 1, 19) {
-				// In Go 1.19 (specifically eee6f9f82) the order registers are saved was changed.
-				bpoff = 22
-				lroff = 23
-			}
-			newsp, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*24), int64(it.bi.Arch.PtrSize()))
-			newbp, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*bpoff), int64(it.bi.Arch.PtrSize()))
-			newlr, _ := readUintRaw(it.mem, uint64(it.regs.SP()+8*lroff), int64(it.bi.Arch.PtrSize()))
-			if it.regs.Reg(it.regs.BPRegNum) != nil {
-				it.regs.Reg(it.regs.BPRegNum).Uint64Val = uint64(newbp)
-			} else {
-				reg, _ := it.readRegisterAt(it.regs.BPRegNum, it.regs.SP()+8*bpoff)
-				it.regs.AddReg(it.regs.BPRegNum, reg)
-			}
-			it.regs.Reg(it.regs.LRRegNum).Uint64Val = uint64(newlr)
-			it.regs.Reg(it.regs.SPRegNum).Uint64Val = uint64(newsp)
-			it.pc = newlr
-			return true
-		default:
-			if it.systemstack && it.top && it.g != nil && strings.HasPrefix(it.frame.Current.Fn.Name, "runtime.") && it.frame.Current.Fn.Name != "runtime.throw" && it.frame.Current.Fn.Name != "runtime.fatalthrow" {
-				// The runtime switches to the system stack in multiple places.
-				// This usually happens through a call to runtime.systemstack but there
-				// are functions that switch to the system stack manually (for example
-				// runtime.morestack).
-				// Since we are only interested in printing the system stack for cgo
-				// calls we switch directly to the goroutine stack if we detect that the
-				// function at the top of the stack is a runtime function.
-				it.switchToGoroutineStack()
-				return true
-			}
 		}
 	}
 

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -191,6 +191,7 @@ type stackIterator struct {
 
 	g                  *G     // the goroutine being stacktraced, nil if we are stacktracing a goroutine-less thread
 	g0_sched_sp        uint64 // value of g0.sched.sp (see comments around its use)
+	g0_sched_bp        uint64 // value of g0.sched.sp (see comments around its use)
 	g0_sched_sp_loaded bool   // g0_sched_sp was loaded from g0
 
 	opts StacktraceOptions
@@ -407,7 +408,14 @@ func (it *stackIterator) advanceRegs() (callFrameRegs op.DwarfRegisters, ret uin
 
 	callimage := it.bi.PCToImage(it.pc)
 
-	callFrameRegs = op.DwarfRegisters{StaticBase: callimage.StaticBase, ByteOrder: it.regs.ByteOrder, PCRegNum: it.regs.PCRegNum, SPRegNum: it.regs.SPRegNum, BPRegNum: it.regs.BPRegNum, LRRegNum: it.regs.LRRegNum}
+	callFrameRegs = op.DwarfRegisters{
+		StaticBase: callimage.StaticBase,
+		ByteOrder:  it.regs.ByteOrder,
+		PCRegNum:   it.regs.PCRegNum,
+		SPRegNum:   it.regs.SPRegNum,
+		BPRegNum:   it.regs.BPRegNum,
+		LRRegNum:   it.regs.LRRegNum,
+	}
 
 	// According to the standard the compiler should be responsible for emitting
 	// rules for the RSP register so that it can then be used to calculate CFA,

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -191,7 +191,6 @@ type stackIterator struct {
 
 	g                  *G     // the goroutine being stacktraced, nil if we are stacktracing a goroutine-less thread
 	g0_sched_sp        uint64 // value of g0.sched.sp (see comments around its use)
-	g0_sched_bp        uint64 // value of g0.sched.sp (see comments around its use)
 	g0_sched_sp_loaded bool   // g0_sched_sp was loaded from g0
 
 	opts StacktraceOptions

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -874,8 +874,8 @@ func (v *Variable) parseG() (*G, error) {
 	if bpvar := schedVar.fieldVariable("bp"); /* +rtype -opt uintptr */ bpvar != nil && bpvar.Value != nil {
 		bp, _ = constant.Int64Val(bpvar.Value)
 	}
-	if bpvar := schedVar.fieldVariable("lr"); /* +rtype -opt uintptr */ bpvar != nil && bpvar.Value != nil {
-		lr, _ = constant.Int64Val(bpvar.Value)
+	if lrvar := schedVar.fieldVariable("lr"); /* +rtype -opt uintptr */ lrvar != nil && lrvar.Value != nil {
+		lr, _ = constant.Int64Val(lrvar.Value)
 	}
 
 	unreadable := false


### PR DESCRIPTION
This patch introduces some changes, particularly to arm64SwitchStack
which fixes the test when running on linux/arm64. The changes are
specific to linux, integrating them directly causes the test to fail on
apple/m1, so special case linux for now.

Fixes #2340