### PR TITLE
starbind: fix Starlark slice unmarshaling

### DIFF
--- a/pkg/terminal/starbind/conv.go
+++ b/pkg/terminal/starbind/conv.go
@@ -664,8 +664,9 @@ func unmarshalStarlarkValueIntl(val starlark.Value, dst reflect.Value, path stri
 		if dst.Kind() != reflect.Slice {
 			return converr()
 		}
+		dst.Set(reflect.MakeSlice(dst.Type(), val.Len(), val.Len()))
 		for i := 0; i < val.Len(); i++ {
-			cur := reflect.New(dst.Type().Elem())
+			cur := dst.Index(i).Addr()
 			err := unmarshalStarlarkValueIntl(val.Index(i), cur, path)
 			if err != nil {
 				return err

--- a/pkg/terminal/starbind/conv_test.go
+++ b/pkg/terminal/starbind/conv_test.go
@@ -1,0 +1,29 @@
+package starbind
+
+import (
+	"go.starlark.net/starlark"
+	"testing"
+)
+
+func TestConv(t *testing.T) {
+	script := `
+# A list global that we'll unmarhsal into a slice.
+x = [1,2]
+`
+	globals, err := starlark.ExecFile(&starlark.Thread{}, "test.star", script, nil)
+	starlarkVal, ok := globals["x"]
+	if !ok {
+		t.Fatal("missing global 'x'")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var x []int
+	err = unmarshalStarlarkValue(starlarkVal, &x, "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(x) != 2 || x[0] != 1 || x[1] != 2 {
+		t.Fatalf("expected [1 2], got: %v", x)
+	}
+}


### PR DESCRIPTION
The unmarshaling code for slices wasn't actually setting the destination. This patch fixes it.