### PR TITLE
dwarf,proc: fix typos in comments and error messages

### DIFF
--- a/pkg/dwarf/godwarf/tree_test.go
+++ b/pkg/dwarf/godwarf/tree_test.go
@@ -50,7 +50,7 @@ func TestRangeContains(t *testing.T) {
 	for _, tc := range tcs {
 		if rangeContains(tc.a, tc.b) != tc.tgt {
 			if tc.tgt {
-				t.Errorf("range %v does not contan %v (but should)", tc.a, tc.b)
+				t.Errorf("range %v does not contain %v (but should)", tc.a, tc.b)
 			} else {
 				t.Errorf("range %v does contain %v (but shouldn't)", tc.a, tc.b)
 			}
@@ -81,7 +81,7 @@ func TestRangesContains(t *testing.T) {
 	for _, tc := range tcs {
 		if rangesContains(tc.rngs1, tc.rngs2) != tc.tgt {
 			if tc.tgt {
-				t.Errorf("ranges %v does not contan %v (but should)", tc.rngs1, tc.rngs2)
+				t.Errorf("ranges %v does not contain %v (but should)", tc.rngs1, tc.rngs2)
 			} else {
 				t.Errorf("ranges %v does contain %v (but shouldn't)", tc.rngs1, tc.rngs2)
 			}

--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -42,7 +42,7 @@ const (
 	encImaginaryFloat = 0x09
 )
 
-const cyclicalTypeStop = "<cyclical>" // guard value printed for types with a cyclical definition, to avoid inifinite recursion in Type.String
+const cyclicalTypeStop = "<cyclical>" // guard value printed for types with a cyclical definition, to avoid infinite recursion in Type.String
 
 type recCheck map[dwarf.Offset]struct{}
 

--- a/pkg/dwarf/reader/reader.go
+++ b/pkg/dwarf/reader/reader.go
@@ -228,7 +228,7 @@ func (reader *Reader) NextMemberVariable() (*dwarf.Entry, error) {
 }
 
 // NextPackageVariable moves the reader to the next debug entry that describes a package variable.
-// Any TagVariable entry that is not inside a sub prgram entry and is marked external is considered a package variable.
+// Any TagVariable entry that is not inside a sub program entry and is marked external is considered a package variable.
 func (reader *Reader) NextPackageVariable() (*dwarf.Entry, error) {
 	for entry, err := reader.Next(); entry != nil; entry, err = reader.Next() {
 		if err != nil {

--- a/pkg/proc/i386_disasm.go
+++ b/pkg/proc/i386_disasm.go
@@ -17,7 +17,7 @@ func i386AsmDecode(asmInst *AsmInstruction, mem []byte, regs *op.DwarfRegisters,
 
 // Possible stacksplit prologues are inserted by stacksplit in
 // $GOROOT/src/cmd/internal/obj/x86/obj6.go.
-// If 386 on linux when pie, the stacksplit prologue beigin with `call __x86.get_pc_thunk.` sometime.
+// If 386 on linux when pie, the stacksplit prologue begin with `call __x86.get_pc_thunk.` sometime.
 var prologuesI386 []opcodeSeq
 
 func init() {

--- a/pkg/proc/linutil/dynamic.go
+++ b/pkg/proc/linutil/dynamic.go
@@ -38,7 +38,7 @@ func readUintRaw(reader io.Reader, order binary.ByteOrder, ptrSize int) (uint64,
 		}
 		return n, nil
 	}
-	return 0, fmt.Errorf("not supprted ptr size %d", ptrSize)
+	return 0, fmt.Errorf("not supported ptr size %d", ptrSize)
 }
 
 // dynamicSearchDebug searches for the DT_DEBUG entry in the .dynamic section

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2840,7 +2840,7 @@ func TestNextInDeferReturn(t *testing.T) {
 	// runtime.deferreturn updates the G struct in a way that for one
 	// instruction leaves the curg._defer field non-nil but with curg._defer.fn
 	// field being nil.
-	// We need to deal with this without panicing.
+	// We need to deal with this without panicking.
 	protest.AllowRecording(t)
 	withTestProcess("defercall", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "runtime.deferreturn")
@@ -3735,7 +3735,7 @@ func TestHaltKeepsSteppingBreakpoints(t *testing.T) {
 
 func TestDisassembleGlobalVars(t *testing.T) {
 	skipOn(t, "broken - global variable symbolication", "arm64") // On ARM64 symLookup can't look up variables due to how they are loaded, see issue #1778
-	// On 386 linux when pie, the genered code use __x86.get_pc_thunk to ensure position-independent.
+	// On 386 linux when pie, the generated code use __x86.get_pc_thunk to ensure position-independent.
 	// Locate global variable by
 	//    `CALL __x86.get_pc_thunk.ax(SB) 0xb0f7f
 	//     LEAL 0xc0a19(AX), AX`


### PR DESCRIPTION
This PR fixes typos in the `pkg` folder.