### PR TITLE
DAP sets suspended breakpoints.

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1379,7 +1379,7 @@ func (s *Session) setBreakpoints(prefix string, totalBps int, metadataFunc func(
 				err = setLogMessage(bp, want.logMessage)
 				if err == nil {
 					// Create new breakpoints.
-					got, err = s.debugger.CreateBreakpoint(bp, "", nil, false)
+					got, err = s.debugger.CreateBreakpoint(bp, "", nil, true)
 				}
 			}
 		}


### PR DESCRIPTION
In VSCode, when you set a breakpoint in code that is in a plugin, it will not work. You have to re-activate the breakpoint manually after plugin.Open is hit. This (untested) commit, should fix that.