### PR TITLE
_scripts: fix typos

### DIFF
--- a/_scripts/gen-travis.go
+++ b/_scripts/gen-travis.go
@@ -26,7 +26,7 @@ var minVersion = goVersion{Major: goversion.MinSupportedVersionOfGoMajor, Minor:
 func (v goVersion) dec() goVersion {
 	v.Minor--
 	if v.Minor < 0 {
-		panic("TODO: fill the maximum minor version number for v.Maxjor here")
+		panic("TODO: fill the maximum minor version number for v.Major here")
 	}
 	return v
 }

--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -144,7 +144,7 @@ func checkCert() bool {
 		return false
 	}
 	if err != nil {
-		fmt.Printf("An error occoured when generating and installing a new certificate: %v\n", err)
+		fmt.Printf("An error occurred when generating and installing a new certificate: %v\n", err)
 		return false
 	}
 	os.Setenv("CERT", "dlv-cert")


### PR DESCRIPTION
This PR fixes typos in `_scripts` files.