### PR TITLE
*: Fix ppc64le test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: vet
 	@go run _scripts/make.go test -v
 
 vet:
-	@go vet $$(go list ./... | grep -v native)
+	@go vet -tags exp.linuxppc64le $$(go list -tags exp.linuxppc64le ./... | grep -v native)
 
 test-proc-run:
 	@go run _scripts/make.go test -s proc -r $(RUN)

--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -75,12 +75,3 @@ if [ "$version" = "gotip" ]; then
 else
 	exit $x
 fi
-
-export GOARCH=ppc64le
-go run _scripts/make.go --tags exp.linuxppc64le
-x=$?
-if [ "$version" = "gotip" ]; then
-	exit 0
-else
-	exit $x
-fi


### PR DESCRIPTION
We must pass the build tag through during the 'vet' check, and additionally there was some extra commands at the end of test_linux.sh that were not necessary.