### PR TITLE
cmd/dlv: fix exit status for trace subcommand 

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -732,6 +732,9 @@ func traceCmd(cmd *cobra.Command, args []string) {
 		err = cmds.Call("continue", t)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
+			if strings.Contains(err.Error(), "exited") {
+				return 0
+			}
 			return 1
 		}
 		return 0

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -732,10 +732,9 @@ func traceCmd(cmd *cobra.Command, args []string) {
 		err = cmds.Call("continue", t)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			if strings.Contains(err.Error(), "exited") {
-				return 0
+			if !strings.Contains(err.Error(), "exited") {
+				return 1
 			}
-			return 1
 		}
 		return 0
 	}()

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1033,7 +1033,7 @@ func TestTrace(t *testing.T) {
 	if !bytes.Contains(output, expected) {
 		t.Fatalf("expected:\n%s\ngot:\n%s", string(expected), string(output))
 	}
-	cmd.Wait()
+	assertNoError(cmd.Wait(), t, "cmd.Wait()")
 }
 
 func TestTraceMultipleGoroutines(t *testing.T) {


### PR DESCRIPTION
We currently return an error when the command exits because a process
exited error is always returned. Detect this like we do in other code
paths to return a 0 exit code instead of nonzero which indicates the
command itself failed and can confuse other tools.