### PR TITLE
service/dap: use reloaded value

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2485,6 +2485,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 			value += fmt.Sprintf(" - FAILED TO LOAD: %s", err)
 		} else {
 			v.Children = vLoaded.Children
+			v.Value = vLoaded.Value
 			value = api.ConvertVar(v).SinglelineString()
 		}
 		return value


### PR DESCRIPTION
The only part of the reloaded value that was used was the Children. This caused a bug where the Time format string was reloaded, but it was not being displayed.

Fixes go-delve/delve#3342