### PR TITLE
goversion,teamcity: update test matrix and fix build scripts

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -35,29 +35,29 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2020.2"
 
 val targets = arrayOf(
-        "linux/amd64/1.18",
         "linux/amd64/1.19",
         "linux/amd64/1.20",
+        "linux/amd64/1.21",
         "linux/amd64/tip",
 
-        "linux/386/1.20",
+        "linux/386/1.21",
 
-        "linux/arm64/1.20",
+        "linux/arm64/1.21",
         "linux/arm64/tip",
 
-        "linux/ppc64le/1.20",
+        "linux/ppc64le/1.21",
         "linux/ppc64le/tip",
 
-        "windows/amd64/1.20",
+        "windows/amd64/1.21",
         "windows/amd64/tip",
 
-        "windows/arm64/1.20",
+        "windows/arm64/1.21",
         "windows/arm64/tip",
 
-        "mac/amd64/1.20",
+        "mac/amd64/1.21",
         "mac/amd64/tip",
 
-        "mac/arm64/1.20",
+        "mac/arm64/1.21",
         "mac/arm64/tip"
 )
 

--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -22,7 +22,7 @@ function getgo {
 
 if [ "$version" = "gotip" ]; then
 	echo Building Go from tip
-	getgo $(curl https://go.dev/VERSION?m=text)
+	getgo $(curl https://go.dev/VERSION?m=text | head -1)
 	export GOROOT_BOOTSTRAP=$GOROOT
 	export GOROOT=/usr/local/go/go-tip
 	git clone https://go.googlesource.com/go /usr/local/go/go-tip

--- a/_scripts/test_mac.sh
+++ b/_scripts/test_mac.sh
@@ -8,7 +8,7 @@ ARCH=$2
 TMPDIR=$3
 
 if [ "$GOVERSION" = "gotip" ]; then
-    bootstrapver=$(curl https://go.dev/VERSION?m=text)
+    bootstrapver=$(curl https://go.dev/VERSION?m=text | head -1)
     cd $TMPDIR
     curl -sSL "https://storage.googleapis.com/golang/$bootstrapver.darwin-$ARCH.tar.gz" | tar -xz
     cd -

--- a/_scripts/test_windows.ps1
+++ b/_scripts/test_windows.ps1
@@ -57,7 +57,7 @@ function GetGo($version) {
 
 if ($version -eq "gotip") {
     #Exit 0
-    $latest = Invoke-WebRequest -Uri "https://golang.org/VERSION?m=text" -UseBasicParsing | Select-Object -ExpandProperty Content -ErrorAction Stop
+    $latest = (Invoke-WebRequest -Uri "https://golang.org/VERSION?m=text" -UseBasicParsing | Select-Object -ExpandProperty Content -ErrorAction Stop).Split([Environment]::NewLine) | select -first 1
     GetGo $latest
     $env:GOROOT_BOOTSTRAP = $env:GOROOT
     $env:GOROOT = "$binDir\go\go-tip"

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	MinSupportedVersionOfGoMajor = 1
-	MinSupportedVersionOfGoMinor = 18
+	MinSupportedVersionOfGoMinor = 19
 	MaxSupportedVersionOfGoMajor = 1
 	MaxSupportedVersionOfGoMinor = 21
 	goTooOldErr                  = fmt.Sprintf("Go version %%s is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)


### PR DESCRIPTION
Update test matrix to remove 1.18 and add 1.21, fix build scripts to
deal with the new format returned by:
https://golang.org/VERSION?m=text
which now has an extra second line with the time.
