### PR TITLE
*: remove some code for Go 1.12 or earlier

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2278,19 +2278,11 @@ func TestNextPanicAndDirectCall(t *testing.T) {
 	// Next should not step into a deferred function if it is called
 	// directly, only if it is called through a panic or a deferreturn.
 	// Here we test the case where the function is called by a panic
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
-		testseq("defercall", contNext, []nextTest{
-			{15, 16},
-			{16, 17},
-			{17, 18},
-			{18, 6}}, "main.callAndPanic2", t)
-	} else {
-		testseq("defercall", contNext, []nextTest{
-			{15, 16},
-			{16, 17},
-			{17, 18},
-			{18, 5}}, "main.callAndPanic2", t)
-	}
+	testseq("defercall", contNext, []nextTest{
+		{15, 16},
+		{16, 17},
+		{17, 18},
+		{18, 6}}, "main.callAndPanic2", t)
 }
 
 func TestStepCall(t *testing.T) {
@@ -2321,71 +2313,26 @@ func TestStepCallPtr(t *testing.T) {
 func TestStepReturnAndPanic(t *testing.T) {
 	// Tests that Step works correctly when returning from functions
 	// and when a deferred function is called when panic'ing.
-	switch {
-	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 11):
-		testseq("defercall", contStep, []nextTest{
-			{17, 6},
-			{6, 7},
-			{7, 18},
-			{18, 6},
-			{6, 7}}, "", t)
-	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 10):
-		testseq("defercall", contStep, []nextTest{
-			{17, 5},
-			{5, 6},
-			{6, 7},
-			{7, 18},
-			{18, 5},
-			{5, 6},
-			{6, 7}}, "", t)
-	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 9):
-		testseq("defercall", contStep, []nextTest{
-			{17, 5},
-			{5, 6},
-			{6, 7},
-			{7, 17},
-			{17, 18},
-			{18, 5},
-			{5, 6},
-			{6, 7}}, "", t)
-	default:
-		testseq("defercall", contStep, []nextTest{
-			{17, 5},
-			{5, 6},
-			{6, 7},
-			{7, 18},
-			{18, 5},
-			{5, 6},
-			{6, 7}}, "", t)
-	}
+	testseq("defercall", contStep, []nextTest{
+		{17, 6},
+		{6, 7},
+		{7, 18},
+		{18, 6},
+		{6, 7}}, "", t)
 }
 
 func TestStepDeferReturn(t *testing.T) {
 	// Tests that Step works correctly when a deferred function is
 	// called during a return.
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
-		testseq("defercall", contStep, []nextTest{
-			{11, 6},
-			{6, 7},
-			{7, 12},
-			{12, 13},
-			{13, 6},
-			{6, 7},
-			{7, 13},
-			{13, 28}}, "", t)
-	} else {
-		testseq("defercall", contStep, []nextTest{
-			{11, 5},
-			{5, 6},
-			{6, 7},
-			{7, 12},
-			{12, 13},
-			{13, 5},
-			{5, 6},
-			{6, 7},
-			{7, 13},
-			{13, 28}}, "", t)
-	}
+	testseq("defercall", contStep, []nextTest{
+		{11, 6},
+		{6, 7},
+		{7, 12},
+		{12, 13},
+		{13, 6},
+		{6, 7},
+		{7, 13},
+		{13, 28}}, "", t)
 }
 
 func TestStepIgnorePrivateRuntime(t *testing.T) {
@@ -2410,27 +2357,8 @@ func TestStepIgnorePrivateRuntime(t *testing.T) {
 			{21, 14},
 			{14, 15},
 			{15, 22}}, "", t)
-	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 10):
-		testseq("teststepprog", contStep, []nextTest{
-			{21, 13},
-			{13, 14},
-			{14, 15},
-			{15, 22}}, "", t)
-	case goversion.VersionAfterOrEqual(runtime.Version(), 1, 7):
-		testseq("teststepprog", contStep, []nextTest{
-			{21, 13},
-			{13, 14},
-			{14, 15},
-			{15, 14},
-			{14, 17},
-			{17, 22}}, "", t)
 	default:
-		testseq("teststepprog", contStep, []nextTest{
-			{21, 13},
-			{13, 14},
-			{14, 15},
-			{15, 17},
-			{17, 22}}, "", t)
+		panic("too old")
 	}
 }
 
@@ -2790,15 +2718,9 @@ func TestStepOutPanicAndDirectCall(t *testing.T) {
 	// StepOut should not step into a deferred function if it is called
 	// directly, only if it is called through a panic.
 	// Here we test the case where the function is called by a panic
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
-		testseq2(t, "defercall", "", []seqTest{
-			{contContinue, 17},
-			{contStepout, 6}})
-	} else {
-		testseq2(t, "defercall", "", []seqTest{
-			{contContinue, 17},
-			{contStepout, 5}})
-	}
+	testseq2(t, "defercall", "", []seqTest{
+		{contContinue, 17},
+		{contStepout, 6}})
 }
 
 func TestWorkDir(t *testing.T) {

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1051,11 +1051,6 @@ func TestPackageRenames(t *testing.T) {
 		{"amap2", true, "interface {}(*map[go/ast.BadExpr]net/http.Request) *[{From: 2, To: 3}: *{Method: \"othermethod\", …", "", "interface {}", nil},
 	}
 
-	testcases1_8 := []varTest{
-		// before 1.9 embedded struct fields have fieldname == type
-		{"astruct2", true, `interface {}(*struct { github.com/go-delve/delve/_fixtures/internal/dir1/pkg.SomeType; X int }) *{github.com/go-delve/delve/_fixtures/internal/dir1/pkg.SomeType: github.com/go-delve/delve/_fixtures/internal/dir1/pkg.SomeType {X: 1, Y: 2}, X: 10}`, "", "interface {}", nil},
-	}
-
 	testcases1_9 := []varTest{
 		{"astruct2", true, `interface {}(*struct { github.com/go-delve/delve/_fixtures/internal/dir1/pkg.SomeType; X int }) *{SomeType: github.com/go-delve/delve/_fixtures/internal/dir1/pkg.SomeType {X: 1, Y: 2}, X: 10}`, "", "interface {}", nil},
 	}
@@ -1074,11 +1069,7 @@ func TestPackageRenames(t *testing.T) {
 		assertNoError(p.Continue(), t, "Continue() returned an error")
 		testPackageRenamesHelper(t, p, testcases)
 
-		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 9) {
-			testPackageRenamesHelper(t, p, testcases1_9)
-		} else {
-			testPackageRenamesHelper(t, p, testcases1_8)
-		}
+		testPackageRenamesHelper(t, p, testcases1_9)
 
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 13) {
 			testPackageRenamesHelper(t, p, testcases1_13)


### PR DESCRIPTION
Delve no longer compiles on Go1.12 and earlier, we don't test it on
these versions and they are 4 years old and unsupported. Remove some
code related to Go 1.12 and earlier, mostly from tests.
