### PR TITLE
proc: Fix typos in comments

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1312,7 +1312,7 @@ func (bi *BinaryInfo) openSeparateDebugInfo(image *Image, exe *elf.File, debugIn
 	}
 
 	if debugFilePath == "" && len(bi.BuildID) > 2 {
-		// Previous verrsions of delve looked for the build id in every debug info
+		// Previous versions of delve looked for the build id in every debug info
 		// directory that contained the build-id substring. This behavior deviates
 		// from the ones specified by GDB but we keep it for backwards compatibility.
 		find(func(dir string) bool { return strings.Contains(dir, "build-id") }, fmt.Sprintf("%s/%s.debug", bi.BuildID[:2], bi.BuildID[2:]))
@@ -1543,7 +1543,7 @@ func (bi *BinaryInfo) setGStructOffsetElf(image *Image, exe *elf.File, wg *sync.
 	//   emitting runtime.tlsg, a TLS symbol, which is relocated to the chosen
 	//   offset in libc's TLS block.
 	// - On ARM64 (but really, any architecture other than i386 and 86x64) the
-	//   offset is calculate using runtime.tls_g and the formula is different.
+	//   offset is calculated using runtime.tls_g and the formula is different.
 
 	var tls *elf.Prog
 	for _, prog := range exe.Progs {
@@ -2153,7 +2153,7 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugInfoBytes, debugLineB
 	}
 }
 
-// LookupGenericFunc returns a map that allows searching for instantiations of generic function by specificying a function name without type parameters.
+// LookupGenericFunc returns a map that allows searching for instantiations of generic function by specifying a function name without type parameters.
 // For example the key "pkg.(*Receiver).Amethod" will find all instantiations of Amethod:
 //   - pkg.(*Receiver[.shape.int]).Amethod
 //   - pkg.(*Receiver[.shape.*uint8]).Amethod

--- a/pkg/proc/core/minidump/minidump.go
+++ b/pkg/proc/core/minidump/minidump.go
@@ -193,7 +193,7 @@ func (m *MemoryRange) ReadMemory(buf []byte, addr uint64) (int, error) {
 	return len(buf), nil
 }
 
-// MemoryInfo reprents an entry in the MemoryInfoList stream.
+// MemoryInfo represents an entry in the MemoryInfoList stream.
 // See: https://docs.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_info_list
 type MemoryInfo struct {
 	Addr       uint64
@@ -473,7 +473,7 @@ func readMinidumpHeader(mdmp *Minidump, buf *minidumpBuf) {
 	mdmp.Flags = FileFlags(buf.u64())
 }
 
-// readDirectory reads the list of streams (i.e. the minidum "directory")
+// readDirectory reads the list of streams (i.e. the minidump "directory")
 func readDirectory(mdmp *Minidump, buf *minidumpBuf) {
 	buf.off = int(mdmp.streamOff)
 

--- a/pkg/proc/dump.go
+++ b/pkg/proc/dump.go
@@ -242,7 +242,7 @@ func (t *Target) dumpThreadNotes(notes []elfwriter.Note, state *DumpState, th Th
 	// - register_name_len (2 bytes)
 	// - register_name (register_name_len bytes)
 	// - register_data_len (2 bytes)
-	// - register_data (regiter_data_len bytes)
+	// - register_data (register_data_len bytes)
 
 	buf := new(bytes.Buffer)
 	_ = binary.Write(buf, binary.LittleEndian, uint64(th.ThreadID()))

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -615,7 +615,7 @@ func funcCallCopyOneArg(scope *EvalScope, fncall *functionCallState, actualArg *
 		}
 	}
 
-	//TODO(aarzilli): autmoatic wrapping in interfaces for cases not handled
+	//TODO(aarzilli): automatic wrapping in interfaces for cases not handled
 	// by convertToEface.
 
 	var formalArgVar *Variable

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1015,7 +1015,7 @@ func (p *gdbProcess) handleThreadSignals(cctx *proc.ContinueOnceContext, trapthr
 
 	if p.getCtrlC(cctx) || cctx.GetManualStopRequested() {
 		// If we request an interrupt and a target thread simultaneously receives
-		// an unrelated singal debugserver will discard our interrupt request and
+		// an unrelated signal debugserver will discard our interrupt request and
 		// report the signal but we should stop anyway.
 		shouldStop = true
 	}
@@ -1891,7 +1891,7 @@ func (t *gdbThread) clearBreakpointState() {
 
 // SetCurrentBreakpoint will find and set the threads current breakpoint.
 func (t *gdbThread) SetCurrentBreakpoint(adjustPC bool) error {
-	// adjustPC is ignored, it is the stub's responsibiility to set the PC
+	// adjustPC is ignored, it is the stub's responsibility to set the PC
 	// address correctly after hitting a breakpoint.
 	t.CurrentBreakpoint.Clear()
 	if t.watchAddr > 0 {
@@ -1967,7 +1967,7 @@ func (r *gdbRegisters) FloatLoadError() error {
 
 // SetPC will set the value of the PC register to the given value.
 func (t *gdbThread) setPC(pc uint64) error {
-	_, _ = t.Registers() // Registes must be loaded first
+	_, _ = t.Registers() // Registers must be loaded first
 	t.regs.setPC(pc)
 	if t.p.gcmdok {
 		return t.p.conn.writeRegisters(t.strID, t.regs.buf)

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -81,7 +81,7 @@ func isProtocolErrorUnsupported(err error) bool {
 	return gdberr.code == ""
 }
 
-// GdbMalformedThreadIDError is returned when a the stub responds with a
+// GdbMalformedThreadIDError is returned when the stub responds with a
 // thread ID that does not conform with the Gdb Remote Serial Protocol
 // specification.
 type GdbMalformedThreadIDError struct {

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -459,7 +459,7 @@ func status(pid int, comm string) rune {
 		state rune
 	)
 
-	// The second field of /proc/pid/stat is the name of the task in parenthesis.
+	// The second field of /proc/pid/stat is the name of the task in parentheses.
 	// The name of the task is the base name of the executable for this process limited to TASK_COMM_LEN characters
 	// Since both parenthesis and spaces can appear inside the name of the task and no escaping happens we need to read the name of the executable first
 	// See: include/linux/sched.c:315 and include/linux/sched.c:1510

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -46,7 +46,7 @@ func (t *nativeThread) singleStep() error {
 	// runtime it will have a suspend count greater than 1 and to actually take
 	// a single step we have to resume it multiple times here.
 	// We keep a counter of how many times it was suspended so that after
-	// single-stepping we can re-suspend it the corrent number of times.
+	// single-stepping we can re-suspend it the correct number of times.
 	for {
 		n, err := _ResumeThread(t.os.hThread)
 		if err != nil {

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -623,7 +623,7 @@ func (d *Defer) load() {
 }
 
 // errSPDecreased is used when (*Defer).Next detects a corrupted linked
-// list, specifically when after followin a link pointer the value of SP
+// list, specifically when after following a link pointer the value of SP
 // decreases rather than increasing or staying the same (the defer list is a
 // FIFO list, nodes further down the list have been added by function calls
 // further down the call stack and therefore the SP should always increase).

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -339,7 +339,7 @@ func (p *Target) SwitchThread(tid int) error {
 	return fmt.Errorf("thread %d does not exist", tid)
 }
 
-// detach will detach the target from the underylying process.
+// detach will detach the target from the underlying process.
 // This means the debugger will no longer receive events from the process
 // we were previously debugging.
 // If kill is true then the process will be killed when we detach.

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// TargetGroup reperesents a group of target processes being debugged that
+// TargetGroup represents a group of target processes being debugged that
 // will be resumed and stopped simultaneously.
 // New targets are automatically added to the group if exec catching is
 // enabled and the backend supports it, otherwise the group will always

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -97,7 +97,7 @@ func (ctxt *loadDebugInfoMapsContext) lookupAbstractOrigin(bi *BinaryInfo, off d
 //     the name of the type, and then the type's name is used to look up
 //     debug_info
 //   - After go1.11 the runtimeTypeToDIE map is used to look up the address of
-//     the type and map it drectly to a DIE.
+//     the type and map it directly to a DIE.
 func runtimeTypeToDIE(_type *Variable, dataAddr uint64) (typ godwarf.Type, kind int64, err error) {
 	bi := _type.bi
 

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1392,7 +1392,7 @@ func (v *Variable) loadValueInternal(recurseLevel int, cfg LoadConfig) {
 
 // convertToEface converts srcv into an "interface {}" and writes it to
 // dstv.
-// Dstv must be a variable of type "inteface {}" and srcv must either be an
+// Dstv must be a variable of type "interface {}" and srcv must either be an
 // interface or a pointer shaped variable (map, channel, pointer or struct
 // containing a single pointer)
 func convertToEface(srcv, dstv *Variable) error {


### PR DESCRIPTION
This PR fixes typos in the comments in `proc`.