### PR TITLE
godwarf: Allow extracting a DWARF entry's field

### DIFF
--- a/pkg/dwarf/godwarf/tree.go
+++ b/pkg/dwarf/godwarf/tree.go
@@ -11,14 +11,22 @@ import (
 // entry specified by DW_AT_abstract_origin will be searched recursively.
 type Entry interface {
 	Val(dwarf.Attr) interface{}
+	AttrField(dwarf.Attr) *dwarf.Field
 }
 
 type compositeEntry []*dwarf.Entry
 
 func (ce compositeEntry) Val(attr dwarf.Attr) interface{} {
+	if f := ce.AttrField(attr); f != nil {
+		return f.Val
+	}
+	return nil
+}
+
+func (ce compositeEntry) AttrField(a dwarf.Attr) *dwarf.Field {
 	for _, e := range ce {
-		if r := e.Val(attr); r != nil {
-			return r
+		if f := e.AttrField(a); f != nil {
+			return f
 		}
 	}
 	return nil

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -1248,9 +1248,17 @@ func debugCallProtocolReg(archName string, version int) (uint64, bool) {
 	}
 }
 
-type fakeEntry map[dwarf.Attr]interface{}
+type fakeEntry map[dwarf.Attr]*dwarf.Field
 
 func (e fakeEntry) Val(attr dwarf.Attr) interface{} {
+	if e[attr] == nil {
+		return nil
+	}
+
+	return e[attr].Val
+}
+
+func (e fakeEntry) AttrField(attr dwarf.Attr) *dwarf.Field {
 	return e[attr]
 }
 
@@ -1273,11 +1281,11 @@ func regabiMallocgcWorkaround(bi *BinaryInfo) ([]*godwarf.Tree, error) {
 		if err1 != nil {
 			return nil
 		}
-		var e fakeEntry = map[dwarf.Attr]interface{}{
-			dwarf.AttrName:     name,
-			dwarf.AttrType:     typ.Common().Offset,
-			dwarf.AttrLocation: []byte{byte(op.DW_OP_reg0) + byte(reg)},
-			dwarf.AttrVarParam: isret,
+		var e fakeEntry = map[dwarf.Attr]*dwarf.Field{
+			dwarf.AttrName:     &dwarf.Field{Attr: dwarf.AttrName, Val: name, Class: dwarf.ClassString},
+			dwarf.AttrType:     &dwarf.Field{Attr: dwarf.AttrType, Val: typ.Common().Offset, Class: dwarf.ClassReference},
+			dwarf.AttrLocation: &dwarf.Field{Attr: dwarf.AttrLocation, Val: []byte{byte(op.DW_OP_reg0) + byte(reg)}, Class: dwarf.ClassBlock},
+			dwarf.AttrVarParam: &dwarf.Field{Attr: dwarf.AttrVarParam, Val: isret, Class: dwarf.ClassFlag},
 		}
 
 		return &godwarf.Tree{


### PR DESCRIPTION
Previously it was only possible to extract a value of type `any` using an attribute name. This poses challenges when fields are allowed to have different classes, and it is ambiguous how to handle them.

I for example am seeing a case where a subroutine has a `DW_AT_name` that is not of class string, but string alt, therefore requiring a lookup in the `.debug_str` table. (https://dwarfstd.org/ShowIssue.php?issue=120604.1)

Being able to extract the whole field is better as we can decide what to do based on the class of the field and not guess based on the data type in Go.