### PR TITLE
Add config options for tab printing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,6 +77,9 @@ type Config struct {
 	// Source list comment color, as a terminal escape sequence.
 	SourceListCommentColor string `yaml:"source-list-comment-color"`
 
+	// Source list tab color, as a terminal escape sequence.
+	SourceListTabColor string `yaml:"source-list-tab-color"`
+
 	// number of lines to list above and below cursor when printfile() is
 	// called (i.e. when execution stops, listCommand is used, etc)
 	SourceListLineCount *int `yaml:"source-list-line-count,omitempty"`
@@ -94,6 +97,11 @@ type Config struct {
 	//  - default (or the empty string): use disassembly for step-instruction,
 	//    source for everything else.
 	Position string `yaml:"position"`
+
+	// Tab changes what is printed when a '\t' is encountered in source code.
+	// This can be used to shorten the tabstop (e.g. "  ") or to print a more
+	// visual indent (e.g. ">__ ").
+	Tab string `yaml:"tab"`
 }
 
 func (c *Config) GetSourceListLineCount() int {
@@ -252,6 +260,10 @@ func writeDefaultConfig(f *os.File) error {
 # source-list-number-color: "\x1b[0m"
 # source-list-comment-color: "\x1b[95m"
 # source-list-arrow-color: "\x1b[93m"
+# source-list-tab-color: "\x1b[90m"
+
+# Uncomment to change what is printed instead of '\t'.
+# tab: "... "
 
 # Uncomment to change the number of lines printed above and below cursor when
 # listing source code.

--- a/pkg/terminal/colorize/colorize_test.go
+++ b/pkg/terminal/colorize/colorize_test.go
@@ -58,11 +58,11 @@ func TestPrint(t *testing.T) {
 	// ensures the AST analysis behaves as expected,
 	// please update `printed` if `terminal/colorize.Print` changes.
 	buf := &bytes.Buffer{}
-	colorize.Print(buf, "main.go", bytes.NewBuffer(dat), 1, 30, 10, colors)
+	colorize.Print(buf, "main.go", bytes.NewBuffer(dat), 1, 30, 10, colors, "")
 
 	const printToStdout = false
 	if printToStdout {
-		colorize.Print(os.Stdout, "main.go", bytes.NewBuffer(dat), 1, 30, 10, colors)
+		colorize.Print(os.Stdout, "main.go", bytes.NewBuffer(dat), 1, 30, 10, colors, "")
 	}
 
 	b := bytes.ReplaceAll(buf.Bytes(), []byte("\r\n"), []byte("\n"))

--- a/pkg/terminal/config.go
+++ b/pkg/terminal/config.go
@@ -25,7 +25,7 @@ func configureCmd(t *Term, ctx callContext, args string) error {
 		if t.client != nil { // only happens in tests
 			lcfg := t.loadConfig()
 			t.client.SetReturnValuesLoadConfig(&lcfg)
-			t.updateColorScheme()
+			t.updateConfig()
 		}
 		return nil
 	}

--- a/pkg/terminal/out.go
+++ b/pkg/terminal/out.go
@@ -19,6 +19,7 @@ type transcriptWriter struct {
 	file         *bufio.Writer
 	fh           io.Closer
 	colorEscapes map[colorize.Style]string
+	altTabString string
 }
 
 func (w *transcriptWriter) Write(p []byte) (nn int, err error) {
@@ -38,12 +39,12 @@ func (w *transcriptWriter) Write(p []byte) (nn int, err error) {
 func (w *transcriptWriter) ColorizePrint(path string, reader io.ReadSeeker, startLine, endLine, arrowLine int) error {
 	var err error
 	if !w.fileOnly {
-		err = colorize.Print(w.pw.w, path, reader, startLine, endLine, arrowLine, w.colorEscapes)
+		err = colorize.Print(w.pw.w, path, reader, startLine, endLine, arrowLine, w.colorEscapes, w.altTabString)
 	}
 	if err == nil {
 		if w.file != nil {
 			reader.Seek(0, io.SeekStart)
-			return colorize.Print(w.file, path, reader, startLine, endLine, arrowLine, nil)
+			return colorize.Print(w.file, path, reader, startLine, endLine, arrowLine, nil, w.altTabString)
 		}
 	}
 	return err

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -108,8 +108,9 @@ func New(client service.Client, conf *config.Config) *Term {
 		t.stdout.pw = &pagingWriter{w: getColorableWriter()}
 		t.stdout.colorEscapes = make(map[colorize.Style]string)
 		t.stdout.colorEscapes[colorize.NormalStyle] = terminalResetEscapeCode
-		t.updateColorScheme()
 	}
+
+	t.updateConfig()
 
 	if client != nil {
 		lcfg := t.loadConfig()
@@ -118,6 +119,12 @@ func New(client service.Client, conf *config.Config) *Term {
 
 	t.starlarkEnv = starbind.New(starlarkContext{t}, t.stdout)
 	return t
+}
+
+func (t *Term) updateConfig() {
+	// These are always called together.
+	t.updateColorScheme()
+	t.updateTab()
 }
 
 func (t *Term) updateColorScheme() {
@@ -137,6 +144,7 @@ func (t *Term) updateColorScheme() {
 	t.stdout.colorEscapes[colorize.NumberStyle] = conf.SourceListNumberColor
 	t.stdout.colorEscapes[colorize.CommentStyle] = wd(conf.SourceListCommentColor, ansiBrMagenta)
 	t.stdout.colorEscapes[colorize.ArrowStyle] = wd(conf.SourceListArrowColor, ansiYellow)
+	t.stdout.colorEscapes[colorize.TabStyle] = wd(conf.SourceListTabColor, ansiBrBlack)
 	switch x := conf.SourceListLineColor.(type) {
 	case string:
 		t.stdout.colorEscapes[colorize.LineNoStyle] = x
@@ -148,6 +156,10 @@ func (t *Term) updateColorScheme() {
 	case nil:
 		t.stdout.colorEscapes[colorize.LineNoStyle] = fmt.Sprintf(terminalHighlightEscapeCode, ansiBlue)
 	}
+}
+
+func (t *Term) updateTab() {
+	t.stdout.altTabString = t.conf.Tab
 }
 
 func (t *Term) SetTraceNonInteractive() {


### PR DESCRIPTION
New config "tab" allows user to set a string instead of literal tab (e.g. "... ").

New config "source-list-tab-color" allows that string to be colored.

This builds on top of the `updateColorScheme` change  #3240