### PR TITLE
macho: Enable debugging stripped binaries

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -11,13 +11,16 @@ Tests skipped by each supported backend:
 	* 2 broken - cgo stacktraces
 * darwin/lldb skipped = 1
 	* 1 upstream issue
-* freebsd skipped = 6
+* freebsd skipped = 7
 	* 2 flaky
 	* 4 not implemented
-* linux/386/pie skipped = 1
+	* 1 not working on freebsd
+* linux/386/pie skipped = 2
 	* 1 broken
-* linux/ppc64le skipped = 1
+	* 1 not working on linux/386 with PIE
+* linux/ppc64le skipped = 2
 	* 1 broken - cgo stacktraces
+	* 1 not working on linux/ppc64le when -gcflags=-N -l is passed
 * linux/ppc64le/native skipped = 1
 	* 1 broken in linux ppc64le
 * linux/ppc64le/native/pie skipped = 3
@@ -28,8 +31,9 @@ Tests skipped by each supported backend:
 	* 6 broken
 	* 1 broken - global variable symbolication
 	* 4 not implemented
-* windows skipped = 4
+* windows skipped = 5
 	* 1 broken
+	* 1 not working on windows
 	* 3 see https://github.com/go-delve/delve/issues/2768
 * windows/arm64 skipped = 5
 	* 3 broken

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2331,7 +2331,7 @@ func TestStepCallPtr(t *testing.T) {
 			{6, 7},
 			{7, 11}}, "", t)
 	} else {
-		if runtime.GOOS == "linux" && runtime.GOARCH == "ppc64le" && buildMode == "pie"  {
+		if runtime.GOOS == "linux" && runtime.GOARCH == "ppc64le" && buildMode == "pie" {
 			testseq("teststepprog", contStep, []nextTest{
 				{9, 10},
 				{10, 5},
@@ -3179,8 +3179,9 @@ func TestShadowedFlag(t *testing.T) {
 
 func TestDebugStripped(t *testing.T) {
 	// Currently only implemented for Linux ELF executables.
-	// TODO(derekparker): Add support for Mach-O and PE.
-	skipUnlessOn(t, "linux only", "linux")
+	// TODO(derekparker): Add support for PE.
+	skipOn(t, "not working on windows", "windows")
+	skipOn(t, "not working on freebsd", "freebsd")
 	skipOn(t, "not working on linux/386 with PIE", "linux", "386", "pie")
 	skipOn(t, "not working on linux/ppc64le when -gcflags=-N -l is passed", "linux", "ppc64le")
 	withTestProcessArgs("testnextprog", t, "", []string{}, protest.LinkStrip, func(p *proc.Target, grp *proc.TargetGroup, f protest.Fixture) {


### PR DESCRIPTION
Load a symbol table from pclntab as when debugging stripped ELF binaries.