### PR TITLE
Update github.com/derekparker/trie dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cilium/ebpf v0.7.0
 	github.com/cosiner/argv v0.1.0
 	github.com/creack/pty v1.1.9
-	github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9
+	github.com/derekparker/trie v0.0.0-20221213183930-4c74548207f4
 	github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d
 	github.com/google/go-dap v0.6.0
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9 h1:G765iDCq7bP5opdrPkXk+4V3yfkgV9iGFuheWZ/X/zY=
 github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9/go.mod h1:D6ICZm05D9VN1n/8iOtBxLpXtoGp6HDFUJ1RNVieOSE=
+github.com/derekparker/trie v0.0.0-20221213183930-4c74548207f4 h1:atN94qKNhLpy+9BwbE5nxvFj4rScJi6W3x/NfFmMDg4=
+github.com/derekparker/trie v0.0.0-20221213183930-4c74548207f4/go.mod h1:C7Es+DLenIpPc9J6IYw4jrK0h7S9bKj4DNl8+KxGEXU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/vendor/github.com/derekparker/trie/go.mod
+++ b/vendor/github.com/derekparker/trie/go.mod
@@ -1,0 +1,3 @@
+module github.com/derekparker/trie
+
+go 1.19

--- a/vendor/github.com/derekparker/trie/trie.go
+++ b/vendor/github.com/derekparker/trie/trie.go
@@ -246,7 +246,7 @@ func collect(node *Node) []string {
 		i int
 	)
 	keys := make([]string, 0, node.termCount)
-	nodes := make([]*Node, 1, len(node.children))
+	nodes := make([]*Node, 1, len(node.children)+1)
 	nodes[0] = node
 	for l := len(nodes); l != 0; l = len(nodes) {
 		i = l - 1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/creack/pty v1.1.9
 ## explicit
 github.com/creack/pty
-# github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9
+# github.com/derekparker/trie v0.0.0-20221213183930-4c74548207f4
 ## explicit
 github.com/derekparker/trie
 # github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d


### PR DESCRIPTION
Fixes #3217 with the fix in https://github.com/derekparker/trie/pull/33.

Changes generated by running:
```
$ go get github.com/derekparker/trie
$ go mod vendor
```