### PR TITLE
service: fix typos in comments

### DIFF
--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -429,7 +429,7 @@ func ConvertRegisters(in *op.DwarfRegisters, dwarfRegisterToString func(int, *op
 	return
 }
 
-// ConvertImage convers proc.Image to api.Image.
+// ConvertImage converts proc.Image to api.Image.
 func ConvertImage(image *proc.Image) Image {
 	return Image{Path: image.Path, Address: image.StaticBase}
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -448,7 +448,7 @@ const (
 	ReverseStep = "reverseStep"
 	// StepOut continues to the return address of the current function
 	StepOut = "stepOut"
-	// ReverseStepOut continues backward to the calle rof the current function.
+	// ReverseStepOut continues backward to the caller of the current function.
 	ReverseStepOut = "reverseStepOut"
 	// StepInstruction continues for exactly 1 cpu instruction.
 	StepInstruction = "stepInstruction"

--- a/service/client.go
+++ b/service/client.go
@@ -47,7 +47,7 @@ type Client interface {
 	ReverseStep() (*api.DebuggerState, error)
 	// StepOut continues to the return address of the current function.
 	StepOut() (*api.DebuggerState, error)
-	// ReverseStepOut continues backward to the calle rof the current function.
+	// ReverseStepOut continues backward to the caller of the current function.
 	ReverseStepOut() (*api.DebuggerState, error)
 	// Call resumes process execution while making a function call.
 	Call(goroutineID int64, expr string, unsafe bool) (*api.DebuggerState, error)

--- a/service/dap/daptest/gen/main.go
+++ b/service/dap/daptest/gen/main.go
@@ -83,7 +83,7 @@ func main() {
 	messages := []string{}
 	scope := pkgs[0].Types.Scope()
 	for _, name := range scope.Names() {
-		// Find only types that are embedding go-dap.Respose message.
+		// Find only types that are embedding go-dap.Response message.
 		obj := scope.Lookup(name)
 		if !obj.Exported() {
 			continue // skip unexported

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -203,7 +203,7 @@ type process struct {
 // impact handling of subsequent requests.
 // The fields with cfgName tag can be updated through an evaluation request.
 type launchAttachArgs struct {
-	// stopOnEntry is set to automatically stop the debugee after start.
+	// stopOnEntry is set to automatically stop the debuggee after start.
 	stopOnEntry bool
 	// StackTraceDepth is the maximum length of the returned list of stack frames.
 	StackTraceDepth int `cfgName:"stackTraceDepth"`
@@ -236,7 +236,7 @@ var defaultArgs = launchAttachArgs{
 	substitutePathServerToClient: [][2]string{},
 }
 
-// dapClientCapabilites captures arguments from intitialize request that
+// dapClientCapabilites captures arguments from initialize request that
 // impact handling of subsequent requests.
 type dapClientCapabilites struct {
 	supportsVariableType         bool
@@ -362,7 +362,7 @@ func (s *Session) setLaunchAttachArgs(args LaunchAttachCommonConfig) error {
 // connection. It shuts down the underlying debugger and kills the target
 // process if it was launched by it or stops the noDebug process.
 // This method mustn't be called more than once.
-// StopTriggered notifies other goroutines that stop is in progreess.
+// StopTriggered notifies other goroutines that stop is in progress.
 func (s *Server) Stop() {
 	s.config.log.Debug("DAP server stopping...")
 	defer s.config.log.Debug("DAP server stopped")
@@ -404,7 +404,7 @@ func (s *Session) Close() {
 	// Unless Stop() was called after read loop in ServeDAPCodec()
 	// returned, this will result in a closed connection error
 	// on next read, breaking out the read loop and
-	// allowing the run goroutinee to exit.
+	// allowing the run goroutines to exit.
 	// This connection is closed here and in serveDAPCodec().
 	// If this was a forced shutdown, external stop logic can close this first.
 	// If this was a client loop exit (on error or disconnect), serveDAPCodec()
@@ -417,13 +417,13 @@ func (s *Session) Close() {
 // signals that client sent a disconnect request or there was connection
 // failure or closure. Since the server currently services only one
 // client, this is used as a signal to stop the entire server.
-// The function safeguards agaist closing the channel more
+// The function safeguards against closing the channel more
 // than once and can be called multiple times. It is not thread-safe
 // and is currently only called from the run goroutine.
 func (c *Config) triggerServerStop() {
 	// Avoid accidentally closing the channel twice and causing a panic, when
 	// this function is called more than once because stop was triggered
-	// by multiple conditions simultenously.
+	// by multiple conditions simultaneously.
 	if c.DisconnectChan != nil {
 		close(c.DisconnectChan)
 		c.DisconnectChan = nil
@@ -1428,7 +1428,7 @@ func (s *Session) onSetFunctionBreakpointsRequest(request *dap.SetFunctionBreakp
 		}
 	}, func(i int) (*bpLocation, error) {
 		want := request.Arguments.Breakpoints[i]
-		// Set the function breakpoint breakpoint
+		// Set the function breakpoint
 		spec, err := locspec.Parse(want.Name)
 		if err != nil {
 			return nil, err
@@ -1865,7 +1865,7 @@ func (s *Session) stoppedOnBreakpointGoroutineID(state *api.DebuggerState) (int6
 // stepUntilStopAndNotify is a wrapper around runUntilStopAndNotify that
 // first switches selected goroutine. allowNextStateChange is
 // a channel that will be closed to signal that an
-// asynchornous command has completed setup or was interrupted
+// asynchronous command has completed setup or was interrupted
 // due to an error, so the server is ready to receive new requests.
 func (s *Session) stepUntilStopAndNotify(command string, threadId int, granularity dap.SteppingGranularity, allowNextStateChange chan struct{}) {
 	defer closeIfOpen(allowNextStateChange)
@@ -2500,7 +2500,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		if v.DwarfType != nil && len(v.Children) > 0 && v.Children[0].Addr != 0 && v.Children[0].Kind != reflect.Invalid {
 			if v.Children[0].OnlyAddr { // Not loaded
 				if v.Addr == 0 {
-					// This is equvalent to the following with the cli:
+					// This is equivalent to the following with the cli:
 					//    (dlv) p &a7
 					//    (**main.FooBar)(0xc0000a3918)
 					//
@@ -2887,7 +2887,7 @@ func (s *Session) onSetVariableRequest(request *dap.SetVariableRequest) {
 	}
 
 	if useFnCall {
-		// TODO(hyangah): function call injection currentlly allows to assign return values of
+		// TODO(hyangah): function call injection currently allows to assign return values of
 		// a function call to variables. So, curious users would find set variable
 		// on string would accept expression like `fn()`.
 		if state, retVals, err := s.doCall(goid, frame, fmt.Sprintf("%v=%v", evaluateName, arg.Value)); err != nil {
@@ -2928,7 +2928,7 @@ func (s *Session) onSetVariableRequest(request *dap.SetVariableRequest) {
 	// to update the variable/watch sections if necessary.
 	//
 	// More complicated situation is when the set variable involves call
-	// injection - after the injected call is completed, the debugee can
+	// injection - after the injected call is completed, the debuggee can
 	// be in a completely different state (see the note in doCall) due to
 	// how the call injection is implemented. Ideally, we need to also refresh
 	// the stack frames but that is complicated. For now we don't try to actively
@@ -3463,7 +3463,7 @@ func (s *Session) resumeOnce(command string, allowNextStateChange chan struct{})
 // termination, error, breakpoint, etc, when an appropriate
 // event needs to be sent to the client. allowNextStateChange is
 // a channel that will be closed to signal that an
-// asynchornous command has completed setup or was interrupted
+// asynchronous command has completed setup or was interrupted
 // due to an error, so the server is ready to receive new requests.
 func (s *Session) runUntilStopAndNotify(command string, allowNextStateChange chan struct{}) {
 	state, err := s.runUntilStop(command, allowNextStateChange)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2099,7 +2099,7 @@ func TestVariablesLoading(t *testing.T) {
 							checkChildren(t, c1sa, "c1.sa", 3)
 							ref = checkVarRegex(t, c1sa, 0, `\[0\]`, `c1\.sa\[0\]`, `\*\(\*main\.astruct\)\(0x[0-9a-f]+\)`, `\*main\.astruct`, hasChildren)
 							if ref > 0 {
-								// Auto-loading of fully missing struc children happens here
+								// Auto-loading of fully missing struct children happens here
 								client.VariablesRequest(ref)
 								c1sa0 := client.ExpectVariablesResponse(t)
 								checkChildren(t, c1sa0, "c1.sa[0]", 1)
@@ -4161,7 +4161,7 @@ func TestVariableValueTruncation(t *testing.T) {
 
 					// Compound map keys may be truncated even further
 					// As the keys are always inside of a map container,
-					// this applies to variables requests only, not evalute requests.
+					// this applies to variables requests only, not evaluate requests.
 
 					// key - compound, value - scalar (inlined key:value display) => truncate key if too long
 					ref := checkVarExact(t, locals, -1, "m5", "m5", "map[main.C]int [{s: "+longstr+"}: 1, ]", "map[main.C]int", hasChildren)
@@ -6717,7 +6717,7 @@ func (s *MultiClientCloseServerMock) acceptNewClient(t *testing.T) *daptest.Clie
 func (s *MultiClientCloseServerMock) stop(t *testing.T) {
 	close(s.forceStop)
 	// If the server doesn't have an active session,
-	// closing it would leak the debbuger with the target because
+	// closing it would leak the debugger with the target because
 	// they are part of dap.Session.
 	// We must take it down manually as if we are in rpccommon::ServerImpl::Stop.
 	if s.debugger.IsRunning() {
@@ -6733,7 +6733,7 @@ func (s *MultiClientCloseServerMock) verifyStopped(t *testing.T) {
 	verifyServerStopped(t, s.impl)
 }
 
-// TestAttachRemoteMultiClientDisconnect tests that that remote attach doesn't take down
+// TestAttachRemoteMultiClientDisconnect tests that remote attach doesn't take down
 // the server in multi-client mode unless terminateDebuggee is explicitly set.
 func TestAttachRemoteMultiClientDisconnect(t *testing.T) {
 	closingClientSessionOnly := fmt.Sprintf(daptest.ClosingClient, "halted")
@@ -7039,7 +7039,7 @@ func TestDisassemble(t *testing.T) {
 						t.Errorf("\ngot %#v\nwant instructions[1].Address = %s", dr, pc)
 					}
 
-					// Request zero instrutions.
+					// Request zero instructions.
 					client.DisassembleRequest(pc, 0, 0)
 					dr = client.ExpectDisassembleResponse(t)
 					if len(dr.Body.Instructions) != 0 {

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -106,7 +106,7 @@ type LaunchConfig struct {
 	//    "buildFlags": "-tags=integration -mod=vendor -cover -v"
 	BuildFlags string `json:"buildFlags,omitempty"`
 
-	// Output path for the binary of the debugee.
+	// Output path for the binary of the debuggee.
 	// Relative path is interpreted as the path relative to
 	// the Delve's current working directory.
 	// This is deleted after the debug session ends.
@@ -191,7 +191,7 @@ type LaunchAttachCommonConfig struct {
 // SubstitutePath defines a mapping from a local path to the remote path.
 // Both 'from' and 'to' must be specified and non-null.
 // Empty values can be used to add or remove absolute path prefixes when mapping.
-// For example, mapping with empy 'to' can be used to work with binaries with trimmed paths.
+// For example, mapping with empty 'to' can be used to work with binaries with trimmed paths.
 type SubstitutePath struct {
 	// The local path to be replaced when passing paths to the debugger.
 	From string `json:"from,omitempty"`

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -547,7 +547,7 @@ func (c *RPCClient) FollowExec(v bool, regex string) error {
 	return err
 }
 
-// FollowExecEnabled returns true if follow exex mode is enabled.
+// FollowExecEnabled returns true if follow exec mode is enabled.
 func (c *RPCClient) FollowExecEnabled() bool {
 	out := &FollowExecEnabledOut{}
 	_ = c.call("FollowExecEnabled", FollowExecEnabledIn{}, out)

--- a/service/rpccallback.go
+++ b/service/rpccallback.go
@@ -5,7 +5,7 @@ type RPCCallback interface {
 	Return(out interface{}, err error)
 
 	// SetupDoneChan returns a channel that should be closed to signal that the
-	// asynchornous method has completed setup and the server is ready to
+	// asynchronous method has completed setup and the server is ready to
 	// receive other requests.
 	SetupDoneChan() chan struct{}
 }

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -858,7 +858,7 @@ func Test1Issue355(t *testing.T) {
 }
 
 func Test1Disasm(t *testing.T) {
-	// Tests that disassembling by PC, range, and current PC all yeld similar results
+	// Tests that disassembling by PC, range, and current PC all yield similar results
 	// Tests that disassembly by current PC will return a disassembly containing the instruction at PC
 	// Tests that stepping on a calculated CALL instruction will yield a disassembly that contains the
 	// effective destination of the CALL instruction

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1360,7 +1360,7 @@ func TestIssue355(t *testing.T) {
 }
 
 func TestDisasm(t *testing.T) {
-	// Tests that disassembling by PC, range, and current PC all yeld similar results
+	// Tests that disassembling by PC, range, and current PC all yield similar results
 	// Tests that disassembly by current PC will return a disassembly containing the instruction at PC
 	// Tests that stepping on a calculated CALL instruction will yield a disassembly that contains the
 	// effective destination of the CALL instruction
@@ -1962,7 +1962,7 @@ func TestClientServerConsistentExit(t *testing.T) {
 
 		// Ensure future commands also return the correct exit status.
 		// Previously there was a bug where the command which prompted the
-		// process to exit (continue, next, etc...) would return the corrent
+		// process to exit (continue, next, etc...) would return the current
 		// exit status but subsequent commands would return an incorrect exit
 		// status of 0. To test this we simply repeat the 'next' command and
 		// ensure we get the correct response again.


### PR DESCRIPTION
This PR corrects typos and removes duplicated words.  Changes are only in comments in `service` directory.