### PR TITLE
proc,terminal: remove unused unexported functions

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2832,15 +2832,6 @@ func TestNextInDeferReturn(t *testing.T) {
 	})
 }
 
-func getg(goid int64, gs []*proc.G) *proc.G {
-	for _, g := range gs {
-		if g.ID == goid {
-			return g
-		}
-	}
-	return nil
-}
-
 func TestAttachDetach(t *testing.T) {
 	if testBackend == "lldb" && runtime.GOOS == "linux" {
 		bs, _ := ioutil.ReadFile("/proc/sys/kernel/yama/ptrace_scope")

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -559,19 +559,6 @@ func TestOnPrefixLocals(t *testing.T) {
 	})
 }
 
-func countOccurrences(s, needle string) int {
-	count := 0
-	for {
-		idx := strings.Index(s, needle)
-		if idx < 0 {
-			break
-		}
-		count++
-		s = s[idx+len(needle):]
-	}
-	return count
-}
-
 func listIsAt(t *testing.T, term *FakeTerminal, listcmd string, cur, start, end int) {
 	t.Helper()
 	outstr := term.MustExec(listcmd)


### PR DESCRIPTION
`getg` and `countOccurrences` are leftovers from past tests and are currently unused.