### PR TITLE
teamcity: hold back linux/386 builds to 1.20

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -40,7 +40,7 @@ val targets = arrayOf(
         "linux/amd64/1.21",
         "linux/amd64/tip",
 
-        "linux/386/1.21",
+        "linux/386/1.20",
 
         "linux/arm64/1.21",
         "linux/arm64/tip",


### PR DESCRIPTION
Programs built with `-gcflags='all=-N -l'` do not work on
linux/386/1.21 due to https://github.com/golang/go/issues/61975
