### PR TITLE
service/test: disable TestClientServer_chanGoroutines with rr backend

### DIFF
--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3063,7 +3063,6 @@ var waitReasonStrings = [...]string{
 }
 
 func TestClientServer_chanGoroutines(t *testing.T) {
-	protest.AllowRecording(t)
 	withTestClient2("changoroutines", t, func(c service.Client) {
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")


### PR DESCRIPTION
It doesn't work with rr because it uses runtime.Breakpoint to stop.
