### PR TITLE
all: use "len == 0" rather than "len <= 0" when checking empty slice/…

### DIFF
--- a/pkg/dwarf/dwarfbuilder/info.go
+++ b/pkg/dwarf/dwarfbuilder/info.go
@@ -101,7 +101,7 @@ func (b *Builder) TagOpen(tag dwarf.Tag, name string) dwarf.Offset {
 
 // SetHasChildren sets the current DIE as having children (even if none are added).
 func (b *Builder) SetHasChildren() {
-	if len(b.tagStack) <= 0 {
+	if len(b.tagStack) == 0 {
 		panic("NoChildren with no open tags")
 	}
 	b.tagStack[len(b.tagStack)-1].children = true
@@ -109,7 +109,7 @@ func (b *Builder) SetHasChildren() {
 
 // TagClose closes the current DIE.
 func (b *Builder) TagClose() {
-	if len(b.tagStack) <= 0 {
+	if len(b.tagStack) == 0 {
 		panic("TagClose with no open tags")
 	}
 	tag := b.tagStack[len(b.tagStack)-1]

--- a/pkg/dwarf/op/op.go
+++ b/pkg/dwarf/op/op.go
@@ -348,7 +348,7 @@ func constu(opcode Opcode, ctxt *context) error {
 }
 
 func dup(_ Opcode, ctxt *context) error {
-	if len(ctxt.stack) <= 0 {
+	if len(ctxt.stack) == 0 {
 		return ErrStackUnderflow
 	}
 	ctxt.stack = append(ctxt.stack, ctxt.stack[len(ctxt.stack)-1])
@@ -356,7 +356,7 @@ func dup(_ Opcode, ctxt *context) error {
 }
 
 func drop(_ Opcode, ctxt *context) error {
-	if len(ctxt.stack) <= 0 {
+	if len(ctxt.stack) == 0 {
 		return ErrStackUnderflow
 	}
 	ctxt.stack = ctxt.stack[:len(ctxt.stack)-1]
@@ -541,7 +541,7 @@ func deref(op Opcode, ctxt *context) error {
 		sz = int(n)
 	}
 
-	if len(ctxt.stack) <= 0 {
+	if len(ctxt.stack) == 0 {
 		return ErrStackUnderflow
 	}
 
@@ -549,7 +549,7 @@ func deref(op Opcode, ctxt *context) error {
 	ctxt.stack = ctxt.stack[:len(ctxt.stack)-1]
 
 	if op == DW_OP_xderef || op == DW_OP_xderef_size {
-		if len(ctxt.stack) <= 0 {
+		if len(ctxt.stack) == 0 {
 			return ErrStackUnderflow
 		}
 		// the second element on the stack is the "address space identifier" which we don't do anything with

--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -72,7 +72,7 @@ func Parse(locStr string) (LocationSpec, error) {
 		return fmt.Errorf("Malformed breakpoint location %q at %d: %s", locStr, len(locStr)-len(rest), reason)
 	}
 
-	if len(rest) <= 0 {
+	if len(rest) == 0 {
 		return nil, malformed("empty string")
 	}
 
@@ -578,7 +578,7 @@ func SubstitutePath(path string, rules [][2]string) string {
 }
 
 func addressesToLocation(addrs []uint64) api.Location {
-	if len(addrs) <= 0 {
+	if len(addrs) == 0 {
 		return api.Location{}
 	}
 	return api.Location{PC: addrs[0], PCs: addrs}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -2539,7 +2539,7 @@ func (bi *BinaryInfo) loadDebugInfoMapsInlinedCalls(ctxt *loadDebugInfoMapsConte
 }
 
 func uniq(s []string) []string {
-	if len(s) <= 0 {
+	if len(s) == 0 {
 		return s
 	}
 	src, dst := 1, 1

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -83,7 +83,7 @@ func firstPCAfterPrologueDisassembly(p Process, fn *Function, sameline bool) (ui
 		return fn.Entry, err
 	}
 
-	if len(text) <= 0 {
+	if len(text) == 0 {
 		return fn.Entry, nil
 	}
 

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -292,7 +292,7 @@ func (scope *EvalScope) Locals(flags localsFlags) ([]*Variable, error) {
 		depths = append(depths, depth)
 	}
 
-	if len(vars) <= 0 {
+	if len(vars) == 0 {
 		return vars, nil
 	}
 

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -1127,7 +1127,7 @@ func isCallInjectionStop(t *Target, thread Thread, loc *Location) bool {
 		off = -int64(len(thread.BinInfo().Arch.breakpointInstruction))
 	}
 	text, err := disassembleCurrentInstruction(t, thread, off)
-	if err != nil || len(text) <= 0 {
+	if err != nil || len(text) == 0 {
 		return false
 	}
 	return text[0].IsHardBreak()

--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -200,7 +200,7 @@ func (conn *gdbConn) qSupported(multiprocess bool) (features map[string]bool, er
 	resp := strings.Split(string(respBuf), ";")
 	features = make(map[string]bool)
 	for _, stubfeature := range resp {
-		if len(stubfeature) <= 0 {
+		if len(stubfeature) == 0 {
 			continue
 		} else if equal := strings.Index(stubfeature, "="); equal >= 0 {
 			if stubfeature[:equal] == "PacketSize" {

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -899,7 +899,7 @@ func removePCsBetween(pcs []uint64, start, end uint64) []uint64 {
 }
 
 func setStepIntoBreakpoint(dbp *Target, curfn *Function, text []AsmInstruction, cond ast.Expr) error {
-	if len(text) <= 0 {
+	if len(text) == 0 {
 		return nil
 	}
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1414,7 +1414,7 @@ func (d *Debugger) Sources(filter string) ([]string, error) {
 }
 
 func uniq(s []string) []string {
-	if len(s) <= 0 {
+	if len(s) == 0 {
 		return s
 	}
 	src, dst := 1, 1

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -484,7 +484,7 @@ func Test1ClientServer_traceContinue(t *testing.T) {
 					t.Fatalf("No goroutine information")
 				}
 
-				if len(bpi.Stacktrace) <= 0 {
+				if len(bpi.Stacktrace) == 0 {
 					t.Fatalf("No stacktrace\n")
 				}
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -865,7 +865,7 @@ func TestClientServer_traceContinue(t *testing.T) {
 					t.Fatalf("No goroutine information")
 				}
 
-				if len(bpi.Stacktrace) <= 0 {
+				if len(bpi.Stacktrace) == 0 {
 					t.Fatalf("No stacktrace\n")
 				}
 


### PR DESCRIPTION
…string

This PR simplifies the empty slice/string check since we know that the length of the slice/string must be non-negative.
People may think that this PR is meaningless, and I can totally understand it.