### PR TITLE
proc,terminal: read command line of new processes

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -227,7 +227,7 @@ func OpenCore(corePath, exePath string, debugInfoDirs []string) (*proc.TargetGro
 		DisableAsyncPreempt: false,
 		CanDump:             false,
 	})
-	_, err = addTarget(p, p.pid, currentThread, exePath, proc.StopAttached)
+	_, err = addTarget(p, p.pid, currentThread, exePath, proc.StopAttached, "")
 	return grp, err
 }
 

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -124,7 +124,7 @@ func Record(cmd []string, wd string, quiet bool, redirects [3]string) (tracedir 
 
 // Replay starts an instance of rr in replay mode, with the specified trace
 // directory, and connects to it.
-func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string, rrOnProcessPid int) (*proc.TargetGroup, error) {
+func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string, rrOnProcessPid int, cmdline string) (*proc.TargetGroup, error) {
 	if err := checkRRAvailable(); err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string,
 			safeRemoveAll(p.tracedir)
 		}
 	}
-	tgt, err := p.Dial(init.port, init.exe, 0, debugInfoDirs, proc.StopLaunched)
+	tgt, err := p.Dial(init.port, init.exe, cmdline, 0, debugInfoDirs, proc.StopLaunched)
 	if err != nil {
 		rrcmd.Process.Kill()
 		return nil, err
@@ -293,7 +293,7 @@ func RecordAndReplay(cmd []string, wd string, quiet bool, debugInfoDirs []string
 	if tracedir == "" {
 		return nil, "", err
 	}
-	t, err := Replay(tracedir, quiet, true, debugInfoDirs, 0)
+	t, err := Replay(tracedir, quiet, true, debugInfoDirs, 0, strings.Join(cmd, " "))
 	return t, tracedir, err
 }
 

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -142,4 +142,4 @@ func (t *nativeThread) SoftExc() bool {
 	panic(ErrNativeBackendDisabled)
 }
 
-func initialize(dbp *nativeProcess) error { return nil }
+func initialize(dbp *nativeProcess) (string, error) { return "", nil }

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -207,12 +207,14 @@ func (procgrp *processGroup) procForThread(tid int) *nativeProcess {
 	return nil
 }
 
-func (procgrp *processGroup) add(p *nativeProcess, pid int, currentThread proc.Thread, path string, stopReason proc.StopReason) (*proc.Target, error) {
-	tgt, err := procgrp.addTarget(p, pid, currentThread, path, stopReason)
+func (procgrp *processGroup) add(p *nativeProcess, pid int, currentThread proc.Thread, path string, stopReason proc.StopReason, cmdline string) (*proc.Target, error) {
+	tgt, err := procgrp.addTarget(p, pid, currentThread, path, stopReason, cmdline)
 	if err != nil {
 		return nil, err
 	}
-	procgrp.procs = append(procgrp.procs, p)
+	if tgt != nil {
+		procgrp.procs = append(procgrp.procs, p)
+	}
 	return tgt, nil
 }
 
@@ -285,20 +287,24 @@ func (dbp *nativeProcess) FindBreakpoint(pc uint64, adjustPC bool) (*proc.Breakp
 	return nil, false
 }
 
-func (dbp *nativeProcess) initializeBasic() error {
-	if err := initialize(dbp); err != nil {
-		return err
+func (dbp *nativeProcess) initializeBasic() (string, error) {
+	cmdline, err := initialize(dbp)
+	if err != nil {
+		return "", err
 	}
 	if err := dbp.updateThreadList(); err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return cmdline, nil
 }
 
 // initialize will ensure that all relevant information is loaded
 // so the process is ready to be debugged.
 func (dbp *nativeProcess) initialize(path string, debugInfoDirs []string) (*proc.TargetGroup, error) {
-	dbp.initializeBasic()
+	cmdline, err := dbp.initializeBasic()
+	if err != nil {
+		return nil, err
+	}
 	stopReason := proc.StopLaunched
 	if !dbp.childProcess {
 		stopReason = proc.StopAttached
@@ -321,7 +327,7 @@ func (dbp *nativeProcess) initialize(path string, debugInfoDirs []string) (*proc
 		CanDump:    runtime.GOOS == "linux" || runtime.GOOS == "freebsd" || (runtime.GOOS == "windows" && runtime.GOARCH == "amd64"),
 	})
 	procgrp.addTarget = addTarget
-	tgt, err := procgrp.add(dbp, dbp.pid, dbp.memthread, path, stopReason)
+	tgt, err := procgrp.add(dbp, dbp.pid, dbp.memthread, path, stopReason, cmdline)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -489,4 +489,4 @@ func (dbp *nativeProcess) GetBufferedTracepoints() []ebpf.RawUProbeParams {
 	panic("not implemented")
 }
 
-func initialize(dbp *nativeProcess) error { return nil }
+func initialize(dbp *nativeProcess) (string, error) { return "", nil }

--- a/pkg/proc/native/proc_freebsd.c
+++ b/pkg/proc/native/proc_freebsd.c
@@ -2,11 +2,7 @@
 #include <sys/mount.h>
 #include <sys/queue.h>
 #include <sys/sysctl.h>
-#include <sys/user.h>
-#include <sys/types.h>
 
-#include <libprocstat.h>
-#include <libutil.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>

--- a/pkg/proc/native/proc_freebsd.h
+++ b/pkg/proc/native/proc_freebsd.h
@@ -1,4 +1,7 @@
 #include <sys/types.h>
+#include <sys/user.h>
+#include <libutil.h>
+#include <libprocstat.h>
 
 char * find_command_name(int pid);
 char * find_executable(int pid);

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -172,6 +172,17 @@ func assertLineNumber(p *proc.Target, t *testing.T, lineno int, descr string) (s
 	return f, l
 }
 
+func assertFunctionName(p *proc.Target, t *testing.T, fnname string, descr string) {
+	pc := currentPC(p, t)
+	f, l, fn := p.BinInfo().PCToLine(pc)
+	if fn == nil {
+		t.Fatalf("%s expected function %s got %s:%d", descr, fnname, f, l)
+	}
+	if fn.Name != fnname {
+		t.Fatalf("%s expected function %s got %s %s:%d", descr, fnname, fn.Name, f, l)
+	}
+}
+
 func TestExit(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("continuetestprog", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
@@ -6114,6 +6125,46 @@ func TestStepShadowConcurrentBreakpoint(t *testing.T) {
 		}
 		if stacktraceme2calls != 100 {
 			t.Errorf("wrong number of calls to stacktraceme2 found: %d", stacktraceme2calls)
+		}
+	})
+}
+
+func TestFollowExecRegexFilter(t *testing.T) {
+	skipUnlessOn(t, "follow exec only supported on linux", "linux")
+	withTestProcessArgs("spawn", t, ".", []string{"spawn", "3"}, 0, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+		grp.LogicalBreakpoints[1] = &proc.LogicalBreakpoint{LogicalID: 1, Set: proc.SetBreakpoint{FunctionName: "main.traceme1"}, HitCount: make(map[int64]uint64)}
+		grp.LogicalBreakpoints[2] = &proc.LogicalBreakpoint{LogicalID: 2, Set: proc.SetBreakpoint{FunctionName: "main.traceme2"}, HitCount: make(map[int64]uint64)}
+		grp.LogicalBreakpoints[3] = &proc.LogicalBreakpoint{LogicalID: 3, Set: proc.SetBreakpoint{FunctionName: "main.traceme3"}, HitCount: make(map[int64]uint64)}
+
+		assertNoError(grp.EnableBreakpoint(grp.LogicalBreakpoints[1]), t, "EnableBreakpoint(main.traceme1)")
+		assertNoError(grp.EnableBreakpoint(grp.LogicalBreakpoints[3]), t, "EnableBreakpoint(main.traceme3)")
+
+		assertNoError(grp.FollowExec(true, "spawn.* child C1"), t, "FollowExec")
+
+		assertNoError(grp.Continue(), t, "Continue 1")
+		assertFunctionName(grp.Selected, t, "main.traceme1", "Program did not continue to the expected location (1)")
+		assertNoError(grp.Continue(), t, "Continue 2")
+		assertFunctionName(grp.Selected, t, "main.traceme2", "Program did not continue to the expected location (2)")
+		assertNoError(grp.Continue(), t, "Continue 3")
+		assertFunctionName(grp.Selected, t, "main.traceme3", "Program did not continue to the expected location (3)")
+		err := grp.Continue()
+		if err != nil {
+			_, isexited := err.(proc.ErrProcessExited)
+			if !isexited {
+				assertNoError(err, t, "Continue 4")
+			}
+		} else {
+			t.Fatal("process did not exit after 4 continues")
+		}
+	})
+}
+
+func TestReadTargetArguments(t *testing.T) {
+	protest.AllowRecording(t)
+	withTestProcessArgs("restartargs", t, ".", []string{"one", "two", "three"}, 0, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+		t.Logf("command line: %q\n", p.CmdLine)
+		if !strings.HasSuffix(p.CmdLine, " one two three") {
+			t.Fatalf("wrong command line")
 		}
 	})
 }

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -41,7 +41,8 @@ type Target struct {
 	proc   ProcessInternal
 	recman RecordingManipulationInternal
 
-	pid int
+	pid     int
+	CmdLine string
 
 	// StopReason describes the reason why the target process is stopped.
 	// A process could be stopped for multiple simultaneous reasons, in which
@@ -160,7 +161,7 @@ func DisableAsyncPreemptEnv() []string {
 
 // newTarget returns an initialized Target object.
 // The p argument can optionally implement the RecordingManipulation interface.
-func (grp *TargetGroup) newTarget(p ProcessInternal, pid int, currentThread Thread, path string) (*Target, error) {
+func (grp *TargetGroup) newTarget(p ProcessInternal, pid int, currentThread Thread, path, cmdline string) (*Target, error) {
 	entryPoint, err := p.EntryPoint()
 	if err != nil {
 		return nil, err
@@ -182,6 +183,7 @@ func (grp *TargetGroup) newTarget(p ProcessInternal, pid int, currentThread Thre
 		fncallForG:    make(map[int64]*callInjection),
 		currentThread: currentThread,
 		pid:           pid,
+		CmdLine:       cmdline,
 	}
 
 	if recman, ok := p.(RecordingManipulationInternal); ok {

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -2,8 +2,8 @@ package proc
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/go-delve/delve/pkg/logflags"
@@ -20,6 +20,7 @@ type TargetGroup struct {
 	targets           []*Target
 	Selected          *Target
 	followExecEnabled bool
+	followExecRegex   *regexp.Regexp
 
 	RecordingManipulation
 	recman RecordingManipulationInternal
@@ -48,7 +49,7 @@ type NewTargetGroupConfig struct {
 	CanDump             bool       // Can create core dumps (must implement ProcessInternal.MemoryMap)
 }
 
-type AddTargetFunc func(ProcessInternal, int, Thread, string, StopReason) (*Target, error)
+type AddTargetFunc func(ProcessInternal, int, Thread, string, StopReason, string) (*Target, error)
 
 // NewGroup creates a TargetGroup containing the specified Target.
 func NewGroup(procgrp ProcessGroup, cfg NewTargetGroupConfig) (*TargetGroup, AddTargetFunc) {
@@ -86,17 +87,29 @@ func Restart(grp, oldgrp *TargetGroup, discard func(*LogicalBreakpoint, error)) 
 		}
 	}
 	if oldgrp.followExecEnabled {
-		grp.FollowExec(true, "")
+		rgx := ""
+		if oldgrp.followExecRegex != nil {
+			rgx = oldgrp.followExecRegex.String()
+		}
+		grp.FollowExec(true, rgx)
 	}
 }
 
-func (grp *TargetGroup) addTarget(p ProcessInternal, pid int, currentThread Thread, path string, stopReason StopReason) (*Target, error) {
-	t, err := grp.newTarget(p, pid, currentThread, path)
+func (grp *TargetGroup) addTarget(p ProcessInternal, pid int, currentThread Thread, path string, stopReason StopReason, cmdline string) (*Target, error) {
+	logger := logflags.DebuggerLogger()
+	t, err := grp.newTarget(p, pid, currentThread, path, cmdline)
 	if err != nil {
 		return nil, err
 	}
 	t.StopReason = stopReason
-	//TODO(aarzilli): check if the target's command line matches the regex
+	if grp.followExecRegex != nil && len(grp.targets) > 0 {
+		if !grp.followExecRegex.MatchString(cmdline) {
+			logger.Debugf("Detaching from child target %d %q", t.Pid(), t.CmdLine)
+			t.detach(false)
+			return nil, nil
+		}
+	}
+	logger.Debugf("Adding target %d %q", t.Pid(), t.CmdLine)
 	if t.partOfGroup {
 		panic("internal error: target is already part of group")
 	}
@@ -108,7 +121,7 @@ func (grp *TargetGroup) addTarget(p ProcessInternal, pid int, currentThread Thre
 	if grp.Selected == nil {
 		grp.Selected = t
 	}
-	logger := logflags.DebuggerLogger()
+	t.Breakpoints().Logical = grp.LogicalBreakpoints
 	for _, lbp := range grp.LogicalBreakpoints {
 		if lbp.LogicalID < 0 {
 			continue
@@ -340,8 +353,13 @@ func (grp *TargetGroup) DisableBreakpoint(lbp *LogicalBreakpoint) error {
 // If regex is not the empty string only processes whose command line
 // matches regex will be added to the target group.
 func (grp *TargetGroup) FollowExec(v bool, regex string) error {
-	if regex != "" {
-		return errors.New("regex not implemented")
+	grp.followExecRegex = nil
+	if regex != "" && v {
+		var err error
+		grp.followExecRegex, err = regexp.Compile(regex)
+		if err != nil {
+			return err
+		}
 	}
 	it := ValidTargets{Group: grp}
 	for it.Next() {

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2553,7 +2553,7 @@ func printcontext(t *Term, state *api.DebuggerState) {
 
 	if state.Pid != t.oldPid {
 		if t.oldPid != 0 {
-			fmt.Fprintf(t.stdout, "Switch target process from %d to %d\n", t.oldPid, state.Pid)
+			fmt.Fprintf(t.stdout, "Switch target process from %d to %d (%s)\n", t.oldPid, state.Pid, state.TargetCommandLine)
 		}
 		t.oldPid = state.Pid
 	}

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -454,9 +454,9 @@ func ConvertDumpState(dumpState *proc.DumpState) *DumpState {
 
 // ConvertTarget converts a proc.Target into a api.Target.
 func ConvertTarget(tgt *proc.Target, convertThreadBreakpoint func(proc.Thread) *Breakpoint) *Target {
-	//TODO(aarzilli): copy command line here
 	return &Target{
 		Pid:           tgt.Pid(),
+		CmdLine:       tgt.CmdLine,
 		CurrentThread: ConvertThread(tgt.CurrentThread(), convertThreadBreakpoint(tgt.CurrentThread())),
 	}
 }

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -19,6 +19,8 @@ var ErrNotExecutable = errors.New("not an executable file")
 type DebuggerState struct {
 	// PID of the process we are debugging.
 	Pid int
+	// Command line of the process we are debugging.
+	TargetCommandLine string
 	// Running is true if the process is running and no other information can be collected.
 	Running bool
 	// Recording is true if the process is currently being recorded and no other

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -176,7 +176,7 @@ func New(config *Config, processArgs []string) (*Debugger, error) {
 		switch d.config.Backend {
 		case "rr":
 			d.log.Infof("opening trace %s", d.config.CoreFile)
-			d.target, err = gdbserial.Replay(d.config.CoreFile, false, false, d.config.DebugInfoDirectories, d.config.RrOnProcessPid)
+			d.target, err = gdbserial.Replay(d.config.CoreFile, false, false, d.config.DebugInfoDirectories, d.config.RrOnProcessPid, "")
 		default:
 			d.log.Infof("opening core file %s (executable %s)", d.config.CoreFile, d.processArgs[0])
 			d.target, err = core.OpenCore(d.config.CoreFile, d.processArgs[0], d.config.DebugInfoDirectories)
@@ -335,7 +335,7 @@ func (d *Debugger) recordingRun(run func() (string, error)) (*proc.TargetGroup, 
 		return nil, err
 	}
 
-	return gdbserial.Replay(tracedir, false, true, d.config.DebugInfoDirectories, 0)
+	return gdbserial.Replay(tracedir, false, true, d.config.DebugInfoDirectories, 0, strings.Join(d.processArgs, " "))
 }
 
 // Attach will attach to the process specified by 'pid'.
@@ -568,6 +568,7 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig, withBreakpointInfo bool) (
 
 	state = &api.DebuggerState{
 		Pid:               tgt.Pid(),
+		TargetCommandLine: tgt.CmdLine,
 		SelectedGoroutine: goroutine,
 		Exited:            exited,
 	}


### PR DESCRIPTION
Read the command line of the main target process as well as any other
process Delve attaches to in follow exec mode.

The command line can be viewed using the 'target list' command.

In follow exec mode this command line is used to match the follow exec
regex to decide whether or not to attach to a child process.

On macOS or when using rr the list of arguments is not available for
attached processes since there is no way to use the gdb serial protocol
to read it.

Fixes #2242
