### PR TITLE
pkg/proc,pkg/terminal: close response body in tests

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -741,7 +741,10 @@ func TestNextNetHTTP(t *testing.T) {
 				}
 				time.Sleep(50 * time.Millisecond)
 			}
-			http.Get("http://127.0.0.1:9191")
+			resp, err := http.Get("http://127.0.0.1:9191")
+			if err == nil {
+				resp.Body.Close()
+			}
 		}()
 		if err := grp.Continue(); err != nil {
 			t.Fatal(err)
@@ -2913,7 +2916,10 @@ func TestAttachDetach(t *testing.T) {
 	assertNoError(err, t, "Attach")
 	go func() {
 		time.Sleep(1 * time.Second)
-		http.Get("http://127.0.0.1:9191")
+		resp, err := http.Get("http://127.0.0.1:9191")
+		if err == nil {
+			resp.Body.Close()
+		}
 	}()
 
 	assertNoError(p.Continue(), t, "Continue")

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -693,7 +693,10 @@ func TestIssue827(t *testing.T) {
 	withTestTerminal("notify-v2", t, func(term *FakeTerminal) {
 		go func() {
 			time.Sleep(1 * time.Second)
-			http.Get("http://127.0.0.1:8888/test")
+			resp, err := http.Get("http://127.0.0.1:8888/test")
+			if err == nil {
+				resp.Body.Close()
+			}
 			time.Sleep(1 * time.Second)
 			term.client.Halt()
 		}()


### PR DESCRIPTION
> Go Response Body MUST be closed, even if you don’t read it

https://manishrjain.com/must-close-golang-http-response