### PR TITLE
proc: add waitfor option to attach

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -5,6 +5,8 @@ Tests skipped by each supported backend:
 	* 3 not implemented
 * arm64 skipped = 1
 	* 1 broken - global variable symbolication
+* darwin skipped = 1
+	* 1 waitfor implementation is delegated to debugserver
 * darwin/arm64 skipped = 2
 	* 2 broken - cgo stacktraces
 * darwin/lldb skipped = 1

--- a/Documentation/usage/dlv_attach.md
+++ b/Documentation/usage/dlv_attach.md
@@ -18,8 +18,11 @@ dlv attach pid [executable] [flags]
 ### Options
 
 ```
-      --continue   Continue the debugged process on start.
-  -h, --help       help for attach
+      --continue                 Continue the debugged process on start.
+  -h, --help                     help for attach
+      --waitfor string           Wait for a process with a name beginning with this prefix
+      --waitfor-duration float   Total time to wait for a process
+      --waitfor-interval float   Interval between checks of the process list, in millisecond (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ uninstall:
 	@go run _scripts/make.go uninstall
 
 test: vet
-	@go run _scripts/make.go test
+	@go run _scripts/make.go test -v
 
 vet:
 	@go vet $$(go list ./... | grep -v native)

--- a/pkg/proc/interface.go
+++ b/pkg/proc/interface.go
@@ -2,6 +2,7 @@ package proc
 
 import (
 	"sync"
+	"time"
 
 	"github.com/go-delve/delve/pkg/elfwriter"
 	"github.com/go-delve/delve/pkg/proc/internal/ebpf"
@@ -141,4 +142,11 @@ func (cctx *ContinueOnceContext) GetManualStopRequested() bool {
 	cctx.StopMu.Lock()
 	defer cctx.StopMu.Unlock()
 	return cctx.manualStopRequested
+}
+
+// WaitFor is passed to native.Attach and gdbserver.LLDBAttach to wait for a
+// process to start before attaching.
+type WaitFor struct {
+	Name               string
+	Interval, Duration time.Duration
 }

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -21,8 +21,12 @@ func Launch(_ []string, _ string, _ proc.LaunchFlags, _ []string, _ string, _ st
 }
 
 // Attach returns ErrNativeBackendDisabled.
-func Attach(_ int, _ []string) (*proc.TargetGroup, error) {
+func Attach(_ int, _ *proc.WaitFor, _ []string) (*proc.TargetGroup, error) {
 	return nil, ErrNativeBackendDisabled
+}
+
+func waitForSearchProcess(string, map[int]struct{}) (int, error) {
+	return 0, proc.ErrWaitForNotImplemented
 }
 
 // waitStatus is a synonym for the platform-specific WaitStatus

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -136,8 +136,15 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, _ []string, _ strin
 	return tgt, err
 }
 
+func waitForSearchProcess(string, map[int]struct{}) (int, error) {
+	return 0, proc.ErrWaitForNotImplemented
+}
+
 // Attach to an existing process with the given PID.
-func Attach(pid int, _ []string) (*proc.TargetGroup, error) {
+func Attach(pid int, waitFor *proc.WaitFor, _ []string) (*proc.TargetGroup, error) {
+	if waitFor.Valid() {
+		return nil, proc.ErrWaitForNotImplemented
+	}
 	if err := macutil.CheckRosetta(); err != nil {
 		return nil, err
 	}

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -3,6 +3,7 @@ package native
 // #cgo LDFLAGS: -lprocstat
 // #include <stdlib.h>
 // #include "proc_freebsd.h"
+// #include <sys/sysctl.h>
 import "C"
 import (
 	"fmt"
@@ -14,6 +15,7 @@ import (
 
 	sys "golang.org/x/sys/unix"
 
+	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/go-delve/delve/pkg/proc"
 	"github.com/go-delve/delve/pkg/proc/internal/ebpf"
 
@@ -121,7 +123,15 @@ func Launch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs []str
 // Attach to an existing process with the given PID. Once attached, if
 // the DWARF information cannot be found in the binary, Delve will look
 // for external debug files in the directories passed in.
-func Attach(pid int, debugInfoDirs []string) (*proc.TargetGroup, error) {
+func Attach(pid int, waitFor *proc.WaitFor, debugInfoDirs []string) (*proc.TargetGroup, error) {
+	if waitFor.Valid() {
+		var err error
+		pid, err = WaitFor(waitFor)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	dbp := newProcess(pid)
 
 	var err error
@@ -140,6 +150,31 @@ func Attach(pid int, debugInfoDirs []string) (*proc.TargetGroup, error) {
 		return nil, err
 	}
 	return tgt, nil
+}
+
+func waitForSearchProcess(pfx string, seen map[int]struct{}) (int, error) {
+	log := logflags.DebuggerLogger()
+	ps := C.procstat_open_sysctl()
+	defer C.procstat_close(ps)
+	var cnt C.uint
+	procs := C.procstat_getprocs(ps, C.KERN_PROC_PROC, 0, &cnt)
+	defer C.procstat_freeprocs(ps, procs)
+	proc := procs
+	for i := 0; i < int(cnt); i++ {
+		if _, isseen := seen[int(proc.ki_pid)]; isseen {
+			continue
+		}
+		seen[int(proc.ki_pid)] = struct{}{}
+
+		argv := strings.Join(getCmdLineInternal(ps, proc), " ")
+		log.Debugf("waitfor: new process %q", argv)
+		if strings.HasPrefix(argv, pfx) {
+			return int(proc.ki_pid), nil
+		}
+
+		proc = (*C.struct_kinfo_proc)(unsafe.Pointer(uintptr(unsafe.Pointer(proc)) + unsafe.Sizeof(*proc)))
+	}
+	return 0, nil
 }
 
 func initialize(dbp *nativeProcess) (string, error) {
@@ -230,7 +265,17 @@ func findExecutable(path string, pid int) string {
 func getCmdLine(pid int) string {
 	ps := C.procstat_open_sysctl()
 	kp := C.kinfo_getproc(C.int(pid))
+	goargv := getCmdLineInternal(ps, kp)
+	C.free(unsafe.Pointer(kp))
+	C.procstat_close(ps)
+	return strings.Join(goargv, " ")
+}
+
+func getCmdLineInternal(ps *C.struct_procstat, kp *C.struct_kinfo_proc) []string {
 	argv := C.procstat_getargv(ps, kp, 0)
+	if argv == nil {
+		return nil
+	}
 	goargv := []string{}
 	for {
 		arg := *argv
@@ -240,9 +285,8 @@ func getCmdLine(pid int) string {
 		argv = (**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(argv)) + unsafe.Sizeof(*argv)))
 		goargv = append(goargv, C.GoString(arg))
 	}
-	C.free(unsafe.Pointer(kp))
-	C.procstat_close(ps)
-	return strings.Join(goargv, " ")
+	C.procstat_freeargv(ps)
+	return goargv
 }
 
 func trapWait(procgrp *processGroup, pid int) (*nativeThread, error) {

--- a/pkg/proc/proc_unix_test.go
+++ b/pkg/proc/proc_unix_test.go
@@ -87,7 +87,7 @@ func TestSignalDeath(t *testing.T) {
 	assertNoError(err, t, "StdoutPipe")
 	cmd.Stderr = os.Stderr
 	assertNoError(cmd.Start(), t, "starting fixture")
-	p, err := native.Attach(cmd.Process.Pid, []string{})
+	p, err := native.Attach(cmd.Process.Pid, nil, []string{})
 	assertNoError(err, t, "Attach")
 	stdout.Close() // target will receive SIGPIPE later on
 	err = p.Continue()

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -654,3 +654,9 @@ func (*dummyRecordingManipulation) ClearCheckpoint(int) error { return ErrNotRec
 func (*dummyRecordingManipulation) Restart(*ContinueOnceContext, string) (Thread, error) {
 	return nil, ErrNotRecorded
 }
+
+var ErrWaitForNotImplemented = errors.New("waitfor not implemented")
+
+func (waitFor *WaitFor) Valid() bool {
+	return waitFor != nil && waitFor.Name != ""
+}


### PR DESCRIPTION
Adds a waitfor option to 'dlv attach' that waits for a process with a
name starting with a given prefix to appear before attaching to it.

Debugserver on macOS does not support follow-fork mode, but has this
feature instead which is not the same thing but still helps with
multiprocess debugging somewhat.
