### PR TITLE
fix stripping DYLD_INSERT_LIBRARIES on macOS

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -553,7 +553,7 @@ func LLDBLaunch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs [
 		// This is unlike other protected processes, where they just strip it out.
 		env := make([]string, 0, len(process.Env))
 		for _, v := range process.Env {
-			if !(v == "DYLD_INSERT_LIBRARIES") {
+			if !strings.HasPrefix(v, "DYLD_INSERT_LIBRARIES") {
 				env = append(env, v)
 			}
 		}


### PR DESCRIPTION
I just noticed that my fix actually didn't work since I had ill assumption (didn't notice) that the code isn't iterating keys, but `key=value` format, hence this never did anything (I tested the previous iteration where it was HasPrefix and probably didn't test the new one, sorry for that)

https://github.com/go-delve/delve/pull/3181