### PR TITLE
pkg/proc,service/test: refactor to use strings.ReplaceAll

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1899,8 +1899,8 @@ func (bi *BinaryInfo) macOSDebugFrameBugWorkaround() {
 
 // Do not call this function directly it isn't able to deal correctly with package paths
 func (bi *BinaryInfo) findType(name string) (godwarf.Type, error) {
-	name = strings.Replace(name, "interface{", "interface {", -1)
-	name = strings.Replace(name, "struct{", "struct {", -1)
+	name = strings.ReplaceAll(name, "interface{", "interface {")
+	name = strings.ReplaceAll(name, "struct{", "struct {")
 	ref, found := bi.types[name]
 	if !found {
 		return nil, reader.ErrTypeNotFound
@@ -2096,7 +2096,7 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugInfoBytes, debugLineB
 			}
 			gopkg, _ := entry.Val(godwarf.AttrGoPackageName).(string)
 			if cu.isgo && gopkg != "" {
-				bi.PackageMap[gopkg] = append(bi.PackageMap[gopkg], escapePackagePath(strings.Replace(cu.name, "\\", "/", -1)))
+				bi.PackageMap[gopkg] = append(bi.PackageMap[gopkg], escapePackagePath(strings.ReplaceAll(cu.name, "\\", "/")))
 			}
 			image.compileUnits = append(image.compileUnits, cu)
 			if entry.Children {
@@ -2515,7 +2515,7 @@ func escapePackagePath(pkg string) string {
 	if slash < 0 {
 		slash = 0
 	}
-	return pkg[:slash] + strings.Replace(pkg[slash:], ".", "%2e", -1)
+	return pkg[:slash] + strings.ReplaceAll(pkg[slash:], ".", "%2e")
 }
 
 // Looks up symbol (either functions or global variables) at address addr.
@@ -2566,7 +2566,7 @@ func (bi *BinaryInfo) ListPackagesBuildInfo(includeFiles bool) []*PackageBuildIn
 			continue
 		}
 
-		ip := strings.Replace(cu.name, "\\", "/", -1)
+		ip := strings.ReplaceAll(cu.name, "\\", "/")
 		if _, ok := m[ip]; !ok {
 			path := cu.lineInfo.FirstFile()
 			if ext := filepath.Ext(path); ext != ".go" && ext != ".s" {

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -146,7 +146,7 @@ func initialize(dbp *nativeProcess) error {
 	comm, _ := C.find_command_name(C.int(dbp.pid))
 	defer C.free(unsafe.Pointer(comm))
 	comm_str := C.GoString(comm)
-	dbp.os.comm = strings.Replace(string(comm_str), "%", "%%", -1)
+	dbp.os.comm = strings.ReplaceAll(string(comm_str), "%", "%%")
 	return nil
 }
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4795,7 +4795,7 @@ func TestListPackagesBuildInfo(t *testing.T) {
 			if fidx < 0 {
 				continue
 			}
-			if !strings.HasSuffix(strings.Replace(pkg.DirectoryPath, "\\", "/", -1), pkg.ImportPath[fidx:]) {
+			if !strings.HasSuffix(strings.ReplaceAll(pkg.DirectoryPath, "\\", "/"), pkg.ImportPath[fidx:]) {
 				t.Errorf("unexpected suffix: %q %q", pkg.ImportPath, pkg.DirectoryPath)
 			}
 		}
@@ -5872,7 +5872,7 @@ func TestNilPtrDerefInBreakInstr(t *testing.T) {
 
 	withTestProcess("asmnilptr/", t, func(p *proc.Target, fixture protest.Fixture) {
 		f := filepath.Join(fixture.BuildDir, asmfile)
-		f = strings.Replace(f, "\\", "/", -1)
+		f = strings.ReplaceAll(f, "\\", "/")
 		setFileBreakpoint(p, t, f, 5)
 		t.Logf("first continue")
 		assertNoError(p.Continue(), t, "Continue()")

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -293,7 +293,7 @@ func (varCheck *varCheck) checkInScope(line int, scope *proc.EvalScope, t *testi
 
 func (varCheck *varCheck) check(line int, v *proc.Variable, t *testing.T, ctxt string) {
 	typ := v.DwarfType.String()
-	typ = strings.Replace(typ, " ", "", -1)
+	typ = strings.ReplaceAll(typ, " ", "")
 	if typ != varCheck.typ {
 		t.Errorf("%d: wrong type for %s (%s), got %s, expected %s", line, v.Name, ctxt, typ, varCheck.typ)
 	}

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -195,7 +195,7 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	source = filepath.ToSlash(source)
 	sympath, err := filepath.EvalSymlinks(source)
 	if err == nil {
-		source = strings.Replace(sympath, "\\", "/", -1)
+		source = strings.ReplaceAll(sympath, "\\", "/")
 	}
 
 	absdir, _ := filepath.Abs(dir)

--- a/service/test/common_test.go
+++ b/service/test/common_test.go
@@ -56,7 +56,7 @@ func testProgPath(t *testing.T, name string) string {
 	}
 	sympath, err := filepath.EvalSymlinks(fp)
 	if err == nil {
-		fp = strings.Replace(sympath, "\\", "/", -1)
+		fp = strings.ReplaceAll(sympath, "\\", "/")
 	}
 	return fp
 }


### PR DESCRIPTION
Use [strings.ReplaceAll](https://pkg.go.dev/strings#ReplaceAll) instead of `strings.Replace` with `-1` as the last argument.

`strings.ReplaceAll` available since go 1.12. But the code already has `ReplaceAll` occurrences in `pkg/dwarf/line/line_parser.go`, `pkg/proc/native/proc_linux.go`, `pkg/terminal/colorize/colorize_test.go`. So, delve supports go version >= 1.12 and PR changes won't break anything.