### PR TITLE
debuginfod-find stderr may contain diagnostics; look at stdout only

### DIFF
--- a/pkg/proc/debuginfod/debuginfod.go
+++ b/pkg/proc/debuginfod/debuginfod.go
@@ -12,7 +12,7 @@ func execFind(args ...string) (string, error) {
 		return "", err
 	}
 	cmd := exec.Command(debuginfodFind, args...)
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output() // ignore stderr
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Test by setting $DEBUGINFOD_PROGRESS=1 or $DEBUGINFOD_VERBOSE=1
before invoking dlv.  A "no such file or directory" dlv error results the first time,
even though debuginfod-find succeeded.  If rerun (and thus the file is found in
the debuginfod client cache), diagnostics may not be printed, so dlv may work.