### PR TITLE
proc: fix automatic breakpoints visibility

### DIFF
--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -193,6 +193,7 @@ func (grp *TargetGroup) newTarget(p ProcessInternal, pid int, currentThread Thre
 	g, _ := GetG(currentThread)
 	t.selectedGoroutine = g
 
+	t.Breakpoints().Logical = grp.LogicalBreakpoints
 	t.createUnrecoveredPanicBreakpoint()
 	t.createFatalThrowBreakpoint()
 	t.createPluginOpenBreakpoint()

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -108,7 +108,6 @@ func (grp *TargetGroup) addTarget(p ProcessInternal, pid int, currentThread Thre
 	if grp.Selected == nil {
 		grp.Selected = t
 	}
-	t.Breakpoints().Logical = grp.LogicalBreakpoints
 	logger := logflags.DebuggerLogger()
 	for _, lbp := range grp.LogicalBreakpoints {
 		if lbp.LogicalID < 0 {


### PR DESCRIPTION
Unrecovered-panic and fatal-throw were no longer part of the breakpoint
list because starting in 37e44bf they were created before the logical
breakpoints map was switched to the logical breakpoints map of the
target group.
