### PR TITLE
proc: remove addrret field from Stackframe struct

### DIFF
--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -162,8 +162,8 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 		it.systemstack = false
 
 		// advances to the next frame in the call stack
-		it.frame.addrret = uint64(int64(it.regs.SP()) + int64(it.bi.Arch.PtrSize()))
-		it.frame.Ret, _ = readUintRaw(it.mem, it.frame.addrret, int64(it.bi.Arch.PtrSize()))
+		addrret := uint64(int64(it.regs.SP()) + int64(it.bi.Arch.PtrSize()))
+		it.frame.Ret, _ = readUintRaw(it.mem, addrret, int64(it.bi.Arch.PtrSize()))
 		it.pc = it.frame.Ret
 
 		it.top = false

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -211,8 +211,8 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 			it.top = false
 			it.systemstack = false
 			// The return value is stored in the LR register which is saved at 24(SP).
-			it.frame.addrret = uint64(int64(it.regs.SP()) + int64(it.bi.Arch.PtrSize()*3))
-			it.frame.Ret, _ = readUintRaw(it.mem, it.frame.addrret, int64(it.bi.Arch.PtrSize()))
+			addrret := uint64(int64(it.regs.SP()) + int64(it.bi.Arch.PtrSize()*3))
+			it.frame.Ret, _ = readUintRaw(it.mem, addrret, int64(it.bi.Arch.PtrSize()))
 			it.pc = it.frame.Ret
 
 			return true

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -39,8 +39,6 @@ type Stackframe struct {
 	stackHi uint64
 	// Return address for this stack frame (as read from the stack frame itself).
 	Ret uint64
-	// Address to the memory location containing the return address
-	addrret uint64
 	// Err is set if an error occurred during stacktrace
 	Err error
 	// SystemStack is true if this frame belongs to a system stack.
@@ -275,7 +273,7 @@ func (it *stackIterator) newStackframe(ret, retaddr uint64) Stackframe {
 	} else {
 		it.regs.FrameBase = it.frameBase(fn)
 	}
-	r := Stackframe{Current: Location{PC: it.pc, File: f, Line: l, Fn: fn}, Regs: it.regs, Ret: ret, addrret: retaddr, stackHi: it.stackhi, SystemStack: it.systemstack, lastpc: it.pc}
+	r := Stackframe{Current: Location{PC: it.pc, File: f, Line: l, Fn: fn}, Regs: it.regs, Ret: ret, stackHi: it.stackhi, SystemStack: it.systemstack, lastpc: it.pc}
 	if r.Regs.Reg(it.regs.PCRegNum) == nil {
 		r.Regs.AddReg(it.regs.PCRegNum, op.DwarfRegisterFromUint64(it.pc))
 	}
@@ -366,7 +364,6 @@ func (it *stackIterator) appendInlineCalls(frames []Stackframe, frame Stackframe
 			Regs:        frame.Regs,
 			stackHi:     frame.stackHi,
 			Ret:         frame.Ret,
-			addrret:     frame.addrret,
 			Err:         frame.Err,
 			SystemStack: frame.SystemStack,
 			Inlined:     true,


### PR DESCRIPTION
This field was part of the original stack tracing algorithm, we haven't
used this in years.
