### PR TITLE
proc: step breakpoints shouldn't hide normal breakpoints

### DIFF
--- a/_fixtures/stepshadow.go
+++ b/_fixtures/stepshadow.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func main() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go goroutineA(&wg)
+	f := stacktraceme1
+	for i := 0; i < 100; i++ {
+		fmt.Printf("main %d\n", i)
+		f()
+	}
+	wg.Wait()
+}
+
+func goroutineA(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for i := 0; i < 100; i++ {
+		stacktraceme2()
+	}
+}
+
+func stacktraceme1() {
+}
+
+func stacktraceme2() {
+}

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -96,7 +96,7 @@ type Breaklet struct {
 	// the return value will determine if the breaklet should be considered
 	// active.
 	// The callback can have side-effects.
-	callback func(th Thread) bool
+	callback func(th Thread, p *Target) (bool, error)
 
 	// For WatchOutOfScopeBreakpoints and StackResizeBreakpoints the watchpoint
 	// field contains the watchpoint related to this out of scope sentinel.
@@ -294,12 +294,6 @@ func (bpstate *BreakpointState) checkCond(tgt *Target, breaklet *Breaklet, threa
 			}
 		}
 		active = active && nextDeferOk
-		if active {
-			bpstate.Stepping = true
-			if breaklet.Kind == StepBreakpoint {
-				bpstate.SteppingInto = true
-			}
-		}
 
 	case WatchOutOfScopeBreakpoint:
 		if breaklet.checkPanicCall {
@@ -319,9 +313,23 @@ func (bpstate *BreakpointState) checkCond(tgt *Target, breaklet *Breaklet, threa
 
 	if active {
 		if breaklet.callback != nil {
-			active = breaklet.callback(thread)
+			var err error
+			active, err = breaklet.callback(thread, tgt)
+			if err != nil && bpstate.CondError == nil {
+				bpstate.CondError = err
+			}
 		}
 		bpstate.Active = active
+	}
+
+	if bpstate.Active {
+		switch breaklet.Kind {
+		case NextBreakpoint, NextDeferBreakpoint:
+			bpstate.Stepping = true
+		case StepBreakpoint:
+			bpstate.Stepping = true
+			bpstate.SteppingInto = true
+		}
 	}
 }
 

--- a/pkg/proc/stackwatch.go
+++ b/pkg/proc/stackwatch.go
@@ -28,9 +28,9 @@ import (
 func (t *Target) setStackWatchBreakpoints(scope *EvalScope, watchpoint *Breakpoint) error {
 	// Watchpoint Out-of-scope Sentinel
 
-	woos := func(_ Thread) bool {
+	woos := func(_ Thread, _ *Target) (bool, error) {
 		watchpointOutOfScope(t, watchpoint)
-		return true
+		return true, nil
 	}
 
 	topframe, retframe, err := topframe(scope.g, nil)
@@ -111,9 +111,9 @@ func (t *Target) setStackWatchBreakpoints(scope *EvalScope, watchpoint *Breakpoi
 
 	rszbreaklet := rszbp.Breaklets[len(rszbp.Breaklets)-1]
 	rszbreaklet.watchpoint = watchpoint
-	rszbreaklet.callback = func(th Thread) bool {
+	rszbreaklet.callback = func(th Thread, _ *Target) (bool, error) {
 		adjustStackWatchpoint(t, th, watchpoint)
-		return false // we never want this breakpoint to be shown to the user
+		return false, nil // we never want this breakpoint to be shown to the user
 	}
 
 	return nil

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -587,7 +587,7 @@ func (t *Target) dwrapUnwrap(fn *Function) *Function {
 	return fn
 }
 
-func (t *Target) pluginOpenCallback(Thread) bool {
+func (t *Target) pluginOpenCallback(Thread, *Target) (bool, error) {
 	logger := logflags.DebuggerLogger()
 	for _, lbp := range t.Breakpoints().Logical {
 		if isSuspended(t, lbp) {
@@ -599,7 +599,7 @@ func (t *Target) pluginOpenCallback(Thread) bool {
 			}
 		}
 	}
-	return false
+	return false, nil
 }
 
 func isSuspended(t *Target, lbp *LogicalBreakpoint) bool {


### PR DESCRIPTION
When using Step on a function that has a dynamic CALL instruction we
set a Step breakpoint on the call.

When it is hit we determine the destination of the CALL by looking at
registers, set a breakpoint there and continue.

If the Step breakpoint is hit simultaneously with a normal breakpoint
our Step logic will take precedence and the normal breakpoint hit will
be hidden from the user.

Move the Step logic to a breaklet callback so that it does not
interfere with the decision to stop.
