### PR TITLE
TeamCity: fix linux/arm64 build

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -176,6 +176,12 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
                         arch
                     }
                 }
+                val dockerPlatformArch = when (arch) {
+                    "arm64" -> "arm64/v8"
+                    else -> {
+                        dockerArch
+                    }
+                }
                 dockerCommand {
                     name = "Pull Ubuntu"
                     commandType = other {


### PR DESCRIPTION
Change cc05aa2 broke linux/arm64 builds, this should fix them.
