### PR TITLE
Rename vars that collide with the 'builtin' functions or type aliases

### DIFF
--- a/pkg/dwarf/util/buf.go
+++ b/pkg/dwarf/util/buf.go
@@ -70,10 +70,10 @@ func (b *buf) Uint8() uint8 {
 // the 0x80 bit means read another byte.
 func (b *buf) Varint() (c uint64, bits uint) {
 	for i := 0; i < len(b.data); i++ {
-		byte := b.data[i]
-		c |= uint64(byte&0x7F) << bits
+		dataByte := b.data[i]
+		c |= uint64(dataByte&0x7F) << bits
 		bits += 7
-		if byte&0x80 == 0 {
+		if dataByte&0x80 == 0 {
 			b.off += dwarf.Offset(i + 1)
 			b.data = b.data[i+1:]
 			return c, bits

--- a/pkg/proc/core/delve_core.go
+++ b/pkg/proc/core/delve_core.go
@@ -94,16 +94,16 @@ func threadsFromDelveNotes(p *process, notes []*note) (proc.Thread, error) {
 			if readerr != nil {
 				return nil
 			}
-			var len uint16
-			read(&len)
-			if maxlen > 0 && len > maxlen {
+			var length uint16
+			read(&length)
+			if maxlen > 0 && length > maxlen {
 				readerr = fmt.Errorf("maximum len exceeded (%d) reading %s", len, kind)
 				return nil
 			}
-			buf := make([]byte, len)
 			if readerr != nil {
 				return nil
 			}
+			buf := make([]byte, length)
 			_, readerr = body.Read(buf)
 			return buf
 		}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -380,9 +380,9 @@ func (scope *EvalScope) setValue(dstv, srcv *Variable, srcExpr string) error {
 	case reflect.Bool:
 		return dstv.writeBool(constant.BoolVal(srcv.Value))
 	case reflect.Complex64, reflect.Complex128:
-		real, _ := constant.Float64Val(constant.Real(srcv.Value))
-		imag, _ := constant.Float64Val(constant.Imag(srcv.Value))
-		return dstv.writeComplex(real, imag, dstv.RealType.Size())
+		realVal, _ := constant.Float64Val(constant.Real(srcv.Value))
+		imagVal, _ := constant.Float64Val(constant.Imag(srcv.Value))
+		return dstv.writeComplex(realVal, imagVal, dstv.RealType.Size())
 	case reflect.Func:
 		if dstv.RealType.Size() == 0 {
 			if dstv.Name != "" {
@@ -2206,9 +2206,9 @@ func (v *Variable) reslice(low int64, high int64) (*Variable, error) {
 	}
 
 	base := v.Base + uint64(int64(low)*v.stride)
-	len := high - low
+	length := high - low
 
-	if high-low < 0 {
+	if length < 0 {
 		return nil, fmt.Errorf("index out of bounds")
 	}
 
@@ -2223,8 +2223,8 @@ func (v *Variable) reslice(low int64, high int64) (*Variable, error) {
 	}
 
 	r := v.newVariable("", 0, typ, mem)
-	r.Cap = len
-	r.Len = len
+	r.Cap = length
+	r.Len = length
 	r.Base = base
 	r.stride = v.stride
 	r.fieldType = v.fieldType

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -195,11 +195,11 @@ func ConvertVar(v *proc.Variable) *Variable {
 		r.Children[1].Kind = reflect.Float32
 
 		if v.Value != nil {
-			real, _ := constant.Float64Val(constant.Real(v.Value))
-			r.Children[0].Value = strconv.FormatFloat(real, 'f', -1, 32)
+			realVal, _ := constant.Float64Val(constant.Real(v.Value))
+			r.Children[0].Value = strconv.FormatFloat(realVal, 'f', -1, 32)
 
-			imag, _ := constant.Float64Val(constant.Imag(v.Value))
-			r.Children[1].Value = strconv.FormatFloat(imag, 'f', -1, 32)
+			imagVal, _ := constant.Float64Val(constant.Imag(v.Value))
+			r.Children[1].Value = strconv.FormatFloat(imagVal, 'f', -1, 32)
 		} else {
 			r.Children[0].Value = "nil"
 			r.Children[1].Value = "nil"
@@ -216,11 +216,11 @@ func ConvertVar(v *proc.Variable) *Variable {
 		r.Children[1].Kind = reflect.Float64
 
 		if v.Value != nil {
-			real, _ := constant.Float64Val(constant.Real(v.Value))
-			r.Children[0].Value = strconv.FormatFloat(real, 'f', -1, 64)
+			realVal, _ := constant.Float64Val(constant.Real(v.Value))
+			r.Children[0].Value = strconv.FormatFloat(realVal, 'f', -1, 64)
 
-			imag, _ := constant.Float64Val(constant.Imag(v.Value))
-			r.Children[1].Value = strconv.FormatFloat(imag, 'f', -1, 64)
+			imagVal, _ := constant.Float64Val(constant.Imag(v.Value))
+			r.Children[1].Value = strconv.FormatFloat(imagVal, 'f', -1, 64)
 		} else {
 			r.Children[0].Value = "nil"
 			r.Children[1].Value = "nil"

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -189,9 +189,9 @@ func (v *Variable) writeBasicType(buf io.Writer, fmtstr string) {
 			fmt.Fprintf(buf, "(%s + %si)", v.Children[0].Value, v.Children[1].Value)
 			return
 		}
-		real, _ := strconv.ParseFloat(v.Children[0].Value, 64)
-		imag, _ := strconv.ParseFloat(v.Children[1].Value, 64)
-		var x complex128 = complex(real, imag)
+		realVal, _ := strconv.ParseFloat(v.Children[0].Value, 64)
+		imagVal, _ := strconv.ParseFloat(v.Children[1].Value, 64)
+		var x complex128 = complex(realVal, imagVal)
 		fmt.Fprintf(buf, fmtstr, x)
 
 	case reflect.String:

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2863,14 +2863,14 @@ func TestRestart_PreserveFunctionBreakpoint(t *testing.T) {
 
 	dir := protest.FindFixturesDir()
 
-	copy := func(inpath string) {
+	copyFn := func(inpath string) {
 		buf, err := ioutil.ReadFile(inpath)
 		assertNoError(err, t, fmt.Sprintf("Reading %q", inpath))
 		outpath := filepath.Join(dir, "testfnpos.go")
 		assertNoError(ioutil.WriteFile(outpath, buf, 0666), t, fmt.Sprintf("Creating %q", outpath))
 	}
 
-	copy(filepath.Join(dir, "testfnpos1.go"))
+	copyFn(filepath.Join(dir, "testfnpos1.go"))
 
 	withTestClient2Extended("testfnpos", t, 0, [3]string{}, nil, func(c service.Client, f protest.Fixture) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.f1"})


### PR DESCRIPTION
This PR fixes the following lint issues:

<img width="396" alt="image" src="https://user-images.githubusercontent.com/3228886/207576440-3c2abe2c-13e6-45b4-b2d0-1bec48c39605.png">
