### PR TITLE
gdbserial: continue if tcsetpgrp fails

### DIFF
--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -31,8 +31,11 @@ if [ "$version" = "gotip" ]; then
 	cd -
 else
 	echo Finding latest patch version for $version
-	version=$(curl 'https://go.dev/dl/?mode=json&include=all' | jq '.[].version' --raw-output | egrep ^$version'($|\.|^beta|^rc)' | sort -rV | head -1)
 	echo "Go $version on $arch"
+	version=$(curl 'https://go.dev/dl/?mode=json&include=all' | jq '.[].version' --raw-output | egrep ^$version'($|\.|beta|rc)' | sort -rV | head -1)
+	if [ "x$version" = "x" ]; then
+		version=$(curl 'https://go.dev/dl/?mode=json&include=all' | jq '.[].version' --raw-output | egrep ^$version'($|\.)' | sort -rV | head -1)
+	fi
 	getgo $version
 fi
 

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -575,7 +575,7 @@ func LLDBLaunch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs [
 	}
 	if p.conn.pid != 0 && foreground && isatty.IsTerminal(os.Stdin.Fd()) {
 		// Make the target process the controlling process of the tty if it is a foreground process.
-		err = tcsetpgrp(os.Stdin.Fd(), p.conn.pid)
+		err := tcsetpgrp(os.Stdin.Fd(), p.conn.pid)
 		if err != nil {
 			logflags.DebuggerLogger().Errorf("could not set controlling process: %v", err)
 		}

--- a/pkg/proc/gdbserial/gdbserver_unix.go
+++ b/pkg/proc/gdbserial/gdbserver_unix.go
@@ -19,5 +19,9 @@ func foregroundSignalsIgnore() {
 }
 
 func tcsetpgrp(fd uintptr, pid int) error {
-	return unix.IoctlSetPointerInt(int(fd), unix.TIOCSPGRP, pid)
+	pgid, _ := syscall.Getpgid(pid)
+	if pid == pgid {
+		return unix.IoctlSetPointerInt(int(fd), unix.TIOCSPGRP, pid)
+	}
+	return nil
 }


### PR DESCRIPTION
Do not stop if tcsetpgrp errors, also only do it if the target process
got its own process group.

Fixes #3210
