### PR TITLE
pkg/proc: be resilient to the upcoming sys.PtraceLwpInfo changes

### DIFF
--- a/pkg/proc/native/ptrace_freebsd.go
+++ b/pkg/proc/native/ptrace_freebsd.go
@@ -55,7 +55,13 @@ func ptraceGetLwpList(pid int) (tids []int32) {
 
 // Get info of the thread that caused wpid's process to stop.
 func ptraceGetLwpInfo(wpid int) (info sys.PtraceLwpInfoStruct, err error) {
-	err = sys.PtraceLwpInfo(wpid, uintptr(unsafe.Pointer(&info)))
+	var i interface{} = sys.PtraceLwpInfo
+	switch ptraceLwpInfo := i.(type) {
+	case func(int, uintptr) error:
+		err = ptraceLwpInfo(wpid, uintptr(unsafe.Pointer(&info)))
+	case func(int, *sys.PtraceLwpInfoStruct) error:
+		err = ptraceLwpInfo(wpid, &info)
+	}
 	return info, err
 }
 


### PR DESCRIPTION
As part of golang/go#58387 work (CL [469835](https://go-review.googlesource.com/c/sys/+/469835)), the signature of sys.PtraceLwpInfo will change to accept *sys.PtraceLwpInfoStruct instead of an uintptr. As a compatibility measure, update ptraceGetLwpInfo to work with both old and new sys.PtraceLwpInfo signatures.
 