### PR TITLE
TeamCity,Documentation: use new TeamCity URL

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -22,7 +22,7 @@
     </repository>
     <repository>
       <id>teamcity-server</id>
-      <url>https://delve.beta.teamcity.com/app/dsl-plugins-repository</url>
+      <url>https://delve.teamcity.com/app/dsl-plugins-repository</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![license](http://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/go-delve/delve/master/LICENSE)
 [![GoDoc](https://godoc.org/github.com/go-delve/delve?status.svg)](https://godoc.org/github.com/go-delve/delve)
-[![Build Status](https://delve.beta.teamcity.com/app/rest/builds/buildType:(id:Delve_AggregatorBuild)/statusIcon.svg)](https://delve.beta.teamcity.com/viewType.html?buildTypeId=Delve_AggregatorBuild&guest=1)
+[![Build Status](https://delve.teamcity.com/app/rest/builds/buildType:(id:Delve_AggregatorBuild)/statusIcon.svg)](https://delve.teamcity.com/viewType.html?buildTypeId=Delve_AggregatorBuild&guest=1)
 
 The GitHub issue tracker is for **bugs** only. Please use the [developer mailing list](https://groups.google.com/forum/#!forum/delve-dev) for any feature proposals and discussions.
 

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3680,7 +3680,7 @@ func TestLaunchSubstitutePath(t *testing.T) {
 // in the launch configuration to take care of the mapping.
 func TestAttachSubstitutePath(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("test skipped on windows, see https://delve.beta.teamcity.com/project/Delve_windows for details")
+		t.Skip("test skipped on Windows, see https://delve.teamcity.com/project/Delve_windows for details")
 	}
 	runTest(t, "loopprog", func(client *daptest.Client, fixture protest.Fixture) {
 		cmd := execFixture(t, fixture)
@@ -5694,7 +5694,7 @@ func TestLaunchRequestWithEnv(t *testing.T) {
 
 func TestAttachRequest(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("test skipped on windows, see https://delve.beta.teamcity.com/project/Delve_windows for details")
+		t.Skip("test skipped on Windows, see https://delve.teamcity.com/project/Delve_windows for details")
 	}
 	runTest(t, "loopprog", func(client *daptest.Client, fixture protest.Fixture) {
 		// Start the program to attach to


### PR DESCRIPTION
This PR changes `delve.beta.teamcity.com` to `delve.teamcity.com` in README, tests, and TeamCity config.


The old URL is `delve.beta.teamcity.com` and it's unreachable:
[![Build Status](https://delve.beta.teamcity.com/app/rest/builds/buildType:(id:Delve_AggregatorBuild)/statusIcon.svg)](https://delve.beta.teamcity.com/viewType.html?buildTypeId=Delve_AggregatorBuild&guest=1)

New is `delve.teamcity.com`:
[![Build Status](https://delve.teamcity.com/app/rest/builds/buildType:(id:Delve_AggregatorBuild)/statusIcon.svg)](https://delve.teamcity.com/viewType.html?buildTypeId=Delve_AggregatorBuild&guest=1)