### PR TITLE
proc: skip TestDebugStripped on linux/386/pie

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3169,6 +3169,7 @@ func TestDebugStripped(t *testing.T) {
 	// Currently only implemented for Linux ELF executables.
 	// TODO(derekparker): Add support for Mach-O and PE.
 	skipUnlessOn(t, "linux only", "linux")
+	skipOn(t, "not working on linux/386 with PIE", "linux", "386", "pie")
 	withTestProcessArgs("testnextprog", t, "", []string{}, protest.LinkStrip, func(p *proc.Target, grp *proc.TargetGroup, f protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")
 		assertNoError(grp.Continue(), t, "Continue")


### PR DESCRIPTION
PIEs do not have a .data.rel.ro.gopclntab section on linux/386. Disable
the test.
