### PR TITLE
proc: prefer addresses when setting a breakpoint

### DIFF
--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -211,14 +211,14 @@ func enableBreakpointOnTarget(p *Target, lbp *LogicalBreakpoint) error {
 		addrs, err = FindFileLocation(p, lbp.Set.File, lbp.Set.Line)
 	case lbp.Set.FunctionName != "":
 		addrs, err = FindFunctionLocation(p, lbp.Set.FunctionName, lbp.Set.Line)
-	case lbp.Set.Expr != nil:
-		addrs = lbp.Set.Expr(p)
 	case len(lbp.Set.PidAddrs) > 0:
 		for _, pidAddr := range lbp.Set.PidAddrs {
 			if pidAddr.Pid == p.Pid() {
 				addrs = append(addrs, pidAddr.Addr)
 			}
 		}
+	case lbp.Set.Expr != nil:
+		addrs = lbp.Set.Expr(p)
 	default:
 		return fmt.Errorf("breakpoint %d can not be enabled", lbp.LogicalID)
 	}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1342,3 +1342,17 @@ func TestDisassPosCmd(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateBreakpointByLocExpr(t *testing.T) {
+	withTestTerminal("math", t, func(term *FakeTerminal) {
+		out := term.MustExec("break main.main")
+		position1 := strings.Split(out, " set at ")[1]
+		term.MustExec("continue")
+		term.MustExec("clear 1")
+		out = term.MustExec("break +0")
+		position2 := strings.Split(out, " set at ")[1]
+		if position1 != position2 {
+			t.Fatalf("mismatched positions %q and %q\n", position1, position2)
+		}
+	})
+}


### PR DESCRIPTION
If a breakpoint has both a list of addresses and an expression prefer
the list of addresses, otherwise it is impossible to set breakpoint
with expressions that depend on the current scope, like 'break +0'
which sets a breakpoint on the current line.
