### PR TITLE
proc: support multiple functions with the same name

### DIFF
--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -450,7 +450,8 @@ func (loc *NormalLocationSpec) findFuncCandidates(bi *proc.BinaryInfo, limit int
 		}
 		candidateFuncs[fname] = struct{}{}
 	}
-	for _, f := range bi.LookupFunc {
+	for _, fns := range bi.LookupFunc() {
+		f := fns[0]
 		if len(candidateFuncs) >= limit {
 			break
 		}

--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -49,7 +49,7 @@ func AMD64Arch(goos string) *Arch {
 func amd64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *BinaryInfo) *frame.FrameContext {
 	a := bi.Arch
 	if a.sigreturnfn == nil {
-		a.sigreturnfn = bi.LookupFunc["runtime.sigreturn"]
+		a.sigreturnfn = bi.lookupOneFunc("runtime.sigreturn")
 	}
 
 	if fctxt == nil || (a.sigreturnfn != nil && pc >= a.sigreturnfn.Entry && pc < a.sigreturnfn.End) {
@@ -96,7 +96,7 @@ func amd64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *Binary
 	}
 
 	if a.crosscall2fn == nil {
-		a.crosscall2fn = bi.LookupFunc["crosscall2"]
+		a.crosscall2fn = bi.lookupOneFunc("crosscall2")
 	}
 
 	if a.crosscall2fn != nil && pc >= a.crosscall2fn.Entry && pc < a.crosscall2fn.End {

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -60,7 +60,7 @@ func ARM64Arch(goos string) *Arch {
 func arm64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *BinaryInfo) *frame.FrameContext {
 	a := bi.Arch
 	if a.sigreturnfn == nil {
-		a.sigreturnfn = bi.LookupFunc["runtime.sigreturn"]
+		a.sigreturnfn = bi.lookupOneFunc("runtime.sigreturn")
 	}
 
 	if fctxt == nil || (a.sigreturnfn != nil && pc >= a.sigreturnfn.Entry && pc < a.sigreturnfn.End) {
@@ -107,7 +107,7 @@ func arm64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *Binary
 	}
 
 	if a.crosscall2fn == nil {
-		a.crosscall2fn = bi.LookupFunc["crosscall2"]
+		a.crosscall2fn = bi.lookupOneFunc("crosscall2")
 	}
 
 	if a.crosscall2fn != nil && pc >= a.crosscall2fn.Entry && pc < a.crosscall2fn.End {

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -674,8 +674,13 @@ func (t *Target) setBreakpointInternal(logicalID int, addr uint64, kind Breakpoi
 		if breaklet != nil && breaklet.Cond == nil {
 			breaklet.Cond = lbp.Cond
 		}
-		lbp.File = bp.File
-		lbp.Line = bp.Line
+		if lbp.File == "" && lbp.Line == 0 {
+			lbp.File = bp.File
+			lbp.Line = bp.Line
+		} else if bp.File != lbp.File || bp.Line != lbp.Line {
+			lbp.File = "<multiple locations>"
+			lbp.Line = 0
+		}
 		fn := t.BinInfo().PCToFunc(bp.Addr)
 		if fn != nil {
 			lbp.FunctionName = fn.NameWithoutTypeParams()

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -153,7 +153,7 @@ func TestDwarfExprRegisters(t *testing.T) {
 
 	bi, _ := fakeBinaryInfo(t, dwb)
 
-	mainfn := bi.LookupFunc["main.main"]
+	mainfn := bi.LookupFunc()["main.main"][0]
 	mem := newFakeMemory(fakeCFA(), uint64(0), uint64(testCases["b"]))
 	regs := linutil.AMD64Registers{Regs: &linutil.AMD64PtraceRegs{}}
 	regs.Regs.Rax = uint64(testCases["a"])
@@ -215,7 +215,7 @@ func TestDwarfExprComposite(t *testing.T) {
 
 	bi, _ := fakeBinaryInfo(t, dwb)
 
-	mainfn := bi.LookupFunc["main.main"]
+	mainfn := bi.LookupFunc()["main.main"][0]
 
 	mem := newFakeMemory(fakeCFA(), uint64(0), uint64(0), uint16(testCases["pair.v"]), []byte(stringVal))
 	var regs linutil.AMD64Registers
@@ -289,7 +289,7 @@ func TestDwarfExprLoclist(t *testing.T) {
 
 	bi, _ := fakeBinaryInfo(t, dwb)
 
-	mainfn := bi.LookupFunc["main.main"]
+	mainfn := bi.LookupFunc()["main.main"][0]
 
 	mem := newFakeMemory(fakeCFA(), uint16(before), uint16(after))
 	const PC = 0x40100
@@ -326,7 +326,7 @@ func TestIssue1419(t *testing.T) {
 
 	bi, _ := fakeBinaryInfo(t, dwb)
 
-	mainfn := bi.LookupFunc["main.main"]
+	mainfn := bi.LookupFunc()["main.main"][0]
 
 	mem := newFakeMemory(fakeCFA())
 

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -2280,8 +2280,8 @@ func (v *Variable) findMethod(mname string) (*Variable, error) {
 
 		//TODO(aarzilli): support generic functions?
 
-		if fn, ok := v.bi.LookupFunc[fmt.Sprintf("%s.%s.%s", pkg, receiver, mname)]; ok {
-			r, err := functionToVariable(fn, v.bi, v.mem)
+		if fns := v.bi.LookupFunc()[fmt.Sprintf("%s.%s.%s", pkg, receiver, mname)]; len(fns) == 1 {
+			r, err := functionToVariable(fns[0], v.bi, v.mem)
 			if err != nil {
 				return nil, err
 			}
@@ -2293,8 +2293,8 @@ func (v *Variable) findMethod(mname string) (*Variable, error) {
 			return r, nil
 		}
 
-		if fn, ok := v.bi.LookupFunc[fmt.Sprintf("%s.(*%s).%s", pkg, receiver, mname)]; ok {
-			r, err := functionToVariable(fn, v.bi, v.mem)
+		if fns := v.bi.LookupFunc()[fmt.Sprintf("%s.(*%s).%s", pkg, receiver, mname)]; len(fns) == 1 {
+			r, err := functionToVariable(fns[0], v.bi, v.mem)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -1211,8 +1211,8 @@ func findCallInjectionStateForThread(t *Target, thread Thread) (*G, *callInjecti
 func debugCallFunction(bi *BinaryInfo) (*Function, int) {
 	for version := maxDebugCallVersion; version >= 1; version-- {
 		name := debugCallFunctionNamePrefix2 + "V" + strconv.Itoa(version)
-		fn, ok := bi.LookupFunc[name]
-		if ok && fn != nil {
+		fn := bi.lookupOneFunc(name)
+		if fn != nil {
 			return fn, version
 		}
 	}

--- a/pkg/proc/i386_arch.go
+++ b/pkg/proc/i386_arch.go
@@ -43,7 +43,7 @@ func I386Arch(goos string) *Arch {
 func i386FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *BinaryInfo) *frame.FrameContext {
 	i := bi.Arch
 	if i.sigreturnfn == nil {
-		i.sigreturnfn = bi.LookupFunc["runtime.sigreturn"]
+		i.sigreturnfn = bi.lookupOneFunc("runtime.sigreturn")
 	}
 
 	if fctxt == nil || (i.sigreturnfn != nil && pc >= i.sigreturnfn.Entry && pc < i.sigreturnfn.End) {
@@ -90,7 +90,7 @@ func i386FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *BinaryI
 	}
 
 	if i.crosscall2fn == nil {
-		i.crosscall2fn = bi.LookupFunc["crosscall2"]
+		i.crosscall2fn = bi.lookupOneFunc("crosscall2")
 	}
 
 	// TODO(chainhelen), need to check whether there is a bad frame descriptor like amd64.

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -827,10 +827,11 @@ func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf
 		return errors.New("too many arguments in traced function, max is 12 input+return")
 	}
 
-	fn, ok := dbp.bi.LookupFunc[fnName]
-	if !ok {
+	fns := dbp.bi.LookupFunc()[fnName]
+	if len(fns) != 1 {
 		return fmt.Errorf("could not find function: %s", fnName)
 	}
+	fn := fns[0]
 
 	offset, err := dbp.BinInfo().GStructOffset(dbp.Memory())
 	if err != nil {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2991,3 +2991,29 @@ func TestClientServer_autoBreakpoints(t *testing.T) {
 		}
 	})
 }
+
+func TestClientServer_breakpointOnFuncWithABIWrapper(t *testing.T) {
+	// Setting a breakpoint on an assembly function that has an ABI
+	// compatibility wrapper should end up setting a breakpoint on the real
+	// function (also setting a breakpoint on the wrapper is fine).
+	// Issue #3296
+	protest.AllowRecording(t)
+	withTestClient2("math", t, func(c service.Client) {
+		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "runtime.schedinit"})
+		assertNoError(err, t, "CreateBreakpoin()")
+		t.Log(bp)
+
+		found := false
+		for _, pc := range bp.Addrs {
+			text, err := c.DisassemblePC(api.EvalScope{}, pc, api.IntelFlavour)
+			assertNoError(err, t, fmt.Sprint("DisassemblePC", pc))
+			t.Log("First instruction for", pc, text[0])
+			if strings.HasSuffix(text[0].Loc.File, "runtime/proc.go") {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("breakpoint not set on the runtime/proc.go function")
+		}
+	})
+}


### PR DESCRIPTION
The compiler produces ABI compatibility wrappers for some functions.

We have changed the support for breakpoints to allow a single logical
breakpoint to correspond to multiple physical breakpoints, take
advantage of that to set breakpoints on both the ABI wrapper and the
real function.

Fixes #3296
