### PR TITLE
service,terminal: when libraries don't have debug_info print reason

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2547,6 +2547,9 @@ func libraries(t *Term, ctx callContext, args string) error {
 	d := digits(len(libs))
 	for i := range libs {
 		fmt.Fprintf(t.stdout, "%"+strconv.Itoa(d)+"d. %#x %s\n", i, libs[i].Address, libs[i].Path)
+		if libs[i].LoadError != "" {
+			fmt.Fprintf(t.stdout, "    Load error: %s", libs[i].LoadError)
+		}
 	}
 	return nil
 }

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -431,7 +431,12 @@ func ConvertRegisters(in *op.DwarfRegisters, dwarfRegisterToString func(int, *op
 
 // ConvertImage converts proc.Image to api.Image.
 func ConvertImage(image *proc.Image) Image {
-	return Image{Path: image.Path, Address: image.StaticBase}
+	err := image.LoadError()
+	lerr := ""
+	if err != nil {
+		lerr = err.Error()
+	}
+	return Image{Path: image.Path, Address: image.StaticBase, LoadError: lerr}
 }
 
 // ConvertDumpState converts proc.DumpState to api.DumpState.

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -571,8 +571,9 @@ type Checkpoint struct {
 
 // Image represents a loaded shared object (go plugin or shared library)
 type Image struct {
-	Path    string
-	Address uint64
+	Path      string
+	Address   uint64
+	LoadError string
 }
 
 // Ancestor represents a goroutine ancestor


### PR DESCRIPTION
Print the reason why libraries don't have debug info in response to the
'libraries' command.
