### PR TITLE
proc: disable "wait-for" tests on freebsd

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -11,7 +11,8 @@ Tests skipped by each supported backend:
 	* 2 broken - cgo stacktraces
 * darwin/lldb skipped = 1
 	* 1 upstream issue
-* freebsd skipped = 4
+* freebsd skipped = 6
+	* 2 flaky
 	* 4 not implemented
 * linux/386/pie skipped = 1
 	* 1 broken

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -6197,6 +6197,7 @@ func testWaitForSetup(t *testing.T, mu *sync.Mutex, started *bool) (*exec.Cmd, *
 
 func TestWaitFor(t *testing.T) {
 	skipOn(t, "waitfor implementation is delegated to debugserver", "darwin")
+	skipOn(t, "flaky", "freebsd")
 
 	var mu sync.Mutex
 	started := false
@@ -6214,6 +6215,7 @@ func TestWaitFor(t *testing.T) {
 }
 
 func TestWaitForAttach(t *testing.T) {
+	skipOn(t, "flaky", "freebsd")
 	if testBackend == "lldb" && runtime.GOOS == "linux" {
 		bs, _ := ioutil.ReadFile("/proc/sys/kernel/yama/ptrace_scope")
 		if bs == nil || strings.TrimSpace(string(bs)) != "0" {


### PR DESCRIPTION
They are flaky in CI, I can not reproduce the problem locally.
