### PR TITLE
cmd/dlv,service/dap: use randomized name as default output binary

### DIFF
--- a/Documentation/usage/dlv_debug.md
+++ b/Documentation/usage/dlv_debug.md
@@ -20,7 +20,7 @@ dlv debug [package] [flags]
 ```
       --continue        Continue the debugged process on start.
   -h, --help            help for debug
-      --output string   Output path for the binary. (default "./__debug_bin")
+      --output string   Output path for the binary.
       --tty string      TTY to use for the target program
 ```
 

--- a/Documentation/usage/dlv_test.md
+++ b/Documentation/usage/dlv_test.md
@@ -23,7 +23,7 @@ dlv test [package] [flags]
 
 ```
   -h, --help            help for test
-      --output string   Output path for the binary. (default "debug.test")
+      --output string   Output path for the binary.
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/usage/dlv_trace.md
+++ b/Documentation/usage/dlv_trace.md
@@ -24,7 +24,7 @@ dlv trace [package] regexp [flags]
       --ebpf            Trace using eBPF (experimental).
   -e, --exec string     Binary file to exec and trace.
   -h, --help            help for trace
-      --output string   Output path for the binary. (default "debug")
+      --output string   Output path for the binary.
   -p, --pid int         Pid to attach to.
   -s, --stack int       Show stack trace with given depth. (Ignored with --ebpf)
   -t, --test            Trace a test binary.

--- a/pkg/gobuild/defaultexe.go
+++ b/pkg/gobuild/defaultexe.go
@@ -1,0 +1,28 @@
+package gobuild
+
+import (
+	"io/ioutil"
+	"runtime"
+
+	"github.com/go-delve/delve/pkg/logflags"
+)
+
+// DefaultDebugBinaryPath returns an unused file path in the current
+// directory named 'name' followed by a random string
+func DefaultDebugBinaryPath(name string) string {
+	pattern := name
+	if runtime.GOOS == "windows" {
+		pattern += "*.exe"
+	}
+	f, err := ioutil.TempFile(".", pattern)
+	if err != nil {
+		logflags.DebuggerLogger().Errorf("could not create temporary file for build output: %v", err)
+		if runtime.GOOS == "windows" {
+			return name + ".exe"
+		}
+		return name
+	}
+	r := f.Name()
+	f.Close()
+	return r
+}


### PR DESCRIPTION
Using a fixed path as the default output binary means that executing
Delve twice in the same directory will cause the second invocation to
overwrite the output binary of the first instance of Delve, making the
restart command not work correctly.

Fixes #3345
