### PR TITLE
proc: only print warning when gopclntab can not be read for first image

### DIFF
--- a/pkg/proc/pclntab.go
+++ b/pkg/proc/pclntab.go
@@ -61,10 +61,9 @@ func readPcLnTableElf(exe *elf.File, path string) (*gosym.Table, error) {
 	// Find .gopclntab by magic number even if there is no section label
 	magic := magicNumber(bi.GoVersion)
 	pclntabIndex := bytes.Index(tableData, magic)
-	if pclntabIndex < 0 {
-		return nil, fmt.Errorf("could not find magic number in %s ", path)
+	if pclntabIndex >= 0 {
+		tableData = tableData[pclntabIndex:]
 	}
-	tableData = tableData[pclntabIndex:]
 	addr := exe.Section(".text").Addr
 	lineTable := gosym.NewLineTable(tableData, addr)
 	symTable, err := gosym.NewTable([]byte{}, lineTable)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3169,6 +3169,7 @@ func TestDebugStripped(t *testing.T) {
 	// Currently only implemented for Linux ELF executables.
 	// TODO(derekparker): Add support for Mach-O and PE.
 	skipUnlessOn(t, "linux only", "linux")
+	skipOn(t, "does not work with PIE", "pie")
 	withTestProcessArgs("testnextprog", t, "", []string{}, protest.LinkStrip, func(p *proc.Target, grp *proc.TargetGroup, f protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")
 		assertNoError(grp.Continue(), t, "Continue")


### PR DESCRIPTION
Only print the warning that gopclntab can not be read for the first
image (i.e. the executable file), also change the returned when neither
DWARF nor gopclntab are found to preserve the DWARF error.
