### PR TITLE
cmd/dlv: handle ctrl-c during tracing

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -677,7 +677,7 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 		signal.Notify(ch, syscall.SIGINT)
 
 		go func() {
-			for _ = range ch {
+			for range ch {
 				client.Halt()
 			}
 		}()

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -677,9 +677,8 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 		signal.Notify(ch, syscall.SIGINT)
 
 		go func() {
-			for range ch {
-				client.Halt()
-			}
+			<-ch
+			client.Halt()
 		}()
 
 		funcs, err := client.ListFunctions(regexp)

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -672,6 +672,16 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 		}
 		client := rpc2.NewClientFromConn(clientConn)
 		defer client.Detach(true)
+
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGINT)
+
+		go func() {
+			for _ = range ch {
+				client.Halt()
+			}
+		}()
+
 		funcs, err := client.ListFunctions(regexp)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Ensure we send a Halt command to stop the process being traced so that the deferred Detach can run ensuring proper cleanup upon exit.

Fixes #3228