### PR TITLE
proc: fix match condition in TestGnuDebuglink

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -5917,7 +5917,7 @@ func TestGnuDebuglink(t *testing.T) {
 	for i := range normalBinInfo.Functions {
 		normalFn := normalBinInfo.Functions[i]
 		debuglinkFn := debuglinkBinInfo.Functions[i]
-		if normalFn.Entry != debuglinkFn.Entry || normalFn.Name != normalFn.Name {
+		if normalFn.Entry != debuglinkFn.Entry || normalFn.Name != debuglinkFn.Name {
 			t.Fatalf("function definition mismatch")
 		}
 	}


### PR DESCRIPTION
Looks like `normalFn.Name != normalFn.Name` is a copy-paste error.

This mistake was found by the [`gocritic`](https://github.com/go-critic/go-critic):
```
gocritic check -enable dupSubExpr ./...
```