### PR TITLE
proc: refactorings to implement follow-exec mode on Windows

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -454,7 +454,7 @@ func (p *process) Memory() proc.MemoryReadWriter {
 // Detach will always return nil and have no
 // effect as you cannot detach from a core file
 // and have it continue execution or exit.
-func (p *process) Detach(bool) error {
+func (p *process) Detach(int, bool) error {
 	return nil
 }
 

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -748,7 +748,7 @@ func (p *gdbProcess) initialize(path, cmdline string, debugInfoDirs []string, st
 	})
 	_, err = addTarget(p, p.conn.pid, p.currentThread, path, stopReason, cmdline)
 	if err != nil {
-		p.Detach(true)
+		p.Detach(p.conn.pid, true)
 		return nil, err
 	}
 	return grp, nil
@@ -1058,7 +1058,9 @@ func (p *gdbProcess) getCtrlC(cctx *proc.ContinueOnceContext) bool {
 
 // Detach will detach from the target process,
 // if 'kill' is true it will also kill the process.
-func (p *gdbProcess) Detach(kill bool) error {
+// The _pid argument is unused as follow exec
+// mode is not implemented with this backend.
+func (p *gdbProcess) Detach(_pid int, kill bool) error {
 	if kill && !p.exited {
 		err := p.conn.kill()
 		if err != nil {

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -11,6 +11,7 @@ import (
 // ProcessGroup is a group of processes that are resumed at the same time.
 type ProcessGroup interface {
 	ContinueOnce(*ContinueOnceContext) (Thread, StopReason, error)
+	Detach(int, bool) error
 }
 
 // Process represents the target of the debugger. This
@@ -43,7 +44,6 @@ type ProcessInternal interface {
 	// also returns an error describing why the Process is invalid (either
 	// ErrProcessExited or ErrProcessDetached).
 	Valid() (bool, error)
-	Detach(bool) error
 
 	// RequestManualStop attempts to stop all the process' threads.
 	RequestManualStop(cctx *ContinueOnceContext) error

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -57,7 +57,7 @@ func (dbp *nativeProcess) requestManualStop() (err error) {
 	panic(ErrNativeBackendDisabled)
 }
 
-func (dbp *nativeProcess) resume() error {
+func (*processGroup) resume() error {
 	panic(ErrNativeBackendDisabled)
 }
 
@@ -73,7 +73,7 @@ func (dbp *nativeProcess) updateThreadList() error {
 	panic(ErrNativeBackendDisabled)
 }
 
-func (dbp *nativeProcess) kill() (err error) {
+func (*processGroup) kill(dbp *nativeProcess) (err error) {
 	panic(ErrNativeBackendDisabled)
 }
 

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -323,28 +323,6 @@ func (p *Target) SwitchThread(tid int) error {
 	return fmt.Errorf("thread %d does not exist", tid)
 }
 
-// detach will detach the target from the underlying process.
-// This means the debugger will no longer receive events from the process
-// we were previously debugging.
-// If kill is true then the process will be killed when we detach.
-func (t *Target) detach(kill bool) error {
-	if !kill {
-		if t.asyncPreemptChanged {
-			setAsyncPreemptOff(t, t.asyncPreemptOff)
-		}
-		for _, bp := range t.Breakpoints().M {
-			if bp != nil {
-				err := t.ClearBreakpoint(bp.Addr)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-	t.StopReason = StopUnknown
-	return t.proc.Detach(kill)
-}
-
 // setAsyncPreemptOff enables or disables async goroutine preemption by
 // writing the value 'v' to runtime.debug.asyncpreemptoff.
 // A value of '1' means off, a value of '0' means on.


### PR DESCRIPTION
Miscellaneous non-functional changes to prepare for adding support for
follow-exec mode on Windows:

* removed (*nativeProcess).wait function from Windows backend (unused).
* move close of ptraceDoneChan from release to handlePtraceFuncs, this
makes postExit callable by a function executed by execPtraceFunc.

* change addTarget to detach before creating the target object if we
don't actually want to attach to the child process, also moved the
detach call to (*processGroup).add instead of having one in addTarget
and one in the code that calls (*processGroup).add.

* changed Detach to be a method of TargetGroup/ProcessGroup, the
Windows backend will need access to the process group to call
WaitForDebugEvent.

* moved resume method to processGroup. First all threads stopped at a
breakpoint need to be stepped, then all other threads can be resumed. This is true also for linux even though it didn't cause the current
tests to fail.
