### PR TITLE
TeamCity: fix windows/amd64 builds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -204,7 +204,7 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
                     scriptMode = file {
                         path = "_scripts/test_windows.ps1"
                     }
-                    param("jetbrains_powershell_scriptArguments", "-version ${"go$version"} -arch $arch -binDir %teamcity.build.systemDir%")
+                    param("jetbrains_powershell_scriptArguments", "-version ${"go$version"} -arch $arch")
                 }
             }
             "mac" -> {

--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -5,7 +5,6 @@ param (
 )
 
 if ($binDir -eq "") {
-    # TODO: remove once the current version of settings.kts gets to master.
     $binDir = Resolve-Path "../../system" # working directory
 }
 


### PR DESCRIPTION
Windows/amd64 builds are not runnning because the current settings.kts
has an implicity requirement to property teamcity.build.systemDir which
does not exist on windows/amd64 agents.
