### PR TITLE
dwarf: ignore DeclLine for function args

### DIFF
--- a/_fixtures/decllinetest.go
+++ b/_fixtures/decllinetest.go
@@ -11,6 +11,9 @@ func main() {
 	f1(a, b)
 }
 
-func f1(a, b int) {
+func f1(
+	a int,
+	b int,
+) {
 	fmt.Printf("%d %d\n", a, b)
 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3612,7 +3612,11 @@ func TestDeclLine(t *testing.T) {
 		setFileBreakpoint(p, t, fixture.Source, 9)
 		setFileBreakpoint(p, t, fixture.Source, 10)
 		setFileBreakpoint(p, t, fixture.Source, 11)
-		setFileBreakpoint(p, t, fixture.Source, 14)
+		b := setFunctionBreakpoint(p, t, "main.f1")
+		if b.Line != 14 {
+			// Line 14 is hard-coded below.
+			t.Fatalf("expected \"main.f1\" breakpoint to be set on line 14, but got line: %d", b.Line)
+		}
 
 		assertNoError(grp.Continue(), t, "Continue 1")
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 15) {
@@ -3635,6 +3639,9 @@ func TestDeclLine(t *testing.T) {
 		testDeclLineCount(t, p, 11, []string{"a", "b"})
 
 		assertNoError(grp.Continue(), t, "Continue 5")
+		// On line 14, we expect the function's arguments to be available, even
+		// though their DW_AT_decl_line declares higher line numbers. The decl_line
+		// is supposed to be ignored for the visibility of arguments.
 		testDeclLineCount(t, p, 14, []string{"a", "b"})
 	})
 }


### PR DESCRIPTION
Before this patch, the visibility of function arguments for purposes
like the `locals` command was considered to start on the line on which
they are declared. I believe this was incorrect; instead their
visibility should start at the beginning of the function. This makes a
difference for function declarations like:

```
1: func foo(
2:   a int,
3:   b int,
4: )
```

Here, foo() starts on line 1 (e.g. a breakpoint on "foo" will break on
:1), but "a" has a decl_line of :2 and "b" has :3. This was causing a
and b to not be readable for a few instructions at the beginning of the
function, although they should have been.

This patch fixes it by ignoring decl_line for function arguments,
essentially making them visible throughout the function.

Note that function arguments are not subject to the bug in location
lists described in https://github.com/golang/go/issues/60493. That
issues describes how the loclists for some variables erroneously extends
to the end of the function's code, covering trailing code related to
stack growth that should not be covered because the respective variables
have yet to be initialized when that code runs. The decl_line check
helps Delve avoid making the variables visible during that trailing
code, and thus prevents reading garbage. However, function arguments are
already initialized when the stack growth runs, and they can be read
just fine from the respective PCs (so their loclist is fine). So, this
patch does not introduce a regression (additionally, function args
declared on the same line as the function were already unprotected by
the decl_line check).