### PR TITLE
cmd/commands: fix to read debug info file from correct directory in trace command

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -303,7 +303,8 @@ to know what functions your process is executing.
 
 The output of the trace sub command is printed to stderr, so if you would like to
 only see the output of the trace operations you can redirect stdout.`,
-		Run: traceCmd,
+		Run: func(cmd *cobra.Command, args []string) {
+			os.Exit(traceCmd(cmd, args, conf)) }, 
 	}
 	traceCommand.Flags().IntVarP(&traceAttachPid, "pid", "p", 0, "Pid to attach to.")
 	traceCommand.Flags().StringVarP(&traceExecFile, "exec", "e", "", "Binary file to exec and trace.")
@@ -574,7 +575,7 @@ func debugCmd(cmd *cobra.Command, args []string) {
 	os.Exit(status)
 }
 
-func traceCmd(cmd *cobra.Command, args []string) {
+func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 	status := func() int {
 		err := logflags.Setup(log, logOutput, logDest)
 		defer logflags.Close()
@@ -648,6 +649,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 				WorkingDir:     workingDir,
 				Backend:        backend,
 				CheckGoVersion: checkGoVersion,
+				DebugInfoDirectories: conf.DebugInfoDirectories,
 			},
 		})
 		if err := server.Run(); err != nil {
@@ -769,7 +771,7 @@ func traceCmd(cmd *cobra.Command, args []string) {
 		}
 		return 0
 	}()
-	os.Exit(status)
+	return status
 }
 
 func isBreakpointExistsErr(err error) bool {


### PR DESCRIPTION
I use dlv 1.20.2 (the latest). I experienced the problem that dlv trace -e always fails to read separated debug info like the below,

```
$ ~/go/bin/dlv trace --log -e /usr/bin/hugo 'commands\.new.*'
2023-06-05T01:50:12+09:00 info layer=debugger launching process with args: [/usr/bin/hugo]                                                                          
2023-06-05T01:50:12+09:00 warning layer=debugger gnu_debuglink link "7c03fe5487be2cbd7f7097fae18a1337dc56bf.debug" not found in any debug info directory            
could not launch process: could not open debug info - debuggee must not be built with 'go run' or -ldflags='-s -w', which strip debug info
```

 The root cause is that the traceCmd function in cmd/dlv/cmds/commands.go doesn't reference conf.DebugInfoDirectories, therefore, openSeparateDebugInfo function in pkg/proc/bininfo.go tries to find the debug info in the wrong directory.

I suggest this PR to fix this problem.
