### PR TITLE
Default to stop test_windows.ps1 when there is an error

### DIFF
--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -9,7 +9,7 @@ if ($binDir -eq "") {
 }
 
 
-Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
+Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
 
 # Install MinGW.
 if ($arch -eq "amd64")
@@ -22,14 +22,14 @@ if ($arch -eq "amd64")
     $name = "llvm-mingw-$llvmVersion-ucrt-aarch64"
     if (-Not(Test-Path "$binDir\llvm-mingw\$name"))
     {
-        New-Item "$binDir\llvm-mingw" -ItemType Directory -ErrorAction SilentlyContinue
+        New-Item "$binDir\llvm-mingw" -ItemType Directory
         $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$llvmVersion/$name.zip"
         Invoke-WebRequest -UserAgent wget -Uri $url -OutFile "$env:TEMP\$name.zip"
         Expand-Archive -Force -LiteralPath "$env:TEMP\$name.zip" -DestinationPath "$binDir\llvm-mingw\"
     }
     $env:PATH = "$binDir\llvm-mingw\$name\bin;$env:PATH"
 } else {
-    Write-Error "Unsupported architecture: $arch" -ErrorAction Stop
+    Throw "Unsupported architecture: $arch"
 }
 
 # Install Procdump

--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -9,7 +9,7 @@ if ($binDir -eq "") {
 }
 
 
-Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction Stop
+Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
 
 # Install MinGW.
 if ($arch -eq "amd64")
@@ -22,9 +22,9 @@ if ($arch -eq "amd64")
     $name = "llvm-mingw-$llvmVersion-ucrt-aarch64"
     if (-Not(Test-Path "$binDir\llvm-mingw\$name"))
     {
-        New-Item "$binDir\llvm-mingw" -ItemType Directory
+        New-Item "$binDir\llvm-mingw" -ItemType Directory -ErrorAction SilentlyContinue
         $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$llvmVersion/$name.zip"
-        Invoke-WebRequest -UserAgent wget -Uri $url -OutFile "$env:TEMP\$name.zip"
+        Invoke-WebRequest -UserAgent wget -Uri $url -OutFile "$env:TEMP\$name.zip" -ErrorAction Stop
         Expand-Archive -Force -LiteralPath "$env:TEMP\$name.zip" -DestinationPath "$binDir\llvm-mingw\"
     }
     $env:PATH = "$binDir\llvm-mingw\$name\bin;$env:PATH"
@@ -48,7 +48,7 @@ function GetGo($version) {
     {
         $file = "$version.windows-$arch.zip"
         $url = "https://dl.google.com/go/$file"
-        Invoke-WebRequest -UserAgent wget -Uri $url -OutFile "$env:TEMP\$file"
+        Invoke-WebRequest -UserAgent wget -Uri $url -OutFile "$env:TEMP\$file" -ErrorAction Stop
         Expand-Archive -Force -LiteralPath "$env:TEMP\$file" -DestinationPath "$env:TEMP\$version"
         New-Item $env:GOROOT -ItemType Directory
         Move-Item -Path "$env:TEMP\$version\go\*" -Destination $env:GOROOT -Force
@@ -57,7 +57,7 @@ function GetGo($version) {
 
 if ($version -eq "gotip") {
     #Exit 0
-    $latest = Invoke-WebRequest -Uri "https://golang.org/VERSION?m=text" -UseBasicParsing | Select-Object -ExpandProperty Content
+    $latest = Invoke-WebRequest -Uri "https://golang.org/VERSION?m=text" -UseBasicParsing | Select-Object -ExpandProperty Content -ErrorAction Stop
     GetGo $latest
     $env:GOROOT_BOOTSTRAP = $env:GOROOT
     $env:GOROOT = "$binDir\go\go-tip"
@@ -74,7 +74,7 @@ if ($version -eq "gotip") {
 } else {
     # Install Go
     Write-Host "Finding latest patch version for $version"
-    $versions = Invoke-WebRequest -Uri "https://golang.org/dl/?mode=json&include=all" -UseBasicParsing | foreach {$_.Content} | ConvertFrom-Json
+    $versions = Invoke-WebRequest -Uri "https://golang.org/dl/?mode=json&include=all" -UseBasicParsing | foreach {$_.Content} | ConvertFrom-Json -ErrorAction Stop
     $v = $versions | foreach {$_.version} | Select-String -Pattern "^$version($|\.)" | Sort-Object -Descending | Select-Object -First 1
     if ($v -eq $null) {
       $v = $versions | foreach {$_.version} | Select-String -Pattern "^$version(rc)" | Sort-Object -Descending | Select-Object -First 1


### PR DESCRIPTION
There are several bootstrapping situations that can leave Windows builders in a bad state.

For example, the windows/arm64 builder has been failing since last week because it failed to download the new go1.20.1 version and left a directory which marks it as installed, making following runs to fail because `go` could not be found.

This PR updates the Windows testing script to fix that.