### PR TITLE
proc/native: fix FreeBSD backend

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -11,8 +11,7 @@ Tests skipped by each supported backend:
 	* 1 broken - cgo stacktraces
 * darwin/lldb skipped = 1
 	* 1 upstream issue
-* freebsd skipped = 16
-	* 12 broken
+* freebsd skipped = 4
 	* 4 not implemented
 * linux/386/pie skipped = 1
 	* 1 broken

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1036,11 +1036,6 @@ func TestTrace(t *testing.T) {
 }
 
 func TestTraceMultipleGoroutines(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		//TODO(aarzilli): investigate further when the FreeBSD backend is more stable.
-		t.Skip("temporarily disabled due to issues with FreeBSD in Delve and Go")
-	}
-
 	dlvbin, tmpdir := getDlvBin(t)
 	defer os.RemoveAll(tmpdir)
 

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -246,14 +246,12 @@ func (dbp *nativeProcess) initialize(path string, debugInfoDirs []string) (*proc
 		// We disable asyncpreempt for the following reasons:
 		//  - on Windows asyncpreempt is incompatible with debuggers, see:
 		//    https://github.com/golang/go/issues/36494
-		//  - freebsd's backend is generally broken and asyncpreempt makes it even more so, see:
-		//    https://github.com/go-delve/delve/issues/1754
 		//  - on linux/arm64 asyncpreempt can sometimes restart a sequence of
 		//    instructions, if the sequence happens to contain a breakpoint it will
 		//    look like the breakpoint was hit twice when it was "logically" only
 		//    executed once.
 		//    See: https://go-review.googlesource.com/c/go/+/208126
-		DisableAsyncPreempt: runtime.GOOS == "windows" || runtime.GOOS == "freebsd" || (runtime.GOOS == "linux" && runtime.GOARCH == "arm64"),
+		DisableAsyncPreempt: runtime.GOOS == "windows" || (runtime.GOOS == "linux" && runtime.GOARCH == "arm64"),
 
 		StopReason:   stopReason,
 		CanDump:      runtime.GOOS == "linux" || (runtime.GOOS == "windows" && runtime.GOARCH == "amd64"),

--- a/pkg/proc/native/ptrace_freebsd.go
+++ b/pkg/proc/native/ptrace_freebsd.go
@@ -10,6 +10,7 @@ import "C"
 
 import (
 	"unsafe"
+	"syscall"
 
 	sys "golang.org/x/sys/unix"
 )
@@ -65,4 +66,36 @@ func ptraceReadData(id int, addr uintptr, data []byte) (n int, err error) {
 // id may be a PID or an LWPID
 func ptraceWriteData(id int, addr uintptr, data []byte) (n int, err error) {
 	return sys.PtraceIO(sys.PIOD_WRITE_D, id, addr, data, len(data))
+}
+
+func ptraceSuspend(id int) error {
+	_, _, e1 := sys.Syscall6(sys.SYS_PTRACE, uintptr(C.PT_SUSPEND), uintptr(id), uintptr(1), uintptr(0), 0, 0)
+	if e1 != 0 {
+		return syscall.Errno(e1)
+	}
+	return nil
+}
+
+func ptraceResume(id int) error {
+	_, _, e1 := sys.Syscall6(sys.SYS_PTRACE, uintptr(C.PT_RESUME), uintptr(id), uintptr(1), uintptr(0), 0, 0)
+	if e1 != 0 {
+		return syscall.Errno(e1)
+	}
+	return nil
+}
+
+func ptraceSetStep(id int) error {
+	_, _, e1 := sys.Syscall6(sys.SYS_PTRACE, uintptr(C.PT_SETSTEP), uintptr(id), uintptr(0), uintptr(0), 0, 0)
+	if e1 != 0 {
+		return syscall.Errno(e1)
+	}
+	return nil
+}
+
+func ptraceClearStep(id int) error {
+	_, _, e1 := sys.Syscall6(sys.SYS_PTRACE, uintptr(C.PT_CLEARSTEP), uintptr(id), uintptr(0), uintptr(0), 0, 0)
+	if e1 != 0 {
+		return syscall.Errno(e1)
+	}
+	return nil
 }

--- a/pkg/proc/native/threads.go
+++ b/pkg/proc/native/threads.go
@@ -22,26 +22,6 @@ type nativeThread struct {
 	common         proc.CommonThread
 }
 
-// Continue the execution of this thread.
-//
-// If we are currently at a breakpoint, we'll clear it
-// first and then resume execution. Thread will continue until
-// it hits a breakpoint or is signaled.
-func (t *nativeThread) Continue() error {
-	pc, err := t.PC()
-	if err != nil {
-		return err
-	}
-	// Check whether we are stopped at a breakpoint, and
-	// if so, single step over it before continuing.
-	if _, ok := t.dbp.FindBreakpoint(pc, false); ok {
-		if err := t.StepInstruction(); err != nil {
-			return err
-		}
-	}
-	return t.resume()
-}
-
 // StepInstruction steps a single instruction.
 //
 // Executes exactly one instruction and then returns.

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -143,3 +143,23 @@ func (t *nativeThread) withDebugRegisters(f func(*amd64util.DebugRegisters) erro
 func (t *nativeThread) SoftExc() bool {
 	return false
 }
+
+// Continue the execution of this thread.
+//
+// If we are currently at a breakpoint, we'll clear it
+// first and then resume execution. Thread will continue until
+// it hits a breakpoint or is signaled.
+func (t *nativeThread) Continue() error {
+	pc, err := t.PC()
+	if err != nil {
+		return err
+	}
+	// Check whether we are stopped at a breakpoint, and
+	// if so, single step over it before continuing.
+	if _, ok := t.dbp.FindBreakpoint(pc, false); ok {
+		if err := t.StepInstruction(); err != nil {
+			return err
+		}
+	}
+	return t.resume()
+}

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -120,3 +120,23 @@ func (t *nativeThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
 func (t *nativeThread) SoftExc() bool {
 	return t.os.setbp
 }
+
+// Continue the execution of this thread.
+//
+// If we are currently at a breakpoint, we'll clear it
+// first and then resume execution. Thread will continue until
+// it hits a breakpoint or is signaled.
+func (t *nativeThread) Continue() error {
+	pc, err := t.PC()
+	if err != nil {
+		return err
+	}
+	// Check whether we are stopped at a breakpoint, and
+	// if so, single step over it before continuing.
+	if _, ok := t.dbp.FindBreakpoint(pc, false); ok {
+		if err := t.StepInstruction(); err != nil {
+			return err
+		}
+	}
+	return t.resume()
+}

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -107,22 +107,6 @@ func (t *nativeThread) singleStep() error {
 	return t.setContext(context)
 }
 
-func (t *nativeThread) resume() error {
-	var err error
-	t.dbp.execPtraceFunc(func() {
-		//TODO: Note that we are ignoring the thread we were asked to continue and are continuing the
-		//thread that we last broke on.
-		err = _ContinueDebugEvent(uint32(t.dbp.pid), uint32(t.ID), _DBG_CONTINUE)
-	})
-	return err
-}
-
-// Stopped returns whether the thread is stopped at the operating system
-// level. On windows this always returns true.
-func (t *nativeThread) Stopped() bool {
-	return true
-}
-
 func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
 	if t.dbp.exited {
 		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -586,7 +586,6 @@ func TestNextGeneral(t *testing.T) {
 }
 
 func TestNextConcurrent(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	testcases := []nextTest{
 		{8, 9},
 		{9, 10},
@@ -622,7 +621,6 @@ func TestNextConcurrent(t *testing.T) {
 }
 
 func TestNextConcurrentVariant2(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	// Just like TestNextConcurrent but instead of removing the initial breakpoint we check that when it happens is for other goroutines
 	testcases := []nextTest{
 		{8, 9},
@@ -1472,7 +1470,6 @@ func TestIssue325(t *testing.T) {
 }
 
 func TestBreakpointCounts(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	protest.AllowRecording(t)
 	withTestProcess("bpcountstest", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 12)
@@ -1504,7 +1501,6 @@ func TestBreakpointCounts(t *testing.T) {
 }
 
 func TestHardcodedBreakpointCounts(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	withTestProcess("hcbpcountstest", t, func(p *proc.Target, fixture protest.Fixture) {
 		counts := map[int64]int{}
 		for {
@@ -1716,7 +1712,6 @@ func BenchmarkLocalVariables(b *testing.B) {
 }
 
 func TestCondBreakpoint(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	protest.AllowRecording(t)
 	withTestProcess("parallel_next", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 9)
@@ -1738,7 +1733,6 @@ func TestCondBreakpoint(t *testing.T) {
 }
 
 func TestCondBreakpointError(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	protest.AllowRecording(t)
 	withTestProcess("parallel_next", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 9)
@@ -2101,7 +2095,6 @@ func TestIssue462(t *testing.T) {
 }
 
 func TestNextParked(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	protest.AllowRecording(t)
 	withTestProcess("parallel_next", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFunctionBreakpoint(p, t, "main.sayhi")
@@ -2152,7 +2145,6 @@ func TestNextParked(t *testing.T) {
 }
 
 func TestStepParked(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	protest.AllowRecording(t)
 	withTestProcess("parallel_next", t, func(p *proc.Target, fixture protest.Fixture) {
 		bp := setFunctionBreakpoint(p, t, "main.sayhi")
@@ -2481,7 +2473,6 @@ func TestStepOut(t *testing.T) {
 }
 
 func TestStepConcurrentDirect(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	skipOn(t, "broken - step concurrent", "windows", "arm64")
 	protest.AllowRecording(t)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
@@ -2546,7 +2537,6 @@ func TestStepConcurrentDirect(t *testing.T) {
 }
 
 func TestStepConcurrentPtr(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	protest.AllowRecording(t)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 24)
@@ -4633,7 +4623,6 @@ func testCallConcurrentCheckReturns(p *proc.Target, t *testing.T, gid1, gid2 int
 }
 
 func TestCallConcurrent(t *testing.T) {
-	skipOn(t, "broken", "freebsd")
 	protest.MustSupportFunctionCalls(t, testBackend)
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, fixture protest.Fixture) {
 		grp := proc.NewGroup(p)
@@ -5152,7 +5141,6 @@ func TestRequestManualStopWhileStopped(t *testing.T) {
 
 func TestStepOutPreservesGoroutine(t *testing.T) {
 	// Checks that StepOut preserves the currently selected goroutine.
-	skipOn(t, "broken", "freebsd")
 	rand.Seed(time.Now().Unix())
 	withTestProcess("issue2113", t, func(p *proc.Target, fixture protest.Fixture) {
 		assertNoError(p.Continue(), t, "Continue()")
@@ -5894,6 +5882,7 @@ func TestNilPtrDerefInBreakInstr(t *testing.T) {
 			// this is also ok
 			return
 		}
+		t.Logf("third continue")
 		assertNoError(err, t, "Continue()")
 		bp := p.CurrentThread().Breakpoint()
 		if bp != nil {

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -456,9 +456,6 @@ func TestScopePrefix(t *testing.T) {
 }
 
 func TestOnPrefix(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
-	}
 	const prefix = "\ti: "
 	test.AllowRecording(t)
 	lenient := false
@@ -520,9 +517,6 @@ func TestNoVars(t *testing.T) {
 }
 
 func TestOnPrefixLocals(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
-	}
 	const prefix = "\ti: "
 	test.AllowRecording(t)
 	withTestTerminal("goroutinestackprog", t, func(term *FakeTerminal) {

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -485,9 +485,6 @@ func TestLaunchStopOnEntry(t *testing.T) {
 
 // TestAttachStopOnEntry is like TestLaunchStopOnEntry, but with attach request.
 func TestAttachStopOnEntry(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.SkipNow()
-	}
 	runTest(t, "loopprog", func(client *daptest.Client, fixture protest.Fixture) {
 		// Start the program to attach to
 		cmd := exec.Command(fixture.Path)
@@ -3435,9 +3432,6 @@ func TestHaltPreventsAutoResume(t *testing.T) {
 // goroutine is hit the correct number of times and log points set in the
 // children goroutines produce the correct number of output events.
 func TestConcurrentBreakpointsLogPoints(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.SkipNow()
-	}
 	tests := []struct {
 		name        string
 		fixture     string
@@ -3685,9 +3679,6 @@ func TestLaunchSubstitutePath(t *testing.T) {
 // that does not exist and expects the substitutePath attribute
 // in the launch configuration to take care of the mapping.
 func TestAttachSubstitutePath(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.SkipNow()
-	}
 	if runtime.GOOS == "windows" {
 		t.Skip("test skipped on windows, see https://delve.beta.teamcity.com/project/Delve_windows for details")
 	}
@@ -4616,9 +4607,6 @@ func getPC(t *testing.T, client *daptest.Client, threadId int) (uint64, error) {
 // TestNextParked tests that we can switched selected goroutine to a parked one
 // and perform next operation on it.
 func TestNextParked(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.SkipNow()
-	}
 	runTest(t, "parallel_next", func(client *daptest.Client, fixture protest.Fixture) {
 		runDebugSessionWithBPs(t, client, "launch",
 			// Launch
@@ -4681,7 +4669,8 @@ func testNextParkedHelper(t *testing.T, client *daptest.Client, fixture protest.
 		// 2. hasn't called wg.Done yet
 		// 3. is not the currently selected goroutine
 		for _, g := range threads.Body.Threads {
-			if g.Id == se.Body.ThreadId { // Skip selected goroutine
+			if g.Id == se.Body.ThreadId || g.Id == 0 {
+				// Skip selected goroutine and goroutine 0
 				continue
 			}
 			client.StackTraceRequest(g.Id, 0, 5)
@@ -4709,9 +4698,6 @@ func testNextParkedHelper(t *testing.T, client *daptest.Client, fixture protest.
 // and checks that StepOut preserves the currently selected goroutine.
 func TestStepOutPreservesGoroutine(t *testing.T) {
 	// Checks that StepOut preserves the currently selected goroutine.
-	if runtime.GOOS == "freebsd" {
-		t.SkipNow()
-	}
 	rand.Seed(time.Now().Unix())
 	runTest(t, "issue2113", func(client *daptest.Client, fixture protest.Fixture) {
 		runDebugSessionWithBPs(t, client, "launch",
@@ -4862,9 +4848,6 @@ func TestBadAccess(t *testing.T) {
 // again will produce an error with a helpful message, and 'continue'
 // will resume the program.
 func TestNextWhileNexting(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
-	}
 	// a breakpoint triggering during a 'next' operation will interrupt 'next''
 	// Unlike the test for the terminal package, we cannot be certain
 	// of the number of breakpoints we expect to hit, since multiple
@@ -5710,9 +5693,6 @@ func TestLaunchRequestWithEnv(t *testing.T) {
 }
 
 func TestAttachRequest(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.SkipNow()
-	}
 	if runtime.GOOS == "windows" {
 		t.Skip("test skipped on windows, see https://delve.beta.teamcity.com/project/Delve_windows for details")
 	}
@@ -6638,9 +6618,6 @@ func TestAttachRemoteToDlvLaunchHaltedStopOnEntry(t *testing.T) {
 }
 
 func TestAttachRemoteToDlvAttachHaltedStopOnEntry(t *testing.T) {
-	if runtime.GOOS == "freebsd" || runtime.GOOS == "windows" {
-		t.SkipNow()
-	}
 	cmd, dbg := attachDebuggerWithTargetHalted(t, "http_server")
 	runTestWithDebugger(t, dbg, func(client *daptest.Client) {
 		client.AttachRequest(map[string]interface{}{"mode": "remote", "stopOnEntry": true})

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -985,9 +985,6 @@ func Test1NegativeStackDepthBug(t *testing.T) {
 }
 
 func Test1ClientServer_CondBreakpoint(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
-	}
 	withTestClient1("parallel_next", t, func(c *rpc1.RPCClient) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sayhi", Line: 1})
 		assertNoError(err, t, "CreateBreakpoint()")

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1496,9 +1496,6 @@ func TestNegativeStackDepthBug(t *testing.T) {
 }
 
 func TestClientServer_CondBreakpoint(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		t.Skip("test is not valid on FreeBSD")
-	}
 	protest.AllowRecording(t)
 	withTestClient2("parallel_next", t, func(c service.Client) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.sayhi", Line: 1})


### PR DESCRIPTION
* use PT_SUSPEND/PT_RESUME to control running threads in
resume/stop/singleStep
* change manual stop signal from SIGTRAP to SIGSTOP to make manual stop
handling simpler
* change (*nativeProcess).trapWaitInternal to suspend newly created
threads when we are stepping a thread
* change (*nativeProcess).trapWaitInternal to handle some unhandled
stop events
* remove misleading (*nativeProcess).waitFast which does not do
anything different from the normal wait variant
* rewrite (*nativeProcess).stop to only set breakpoints for threads of
which we have received SIGTRAP
* rewrite (*nativeThread).singleStep to actually execute a single
instruction and to properly route signals
