### PR TITLE
proc,service: simplify tests with T.Setenv

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -208,7 +208,7 @@ func getDlvBin(t *testing.T) string {
 	// from getDlvBinEBPF lets clear it here so
 	// we can ensure we don't get build errors
 	// depending on the test ordering.
-	os.Setenv("CGO_LDFLAGS", ldFlags)
+	t.Setenv("CGO_LDFLAGS", ldFlags)
 	var tags string
 	if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" {
 		tags = "-tags=exp.winarm64"

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2981,7 +2981,7 @@ func TestPackageWithPathVar(t *testing.T) {
 
 func TestEnvironment(t *testing.T) {
 	protest.AllowRecording(t)
-	os.Setenv("SOMEVAR", "bah")
+	t.Setenv("SOMEVAR", "bah")
 	withTestProcess("testenv", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		assertNoError(grp.Continue(), t, "Continue()")
 		v := evalVariable(p, t, "x")
@@ -3047,7 +3047,7 @@ func TestIssue877(t *testing.T) {
 		t.Skip("broken")
 	}
 	const envval = "/usr/local/lib"
-	os.Setenv("DYLD_LIBRARY_PATH", envval)
+	t.Setenv("DYLD_LIBRARY_PATH", envval)
 	withTestProcess("issue877", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		assertNoError(grp.Continue(), t, "Continue()")
 		v := evalVariable(p, t, "dyldenv")
@@ -4479,12 +4479,7 @@ func TestListImages(t *testing.T) {
 }
 
 func TestAncestors(t *testing.T) {
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
-		t.Skip("not supported on Go <= 1.10")
-	}
-	savedGodebug := os.Getenv("GODEBUG")
-	os.Setenv("GODEBUG", "tracebackancestors=100")
-	defer os.Setenv("GODEBUG", savedGodebug)
+	t.Setenv("GODEBUG", "tracebackancestors=100")
 	withTestProcess("testnextprog", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.testgoroutine")
 		assertNoError(grp.Continue(), t, "Continue()")

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -122,7 +122,7 @@ func withTestTerminalBuildFlags(name string, t testing.TB, buildFlags test.Build
 	if testBackend == "rr" {
 		test.MustHaveRecordingAllowed(t)
 	}
-	os.Setenv("TERM", "dumb")
+	t.Setenv("TERM", "dumb")
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("couldn't start listener: %s\n", err)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -5719,16 +5719,9 @@ func TestLaunchRequestWithEnv(t *testing.T) {
 	} {
 
 		t.Run(tc.name, func(t *testing.T) {
-			// cleanup
-			defer func() {
-				os.Unsetenv("SOMEVAR")
-				os.Unsetenv("SOMEVAR2")
-				os.Unsetenv("SOMEVAR3")
-			}()
-
 			for k, v := range tc.initEnv {
 				if v != nil {
-					os.Setenv(k, *v)
+					t.Setenv(k, *v)
 				}
 			}
 

--- a/service/debugger/debugger_test.go
+++ b/service/debugger/debugger_test.go
@@ -34,13 +34,6 @@ func TestDebugger_LaunchNoMain(t *testing.T) {
 }
 
 func TestDebugger_LaunchInvalidFormat(t *testing.T) {
-	goos := os.Getenv("GOOS")
-	goarch := os.Getenv("GOARCH")
-	defer func() {
-		// restore environment values
-		os.Setenv("GOOS", goos)
-		os.Setenv("GOARCH", goarch)
-	}()
 	fixturesDir := protest.FindFixturesDir()
 	buildtestdir := filepath.Join(fixturesDir, "buildtest")
 	debugname := "debug"
@@ -51,12 +44,12 @@ func TestDebugger_LaunchInvalidFormat(t *testing.T) {
 		"linux":   "windows",
 	}
 	if runtime.GOARCH == "arm64" && runtime.GOOS == "linux" {
-		os.Setenv("GOARCH", "amd64")
+		t.Setenv("GOARCH", "amd64")
 	}
 	if runtime.GOARCH == "ppc64le" && runtime.GOOS == "linux" {
-		os.Setenv("GOARCH", "amd64")
+		t.Setenv("GOARCH", "amd64")
 	}
-	os.Setenv("GOOS", switchOS[runtime.GOOS])
+	t.Setenv("GOOS", switchOS[runtime.GOOS])
 	exepath := filepath.Join(buildtestdir, debugname)
 	if err := gobuild.GoBuild(debugname, []string{buildtestdir}, fmt.Sprintf("-o %s", exepath)); err != nil {
 		t.Fatalf("go build error %v", err)

--- a/service/debugger/debugger_unix_test.go
+++ b/service/debugger/debugger_unix_test.go
@@ -20,10 +20,6 @@ import (
 )
 
 func TestDebugger_LaunchNoExecutablePerm(t *testing.T) {
-	defer func() {
-		os.Setenv("GOOS", runtime.GOOS)
-		os.Setenv("GOARCH", runtime.GOARCH)
-	}()
 	fixturesDir := protest.FindFixturesDir()
 	buildtestdir := filepath.Join(fixturesDir, "buildtest")
 	debugname := "debug"
@@ -34,12 +30,12 @@ func TestDebugger_LaunchNoExecutablePerm(t *testing.T) {
 		"linux":   "windows",
 	}
 	if runtime.GOARCH == "arm64" && runtime.GOOS == "linux" {
-		os.Setenv("GOARCH", "amd64")
+		t.Setenv("GOARCH", "amd64")
 	}
 	if runtime.GOARCH == "ppc64le" && runtime.GOOS == "linux" {
-		os.Setenv("GOARCH", "amd64")
+		t.Setenv("GOARCH", "amd64")
 	}
-	os.Setenv("GOOS", switchOS[runtime.GOOS])
+	t.Setenv("GOOS", switchOS[runtime.GOOS])
 	exepath := filepath.Join(buildtestdir, debugname)
 	defer os.Remove(exepath)
 	if err := gobuild.GoBuild(debugname, []string{buildtestdir}, fmt.Sprintf("-o %s", exepath)); err != nil {
@@ -65,8 +61,8 @@ func TestDebugger_LaunchWithTTY(t *testing.T) {
 		}
 	}
 	// Ensure no env meddling is leftover from previous tests.
-	os.Setenv("GOOS", runtime.GOOS)
-	os.Setenv("GOARCH", runtime.GOARCH)
+	t.Setenv("GOOS", runtime.GOOS)
+	t.Setenv("GOARCH", runtime.GOARCH)
 
 	p, tty, err := pty.Open()
 	if err != nil {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -231,7 +231,7 @@ func main() {
 
 func TestRestart_rebuild(t *testing.T) {
 	// In the original fixture file the env var tested for is SOMEVAR.
-	os.Setenv("SOMEVAR", "bah")
+	t.Setenv("SOMEVAR", "bah")
 
 	withTestClient2Extended("testenv", t, 0, [3]string{}, nil, func(c service.Client, f protest.Fixture) {
 		<-c.Continue()
@@ -258,7 +258,7 @@ func TestRestart_rebuild(t *testing.T) {
 
 		// First set our new env var and ensure later that the
 		// modified source code picks it up.
-		os.Setenv("SOMEMODIFIEDVAR", "foobar")
+		t.Setenv("SOMEMODIFIEDVAR", "foobar")
 
 		// Restart the program, rebuilding from source.
 		_, err = c.Restart(true)
@@ -2194,9 +2194,7 @@ func TestAncestors(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 11) {
 		t.Skip("not supported on Go <= 1.10")
 	}
-	savedGodebug := os.Getenv("GODEBUG")
-	os.Setenv("GODEBUG", "tracebackancestors=100")
-	defer os.Setenv("GODEBUG", savedGodebug)
+	t.Setenv("GODEBUG", "tracebackancestors=100")
 	withTestClient2("testnextprog", t, func(c service.Client) {
 		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.testgoroutine", Line: -1})
 		assertNoError(err, t, "CreateBreakpoint")


### PR DESCRIPTION
This PR refactors tests by replacing `os.Setenv` with [`t.Setenv`](https://pkg.go.dev/testing#T.Setenv).