### PR TITLE
*: fix arm64 docker builds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -177,7 +177,7 @@ class TestBuild(val os: String, val arch: String, version: String, buildId: Abso
                     }
                 }
                 val dockerPlatformArch = when (arch) {
-                    "arm64" -> "arm64/v8"
+                    "arm64" -> "arm64v8"
                     else -> {
                         dockerArch
                     }


### PR DESCRIPTION
There is an error in the TeamCity test logs:

```
docker: Error response from daemon: image with reference
arm64v8/ubuntu:20.04 was found but does not match the specified
platform: wanted linux/arm64v8, actual: linux/arm64/v8.
```