### PR TITLE
pkg/terminal: use reflect.Value.IsValid to check a zero Value

### DIFF
--- a/pkg/terminal/colorize/colorize.go
+++ b/pkg/terminal/colorize/colorize.go
@@ -134,13 +134,13 @@ func Print(out io.Writer, path string, reader io.Reader, startLine, endLine, arr
 
 		tokposval := nval.FieldByName("TokPos")
 		tokval := nval.FieldByName("Tok")
-		if tokposval != (reflect.Value{}) && tokval != (reflect.Value{}) {
+		if tokposval.IsValid() && tokval.IsValid() {
 			emit(tokval.Interface().(token.Token), tokposval.Interface().(token.Pos), token.NoPos)
 		}
 
 		for _, kwname := range []string{"Case", "Begin", "Defer", "For", "Func", "Go", "Interface", "Map", "Return", "Select", "Struct", "Switch"} {
 			kwposval := nval.FieldByName(kwname)
-			if kwposval != (reflect.Value{}) {
+			if kwposval.IsValid() {
 				kwpos, ok := kwposval.Interface().(token.Pos)
 				if ok && kwpos != token.NoPos {
 					emit(token.ILLEGAL, kwpos, token.NoPos)

--- a/pkg/terminal/starbind/conv.go
+++ b/pkg/terminal/starbind/conv.go
@@ -181,7 +181,7 @@ func (v structAsStarlarkValue) Attr(name string) (starlark.Value, error) {
 		return r, err
 	}
 	r := v.v.FieldByName(name)
-	if r == (reflect.Value{}) {
+	if !r.IsValid() {
 		return starlark.None, fmt.Errorf("no field named %q in %T", name, v.v.Interface())
 	}
 	return v.env.interfaceToStarlarkValue(r.Interface()), nil
@@ -681,7 +681,7 @@ func unmarshalStarlarkValueIntl(val starlark.Value, dst reflect.Value, path stri
 			}
 			fieldName := string(k.(starlark.String))
 			dstfield := dst.FieldByName(fieldName)
-			if dstfield == (reflect.Value{}) {
+			if !dstfield.IsValid() {
 				return converr(fmt.Sprintf("unknown field %s", fieldName))
 			}
 			valfield, _, _ := val.Get(starlark.String(fieldName))


### PR DESCRIPTION
I searched the source code of Go, and found no usages of "== (reflect.Value{})" and "!= (reflect.Value{})". I think it's more idiomatic to use "IsValid" to check a zero Value.

Please take a look, thanks.