### PR TITLE
proc/gdbserver: set child process pgrp as foreground group

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -573,6 +573,13 @@ func LLDBLaunch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs [
 	} else {
 		tgt, err = p.Dial(port, cmd[0], 0, debugInfoDirs, proc.StopLaunched)
 	}
+	if p.conn.pid != 0 && foreground && isatty.IsTerminal(os.Stdin.Fd()) {
+		// Make the target process the controlling process of the tty if it is a foreground process.
+		err = tcsetpgrp(os.Stdin.Fd(), p.conn.pid)
+		if err != nil {
+			logflags.DebuggerLogger().Errorf("could not set controlling process: %v", err)
+		}
+	}
 	return tgt, err
 }
 

--- a/pkg/proc/gdbserial/gdbserver_unix.go
+++ b/pkg/proc/gdbserial/gdbserver_unix.go
@@ -6,6 +6,8 @@ package gdbserial
 import (
 	"os/signal"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func sysProcAttr(foreground bool) *syscall.SysProcAttr {
@@ -14,4 +16,8 @@ func sysProcAttr(foreground bool) *syscall.SysProcAttr {
 
 func foregroundSignalsIgnore() {
 	signal.Ignore(syscall.SIGTTOU, syscall.SIGTTIN)
+}
+
+func tcsetpgrp(fd uintptr, pid int) error {
+	return unix.IoctlSetPointerInt(int(fd), unix.TIOCSPGRP, pid)
 }

--- a/pkg/proc/gdbserial/gdbserver_windows.go
+++ b/pkg/proc/gdbserial/gdbserver_windows.go
@@ -8,3 +8,7 @@ func sysProcAttr(foreground bool) *syscall.SysProcAttr {
 
 func foregroundSignalsIgnore() {
 }
+
+func tcsetpgrp(fd uintptr, pid int) error {
+	return nil
+}


### PR DESCRIPTION
Newer versions of debugserver (which contain [1]) will spawn the target
process on a new process group, when we detect that this happen, and we
are a headless instance and stdin is a tty, make the child process'
process group the controlling group for the terminal.

[1] https://reviews.llvm.org/rG33ac4fddc7906ba712c50cd3a9b02ae041d751ab
