### PR TITLE
pkg,service: make receiver names consistent

### DIFF
--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -102,7 +102,7 @@ type BasicType struct {
 	BitOffset int64
 }
 
-func (b *BasicType) Basic() *BasicType { return b }
+func (t *BasicType) Basic() *BasicType { return t }
 
 func (t *BasicType) String() string { return t.stringIntl(nil) }
 

--- a/pkg/dwarf/op/regs.go
+++ b/pkg/dwarf/op/regs.go
@@ -165,19 +165,19 @@ func (reg *DwarfRegister) FillBytes() {
 	binary.LittleEndian.PutUint64(reg.Bytes, reg.Uint64Val)
 }
 
-// Overwrite takes the contents of reg1 and overwrites them with the contents
+// Overwrite takes the contents of reg and overwrites them with the contents
 // of reg2 in little-endian order, returning a new register. The new register
 // will always contain the complete contents of both registers, so if reg2 is
-// larger than reg1, the final register will be reg2's size.
-func (reg1 *DwarfRegister) Overwrite(reg2 *DwarfRegister) *DwarfRegister {
-	reg1.FillBytes()
+// larger than reg, the final register will be reg2's size.
+func (reg *DwarfRegister) Overwrite(reg2 *DwarfRegister) *DwarfRegister {
+	reg.FillBytes()
 	reg2.FillBytes()
-	width := len(reg1.Bytes)
-	if len(reg2.Bytes) > len(reg1.Bytes) {
+	width := len(reg.Bytes)
+	if len(reg2.Bytes) > len(reg.Bytes) {
 		width = len(reg2.Bytes)
 	}
 	b := make([]byte, width)
-	copy(b, reg1.Bytes)
+	copy(b, reg.Bytes)
 	copy(b, reg2.Bytes)
 	return DwarfRegisterFromBytes(b)
 }

--- a/pkg/proc/amd64util/xsave.go
+++ b/pkg/proc/amd64util/xsave.go
@@ -36,34 +36,34 @@ type AMD64PtraceFpRegs struct {
 }
 
 // Decode decodes an XSAVE area to a list of name/value pairs of registers.
-func (xsave *AMD64Xstate) Decode() []proc.Register {
+func (xstate *AMD64Xstate) Decode() []proc.Register {
 	var regs []proc.Register
 	// x87 registers
-	regs = proc.AppendUint64Register(regs, "CW", uint64(xsave.Cwd))
-	regs = proc.AppendUint64Register(regs, "SW", uint64(xsave.Swd))
-	regs = proc.AppendUint64Register(regs, "TW", uint64(xsave.Ftw))
-	regs = proc.AppendUint64Register(regs, "FOP", uint64(xsave.Fop))
-	regs = proc.AppendUint64Register(regs, "FIP", xsave.Rip)
-	regs = proc.AppendUint64Register(regs, "FDP", xsave.Rdp)
+	regs = proc.AppendUint64Register(regs, "CW", uint64(xstate.Cwd))
+	regs = proc.AppendUint64Register(regs, "SW", uint64(xstate.Swd))
+	regs = proc.AppendUint64Register(regs, "TW", uint64(xstate.Ftw))
+	regs = proc.AppendUint64Register(regs, "FOP", uint64(xstate.Fop))
+	regs = proc.AppendUint64Register(regs, "FIP", xstate.Rip)
+	regs = proc.AppendUint64Register(regs, "FDP", xstate.Rdp)
 
-	for i := 0; i < len(xsave.StSpace); i += 4 {
+	for i := 0; i < len(xstate.StSpace); i += 4 {
 		var buf bytes.Buffer
-		binary.Write(&buf, binary.LittleEndian, uint64(xsave.StSpace[i+1])<<32|uint64(xsave.StSpace[i]))
-		binary.Write(&buf, binary.LittleEndian, uint16(xsave.StSpace[i+2]))
+		binary.Write(&buf, binary.LittleEndian, uint64(xstate.StSpace[i+1])<<32|uint64(xstate.StSpace[i]))
+		binary.Write(&buf, binary.LittleEndian, uint16(xstate.StSpace[i+2]))
 		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("ST(%d)", i/4), buf.Bytes())
 	}
 
 	// SSE registers
-	regs = proc.AppendUint64Register(regs, "MXCSR", uint64(xsave.Mxcsr))
-	regs = proc.AppendUint64Register(regs, "MXCSR_MASK", uint64(xsave.MxcrMask))
+	regs = proc.AppendUint64Register(regs, "MXCSR", uint64(xstate.Mxcsr))
+	regs = proc.AppendUint64Register(regs, "MXCSR_MASK", uint64(xstate.MxcrMask))
 
-	for i := 0; i < len(xsave.XmmSpace); i += 16 {
+	for i := 0; i < len(xstate.XmmSpace); i += 16 {
 		n := i / 16
-		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("XMM%d", n), xsave.XmmSpace[i:i+16])
-		if xsave.AvxState {
-			regs = proc.AppendBytesRegister(regs, fmt.Sprintf("YMM%d", n), xsave.YmmSpace[i:i+16])
-			if xsave.Avx512State {
-				regs = proc.AppendBytesRegister(regs, fmt.Sprintf("ZMM%d", n), xsave.ZmmSpace[n*32:(n+1)*32])
+		regs = proc.AppendBytesRegister(regs, fmt.Sprintf("XMM%d", n), xstate.XmmSpace[i:i+16])
+		if xstate.AvxState {
+			regs = proc.AppendBytesRegister(regs, fmt.Sprintf("YMM%d", n), xstate.YmmSpace[i:i+16])
+			if xstate.Avx512State {
+				regs = proc.AppendBytesRegister(regs, fmt.Sprintf("ZMM%d", n), xstate.ZmmSpace[n*32:(n+1)*32])
 			}
 		}
 	}

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -124,8 +124,8 @@ func (a *Arch) DerefTLS() bool {
 // getAsmRegister returns the value of the asm register asmreg using the asmRegisters table of arch.
 // The interpretation of asmreg is architecture specific and defined by the disassembler.
 // A mask value of 0 inside asmRegisters is equivalent to ^uint64(0).
-func (arch *Arch) getAsmRegister(regs *op.DwarfRegisters, asmreg int) (uint64, error) {
-	hwreg, ok := arch.asmRegisters[asmreg]
+func (a *Arch) getAsmRegister(regs *op.DwarfRegisters, asmreg int) (uint64, error) {
+	hwreg, ok := a.asmRegisters[asmreg]
 	if !ok {
 		return 0, ErrUnknownRegister
 	}

--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -277,18 +277,18 @@ func (p *process) SupportsBPF() bool {
 	return false
 }
 
-func (dbp *process) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
+func (p *process) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	panic("not implemented")
 }
 
 // StartCallInjection notifies the backend that we are about to inject a function call.
 func (p *process) StartCallInjection() (func(), error) { return func() {}, nil }
 
-func (dbp *process) EnableURetProbes() error {
+func (p *process) EnableURetProbes() error {
 	panic("not implemented")
 }
 
-func (dbp *process) DisableURetProbes() error {
+func (p *process) DisableURetProbes() error {
 	panic("not implemented")
 }
 
@@ -492,6 +492,6 @@ func (p *process) DumpProcessNotes(notes []elfwriter.Note, threadDone func()) (t
 	return false, notes, nil
 }
 
-func (dbp *process) GetBufferedTracepoints() []ebpf.RawUProbeParams {
+func (p *process) GetBufferedTracepoints() []ebpf.RawUProbeParams {
 	return nil
 }

--- a/pkg/proc/disasm.go
+++ b/pkg/proc/disasm.go
@@ -176,6 +176,6 @@ func disassemble(memrw MemoryReadWriter, regs Registers, breakpoints *Breakpoint
 
 // Text will return the assembly instructions in human readable format according to
 // the flavour specified.
-func (inst *AsmInstruction) Text(flavour AssemblyFlavour, bi *BinaryInfo) string {
-	return inst.Inst.Text(flavour, inst.Loc.PC, bi.symLookup)
+func (instr *AsmInstruction) Text(flavour AssemblyFlavour, bi *BinaryInfo) string {
+	return instr.Inst.Text(flavour, instr.Loc.PC, bi.symLookup)
 }

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -77,6 +77,8 @@ import (
 	"sync"
 	"time"
 
+	isatty "github.com/mattn/go-isatty"
+
 	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/elfwriter"
 	"github.com/go-delve/delve/pkg/logflags"
@@ -84,7 +86,6 @@ import (
 	"github.com/go-delve/delve/pkg/proc/internal/ebpf"
 	"github.com/go-delve/delve/pkg/proc/linutil"
 	"github.com/go-delve/delve/pkg/proc/macutil"
-	isatty "github.com/mattn/go-isatty"
 )
 
 const (
@@ -375,11 +376,11 @@ func (p *gdbProcess) SupportsBPF() bool {
 	return false
 }
 
-func (dbp *gdbProcess) GetBufferedTracepoints() []ebpf.RawUProbeParams {
+func (p *gdbProcess) GetBufferedTracepoints() []ebpf.RawUProbeParams {
 	return nil
 }
 
-func (dbp *gdbProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
+func (p *gdbProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf.UProbeArgMap) error {
 	panic("not implemented")
 }
 
@@ -1977,7 +1978,7 @@ func (regs *gdbRegisters) byName(name string) uint64 {
 	return binary.LittleEndian.Uint64(reg.value)
 }
 
-func (r *gdbRegisters) FloatLoadError() error {
+func (regs *gdbRegisters) FloatLoadError() error {
 	return nil
 }
 

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -237,7 +237,7 @@ func (check *scopeCheck) Parse(descr string, t *testing.T) {
 	}
 }
 
-func (scopeCheck *scopeCheck) checkLocalsAndArgs(p *proc.Target, t *testing.T) (*proc.EvalScope, bool) {
+func (check *scopeCheck) checkLocalsAndArgs(p *proc.Target, t *testing.T) (*proc.EvalScope, bool) {
 	scope, err := proc.GoroutineScope(p, p.CurrentThread())
 	assertNoError(err, t, "GoroutineScope()")
 
@@ -249,16 +249,16 @@ func (scopeCheck *scopeCheck) checkLocalsAndArgs(p *proc.Target, t *testing.T) (
 	assertNoError(err, t, "LocalVariables()")
 
 	for _, arg := range args {
-		scopeCheck.checkVar(arg, t)
+		check.checkVar(arg, t)
 	}
 
 	for _, local := range locals {
-		scopeCheck.checkVar(local, t)
+		check.checkVar(local, t)
 	}
 
-	for i := range scopeCheck.varChecks {
-		if !scopeCheck.varChecks[i].ok {
-			t.Errorf("%d: variable %s not found", scopeCheck.line, scopeCheck.varChecks[i].name)
+	for i := range check.varChecks {
+		if !check.varChecks[i].ok {
+			t.Errorf("%d: variable %s not found", check.line, check.varChecks[i].name)
 			ok = false
 		}
 	}

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -296,28 +296,28 @@ func (t *Target) SelectedGoroutine() *G {
 }
 
 // SwitchGoroutine will change the selected and active goroutine.
-func (p *Target) SwitchGoroutine(g *G) error {
-	if ok, err := p.Valid(); !ok {
+func (t *Target) SwitchGoroutine(g *G) error {
+	if ok, err := t.Valid(); !ok {
 		return err
 	}
 	if g == nil {
 		return nil
 	}
 	if g.Thread != nil {
-		return p.SwitchThread(g.Thread.ThreadID())
+		return t.SwitchThread(g.Thread.ThreadID())
 	}
-	p.selectedGoroutine = g
+	t.selectedGoroutine = g
 	return nil
 }
 
 // SwitchThread will change the selected and active thread.
-func (p *Target) SwitchThread(tid int) error {
-	if ok, err := p.Valid(); !ok {
+func (t *Target) SwitchThread(tid int) error {
+	if ok, err := t.Valid(); !ok {
 		return err
 	}
-	if th, ok := p.FindThread(tid); ok {
-		p.currentThread = th
-		p.selectedGoroutine, _ = GetG(p.CurrentThread())
+	if th, ok := t.FindThread(tid); ok {
+		t.currentThread = th
+		t.selectedGoroutine, _ = GetG(t.CurrentThread())
 		return nil
 	}
 	return fmt.Errorf("thread %d does not exist", tid)
@@ -490,16 +490,16 @@ func (t *Target) GetBufferedTracepoints() []*UProbeTraceResult {
 
 // ResumeNotify specifies a channel that will be closed the next time
 // Continue finishes resuming the targets.
-func (t *TargetGroup) ResumeNotify(ch chan<- struct{}) {
-	t.cctx.ResumeChan = ch
+func (grp *TargetGroup) ResumeNotify(ch chan<- struct{}) {
+	grp.cctx.ResumeChan = ch
 }
 
 // RequestManualStop attempts to stop all the processes' threads.
-func (t *TargetGroup) RequestManualStop() error {
-	t.cctx.StopMu.Lock()
-	defer t.cctx.StopMu.Unlock()
-	t.cctx.manualStopRequested = true
-	return t.Selected.proc.RequestManualStop(t.cctx)
+func (grp *TargetGroup) RequestManualStop() error {
+	grp.cctx.StopMu.Lock()
+	defer grp.cctx.StopMu.Unlock()
+	grp.cctx.manualStopRequested = true
+	return grp.Selected.proc.RequestManualStop(grp.cctx)
 }
 
 const (

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -1248,8 +1248,8 @@ func (w *onNextGoroutineWalker) Visit(n ast.Node) ast.Visitor {
 	return w
 }
 
-func (tgt *Target) clearHardcodedBreakpoints() {
-	threads := tgt.ThreadList()
+func (t *Target) clearHardcodedBreakpoints() {
+	threads := t.ThreadList()
 	for _, thread := range threads {
 		if thread.Breakpoint().Breakpoint != nil && thread.Breakpoint().LogicalID() == hardcodedBreakpointID {
 			thread.Breakpoint().Active = false
@@ -1263,10 +1263,10 @@ func (tgt *Target) clearHardcodedBreakpoints() {
 // program's text) and sets a fake breakpoint on them with logical id
 // hardcodedBreakpointID.
 // It checks trapthread and all threads that have SoftExc returning true.
-func (tgt *Target) handleHardcodedBreakpoints(trapthread Thread, threads []Thread) error {
-	mem := tgt.Memory()
-	arch := tgt.BinInfo().Arch
-	recorded, _ := tgt.recman.Recorded()
+func (t *Target) handleHardcodedBreakpoints(trapthread Thread, threads []Thread) error {
+	mem := t.Memory()
+	arch := t.BinInfo().Arch
+	recorded, _ := t.recman.Recorded()
 
 	isHardcodedBreakpoint := func(thread Thread, pc uint64) uint64 {
 		for _, bpinstr := range [][]byte{arch.BreakpointInstruction(), arch.AltBreakpointInstruction()} {
@@ -1310,7 +1310,7 @@ func (tgt *Target) handleHardcodedBreakpoints(trapthread Thread, threads []Threa
 		hcbp.Logical = &LogicalBreakpoint{}
 		hcbp.Logical.Name = HardcodedBreakpoint
 		hcbp.Breaklets = []*Breaklet{{Kind: UserBreakpoint, LogicalID: hardcodedBreakpointID}}
-		tgt.StopReason = StopHardcodedBreakpoint
+		t.StopReason = StopHardcodedBreakpoint
 	}
 
 	for _, thread := range threads {
@@ -1330,7 +1330,7 @@ func (tgt *Target) handleHardcodedBreakpoints(trapthread Thread, threads []Threa
 
 		switch {
 		case loc.Fn.Name == "runtime.breakpoint":
-			if recorded, _ := tgt.recman.Recorded(); recorded {
+			if recorded, _ := t.recman.Recorded(); recorded {
 				setHardcodedBreakpoint(thread, loc)
 				continue
 			}
@@ -1344,11 +1344,11 @@ func (tgt *Target) handleHardcodedBreakpoints(trapthread Thread, threads []Threa
 			// runtime.Breakpoint.
 			// On go < 1.8 it was sufficient to single-step twice on go1.8 a change
 			// to the compiler requires 4 steps.
-			if err := stepInstructionOut(tgt, thread, "runtime.breakpoint", "runtime.Breakpoint"); err != nil {
+			if err := stepInstructionOut(t, thread, "runtime.breakpoint", "runtime.Breakpoint"); err != nil {
 				return err
 			}
 			setHardcodedBreakpoint(thread, loc)
-		case g == nil || tgt.fncallForG[g.ID] == nil:
+		case g == nil || t.fncallForG[g.ID] == nil:
 			if isHardcodedBreakpoint(thread, loc.PC) > 0 {
 				stepOverBreak(thread, loc.PC)
 				setHardcodedBreakpoint(thread, loc)

--- a/pkg/terminal/docgen.go
+++ b/pkg/terminal/docgen.go
@@ -38,7 +38,7 @@ func replaceDocPath(s string) string {
 	}
 }
 
-func (commands *Commands) WriteMarkdown(w io.Writer) {
+func (c *Commands) WriteMarkdown(w io.Writer) {
 	fmt.Fprint(w, "# Configuration and Command History\n\n")
 	fmt.Fprint(w, "If `$XDG_CONFIG_HOME` is set, then configuration and command history files are located in `$XDG_CONFIG_HOME/dlv`. ")
 	fmt.Fprint(w, "Otherwise, they are located in `$HOME/.config/dlv` on Linux and `$HOME/.dlv` on other systems.\n\n")
@@ -52,7 +52,7 @@ func (commands *Commands) WriteMarkdown(w io.Writer) {
 
 		fmt.Fprint(w, "Command | Description\n")
 		fmt.Fprint(w, "--------|------------\n")
-		for _, cmd := range commands.cmds {
+		for _, cmd := range c.cmds {
 			if cmd.group != cgd.group {
 				continue
 			}
@@ -66,7 +66,7 @@ func (commands *Commands) WriteMarkdown(w io.Writer) {
 
 	}
 
-	for _, cmd := range commands.cmds {
+	for _, cmd := range c.cmds {
 		fmt.Fprintf(w, "## %s\n%s\n\n", cmd.aliases[0], replaceDocPath(cmd.helpMsg))
 		if len(cmd.aliases) > 1 {
 			fmt.Fprint(w, "Aliases:")

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -292,8 +292,8 @@ func (s *RPCServer) ListGoroutines(arg interface{}, goroutines *[]*api.Goroutine
 	return nil
 }
 
-func (c *RPCServer) AttachedToExistingProcess(arg interface{}, answer *bool) error {
-	if c.config.Debugger.AttachPid != 0 {
+func (s *RPCServer) AttachedToExistingProcess(arg interface{}, answer *bool) error {
+	if s.config.Debugger.AttachPid != 0 {
 		*answer = true
 	}
 	return nil
@@ -304,9 +304,9 @@ type FindLocationArgs struct {
 	Loc   string
 }
 
-func (c *RPCServer) FindLocation(args FindLocationArgs, answer *[]api.Location) error {
+func (s *RPCServer) FindLocation(args FindLocationArgs, answer *[]api.Location) error {
 	var err error
-	*answer, _, err = c.debugger.FindLocation(args.Scope.GoroutineID, args.Scope.Frame, args.Scope.DeferredCall, args.Loc, false, nil)
+	*answer, _, err = s.debugger.FindLocation(args.Scope.GoroutineID, args.Scope.Frame, args.Scope.DeferredCall, args.Loc, false, nil)
 	return err
 }
 
@@ -316,15 +316,15 @@ type DisassembleRequest struct {
 	Flavour        api.AssemblyFlavour
 }
 
-func (c *RPCServer) Disassemble(args DisassembleRequest, answer *api.AsmInstructions) error {
+func (s *RPCServer) Disassemble(args DisassembleRequest, answer *api.AsmInstructions) error {
 	var err error
-	insts, err := c.debugger.Disassemble(args.Scope.GoroutineID, args.StartPC, args.EndPC)
+	insts, err := s.debugger.Disassemble(args.Scope.GoroutineID, args.StartPC, args.EndPC)
 	if err != nil {
 		return err
 	}
 	*answer = make(api.AsmInstructions, len(insts))
 	for i := range insts {
-		(*answer)[i] = api.ConvertAsmInstruction(insts[i], c.debugger.AsmInstructionText(&insts[i], proc.AssemblyFlavour(args.Flavour)))
+		(*answer)[i] = api.ConvertAsmInstruction(insts[i], s.debugger.AsmInstructionText(&insts[i], proc.AssemblyFlavour(args.Flavour)))
 	}
 	return nil
 }

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -684,8 +684,8 @@ type AttachedToExistingProcessOut struct {
 }
 
 // AttachedToExistingProcess returns whether we attached to a running process or not
-func (c *RPCServer) AttachedToExistingProcess(arg AttachedToExistingProcessIn, out *AttachedToExistingProcessOut) error {
-	if c.config.Debugger.AttachPid != 0 {
+func (s *RPCServer) AttachedToExistingProcess(arg AttachedToExistingProcessIn, out *AttachedToExistingProcessOut) error {
+	if s.config.Debugger.AttachPid != 0 {
 		out.Answer = true
 	}
 	return nil
@@ -722,9 +722,9 @@ type FindLocationOut struct {
 //	* *<address> returns the location corresponding to the specified address
 //
 // NOTE: this function does not actually set breakpoints.
-func (c *RPCServer) FindLocation(arg FindLocationIn, out *FindLocationOut) error {
+func (s *RPCServer) FindLocation(arg FindLocationIn, out *FindLocationOut) error {
 	var err error
-	out.Locations, out.SubstituteLocExpr, err = c.debugger.FindLocation(arg.Scope.GoroutineID, arg.Scope.Frame, arg.Scope.DeferredCall, arg.Loc, arg.IncludeNonExecutableLines, arg.SubstitutePathRules)
+	out.Locations, out.SubstituteLocExpr, err = s.debugger.FindLocation(arg.Scope.GoroutineID, arg.Scope.Frame, arg.Scope.DeferredCall, arg.Loc, arg.IncludeNonExecutableLines, arg.SubstitutePathRules)
 	return err
 }
 
@@ -745,15 +745,15 @@ type DisassembleOut struct {
 // Scope is used to mark the instruction the specified goroutine is stopped at.
 //
 // Disassemble will also try to calculate the destination address of an absolute indirect CALL if it happens to be the instruction the selected goroutine is stopped at.
-func (c *RPCServer) Disassemble(arg DisassembleIn, out *DisassembleOut) error {
+func (s *RPCServer) Disassemble(arg DisassembleIn, out *DisassembleOut) error {
 	var err error
-	insts, err := c.debugger.Disassemble(arg.Scope.GoroutineID, arg.StartPC, arg.EndPC)
+	insts, err := s.debugger.Disassemble(arg.Scope.GoroutineID, arg.StartPC, arg.EndPC)
 	if err != nil {
 		return err
 	}
 	out.Disassemble = make(api.AsmInstructions, len(insts))
 	for i := range insts {
-		out.Disassemble[i] = api.ConvertAsmInstruction(insts[i], c.debugger.AsmInstructionText(&insts[i], proc.AssemblyFlavour(arg.Flavour)))
+		out.Disassemble[i] = api.ConvertAsmInstruction(insts[i], s.debugger.AsmInstructionText(&insts[i], proc.AssemblyFlavour(arg.Flavour)))
 	}
 	return nil
 }


### PR DESCRIPTION
This PR renames receiver names to be consistent across all methods in the same struct.