### PR TITLE
refactor: replace `Readdir(-1)` with `os.ReadDir`

### DIFF
--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -504,12 +504,7 @@ func procdump(t *testing.T, exePath string) string {
 		t.Fatalf("possible error running procdump64, output: %q, error: %v", string(out), err)
 	}
 
-	dh, err := os.Open(exeDir)
-	if err != nil {
-		t.Fatalf("could not open executable file directory %q: %v", exeDir, err)
-	}
-	defer dh.Close()
-	fis, err := dh.Readdir(-1)
+	fis, err := os.ReadDir(exeDir)
 	if err != nil {
 		t.Fatalf("could not read executable file directory %q: %v", exeDir, err)
 	}

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -300,12 +300,7 @@ func RecordAndReplay(cmd []string, wd string, quiet bool, debugInfoDirs []string
 // safeRemoveAll removes dir and its contents but only as long as dir does
 // not contain directories.
 func safeRemoveAll(dir string) {
-	dh, err := os.Open(dir)
-	if err != nil {
-		return
-	}
-	defer dh.Close()
-	fis, err := dh.Readdir(-1)
+	fis, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -279,12 +279,7 @@ func MustHaveRecordingAllowed(t testing.TB) {
 // SafeRemoveAll removes dir and its contents but only as long as dir does
 // not contain directories.
 func SafeRemoveAll(dir string) {
-	dh, err := os.Open(dir)
-	if err != nil {
-		return
-	}
-	defer dh.Close()
-	fis, err := dh.Readdir(-1)
+	fis, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
We can simplify the following code

```go
dir, err := os.Open(dirname)
if err != nil {
	return err
}
defer dir.Close()

dirs, err := dir.Readdir(-1)
```

with just `os.ReadDir(dirname)`. `os.ReadDir` is recommended over `Readdir()`, as stated in the official doc [^1]

[^1]: "Most clients are better served by the more efficient ReadDir method." https://pkg.go.dev/os#File.Readdir