### PR TITLE
chore: don't ignore directory cmd/dlv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 tags
 .dbg_history
 **/**/dlv
+!cmd/dlv/
 .vagrant
 **/*.swp
 localtests


### PR DESCRIPTION
Currently, cmd/dlv is ignored, breaks tools which read the gitignore file. For example, rg can't search files under cmd/dlv.