### PR TITLE
pkg/proc/internal/ebpf: remove redundant nil check

### DIFF
--- a/pkg/proc/internal/ebpf/helpers.go
+++ b/pkg/proc/internal/ebpf/helpers.go
@@ -71,10 +71,8 @@ func (ctx *EBPFContext) Close() {
 	if ctx.objs != nil {
 		ctx.objs.Close()
 	}
-	if ctx.links != nil {
-		for _, l := range ctx.links {
-			l.Close()
-		}
+	for _, l := range ctx.links {
+		l.Close()
 	}
 }
 


### PR DESCRIPTION
From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary.