### PR TITLE
Removed extra docs for Go 1.16.

### DIFF
--- a/Documentation/installation/README.md
+++ b/Documentation/installation/README.md
@@ -9,19 +9,6 @@ $ cd delve
 $ go install github.com/go-delve/delve/cmd/dlv
 ```
 
-Alternatively, on Go version 1.16 or later:
-
-```
-# Install the latest release:
-$ go install github.com/go-delve/delve/cmd/dlv@latest
-
-# Install at tree head:
-$ go install github.com/go-delve/delve/cmd/dlv@master
-
-# Install at a specific version or pseudo-version:
-$ go install github.com/go-delve/delve/cmd/dlv@v1.7.3
-$ go install github.com/go-delve/delve/cmd/dlv@v1.7.4-0.20211208103735-2f13672765fe
-```
 See [Versions](https://go.dev/ref/mod#versions) and [Pseudo-versions](https://go.dev/ref/mod#pseudo-versions) for how to format the version suffixes.
 
 See `go help install` for details on where the `dlv` executable is saved.


### PR DESCRIPTION
Removed extra docs for Go 1.16.