### PR TITLE
proc/test: reenable cgo testing on FreeBSD

### DIFF
--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -364,8 +364,9 @@ var hasCgo = func() bool {
 	if strings.TrimSpace(string(out)) != "1" {
 		return false
 	}
-	_, err = exec.LookPath("gcc")
-	return err == nil
+	_, err1 := exec.LookPath("gcc")
+	_, err2 := exec.LookPath("clang")
+	return (err1 == nil) || (err2 == nil)
 }()
 
 func MustHaveCgo(t *testing.T) {


### PR DESCRIPTION
Cgo testing on FreeBSD was accidentally disabled by 4e24209, FreeBSD
does not have gcc by default anymore.
