### PR TITLE
Print build command line before executing build

### DIFF
--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -46,6 +46,16 @@ func GoBuildCombinedOutput(debugname string, pkgs []string, buildflags string) (
 	return gocommandCombinedOutput("build", args...)
 }
 
+func MakeGoBuildCmd(debugname string, pkgs []string, buildflags string) (string, *exec.Cmd) {
+	args := goBuildArgs(debugname, pkgs, buildflags, false)
+	return gocommandExecCmd("build", args...)
+}
+
+func MakeGoTestCmd(debugname string, pkgs []string, buildflags string) (string, *exec.Cmd) {
+	args := goBuildArgs(debugname, pkgs, buildflags, true)
+	return gocommandExecCmd("test", args...)
+}
+
 // GoTestBuild builds test files 'pkgs' with the specified 'buildflags'
 // and writes the output at 'debugname'.
 func GoTestBuild(debugname string, pkgs []string, buildflags string) error {


### PR DESCRIPTION
This PR addresses https://github.com/go-delve/delve/issues/3173 by adding an output event before executing build command. In order to not break compatibility, added some functions to `pkg/gobuild`. 