### PR TITLE
Documentation: add -test.run to test example

### DIFF
--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -11,7 +11,7 @@ unit tests. By default Delve will debug the tests in the current directory.
 Alternatively you can specify a package name, and Delve will debug the tests in
 that package instead. Double-dashes `--` can be used to pass arguments to the test program:
 
-dlv test [package] -- -test.v -other-argument
+dlv test [package] -- -test.run TestSometing -test.v -other-argument
 
 See also: 'go help testflag'.
 

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -278,7 +278,7 @@ unit tests. By default Delve will debug the tests in the current directory.
 Alternatively you can specify a package name, and Delve will debug the tests in
 that package instead. Double-dashes ` + "`--`" + ` can be used to pass arguments to the test program:
 
-dlv test [package] -- -test.v -other-argument
+dlv test [package] -- -test.run TestSometing -test.v -other-argument
 
 See also: 'go help testflag'.`,
 		Run: testCmd,


### PR DESCRIPTION
Add -test.run to the example of how 'dlv test' can be used.
