### PR TITLE
proc: replace deprecated os.SEEK_CUR with io.SeekCurrent

### DIFF
--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -340,14 +340,14 @@ func readNote(r io.ReadSeeker, machineType elf.Machine) (*note, error) {
 
 // skipPadding moves r to the next multiple of pad.
 func skipPadding(r io.ReadSeeker, pad int64) error {
-	pos, err := r.Seek(0, os.SEEK_CUR)
+	pos, err := r.Seek(0, io.SeekCurrent)
 	if err != nil {
 		return err
 	}
 	if pos%pad == 0 {
 		return nil
 	}
-	if _, err := r.Seek(pad-(pos%pad), os.SEEK_CUR); err != nil {
+	if _, err := r.Seek(pad-(pos%pad), io.SeekCurrent); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -2293,7 +2293,7 @@ func (v *Variable) ConstDescr() string {
 	}
 	if typename := v.DwarfType.Common().Name; !strings.Contains(typename, ".") || strings.HasPrefix(typename, "C.") {
 		// only attempt to use constants for user defined type, otherwise every
-		// int variable with value 1 will be described with os.SEEK_CUR and other
+		// int variable with value 1 will be described with io.SeekCurrent and other
 		// similar problems.
 		return ""
 	}


### PR DESCRIPTION
This PR refactors two files in `proc` by replacing `os.SEEK_CUR` with `io.SeekCurrent`.

`os.SEEK_CUR` is deprecated. [Documentation](https://pkg.go.dev/os@go1.15.15#pkg-constants) suggests using  `io.SeekCurrent`.