### PR TITLE
proc: fix stacktraces on freebsd/amd64/go1.20

### DIFF
--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -200,8 +200,16 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 
 		return true
 
-	case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":
+	case "runtime.goexit", "runtime.rt0_go":
 		// Look for "top of stack" functions.
+		it.atend = true
+		return true
+
+	case "runtime.mcall":
+		if it.systemstack && it.g != nil {
+			it.switchToGoroutineStack()
+			return true
+		}
 		it.atend = true
 		return true
 

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -217,10 +217,19 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 			return true
 		}
 
-	case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":
+	case "runtime.goexit", "runtime.rt0_go":
 		// Look for "top of stack" functions.
 		it.atend = true
 		return true
+
+	case "runtime.mcall":
+		if it.systemstack && it.g != nil {
+			it.switchToGoroutineStack()
+			return true
+		}
+		it.atend = true
+		return true
+
 	case "crosscall2":
 		// The offsets get from runtime/cgo/asm_arm64.s:10
 		bpoff := uint64(14)

--- a/pkg/proc/i386_arch.go
+++ b/pkg/proc/i386_arch.go
@@ -127,8 +127,16 @@ func i386SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 	switch it.frame.Current.Fn.Name {
 	case "runtime.asmcgocall", "runtime.cgocallback_gofunc": // TODO(chainhelen), need to support cgo stacktraces.
 		return false
-	case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":
+	case "runtime.goexit", "runtime.rt0_go":
 		// Look for "top of stack" functions.
+		it.atend = true
+		return true
+
+	case "runtime.mcall":
+		if it.systemstack && it.g != nil {
+			it.switchToGoroutineStack()
+			return true
+		}
 		it.atend = true
 		return true
 

--- a/pkg/proc/ppc64le_arch.go
+++ b/pkg/proc/ppc64le_arch.go
@@ -106,8 +106,15 @@ func ppc64leSwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) boo
 		switch it.frame.Current.Fn.Name {
 		case "runtime.asmcgocall", "runtime.cgocallback_gofunc", "runtime.sigpanic", "runtime.cgocallback":
 			//do nothing
-		case "runtime.goexit", "runtime.rt0_go", "runtime.mcall":
+		case "runtime.goexit", "runtime.rt0_go":
 			// Look for "top of stack" functions.
+			it.atend = true
+			return true
+		case "runtime.mcall":
+			if it.systemstack && it.g != nil {
+				it.switchToGoroutineStack()
+				return true
+			}
 			it.atend = true
 			return true
 		case "crosscall2":


### PR DESCRIPTION
TestStacktraceGoroutine failed intermittently on freebsd/amd64/go1.20
due to stacktraces being broken when doing a runtime.nanotime system
call.
