### PR TITLE
TeamCity: actually run linux/386 tests on linux/386

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -192,6 +192,7 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
                         --env TEAMCITY_VERSION=${'$'}TEAMCITY_VERSION
                         --env CI=true
                         --privileged
+                        --platform linux/$dockerArch
                         $dockerArch/ubuntu:20.04
                         /delve/_scripts/test_linux.sh ${"go$version"} $arch
                     """.trimIndent()


### PR DESCRIPTION
It seems that our linux/386 builders no longer (or never did?) use
linux/386, the i386/ubuntu:20.04 docker image has become (or always
was?) multiarchitecture and docker starterd picking (always picked?)
the amd64 version. This change should fix the problem (or break
everything).
