### PR TITLE
Documentation: fix typo and grammar issues

### DIFF
--- a/Documentation/api/ClientHowto.md
+++ b/Documentation/api/ClientHowto.md
@@ -122,7 +122,7 @@ breakpoints: "next" will continue until the next line of the program,
 unexported runtime functions).
 
 All of "next", "step" and "stepout" operate on the selected goroutine. The
-selected gorutine is described by the `SelectedGoroutine` field of
+selected goroutine is described by the `SelectedGoroutine` field of
 `DebuggerState`. Every time `Command` returns the selected goroutine will be
 reset to the goroutine that triggered the breakpoint.
 
@@ -203,7 +203,7 @@ There are several API entry points to evaluate variables in Delve:
 * RPCServer.ListPackageVars returns all global variables in all packages
 * PRCServer.ListLocalVars returns all local variables of a stack frame
 * RPCServer.ListFunctionArgs returns all function arguments of a stack frame
-* RPCServer.Eval evaluets an expression on a given stack frame
+* RPCServer.Eval evaluates an expression on a given stack frame
 
 All those API calls take a LoadConfig argument. The LoadConfig specifies how
 much of the variable's value should actually be loaded. Because of

--- a/Documentation/api/dap/README.md
+++ b/Documentation/api/dap/README.md
@@ -4,7 +4,7 @@ Delve exposes a [DAP](https://microsoft.github.io/debug-adapter-protocol/overvie
 
 This interface is served over a streaming TCP socket using `dlv` server in one of the two headless modes:
 1. [`dlv dap`](../../usage/dlv_dap.md) - starts a single-use DAP-only server that waits for a client to specify launch/attach configuration for starting the debug session.
-2. `dlv --headless <command> <debugee>` - starts a general server, enters a debug session for the specified debuggee and waits for a [JSON-RPC](../json-rpc/README.md) or a [DAP](https://microsoft.github.io/debug-adapter-protocol/overview) remote-attach client to begin interactive debugging. Can be used in multi-client mode with the following options:
+2. `dlv --headless <command> <debuggee>` - starts a general server, enters a debug session for the specified debuggee and waits for a [JSON-RPC](../json-rpc/README.md) or a [DAP](https://microsoft.github.io/debug-adapter-protocol/overview) remote-attach client to begin interactive debugging. Can be used in multi-client mode with the following options:
    *  `--accept-multiclient` - use to support connections from multiple clients
    *  `--continue` - use to resume debuggee execution as soon as server session starts
 
@@ -73,7 +73,7 @@ Not all of the configurations are supported by each of the two available DAP ser
 
 ### Single-Client Mode
 
-When used with `dlv dap` or `dlv --headless --accept-multiclient=false` (default), the DAP server will shut itself down at the end of the debug session, when the client sends a [disconnect request](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect). If the debuggee was launched, it will be taken down as well. If the debugee was attached to, `terminateDebuggee` option will be respected.
+When used with `dlv dap` or `dlv --headless --accept-multiclient=false` (default), the DAP server will shut itself down at the end of the debug session, when the client sends a [disconnect request](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect). If the debuggee was launched, it will be taken down as well. If the debuggee was attached to, `terminateDebuggee` option will be respected.
 
 When the program terminates, we send a [terminated event](https://microsoft.github.io/debug-adapter-protocol/specification#Events_Terminated), which is expected to trigger a [disconnect request](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect) from the client for a session and a server shutdown. The [restart request](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Restart) is not yet supported. 
 
@@ -83,7 +83,7 @@ Pressing Ctrl-C on the terminal where a headless server is running sends SIGINT 
 
 ### Multi-Client Mode
 
-When used with `dlv --headless --accept-multiclient=true`, the DAP server will honor the multi-client mode when a client [disconnects](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect)) or client connection fails. The server will remain running and ready for a new client connection, and the debuggee will remain in whatever state it was at the time of disconnect - running or halted. Once [`suspendDebuggee`](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect) option is supported by frontends like VS Code ([vscode/issues/134412](https://github.com/microsoft/vscode/issues/134412)), we will update the server to offer this as a way to specify debuggee state on disconnect.
+When used with `dlv --headless --accept-multiclient=true`, the DAP server will honor the multi-client mode when a client [disconnects](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect) or client connection fails. The server will remain running and ready for a new client connection, and the debuggee will remain in whatever state it was at the time of disconnect - running or halted. Once [`suspendDebuggee`](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect) option is supported by frontends like VS Code ([vscode/issues/134412](https://github.com/microsoft/vscode/issues/134412)), we will update the server to offer this as a way to specify debuggee state on disconnect.
 
 The client may request full shutdown of the server and the debuggee with [`terminateDebuggee`](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect) option.
 

--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -199,7 +199,7 @@ With the -hitcount option a condition on the breakpoint hit count can be set, th
 
 The -per-g-hitcount option works like -hitcount, but use per goroutine hitcount to compare with n.
 
-With the -clear option a condtion on the breakpoint can removed.
+With the -clear option a condition on the breakpoint can removed.
 	
 The '% n' form means we should stop at the breakpoint when the hitcount is a multiple of n.
 

--- a/Documentation/cli/expr.md
+++ b/Documentation/cli/expr.md
@@ -133,7 +133,7 @@ Because many architectures have SIMD registers that can be used by the applicati
 
 * `REGNAME.intN` returns the register REGNAME as an array of intN elements.
 * `REGNAME.uintN` returns the register REGNAME as an array of uintN elements.
-* `REGNAME.floatN` returns the register REGNAME as an array fo floatN elements.
+* `REGNAME.floatN` returns the register REGNAME as an array of floatN elements.
 
 In all cases N must be a power of 2.
 

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -178,7 +178,7 @@ def command_echo_expr(a, b, c):
 	print("a", a, "b", b, "c", c)
 ```
 
-The first commnad, `echo`, takes its arguments as a single string, while for `echo_expr` it will be possible to pass starlark expression as arguments:
+The first command, `echo`, takes its arguments as a single string, while for `echo_expr` it will be possible to pass starlark expression as arguments:
 
 ```
 (dlv) echo 2+2, 2-1, 2*3

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -11,7 +11,7 @@ unit tests. By default Delve will debug the tests in the current directory.
 Alternatively you can specify a package name, and Delve will debug the tests in
 that package instead. Double-dashes `--` can be used to pass arguments to the test program:
 
-dlv test [package] -- -test.run TestSometing -test.v -other-argument
+dlv test [package] -- -test.run TestSomething -test.v -other-argument
 
 See also: 'go help testflag'.
 

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -278,7 +278,7 @@ unit tests. By default Delve will debug the tests in the current directory.
 Alternatively you can specify a package name, and Delve will debug the tests in
 that package instead. Double-dashes ` + "`--`" + ` can be used to pass arguments to the test program:
 
-dlv test [package] -- -test.run TestSometing -test.v -other-argument
+dlv test [package] -- -test.run TestSomething -test.v -other-argument
 
 See also: 'go help testflag'.`,
 		Run: testCmd,

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -476,7 +476,7 @@ With the -hitcount option a condition on the breakpoint hit count can be set, th
 
 The -per-g-hitcount option works like -hitcount, but use per goroutine hitcount to compare with n.
 
-With the -clear option a condtion on the breakpoint can removed.
+With the -clear option a condition on the breakpoint can removed.
 	
 The '% n' form means we should stop at the breakpoint when the hitcount is a multiple of n.
 


### PR DESCRIPTION
Fix typos in `*.md` files and in `*.go` filesfrom which docs are generated.