### PR TITLE
*: reduce sleep timeout in test program

### DIFF
--- a/_fixtures/ebpf_trace2.go
+++ b/_fixtures/ebpf_trace2.go
@@ -12,7 +12,7 @@ func main() {
 	}
 	for i = 5; i < 10; i++ {
 		tracedFunction(i)
-		time.Sleep(time.Second)
+		time.Sleep(time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
This larger timeout is not essential for the test and can be reduced to make full test runs quicker.