### PR TITLE
debugger: Fix issue with breakpoint reset after restart (#3423)

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -773,6 +773,15 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string,
 			return nil, err
 		}
 	}
+	if lbp.Set.FunctionName == "" && lbp.FunctionName != "" {
+		lbp.Set.FunctionName = lbp.FunctionName
+	}
+	if lbp.Set.File == "" && lbp.File != "" {
+		lbp.Set.File = lbp.File
+	}
+	if lbp.Set.Line == 0 && lbp.Line != 0 {
+		lbp.Set.Line = lbp.Line
+	}
 
 	createdBp := d.convertBreakpoint(lbp)
 	d.log.Infof("created breakpoint: %#v", createdBp)


### PR DESCRIPTION
This commit addresses an issue where breakpoints would get set to address 0 after a restart. The issue was rooted in the lack of preservation of certain breakpoint information during the process of creating a breakpoint in the Debugger's CreateBreakpoint method.