### PR TITLE
proc, dwarf: merge variable declaration with assignment on next line

### DIFF
--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -189,8 +189,7 @@ func (lineInfo *DebugLineInfo) AllPCsBetween(begin, end uint64, excludeFile stri
 // copy returns a copy of this state machine, running the returned state
 // machine will not affect sm.
 func (sm *StateMachine) copy() *StateMachine {
-	var r StateMachine
-	r = *sm
+	r := *sm
 	r.buf = bytes.NewBuffer(sm.buf.Bytes())
 	return &r
 }

--- a/pkg/proc/core/minidump/minidump.go
+++ b/pkg/proc/core/minidump/minidump.go
@@ -421,8 +421,7 @@ func Open(path string, logfn func(fmt string, args ...interface{})) (*Minidump, 
 func decodeUTF16(in []byte) string {
 	utf16encoded := []uint16{}
 	for i := 0; i+1 < len(in); i += 2 {
-		var ch uint16
-		ch = uint16(in[i]) + uint16(in[i+1])<<8
+		ch := uint16(in[i]) + uint16(in[i+1])<<8
 		utf16encoded = append(utf16encoded, ch)
 	}
 	s := string(utf16.Decode(utf16encoded))

--- a/pkg/proc/winutil/regs_amd64_arch.go
+++ b/pkg/proc/winutil/regs_amd64_arch.go
@@ -171,8 +171,7 @@ func (r *AMD64Registers) GAddr() (uint64, bool) {
 
 // Copy returns a copy of these registers that is guaranteed not to change.
 func (r *AMD64Registers) Copy() (proc.Registers, error) {
-	var rr AMD64Registers
-	rr = *r
+	rr := *r
 	rr.Context = NewAMD64CONTEXT()
 	*(rr.Context) = *(r.Context)
 	rr.fltSave = &rr.Context.FltSave


### PR DESCRIPTION
This PR refactors code in `proc` and `dwarf` by merging variables declaration with assignments on the next line.