### PR TITLE
pkg/proc: do not check decl line for FunctionArguments

### DIFF
--- a/_fixtures/traceprog.go
+++ b/_fixtures/traceprog.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func callme(i int) int {
+	return i * i
+}
+
+func main() {
+	j := 0
+	j += callme(2)
+	fmt.Println(j)
+}

--- a/pkg/dwarf/line/line_parser.go
+++ b/pkg/dwarf/line/line_parser.go
@@ -81,6 +81,7 @@ func ParseAll(data []byte, debugLineStr []byte, logfn func(string, ...interface{
 // DW_AT_comp_dir attribute of the associated compile unit.
 func Parse(compdir string, buf *bytes.Buffer, debugLineStr []byte, logfn func(string, ...interface{}), staticBase uint64, normalizeBackslash bool, ptrSize int) *DebugLineInfo {
 	dbl := new(DebugLineInfo)
+	dbl.endSeqIsValid = true
 	dbl.Logf = logfn
 	if logfn == nil {
 		dbl.Logf = func(string, ...interface{}) {}

--- a/pkg/dwarf/line/line_parser.go
+++ b/pkg/dwarf/line/line_parser.go
@@ -81,7 +81,6 @@ func ParseAll(data []byte, debugLineStr []byte, logfn func(string, ...interface{
 // DW_AT_comp_dir attribute of the associated compile unit.
 func Parse(compdir string, buf *bytes.Buffer, debugLineStr []byte, logfn func(string, ...interface{}), staticBase uint64, normalizeBackslash bool, ptrSize int) *DebugLineInfo {
 	dbl := new(DebugLineInfo)
-	dbl.endSeqIsValid = true
 	dbl.Logf = logfn
 	if logfn == nil {
 		dbl.Logf = func(string, ...interface{}) {}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -474,7 +474,7 @@ func (scope *EvalScope) LocalVariables(cfg LoadConfig) ([]*Variable, error) {
 
 // FunctionArguments returns the name, value, and type of all current function arguments.
 func (scope *EvalScope) FunctionArguments(cfg LoadConfig) ([]*Variable, error) {
-	vars, err := scope.Locals(0)
+	vars, err := scope.Locals(localsNoDeclLineCheck)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This essentially reverts #2235.

Fixes a bug where we cannot get locals (including arguments and return values) from a given scope because the line number state machine ends up in an invalid state because of this parameter being set to false.

Also fixes some disassembly output:

Before:

```
TEXT main.callme(SB) /home/deparker/Code/delve/localtests/trace/main.go
=>      main.go:5       0x49c8a0*       4883ec10                sub rsp, 0x10
        main.go:5       0x49c8a4        48896c2408              mov qword ptr [rsp+0x8], rbp
        main.go:5       0x49c8a9        488d6c2408              lea rbp, ptr [rsp+0x8]
        main.go:5       0x49c8ae        4889442418              mov qword ptr [rsp+0x18], rax
        main.go:5       0x49c8b3        48c7042400000000        mov qword ptr [rsp], 0x0
        main.go:6       0x49c8bb        480fafc0                imul rax, rax
        main.go:6       0x49c8bf        48890424                mov qword ptr [rsp], rax
        .:0             0x49c8c3        488b6c2408              mov rbp, qword ptr [rsp+0x8]
        .:0             0x49c8c8        4883c410                add rsp, 0x10
        .:0             0x49c8cc        c3                      ret
```

After:

```
TEXT main.callme(SB) /home/deparker/Code/delve/localtests/trace/main.go
=>      main.go:5       0x49c8a0        4883ec10                sub rsp, 0x10
        main.go:5       0x49c8a4        48896c2408              mov qword ptr [rsp+0x8], rbp
        main.go:5       0x49c8a9        488d6c2408              lea rbp, ptr [rsp+0x8]
        main.go:5       0x49c8ae        4889442418              mov qword ptr [rsp+0x18], rax
        main.go:5       0x49c8b3        48c7042400000000        mov qword ptr [rsp], 0x0
        main.go:6       0x49c8bb        480fafc0                imul rax, rax
        main.go:6       0x49c8bf        48890424                mov qword ptr [rsp], rax
        main.go:6       0x49c8c3        488b6c2408              mov rbp, qword ptr [rsp+0x8]
        main.go:6       0x49c8c8        4883c410                add rsp, 0x10
        main.go:6       0x49c8cc        c3                      ret
```