### PR TITLE
pkg/proc: add missing response body Close in test

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2917,6 +2917,7 @@ func TestAttachDetach(t *testing.T) {
 		assertNoError(err, t, "Page request after detach")
 		bs, err := ioutil.ReadAll(resp.Body)
 		assertNoError(err, t, "Reading /nobp page")
+		defer resp.Body.Close()
 		if out := string(bs); !strings.Contains(out, "hello, world!") {
 			t.Fatalf("/nobp page does not contain \"hello, world!\": %q", out)
 		}


### PR DESCRIPTION
From the [doc](https://pkg.go.dev/net/http#Get):
```
// When err is nil, resp always contains a non-nil resp.Body.
// Caller should close resp.Body when done reading from it.
```