### PR TITLE
proc: fix test by adding missing assert

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1360,6 +1360,7 @@ func TestFrameEvaluation(t *testing.T) {
 		assertNoError(err, t, "GetG()")
 
 		frames, err := g.Stacktrace(40, 0)
+		assertNoError(err, t, "Stacktrace()")
 		t.Logf("Goroutine %d %#v", g.ID, g.Thread)
 		logStacktrace(t, p, frames)
 


### PR DESCRIPTION
This PR adds a check for `err` after calling `g.Stacktrace` in `TestFrameEvaluation`.