### PR TITLE
pkg/terminal: use default for Y/n empty response

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1754,7 +1754,7 @@ func setBreakpoint(t *Term, ctx callContext, tracepoint bool, argstr string) ([]
 	if findLocErr != nil && shouldAskToSuspendBreakpoint(t) {
 		fmt.Fprintf(os.Stderr, "Command failed: %s\n", findLocErr.Error())
 		findLocErr = nil
-		answer, err := yesno(t.line, "Set a suspended breakpoint (Delve will try to set this breakpoint when a plugin is loaded) [Y/n]?")
+		answer, err := yesno(t.line, "Set a suspended breakpoint (Delve will try to set this breakpoint when a plugin is loaded) [Y/n]?", "yes")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -420,13 +420,16 @@ func (t *Term) promptForInput() (string, error) {
 	return l, nil
 }
 
-func yesno(line *liner.State, question string) (bool, error) {
+func yesno(line *liner.State, question, defaultAnswer string) (bool, error) {
 	for {
 		answer, err := line.Prompt(question)
 		if err != nil {
 			return false, err
 		}
 		answer = strings.ToLower(strings.TrimSpace(answer))
+		if answer == "" {
+			answer = defaultAnswer
+		}
 		switch answer {
 		case "n", "no":
 			return false, nil
@@ -457,7 +460,7 @@ func (t *Term) handleExit() (int, error) {
 	if err != nil {
 		if isErrProcessExited(err) {
 			if t.client.IsMulticlient() {
-				answer, err := yesno(t.line, "Remote process has exited. Would you like to kill the headless instance? [Y/n] ")
+				answer, err := yesno(t.line, "Remote process has exited. Would you like to kill the headless instance? [Y/n] ", "yes")
 				if err != nil {
 					return 2, io.EOF
 				}
@@ -483,7 +486,7 @@ func (t *Term) handleExit() (int, error) {
 
 		doDetach := true
 		if t.client.IsMulticlient() {
-			answer, err := yesno(t.line, "Would you like to kill the headless instance? [Y/n] ")
+			answer, err := yesno(t.line, "Would you like to kill the headless instance? [Y/n] ", "yes")
 			if err != nil {
 				return 2, io.EOF
 			}
@@ -493,7 +496,7 @@ func (t *Term) handleExit() (int, error) {
 		if doDetach {
 			kill := true
 			if t.client.AttachedToExistingProcess() {
-				answer, err := yesno(t.line, "Would you like to kill the process? [Y/n] ")
+				answer, err := yesno(t.line, "Would you like to kill the process? [Y/n] ", "yes")
 				if err != nil {
 					return 2, io.EOF
 				}


### PR DESCRIPTION
The typical convention with `[Y/n]` type command line questions is that the capitalized letter represents the default if the user simply hits "enter" instead of typing an actual response. This patch fixes our implementation to use the implied default response.