### PR TITLE
service/dap: strip package paths from symbols in callstack

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1684,7 +1684,17 @@ func fnName(loc *proc.Location) string {
 	if loc.Fn == nil {
 		return "???"
 	}
-	return loc.Fn.Name
+	fullSymbol := loc.Fn.Name
+	packagePath := loc.Fn.PackageName()
+	lastSlash := strings.LastIndex(packagePath, "/")
+	if lastSlash >= 0 {
+		// strip everything until the last slash from the package path
+		return fullSymbol[lastSlash+1:]
+	}
+
+	// We either have no package name at all, or it doesn't contain a slash:
+	// return name unchanged
+	return fullSymbol
 }
 
 func fnPackageName(loc *proc.Location) string {


### PR DESCRIPTION
This solves the problem that function names with long package paths are hard to read when the callstack window is narrow, because all you see is the beginning of the package path.

For example, instead of

```
  github.com/some/long/package/path/pkg.(*SomeType).SomeMethod
```

we now display

```
  pkg.(*SomeType).SomeMethod
```

Fixes #3323.