### PR TITLE
proc,ebpf: mark as unreadable args with unsupported types with ebpf

### DIFF
--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -451,6 +451,11 @@ func (t *Target) GetBufferedTracepoints() []*UProbeTraceResult {
 		v.Addr = ip.Addr
 		v.Kind = ip.Kind
 
+		if v.RealType == nil {
+			v.Unreadable = errors.New("type not supported by ebpf")
+			return v
+		}
+
 		cachedMem := CreateLoadedCachedMemory(ip.Data)
 		compMem, _ := CreateCompositeMemory(cachedMem, t.BinInfo().Arch, op.DwarfRegisters{}, ip.Pieces, ip.RealType.Common().ByteSize)
 		v.mem = compMem


### PR DESCRIPTION
Only a few types can be read with ebpf, mark everything else as
unreadable so that there are no downstream crashes.

Fixes #3443
