### PR TITLE
terminal: Fix printing boolean values in Starlark scripts

### DIFF
--- a/pkg/terminal/starbind/conv.go
+++ b/pkg/terminal/starbind/conv.go
@@ -19,6 +19,8 @@ var autoLoadConfig = api.LoadConfig{MaxVariableRecurse: 1, MaxStringLen: 1024, M
 // decoding JSON) into a starlark.Value.
 func (env *Env) interfaceToStarlarkValue(v interface{}) starlark.Value {
 	switch v := v.(type) {
+	case bool:
+		return starlark.Bool(bool(v))
 	case uint8:
 		return starlark.MakeUint64(uint64(v))
 	case uint16:
@@ -231,6 +233,9 @@ func (env *Env) variableValueToStarlarkValue(v *api.Variable, top bool) (starlar
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint, reflect.Uintptr:
 		n, _ := strconv.ParseUint(v.Value, 0, 64)
 		return starlark.MakeUint64(n), nil
+	case reflect.Bool:
+		n, _ := strconv.ParseBool(v.Value)
+		return starlark.Bool(n), nil
 	case reflect.Float32, reflect.Float64:
 		switch v.Value {
 		case "+Inf":


### PR DESCRIPTION
Hi. Without this fix, Starlark fails to print boolean fields.
I hit this while trying to debug GeeseFS, it fails with messages similar to:
`Command failed: *github.com/yandex-cloud/geesefs/internal.FileBuffer has no .loading field or method (did you mean .loading?)`
Yes I did mean .loading! :)
Test case. `main.go`:
```
package main

import "runtime"

type A struct {
    field bool
}

func main() {
    var a A
    a.field = true
    runtime.Breakpoint()
}
```
test.star:
```
a = eval(None, "a")
print(a.Variable.Value.field)
```
cli:
```
$ ../dlv debug .
Type 'help' for list of commands.
(dlv) c
> [hardcoded-breakpoint] main.main() ./booltest.go:13 (hits total:0) (PC: 0x45f1c5)
     8:
     9: func main() {
    10:     var a A
    11:     a.field = true
    12:     runtime.Breakpoint()
=>  13: }
(dlv) source test.star
Command failed: main.A has no .field field or method (did you mean .field?)
```