### PR TITLE
proc: fix runtime type handling for Go 1.21

### DIFF
--- a/_scripts/rtype-out.txt
+++ b/_scripts/rtype-out.txt
@@ -15,7 +15,7 @@ type bmap struct {
 }
 
 type eface struct {
-	_type *_type
+	_type *_type|*internal/abi.Type
 	data unsafe.Pointer
 }
 
@@ -50,7 +50,7 @@ type iface struct {
 }
 
 type itab struct {
-	_type *_type
+	_type *_type|*internal/abi.Type
 }
 
 type moduledata struct {

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -1263,6 +1263,8 @@ func (e fakeEntry) AttrField(attr dwarf.Attr) *dwarf.Field {
 }
 
 func regabiMallocgcWorkaround(bi *BinaryInfo) ([]*godwarf.Tree, error) {
+	ptrToRuntimeType := "*" + bi.runtimeTypeTypename()
+
 	var err1 error
 
 	t := func(name string) godwarf.Type {
@@ -1298,7 +1300,7 @@ func regabiMallocgcWorkaround(bi *BinaryInfo) ([]*godwarf.Tree, error) {
 	case "amd64":
 		r := []*godwarf.Tree{
 			m("size", t("uintptr"), regnum.AMD64_Rax, false),
-			m("typ", t("*runtime._type"), regnum.AMD64_Rbx, false),
+			m("typ", t(ptrToRuntimeType), regnum.AMD64_Rbx, false),
 			m("needzero", t("bool"), regnum.AMD64_Rcx, false),
 			m("~r1", t("unsafe.Pointer"), regnum.AMD64_Rax, true),
 		}
@@ -1306,7 +1308,7 @@ func regabiMallocgcWorkaround(bi *BinaryInfo) ([]*godwarf.Tree, error) {
 	case "arm64":
 		r := []*godwarf.Tree{
 			m("size", t("uintptr"), regnum.ARM64_X0, false),
-			m("typ", t("*runtime._type"), regnum.ARM64_X0+1, false),
+			m("typ", t(ptrToRuntimeType), regnum.ARM64_X0+1, false),
 			m("needzero", t("bool"), regnum.ARM64_X0+2, false),
 			m("~r1", t("unsafe.Pointer"), regnum.ARM64_X0, true),
 		}

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -212,7 +212,7 @@ func TestSetVariable(t *testing.T) {
 			assertNoError(err, t, "EvalVariable()")
 			assertVariable(t, variable, varTest{tc.name, true, tc.startVal, "", tc.typ, nil})
 
-			assertNoError(setVariable(p, tc.name, tc.expr), t, "SetVariable()")
+			assertNoError(setVariable(p, tc.name, tc.expr), t, fmt.Sprintf("SetVariable(%q, %q)", tc.name, tc.expr))
 
 			variable, err = evalVariableWithCfg(p, tc.name, pnormalLoadConfig)
 			assertNoError(err, t, "EvalVariable()")
@@ -856,6 +856,7 @@ func TestEvalExpression(t *testing.T) {
 		assertNoError(grp.Continue(), t, "Continue() returned an error")
 		for i, tc := range testcases {
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				t.Logf("%q", tc.name)
 				variable, err := evalVariableWithCfg(p, tc.name, pnormalLoadConfig)
 				if err != nil && err.Error() == "evaluating methods not supported on this version of Go" {
 					// this type of eval is unsupported with the current version of Go.


### PR DESCRIPTION
Go 1.21 renamed runtime._type to internal/abi.Type and changed the name
of its fields. Update Delve so that it uses the new names for loading
interfaces and generic type parameters.
