### PR TITLE
dwarf/line: enable TestGrafana for Windows

### DIFF
--- a/pkg/dwarf/line/state_machine_test.go
+++ b/pkg/dwarf/line/state_machine_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"runtime"
 	"testing"
 
 	pdwarf "github.com/go-delve/delve/pkg/dwarf"
@@ -36,9 +35,6 @@ func TestGrafana(t *testing.T) {
 	// of grafana to the output generated using debug/dwarf.LineReader on the
 	// same section.
 
-	if runtime.GOOS == "windows" {
-		t.Skip("filepath.Join ruins this test on windows")
-	}
 	debugBytes, err := slurpGzip("_testdata/debug.grafana.debug.gz")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The test `TestGrafana` succeeds on Windows:
- https://delve.teamcity.com/buildConfiguration/Delve_windows_amd64_1_20/45212?buildTab=tests&name=TestGrafana
- https://delve.teamcity.com/buildConfiguration/Delve_windows_amd64_tip/45213?buildTab=tests&name=TestGrafana