### PR TITLE
proc,service,terminal: add ways to list goroutines waiting on a channel

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -386,7 +386,7 @@ Aliases: gr
 ## goroutines
 List program goroutines.
 
-	goroutines [-u|-r|-g|-s] [-t [depth]] [-l] [-with loc expr] [-without loc expr] [-group argument] [-exec command]
+	goroutines [-u|-r|-g|-s] [-t [depth]] [-l] [-with loc expr] [-without loc expr] [-group argument] [-chan expr] [-exec command]
 
 Print out info for every goroutine. The flag controls what information is shown along with each goroutine:
 
@@ -436,6 +436,14 @@ To only display user (or runtime) goroutines, use:
 
 	goroutines -with user
 	goroutines -without user
+
+CHANNELS
+	
+To only show goroutines waiting to send to or receive from a specific channel use:
+
+	goroutines -chan expr
+	
+Note that 'expr' must not contain spaces.
 
 GROUPING
 

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -51,7 +51,7 @@ checkpoints() | Equivalent to API call [ListCheckpoints](https://godoc.org/githu
 dynamic_libraries() | Equivalent to API call [ListDynamicLibraries](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListDynamicLibraries)
 function_args(Scope, Cfg) | Equivalent to API call [ListFunctionArgs](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListFunctionArgs)
 functions(Filter) | Equivalent to API call [ListFunctions](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListFunctions)
-goroutines(Start, Count, Filters, GoroutineGroupingOptions) | Equivalent to API call [ListGoroutines](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListGoroutines)
+goroutines(Start, Count, Filters, GoroutineGroupingOptions, EvalScope) | Equivalent to API call [ListGoroutines](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListGoroutines)
 local_vars(Scope, Cfg) | Equivalent to API call [ListLocalVars](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListLocalVars)
 package_vars(Filter, Cfg) | Equivalent to API call [ListPackageVars](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListPackageVars)
 packages_build_info(IncludeFiles) | Equivalent to API call [ListPackagesBuildInfo](https://godoc.org/github.com/go-delve/delve/service/rpc2#RPCServer.ListPackagesBuildInfo)

--- a/_fixtures/changoroutines.go
+++ b/_fixtures/changoroutines.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"runtime"
+	"time"
+)
+
+func main() {
+	blockingchan1 := make(chan int)
+	blockingchan2 := make(chan int)
+
+	go sendToChan("one", blockingchan1)
+	go sendToChan("two", blockingchan1)
+	go recvFromChan(blockingchan2)
+	time.Sleep(time.Second)
+
+	runtime.Breakpoint()
+}
+
+func sendToChan(name string, ch chan<- int) {
+	ch <- 1
+}
+
+func recvFromChan(ch <-chan int) {
+	<-ch
+}

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -1143,6 +1143,15 @@ func (env *Env) starlarkPredeclare() (starlark.StringDict, map[string]string) {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 4 && args[4] != starlark.None {
+			err := unmarshalStarlarkValue(args[4], &rpcArgs.EvalScope, "EvalScope")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		} else {
+			scope := env.ctx.Scope()
+			rpcArgs.EvalScope = &scope
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
@@ -1154,6 +1163,8 @@ func (env *Env) starlarkPredeclare() (starlark.StringDict, map[string]string) {
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Filters, "Filters")
 			case "GoroutineGroupingOptions":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.GoroutineGroupingOptions, "GoroutineGroupingOptions")
+			case "EvalScope":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.EvalScope, "EvalScope")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}
@@ -1167,7 +1178,7 @@ func (env *Env) starlarkPredeclare() (starlark.StringDict, map[string]string) {
 		}
 		return env.interfaceToStarlarkValue(rpcRet), nil
 	})
-	doc["goroutines"] = "builtin goroutines(Start, Count, Filters, GoroutineGroupingOptions)\n\ngoroutines lists all goroutines.\nIf Count is specified ListGoroutines will return at the first Count\ngoroutines and an index in Nextg, that can be passed as the Start\nparameter, to get more goroutines from ListGoroutines.\nPassing a value of Start that wasn't returned by ListGoroutines will skip\nan undefined number of goroutines.\n\nIf arg.Filters are specified the list of returned goroutines is filtered\napplying the specified filters.\nFor example:\n\n\tListGoroutinesFilter{ Kind: ListGoroutinesFilterUserLoc, Negated: false, Arg: \"afile.go\" }\n\nwill only return goroutines whose UserLoc contains \"afile.go\" as a substring.\nMore specifically a goroutine matches a location filter if the specified\nlocation, formatted like this:\n\n\tfilename:lineno in function\n\ncontains Arg[0] as a substring.\n\nFilters can also be applied to goroutine labels:\n\n\tListGoroutineFilter{ Kind: ListGoroutinesFilterLabel, Negated: false, Arg: \"key=value\" }\n\nthis filter will only return goroutines that have a key=value label.\n\nIf arg.GroupBy is not GoroutineFieldNone then the goroutines will\nbe grouped with the specified criterion.\nIf the value of arg.GroupBy is GoroutineLabel goroutines will\nbe grouped by the value of the label with key GroupByKey.\nFor each group a maximum of MaxGroupMembers example goroutines are\nreturned, as well as the total number of goroutines in the group."
+	doc["goroutines"] = "builtin goroutines(Start, Count, Filters, GoroutineGroupingOptions, EvalScope)\n\ngoroutines lists all goroutines.\nIf Count is specified ListGoroutines will return at the first Count\ngoroutines and an index in Nextg, that can be passed as the Start\nparameter, to get more goroutines from ListGoroutines.\nPassing a value of Start that wasn't returned by ListGoroutines will skip\nan undefined number of goroutines.\n\nIf arg.Filters are specified the list of returned goroutines is filtered\napplying the specified filters.\nFor example:\n\n\tListGoroutinesFilter{ Kind: ListGoroutinesFilterUserLoc, Negated: false, Arg: \"afile.go\" }\n\nwill only return goroutines whose UserLoc contains \"afile.go\" as a substring.\nMore specifically a goroutine matches a location filter if the specified\nlocation, formatted like this:\n\n\tfilename:lineno in function\n\ncontains Arg[0] as a substring.\n\nFilters can also be applied to goroutine labels:\n\n\tListGoroutineFilter{ Kind: ListGoroutinesFilterLabel, Negated: false, Arg: \"key=value\" }\n\nthis filter will only return goroutines that have a key=value label.\n\nIf arg.GroupBy is not GoroutineFieldNone then the goroutines will\nbe grouped with the specified criterion.\nIf the value of arg.GroupBy is GoroutineLabel goroutines will\nbe grouped by the value of the label with key GroupByKey.\nFor each group a maximum of MaxGroupMembers example goroutines are\nreturned, as well as the total number of goroutines in the group."
 	r["local_vars"] = starlark.NewBuiltin("local_vars", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		if err := isCancelled(thread); err != nil {
 			return starlark.None, decorateError(thread, err)

--- a/service/api/command.go
+++ b/service/api/command.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -98,6 +99,13 @@ func ParseGoroutineArgs(argstr string) ([]ListGoroutinesFilter, GoroutineGroupin
 				i++
 			}
 			batchSize = 0 // grouping only works well if run on all goroutines
+
+		case "-chan":
+			i++
+			if i >= len(args) {
+				return nil, GoroutineGroupingOptions{}, 0, 0, 0, 0, "", errors.New("not enough arguments after -chan")
+			}
+			filters = append(filters, ListGoroutinesFilter{Kind: GoroutineWaitingOnChannel, Arg: args[i]})
 
 		case "-exec":
 			flags |= PrintGoroutinesExec

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -635,14 +635,15 @@ type ListGoroutinesFilter struct {
 type GoroutineField uint8
 
 const (
-	GoroutineFieldNone  GoroutineField = iota
-	GoroutineCurrentLoc                // the goroutine's CurrentLoc
-	GoroutineUserLoc                   // the goroutine's UserLoc
-	GoroutineGoLoc                     // the goroutine's GoStatementLoc
-	GoroutineStartLoc                  // the goroutine's StartLoc
-	GoroutineLabel                     // the goroutine's label
-	GoroutineRunning                   // the goroutine is running
-	GoroutineUser                      // the goroutine is a user goroutine
+	GoroutineFieldNone        GoroutineField = iota
+	GoroutineCurrentLoc                      // the goroutine's CurrentLoc
+	GoroutineUserLoc                         // the goroutine's UserLoc
+	GoroutineGoLoc                           // the goroutine's GoStatementLoc
+	GoroutineStartLoc                        // the goroutine's StartLoc
+	GoroutineLabel                           // the goroutine's label
+	GoroutineRunning                         // the goroutine is running
+	GoroutineUser                            // the goroutine is a user goroutine
+	GoroutineWaitingOnChannel                // the goroutine is waiting on the channel specified by the argument
 )
 
 // GoroutineGroup represents a group of goroutines in the return value of

--- a/service/client.go
+++ b/service/client.go
@@ -120,7 +120,7 @@ type Client interface {
 	// ListGoroutines lists all goroutines.
 	ListGoroutines(start, count int) ([]*api.Goroutine, int, error)
 	// ListGoroutinesWithFilter lists goroutines matching the filters
-	ListGoroutinesWithFilter(start, count int, filters []api.ListGoroutinesFilter, group *api.GoroutineGroupingOptions) ([]*api.Goroutine, []api.GoroutineGroup, int, bool, error)
+	ListGoroutinesWithFilter(start, count int, filters []api.ListGoroutinesFilter, group *api.GoroutineGroupingOptions, scope *api.EvalScope) ([]*api.Goroutine, []api.GoroutineGroup, int, bool, error)
 
 	// Stacktrace returns stacktrace
 	Stacktrace(goroutineID int64, depth int, opts api.StacktraceOptions, cfg *api.LoadConfig) ([]api.Stackframe, error)

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -383,16 +383,16 @@ func (c *RPCClient) ListFunctionArgs(scope api.EvalScope, cfg api.LoadConfig) ([
 
 func (c *RPCClient) ListGoroutines(start, count int) ([]*api.Goroutine, int, error) {
 	var out ListGoroutinesOut
-	err := c.call("ListGoroutines", ListGoroutinesIn{start, count, nil, api.GoroutineGroupingOptions{}}, &out)
+	err := c.call("ListGoroutines", ListGoroutinesIn{start, count, nil, api.GoroutineGroupingOptions{}, nil}, &out)
 	return out.Goroutines, out.Nextg, err
 }
 
-func (c *RPCClient) ListGoroutinesWithFilter(start, count int, filters []api.ListGoroutinesFilter, group *api.GoroutineGroupingOptions) ([]*api.Goroutine, []api.GoroutineGroup, int, bool, error) {
+func (c *RPCClient) ListGoroutinesWithFilter(start, count int, filters []api.ListGoroutinesFilter, group *api.GoroutineGroupingOptions, scope *api.EvalScope) ([]*api.Goroutine, []api.GoroutineGroup, int, bool, error) {
 	if group == nil {
 		group = &api.GoroutineGroupingOptions{}
 	}
 	var out ListGoroutinesOut
-	err := c.call("ListGoroutines", ListGoroutinesIn{start, count, filters, *group}, &out)
+	err := c.call("ListGoroutines", ListGoroutinesIn{start, count, filters, *group, scope}, &out)
 	return out.Goroutines, out.Groups, out.Nextg, out.TooManyGroups, err
 }
 


### PR DESCRIPTION
Adds -chan option to the goroutines command to list only the goroutines
running on a specified channel.

Also when printing a variable if it is a channel also print the list of
goroutines that are waiting on it.
