### PR TITLE
pkg,service: refactor to use %q instead of "%s"

### DIFF
--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -69,7 +69,7 @@ func Parse(locStr string) (LocationSpec, error) {
 
 	malformed := func(reason string) error {
 		//lint:ignore ST1005 backwards compatibility
-		return fmt.Errorf("Malformed breakpoint location \"%s\" at %d: %s", locStr, len(locStr)-len(rest), reason)
+		return fmt.Errorf("Malformed breakpoint location %q at %d: %s", locStr, len(locStr)-len(rest), reason)
 	}
 
 	if len(rest) <= 0 {
@@ -109,7 +109,7 @@ func Parse(locStr string) (LocationSpec, error) {
 func parseLocationSpecDefault(locStr, rest string) (LocationSpec, error) {
 	malformed := func(reason string) error {
 		//lint:ignore ST1005 backwards compatibility
-		return fmt.Errorf("Malformed breakpoint location \"%s\" at %d: %s", locStr, len(locStr)-len(rest), reason)
+		return fmt.Errorf("Malformed breakpoint location %q at %d: %s", locStr, len(locStr)-len(rest), reason)
 	}
 
 	v := strings.Split(rest, ":")
@@ -365,7 +365,7 @@ func (ale AmbiguousLocationError) Error() string {
 	} else {
 		candidates = ale.CandidatesString
 	}
-	return fmt.Sprintf("Location \"%s\" ambiguous: %s…", ale.Location, strings.Join(candidates, ", "))
+	return fmt.Sprintf("Location %q ambiguous: %s…", ale.Location, strings.Join(candidates, ", "))
 }
 
 // Find will return a list of locations that match the given location spec.
@@ -396,7 +396,7 @@ func (loc *NormalLocationSpec) Find(t *proc.Target, processArgs []string, scope 
 
 	if matching := len(candidateFiles) + len(candidateFuncs); matching == 0 {
 		if scope == nil {
-			return nil, fmt.Errorf("location \"%s\" not found", locStr)
+			return nil, fmt.Errorf("location %q not found", locStr)
 		}
 		// if no result was found this locations string could be an
 		// expression that the user forgot to prefix with '*', try treating it as
@@ -404,7 +404,7 @@ func (loc *NormalLocationSpec) Find(t *proc.Target, processArgs []string, scope 
 		addrSpec := &AddrLocationSpec{AddrExpr: locStr}
 		locs, err := addrSpec.Find(t, processArgs, scope, locStr, includeNonExecutableLines, nil)
 		if err != nil {
-			return nil, fmt.Errorf("location \"%s\" not found", locStr)
+			return nil, fmt.Errorf("location %q not found", locStr)
 		}
 		return locs, nil
 	} else if matching > 1 {

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -363,7 +363,7 @@ func (scope *EvalScope) setValue(dstv, srcv *Variable, srcExpr string) error {
 
 	if srcv.Unreadable != nil {
 		//lint:ignore ST1005 backwards compatibility
-		return fmt.Errorf("Expression \"%s\" is unreadable: %v", srcExpr, srcv.Unreadable)
+		return fmt.Errorf("Expression %q is unreadable: %v", srcExpr, srcv.Unreadable)
 	}
 
 	// Numerical types
@@ -437,12 +437,12 @@ func (scope *EvalScope) SetVariable(name, value string) error {
 
 	if xv.Addr == 0 {
 		//lint:ignore ST1005 backwards compatibility
-		return fmt.Errorf("Can not assign to \"%s\"", name)
+		return fmt.Errorf("Can not assign to %q", name)
 	}
 
 	if xv.Unreadable != nil {
 		//lint:ignore ST1005 backwards compatibility
-		return fmt.Errorf("Expression \"%s\" is unreadable: %v", name, xv.Unreadable)
+		return fmt.Errorf("Expression %q is unreadable: %v", name, xv.Unreadable)
 	}
 
 	t, err = parser.ParseExpr(value)
@@ -1400,7 +1400,7 @@ func (scope *EvalScope) evalTypeAssert(node *ast.TypeAssertExpr) (*Variable, err
 		return nil, err
 	}
 	if xv.Kind != reflect.Interface {
-		return nil, fmt.Errorf("expression \"%s\" not an interface", exprToString(node.X))
+		return nil, fmt.Errorf("expression %q not an interface", exprToString(node.X))
 	}
 	xv.loadInterface(0, false, loadFullValue)
 	if xv.Unreadable != nil {
@@ -1451,7 +1451,7 @@ func (scope *EvalScope) evalIndex(node *ast.IndexExpr) (*Variable, error) {
 		return nil, err
 	}
 
-	cantindex := fmt.Errorf("expression \"%s\" (%s) does not support indexing", exprToString(node.X), xev.TypeString())
+	cantindex := fmt.Errorf("expression %q (%s) does not support indexing", exprToString(node.X), xev.TypeString())
 
 	switch xev.Kind {
 	case reflect.Ptr:
@@ -1469,7 +1469,7 @@ func (scope *EvalScope) evalIndex(node *ast.IndexExpr) (*Variable, error) {
 
 	case reflect.Slice, reflect.Array, reflect.String:
 		if xev.Base == 0 {
-			return nil, fmt.Errorf("can not index \"%s\"", exprToString(node.X))
+			return nil, fmt.Errorf("can not index %q", exprToString(node.X))
 		}
 		n, err := idxev.asInt()
 		if err != nil {
@@ -1508,7 +1508,7 @@ func (scope *EvalScope) evalReslice(node *ast.SliceExpr) (*Variable, error) {
 		}
 		low, err = lowv.asInt()
 		if err != nil {
-			return nil, fmt.Errorf("can not convert \"%s\" to int: %v", exprToString(node.Low), err)
+			return nil, fmt.Errorf("can not convert %q to int: %v", exprToString(node.Low), err)
 		}
 	}
 
@@ -1521,14 +1521,14 @@ func (scope *EvalScope) evalReslice(node *ast.SliceExpr) (*Variable, error) {
 		}
 		high, err = highv.asInt()
 		if err != nil {
-			return nil, fmt.Errorf("can not convert \"%s\" to int: %v", exprToString(node.High), err)
+			return nil, fmt.Errorf("can not convert %q to int: %v", exprToString(node.High), err)
 		}
 	}
 
 	switch xev.Kind {
 	case reflect.Slice, reflect.Array, reflect.String:
 		if xev.Base == 0 {
-			return nil, fmt.Errorf("can not slice \"%s\"", exprToString(node.X))
+			return nil, fmt.Errorf("can not slice %q", exprToString(node.X))
 		}
 		return xev.reslice(low, high)
 	case reflect.Map:
@@ -1547,7 +1547,7 @@ func (scope *EvalScope) evalReslice(node *ast.SliceExpr) (*Variable, error) {
 		}
 		fallthrough
 	default:
-		return nil, fmt.Errorf("can not slice \"%s\" (type %s)", exprToString(node.X), xev.TypeString())
+		return nil, fmt.Errorf("can not slice %q (type %s)", exprToString(node.X), xev.TypeString())
 	}
 }
 
@@ -1559,7 +1559,7 @@ func (scope *EvalScope) evalPointerDeref(node *ast.StarExpr) (*Variable, error) 
 	}
 
 	if xev.Kind != reflect.Ptr {
-		return nil, fmt.Errorf("expression \"%s\" (%s) can not be dereferenced", exprToString(node.X), xev.TypeString())
+		return nil, fmt.Errorf("expression %q (%s) can not be dereferenced", exprToString(node.X), xev.TypeString())
 	}
 
 	if xev == nilVariable {
@@ -1592,7 +1592,7 @@ func (scope *EvalScope) evalAddrOf(node *ast.UnaryExpr) (*Variable, error) {
 		return nil, err
 	}
 	if xev.Addr == 0 || xev.DwarfType == nil {
-		return nil, fmt.Errorf("can not take address of \"%s\"", exprToString(node.X))
+		return nil, fmt.Errorf("can not take address of %q", exprToString(node.X))
 	}
 
 	return xev.pointerToVariable(), nil
@@ -1660,7 +1660,7 @@ func (scope *EvalScope) evalUnary(node *ast.UnaryExpr) (*Variable, error) {
 		return nil, errOperationOnSpecialFloat
 	}
 	if xv.Value == nil {
-		return nil, fmt.Errorf("operator %s can not be applied to \"%s\"", node.Op.String(), exprToString(node.X))
+		return nil, fmt.Errorf("operator %s can not be applied to %q", node.Op.String(), exprToString(node.X))
 	}
 	rc, err := constantUnaryOp(node.Op, xv.Value)
 	if err != nil {
@@ -1708,7 +1708,7 @@ func negotiateType(op token.Token, xv, yv *Variable) (godwarf.Type, error) {
 
 	if xv.DwarfType != nil && yv.DwarfType != nil {
 		if xv.DwarfType.String() != yv.DwarfType.String() {
-			return nil, fmt.Errorf("mismatched types \"%s\" and \"%s\"", xv.DwarfType.String(), yv.DwarfType.String())
+			return nil, fmt.Errorf("mismatched types %q and %q", xv.DwarfType.String(), yv.DwarfType.String())
 		}
 		return xv.DwarfType, nil
 	} else if xv.DwarfType != nil && yv.DwarfType == nil {
@@ -1813,11 +1813,11 @@ func (scope *EvalScope) evalBinary(node *ast.BinaryExpr) (*Variable, error) {
 			yv.loadValue(loadFullValueLongerStrings)
 		}
 		if xv.Value == nil {
-			return nil, fmt.Errorf("operator %s can not be applied to \"%s\"", node.Op.String(), exprToString(node.X))
+			return nil, fmt.Errorf("operator %s can not be applied to %q", node.Op.String(), exprToString(node.X))
 		}
 
 		if yv.Value == nil {
-			return nil, fmt.Errorf("operator %s can not be applied to \"%s\"", node.Op.String(), exprToString(node.Y))
+			return nil, fmt.Errorf("operator %s can not be applied to %q", node.Op.String(), exprToString(node.Y))
 		}
 
 		rc, err := constantBinaryOp(op, xv.Value, yv.Value)

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1422,7 +1422,7 @@ func (v *Variable) loadValueInternal(recurseLevel int, cfg LoadConfig) {
 	case reflect.Func:
 		v.readFunctionPtr()
 	default:
-		v.Unreadable = fmt.Errorf("unknown or unsupported kind: \"%s\"", v.Kind.String())
+		v.Unreadable = fmt.Errorf("unknown or unsupported kind: %q", v.Kind.String())
 	}
 }
 

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -500,7 +500,7 @@ func TestComplexSetting(t *testing.T) {
 			variable, err := evalVariableWithCfg(p, "c128", pnormalLoadConfig)
 			assertNoError(err, t, "EvalVariable()")
 			if s := api.ConvertVar(variable).SinglelineString(); s != value {
-				t.Fatalf("Wrong value of c128: \"%s\", expected \"%s\" after setting it to \"%s\"", s, value, setExpr)
+				t.Fatalf("Wrong value of c128: %q, expected %q after setting it to %q", s, value, setExpr)
 			}
 		}
 
@@ -890,7 +890,7 @@ func TestEvalAddrAndCast(t *testing.T) {
 		c1addrstr := api.ConvertVar(c1addr).SinglelineString()
 		t.Logf("&c1 → %s", c1addrstr)
 		if !strings.HasPrefix(c1addrstr, "(*main.cstruct)(0x") {
-			t.Fatalf("Invalid value of EvalExpression(&c1) \"%s\"", c1addrstr)
+			t.Fatalf("Invalid value of EvalExpression(&c1) %q", c1addrstr)
 		}
 
 		aaddr, err := evalVariableWithCfg(p, "&(c1.pb.a)", pnormalLoadConfig)
@@ -898,7 +898,7 @@ func TestEvalAddrAndCast(t *testing.T) {
 		aaddrstr := api.ConvertVar(aaddr).SinglelineString()
 		t.Logf("&(c1.pb.a) → %s", aaddrstr)
 		if !strings.HasPrefix(aaddrstr, "(*main.astruct)(0x") {
-			t.Fatalf("invalid value of EvalExpression(&(c1.pb.a)) \"%s\"", aaddrstr)
+			t.Fatalf("invalid value of EvalExpression(&(c1.pb.a)) %q", aaddrstr)
 		}
 
 		a, err := evalVariableWithCfg(p, "*"+aaddrstr, pnormalLoadConfig)
@@ -1667,11 +1667,11 @@ func TestBadUnsafePtr(t *testing.T) {
 		}
 		expErr := "couldn't read pointer"
 		if !strings.Contains(err.Error(), expErr) {
-			t.Fatalf("expected \"%s\", got: \"%s\"", expErr, err)
+			t.Fatalf("expected %q, got: %q", expErr, err)
 		}
 		nexpErr := "nil pointer dereference"
 		if strings.Contains(err.Error(), nexpErr) {
-			t.Fatalf("shouldn't have gotten \"%s\", but got: \"%s\"", nexpErr, err)
+			t.Fatalf("shouldn't have gotten %q, but got: %q", nexpErr, err)
 		}
 	})
 }

--- a/pkg/terminal/starlark_test.go
+++ b/pkg/terminal/starlark_test.go
@@ -219,7 +219,7 @@ v.Children[0].Children[0].Value.XXX
 					t.Fatalf("expected error %q, got success", tc.expErr)
 				}
 				if !strings.Contains(err.Error(), tc.expErr) {
-					t.Fatalf("expected error %q, got \"%s\"", tc.expErr, err)
+					t.Fatalf("expected error %q, got %q", tc.expErr, err)
 				}
 			})
 		}

--- a/service/debugger/debugger_test.go
+++ b/service/debugger/debugger_test.go
@@ -66,7 +66,7 @@ func TestDebugger_LaunchInvalidFormat(t *testing.T) {
 		t.Fatalf("expected error but none was generated")
 	}
 	if err != api.ErrNotExecutable {
-		t.Fatalf("expected error \"%s\" got \"%v\"", api.ErrNotExecutable, err)
+		t.Fatalf("expected error %q got \"%v\"", api.ErrNotExecutable, err)
 	}
 }
 

--- a/service/debugger/debugger_unix_test.go
+++ b/service/debugger/debugger_unix_test.go
@@ -51,7 +51,7 @@ func TestDebugger_LaunchNoExecutablePerm(t *testing.T) {
 		t.Fatalf("expected error but none was generated")
 	}
 	if err != api.ErrNotExecutable {
-		t.Fatalf("expected error \"%s\" got \"%v\"", api.ErrNotExecutable, err)
+		t.Fatalf("expected error %q got \"%v\"", api.ErrNotExecutable, err)
 	}
 }
 


### PR DESCRIPTION
This PR refactors format strings: replace `\"%s\"` with `%q`.