### PR TITLE
service: fix typos in comments, logs, tests, errors, and vars

### DIFF
--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -449,7 +449,7 @@ func PrettyExamineMemory(address uintptr, memArea []byte, isLittleEndian bool, f
 		cols = 8
 		colFormat = fmt.Sprintf("0x%%0%dx", colBytes*2) // Always keep one leading '0x' for hex.
 	default:
-		return fmt.Sprintf("not supprted format %q\n", string(format))
+		return fmt.Sprintf("not supported format %q\n", string(format))
 	}
 	colFormat += "\t"
 

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -407,7 +407,7 @@ type DebuggerCommand struct {
 	// UnsafeCall disables parameter escape checking for function calls.
 	// Go objects can be allocated on the stack or on the heap. Heap objects
 	// can be used by any goroutine; stack objects can only be used by the
-	// goroutine that owns the stack they are allocated on and can not surivive
+	// goroutine that owns the stack they are allocated on and can not survive
 	// the stack frame of allocation.
 	// The Go compiler will use escape analysis to determine whether to
 	// allocate an object on the stack or the heap.

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -556,14 +556,14 @@ func (c *Client) ReadMemoryRequest() {
 }
 
 // DisassembleRequest sends a 'disassemble' request.
-func (c *Client) DisassembleRequest(memoryReference string, instructionOffset, inctructionCount int) {
+func (c *Client) DisassembleRequest(memoryReference string, instructionOffset, instructionCount int) {
 	c.send(&dap.DisassembleRequest{
 		Request: *c.newRequest("disassemble"),
 		Arguments: dap.DisassembleArguments{
 			MemoryReference:   memoryReference,
 			Offset:            0,
 			InstructionOffset: instructionOffset,
-			InstructionCount:  inctructionCount,
+			InstructionCount:  instructionCount,
 			ResolveSymbols:    false,
 		},
 	})

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -71,7 +71,7 @@ import (
 // a dummy/error response to avoid blocking.
 //
 // This is the only goroutine that sends a stop-server signal
-// via config.DisconnecChan when encountering a client connection
+// via config.DisconnectChan when encountering a client connection
 // error or responding to a (synchronous) DAP disconnect request.
 // Once stop is triggered, the goroutine exits.
 //
@@ -124,7 +124,7 @@ type Session struct {
 	// exceptionErr tracks the runtime error that last occurred.
 	exceptionErr error
 	// clientCapabilities tracks special settings for handling debug session requests.
-	clientCapabilities dapClientCapabilites
+	clientCapabilities dapClientCapabilities
 
 	// mu synchronizes access to objects set on start-up (from run goroutine)
 	// and stopped on teardown (from main goroutine)
@@ -236,9 +236,9 @@ var defaultArgs = launchAttachArgs{
 	substitutePathServerToClient: [][2]string{},
 }
 
-// dapClientCapabilites captures arguments from initialize request that
+// dapClientCapabilities captures arguments from initialize request that
 // impact handling of subsequent requests.
-type dapClientCapabilites struct {
+type dapClientCapabilities struct {
 	supportsVariableType         bool
 	supportsVariablePaging       bool
 	supportsRunInTerminalRequest bool
@@ -1072,7 +1072,7 @@ func (s *Session) getPackageDir(pkg string) string {
 	cmd := exec.Command("go", "list", "-f", "{{.Dir}}", pkg)
 	out, err := cmd.Output()
 	if err != nil {
-		s.config.log.Debugf("failed to determin package directory for %v: %v\n%s", pkg, err, out)
+		s.config.log.Debugf("failed to determine package directory for %v: %v\n%s", pkg, err, out)
 		return "."
 	}
 	return string(bytes.TrimSpace(out))
@@ -2594,7 +2594,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 	return value, variablesReference
 }
 
-// onEvaluateRequest handles 'evalute' requests.
+// onEvaluateRequest handles 'evaluate' requests.
 // This is a mandatory request to support.
 // Support the following expressions:
 //
@@ -3127,7 +3127,7 @@ func alignPCs(bi *proc.BinaryInfo, start, end uint64) (uint64, uint64) {
 	// Handle start values:
 	fn := bi.PCToFunc(start)
 	if fn != nil {
-		// start is in a funcition.
+		// start is in a function.
 		start = fn.Entry
 	} else if b, pc := checkOutOfAddressSpace(start, bi); b {
 		start = pc
@@ -3142,7 +3142,7 @@ func alignPCs(bi *proc.BinaryInfo, start, end uint64) (uint64, uint64) {
 
 	// Handle end values:
 	if fn := bi.PCToFunc(end); fn != nil {
-		// end is in a funcition.
+		// end is in a function.
 		end = fn.End
 	} else if b, pc := checkOutOfAddressSpace(end, bi); b {
 		end = pc

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -284,7 +284,7 @@ func TestSessionStop(t *testing.T) {
 			defer client.Close()
 			<-acceptDone
 			if err != nil {
-				t.Fatalf("cannot accept client requireed for testing: %v", err)
+				t.Fatalf("cannot accept client required for testing: %v", err)
 			}
 			session := NewSession(conn, &Config{
 				Config:        &service.Config{DisconnectChan: make(chan struct{})},
@@ -962,7 +962,7 @@ func checkStackFramesNamed(testName string, t *testing.T, got *dap.StackTraceRes
 
 // checkScope is a helper for verifying the values within a ScopesResponse.
 //
-//	i - index of the scope within ScopesRespose.Body.Scopes array
+//	i - index of the scope within ScopesResponse.Body.Scopes array
 //	name - name of the scope
 //	varRef - reference to retrieve variables of this scope. If varRef is negative, the reference is not checked.
 func checkScope(t *testing.T, got *dap.ScopesResponse, i int, name string, varRef int) {
@@ -1668,7 +1668,7 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 					client.ScopesRequest(1000)
 					scopes := client.ExpectScopesResponse(t)
 					if len(scopes.Body.Scopes) > 1 {
-						t.Errorf("\ngot  %#v\nwant len(scopes)=1 (Argumes & Locals)", scopes)
+						t.Errorf("\ngot  %#v\nwant len(scopes)=1 (Arguments & Locals)", scopes)
 					}
 					checkScope(t, scopes, 0, "Locals", localsScope)
 
@@ -2109,7 +2109,7 @@ func TestVariablesLoading(t *testing.T) {
 						}
 					}
 
-					// Fully missing struct auto-loaded when hitting LoadConfig.MaxVariableRecurse (also tests evaluteName corner case)
+					// Fully missing struct auto-loaded when hitting LoadConfig.MaxVariableRecurse (also tests evaluateName corner case)
 					ref = checkVarRegex(t, locals, -1, "aas", "aas", `\[\]main\.a len: 1, cap: 1, \[{aas: \[\]main\.a len: 1, cap: 1, \[\(\*main\.a\)\(0x[0-9a-f]+\)\]}\]`, `\[\]main\.a`, hasChildren)
 					if ref > 0 {
 						client.VariablesRequest(ref)
@@ -2146,7 +2146,7 @@ func TestVariablesLoading(t *testing.T) {
 						checkChildren(t, tm, "tm", 1)
 						ref = checkVarExact(t, tm, 0, "v", "tm.v", "[]map[string]main.astruct len: 1, cap: 1, [[...]]", "[]map[string]main.astruct", hasChildren)
 						if ref > 0 {
-							// Auto-loading of fully missing map chidlren happens here, but they get trancated at MaxArrayValuess
+							// Auto-loading of fully missing map chidlren happens here, but they get truncated at MaxArrayValuess
 							client.VariablesRequest(ref)
 							tmV := client.ExpectVariablesResponse(t)
 							checkChildren(t, tmV, "tm.v", 1)
@@ -4650,7 +4650,7 @@ func testNextParkedHelper(t *testing.T, client *daptest.Client, fixture protest.
 			// ok
 		case *dap.TerminatedEvent:
 			// This is very unlikely to happen. But in theory if all sayhi
-			// gouritines are run serially, there will never be a second parked
+			// goroutines are run serially, there will never be a second parked
 			// sayhi goroutine when another breaks and we will keep trying
 			// until process termination.
 			return -1
@@ -5772,7 +5772,7 @@ func TestPauseAndContinue(t *testing.T) {
 	})
 }
 
-func TestUnupportedCommandResponses(t *testing.T) {
+func TestUnsupportedCommandResponses(t *testing.T) {
 	var got *dap.ErrorResponse
 	runTest(t, "increment", func(client *daptest.Client, fixture protest.Fixture) {
 		seqCnt := 1

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -253,7 +253,7 @@ type CreateBreakpointOut struct {
 }
 
 // CreateBreakpoint creates a new breakpoint. The client is expected to populate `CreateBreakpointIn`
-// with an `api.Breakpoint` struct describing where to set the breakpoing. For more information on
+// with an `api.Breakpoint` struct describing where to set the breakpoint. For more information on
 // how to properly request a breakpoint via the `api.Breakpoint` struct see the documentation for
 // `debugger.CreateBreakpoint` here: https://pkg.go.dev/github.com/go-delve/delve/service/debugger#Debugger.CreateBreakpoint.
 func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpointOut) error {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -611,7 +611,7 @@ func TestClientServer_toggleAmendedBreakpoint(t *testing.T) {
 			t.Fatal(err)
 		}
 		if amended.Cond == "" {
-			t.Fatal("breakpoint amendedments not preserved after toggle")
+			t.Fatal("breakpoint amendments not preserved after toggle")
 		}
 	})
 }
@@ -2188,7 +2188,7 @@ func TestAncestors(t *testing.T) {
 	defer os.Setenv("GODEBUG", savedGodebug)
 	withTestClient2("testnextprog", t, func(c service.Client) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.testgoroutine", Line: -1})
-		assertNoError(err, t, "CreateBreakpoin")
+		assertNoError(err, t, "CreateBreakpoint")
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
 		ancestors, err := c.Ancestors(-1, 1000, 1000)
@@ -2259,7 +2259,7 @@ func TestRerecord(t *testing.T) {
 	withTestClient2("testrerecord", t, func(c service.Client) {
 		fp := testProgPath(t, "testrerecord")
 		_, err := c.CreateBreakpoint(&api.Breakpoint{File: fp, Line: 10})
-		assertNoError(err, t, "CreateBreakpoin")
+		assertNoError(err, t, "CreateBreakpoint")
 
 		gett := func() int {
 			state := <-c.Continue()
@@ -2531,7 +2531,7 @@ func TestToggleBreakpointRestart(t *testing.T) {
 }
 
 func TestStopServerWithClosedListener(t *testing.T) {
-	// Checks that the error erturned by listener.Accept() is ignored when we
+	// Checks that the error returned by listener.Accept() is ignored when we
 	// are trying to shutdown. See issue #1633.
 	if testBackend == "rr" || buildMode == "pie" {
 		t.Skip("N/A")
@@ -3000,7 +3000,7 @@ func TestClientServer_breakpointOnFuncWithABIWrapper(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestClient2("math", t, func(c service.Client) {
 		bp, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "runtime.schedinit"})
-		assertNoError(err, t, "CreateBreakpoin()")
+		assertNoError(err, t, "CreateBreakpoint()")
 		t.Log(bp)
 
 		found := false


### PR DESCRIPTION
This PR corrects spelling mistakes in the `service` folder.