### PR TITLE
gobuild: pass user specified arguments of go build first

### DIFF
--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -61,13 +61,24 @@ func GoTestBuildCombinedOutput(debugname string, pkgs []string, buildflags strin
 }
 
 func goBuildArgs(debugname string, pkgs []string, buildflags string, isTest bool) []string {
-	args := []string{"-o", debugname}
+	var args []string
+
+	bfv := config.SplitQuotedFields(buildflags, '\'')
+	if len(bfv) >= 2 && bfv[0] == "-C" {
+		args = append(args, bfv[:2]...)
+		bfv = bfv[2:]
+	} else if len(bfv) >= 1 && strings.HasPrefix(bfv[0], "-C=") {
+		args = append(args, bfv[0])
+		bfv = bfv[1:]
+	}
+
+	args = append(args, "-o", debugname)
 	if isTest {
 		args = append([]string{"-c"}, args...)
 	}
 	args = append(args, "-gcflags", "all=-N -l")
 	if buildflags != "" {
-		args = append(args, config.SplitQuotedFields(buildflags, '\'')...)
+		args = append(args, bfv...)
 	}
 	args = append(args, pkgs...)
 	return args

--- a/pkg/gobuild/gobuild_test.go
+++ b/pkg/gobuild/gobuild_test.go
@@ -1,0 +1,27 @@
+package gobuild
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-delve/delve/pkg/config"
+)
+
+func TestGoBuildArgsDashC(t *testing.T) {
+	testCases := []struct{ in, tgt string }{
+		{"-C somedir", "-C somedir -o debug -gcflags 'all=-N -l' pkg"},
+		{"-C", "-o debug -gcflags 'all=-N -l' -C pkg"},
+		{"-C=somedir", "-C=somedir -o debug -gcflags 'all=-N -l' pkg"},
+		{"-C somedir -other -args", "-C somedir -o debug -gcflags 'all=-N -l' -other -args pkg"},
+		{"-C=somedir -other -args", "-C=somedir -o debug -gcflags 'all=-N -l' -other -args pkg"},
+	}
+
+	for _, tc := range testCases {
+		out := goBuildArgs("debug", []string{"pkg"}, tc.in, false)
+		tgt := config.SplitQuotedFields(tc.tgt, '\'')
+		t.Logf("%q -> %q", tc.in, out)
+		if !reflect.DeepEqual(out, tgt) {
+			t.Errorf("output mismatch input %q\noutput %q\ntarget %q", tc.in, out, tgt)
+		}
+	}
+}


### PR DESCRIPTION
The -C argument must come first on the command line of 'go build' so
pass the flags specified by build-flags first.

Replaces #3380
