### PR TITLE
_scripts: remove unnecessary os.ExpandEnv

### DIFF
--- a/_scripts/gen-cli-docs.go
+++ b/_scripts/gen-cli-docs.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	fh, err := os.Create(os.ExpandEnv("./Documentation/cli/README.md"))
+	fh, err := os.Create("./Documentation/cli/README.md")
 	if err != nil {
 		log.Fatalf("could not create README.md: %v", err)
 	}


### PR DESCRIPTION
It became redundant after #1649