### PR TITLE
cmds/command: Include hidden flag -c for coredumpctl support

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -327,6 +327,10 @@ Currently supports linux/amd64 and linux/arm64 core files, windows/amd64 minidum
 		},
 		Run: coreCmd,
 	}
+	// -c is unused and exists so delve can be used with coredumpctl
+	core := false
+	coreCommand.Flags().BoolVarP(&core, "core", "c", false, "")
+	coreCommand.Flags().MarkHidden("core")
 	rootCommand.AddCommand(coreCommand)
 
 	// 'version' subcommand.


### PR DESCRIPTION
`coredumpctl` attempts to pass the core file to the debugger through the `-c` flag. However delve does not support such a flag.

This patch makes it a bool flag so we can receive the coredump file from `coredumpctl`

    $ GOTRACEBACK=crash ./main
    panic:
    goroutine 1 [running]:
    [....]
    zsh: IOT instruction (core dumped)  GOTRACEBACK=crash ./main
    $ coredumpctl list main
    TIME                            PID  UID  GID SIG     COREFILE EXE                             SIZE
    Tue 2022-11-15 23:29:07 CET 2047401 1000 1000 SIGABRT present  /tmp/go-test/main 60.2K
    $ coredumpctl gdb --debugger=dlv -A core main
               PID: 2047401 (main)
            Signal: 6 (ABRT)
         Timestamp: Tue 2022-11-15 23:29:07 CET (1min 27s ago)
      Command Line: ./main
        Executable: /tmp/go-test/main
         Owner UID: 1000 (fox)
      Size on Disk: 60.2K
           Message: Process 2047401 (main) of user 1000 dumped core.

                    Module /tmp/go-test/main without build-id.
                    Stack trace of thread 2047401:
                    #0  0x000000000045fa01 n/a (/tmp/go-test/main + 0x5fa01)
                    #1  0x0000000000446d3e n/a (/tmp/go-test/main + 0x46d3e)
                    #2  0x0000000000445487 n/a (/tmp/go-test/main + 0x45487)
                    #3  0x000000000045fce6 n/a (/tmp/go-test/main + 0x5fce6)
                    #4  0x000000000045fde0 n/a (/tmp/go-test/main + 0x5fde0)
                    #5  0x0000000000432a49 n/a (/tmp/go-test/main + 0x32a49)
                    #6  0x000000000043211a n/a (/tmp/go-test/main + 0x3211a)
                    #7  0x000000000048d405 n/a (/tmp/go-test/main + 0x8d405)
                    #8  0x0000000000434db2 n/a (/tmp/go-test/main + 0x34db2)
                    #9  0x000000000045e0e1 n/a (/tmp/go-test/main + 0x5e0e1)
                    ELF object binary architecture: AMD x86-64

    [dlv core /tmp/go-test/main -c /var/tmp/coredump-JizL2g]
    Type 'help' for list of commands.
    (dlv) list main.main
    Showing /tmp/go-test/main.go:3 (PC: 0x457c26)
         1:	package main
         2:
         3:	func main() {
         4:		panic()
         5:	}
    (dlv)

Signed-off-by: Morten Linderud <morten@linderud.pw>