### PR TITLE
service/dap: use == to test io.EOF

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1051,7 +1051,7 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 			for {
 				n, err := reader.Read(out[:])
 				if err != nil {
-					if errors.Is(io.EOF, err) {
+					if err == io.EOF {
 						return
 					}
 					s.config.log.Errorf("failed read by %s - %v ", category, err)


### PR DESCRIPTION
The documentation of io.EOF:
Read must return EOF itself, not an error wrapping EOF, because callers will test for EOF using ==.

This is a trivial change; people may think it's normal use of "errors.Is", even it's OK, it could be
replaced with "errors.Is(err, io.EOF)" in idiomatic way.