### PR TITLE
Documentation: expand project layout to match usage

### DIFF
--- a/Documentation/cli/getting_started.md
+++ b/Documentation/cli/getting_started.md
@@ -14,15 +14,14 @@ otherwise it optionally accepts a package path.
 For example given this project layout:
 
 ```
-.
-├── github.com/me/foo
+github.com/me/foo
 ├── cmd
-│   └── foo
-│       └── main.go
-├── pkg
-│   └── baz
-│       ├── bar.go
-│       └── bar_test.go
+│   └── foo
+│       └── main.go
+└── pkg
+    └── baz
+        ├── bar.go
+        └── bar_test.go
 ```
 
 If you are in the directory `github.com/me/foo/cmd/foo` you can simply run `dlv debug`


### PR DESCRIPTION
The tree view of the project layout seemed to show that "github.com", "cmd", and "pkg" were all in the same directory.  The usage later in the document (and normal go layout) would have them as subdirectories.

The new tree output was generated with the below:
(cd `mktemp -d`
    mkdir -p github.com/me/foo/{cmd/foo,pkg/baz}
    touch github.com/me/foo/{cmd/foo/main,pkg/baz/bar{_test,}}.go
    tree -n --noreport github.com/me/foo
)