### PR TITLE
proc: when stepping set condition on thread ID if there is no curg

### DIFF
--- a/pkg/astutil/astutil.go
+++ b/pkg/astutil/astutil.go
@@ -30,11 +30,17 @@ func Int(n int64) *ast.BasicLit {
 }
 
 // And returns an expression evaluating 'x && y'.
-func And(x, y ast.Expr) *ast.BinaryExpr {
+func And(x, y ast.Expr) ast.Expr {
+	if x == nil || y == nil {
+		return nil
+	}
 	return &ast.BinaryExpr{Op: token.LAND, X: x, Y: y}
 }
 
 // Or returns an expression evaluating 'x || y'.
-func Or(x, y ast.Expr) *ast.BinaryExpr {
+func Or(x, y ast.Expr) ast.Expr {
+	if x == nil || y == nil {
+		return nil
+	}
 	return &ast.BinaryExpr{Op: token.LOR, X: x, Y: y}
 }

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -299,7 +299,7 @@ func TestCore(t *testing.T) {
 	if mainFrame == nil {
 		t.Fatalf("Couldn't find main in stack %v", panickingStack)
 	}
-	msg, err := proc.FrameToScope(p, p.Memory(), nil, *mainFrame).EvalExpression("msg", proc.LoadConfig{MaxStringLen: 64})
+	msg, err := proc.FrameToScope(p, p.Memory(), nil, p.CurrentThread().ThreadID(), *mainFrame).EvalExpression("msg", proc.LoadConfig{MaxStringLen: 64})
 	if err != nil {
 		t.Fatalf("Couldn't EvalVariable(msg, ...): %v", err)
 	}
@@ -434,7 +434,7 @@ mainSearch:
 		t.Fatal("could not find main.main frame")
 	}
 
-	scope := proc.FrameToScope(p, p.Memory(), nil, *mainFrame)
+	scope := proc.FrameToScope(p, p.Memory(), nil, p.CurrentThread().ThreadID(), *mainFrame)
 	loadConfig := proc.LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1}
 	v1, err := scope.EvalExpression("t", loadConfig)
 	assertNoError(err, t, "EvalVariable(t)")

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1199,7 +1199,7 @@ func evalVariableOrError(p *proc.Target, symbol string) (*proc.Variable, error) 
 		var frame proc.Stackframe
 		frame, err = findFirstNonRuntimeFrame(p)
 		if err == nil {
-			scope = proc.FrameToScope(p, p.Memory(), nil, frame)
+			scope = proc.FrameToScope(p, p.Memory(), nil, 0, frame)
 		}
 	} else {
 		scope, err = proc.GoroutineScope(p, p.CurrentThread())
@@ -3101,7 +3101,7 @@ func TestIssue871(t *testing.T) {
 			var frame proc.Stackframe
 			frame, err = findFirstNonRuntimeFrame(p)
 			if err == nil {
-				scope = proc.FrameToScope(p, p.Memory(), nil, frame)
+				scope = proc.FrameToScope(p, p.Memory(), nil, 0, frame)
 			}
 		} else {
 			scope, err = proc.GoroutineScope(p, p.CurrentThread())
@@ -3514,7 +3514,7 @@ func TestIssue1034(t *testing.T) {
 		assertNoError(grp.Continue(), t, "Continue()")
 		frames, err := proc.GoroutineStacktrace(p, p.SelectedGoroutine(), 10, 0)
 		assertNoError(err, t, "Stacktrace")
-		scope := proc.FrameToScope(p, p.Memory(), nil, frames[2:]...)
+		scope := proc.FrameToScope(p, p.Memory(), nil, 0, frames[2:]...)
 		args, _ := scope.FunctionArguments(normalLoadConfig)
 		assertNoError(err, t, "FunctionArguments()")
 		if len(args) > 0 {
@@ -5277,8 +5277,8 @@ func TestDump(t *testing.T) {
 					t.Errorf("Frame mismatch %d.%d\nlive:\t%s\ncore:\t%s", gos[i].ID, j, convertFrame(p.BinInfo().Arch, &frames[j]), convertFrame(p.BinInfo().Arch, &cframes[j]))
 				}
 				if frames[j].Call.Fn != nil && frames[j].Call.Fn.Name == "main.main" {
-					scope = proc.FrameToScope(p, p.Memory(), gos[i], frames[j:]...)
-					cscope = proc.FrameToScope(c, c.Memory(), cgos[i], cframes[j:]...)
+					scope = proc.FrameToScope(p, p.Memory(), gos[i], 0, frames[j:]...)
+					cscope = proc.FrameToScope(c, c.Memory(), cgos[i], 0, cframes[j:]...)
 				}
 			}
 		}

--- a/pkg/proc/stack_sigtramp.go
+++ b/pkg/proc/stack_sigtramp.go
@@ -14,7 +14,7 @@ import (
 // readSigtrampgoContext reads runtime.sigtrampgo context at the specified address
 func (it *stackIterator) readSigtrampgoContext() (*op.DwarfRegisters, error) {
 	logger := logflags.DebuggerLogger()
-	scope := FrameToScope(it.target, it.mem, it.g, it.frame)
+	scope := FrameToScope(it.target, it.mem, it.g, 0, it.frame)
 	bi := it.bi
 
 	findvar := func(name string) *Variable {

--- a/pkg/proc/stackwatch.go
+++ b/pkg/proc/stackwatch.go
@@ -38,7 +38,7 @@ func (t *Target) setStackWatchBreakpoints(scope *EvalScope, watchpoint *Breakpoi
 		return err
 	}
 
-	sameGCond := sameGoroutineCondition(scope.g)
+	sameGCond := sameGoroutineCondition(scope.BinInfo, scope.g, 0)
 	retFrameCond := astutil.And(sameGCond, frameoffCondition(&retframe))
 
 	var deferpc uint64

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -82,7 +82,7 @@ func evalScope(p *proc.Target) (*proc.EvalScope, error) {
 	if err != nil {
 		return nil, err
 	}
-	return proc.FrameToScope(p, p.Memory(), nil, frame), nil
+	return proc.FrameToScope(p, p.Memory(), nil, p.CurrentThread().ThreadID(), frame), nil
 }
 
 func evalVariableWithCfg(p *proc.Target, symbol string, cfg proc.LoadConfig) (*proc.Variable, error) {
@@ -417,7 +417,7 @@ func TestLocalVariables(t *testing.T) {
 				var frame proc.Stackframe
 				frame, err = findFirstNonRuntimeFrame(p)
 				if err == nil {
-					scope = proc.FrameToScope(p, p.Memory(), nil, frame)
+					scope = proc.FrameToScope(p, p.Memory(), nil, p.CurrentThread().ThreadID(), frame)
 				}
 			} else {
 				scope, err = proc.GoroutineScope(p, p.CurrentThread())

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1863,7 +1863,7 @@ func (d *Debugger) convertStacktrace(rawlocs []proc.Stackframe, cfg *proc.LoadCo
 		}
 		if cfg != nil && rawlocs[i].Current.Fn != nil {
 			var err error
-			scope := proc.FrameToScope(d.target.Selected, d.target.Selected.Memory(), nil, rawlocs[i:]...)
+			scope := proc.FrameToScope(d.target.Selected, d.target.Selected.Memory(), nil, 0, rawlocs[i:]...)
 			locals, err := scope.LocalVariables(*cfg)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
If there is no current goroutine when 'next', 'step' or 'stepout' are
used set a condition that the thread ID should stay the same instead.

This makes stepping work for multithreaded C programs or Go programs
that have threads started by cgo code.

Fixes #3262
