### PR TITLE
_scripts: fix log.Printf format specifier

### DIFF
--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -304,7 +304,7 @@ func buildFlags() []string {
 	var ldFlags string
 	buildSHA, err := getBuildSHA()
 	if err != nil {
-		log.Printf("error getting build SHA via git: %w", err)
+		log.Printf("error getting build SHA via git: %v", err)
 	} else {
 		ldFlags = "-X main.Build=" + buildSHA
 	}


### PR DESCRIPTION
This PR replaces `%w` with `%v` in `make.go` because `%w` can be used only in [`fmt.Errorf`](https://pkg.go.dev/fmt#Errorf).