### PR TITLE
all: remove obsolete build tags

### DIFF
--- a/_scripts/gen-cli-docs.go
+++ b/_scripts/gen-cli-docs.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/_scripts/gen-opcodes.go
+++ b/_scripts/gen-opcodes.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/_scripts/gen-usage-docs.go
+++ b/_scripts/gen-usage-docs.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/proc/amd64util/xsave_other.go
+++ b/pkg/proc/amd64util/xsave_other.go
@@ -1,5 +1,4 @@
 //go:build !amd64
-// +build !amd64
 
 package amd64util
 

--- a/pkg/proc/eval_go117.go
+++ b/pkg/proc/eval_go117.go
@@ -1,5 +1,4 @@
 //go:build !go1.18
-// +build !go1.18
 
 package proc
 

--- a/pkg/proc/eval_go118.go
+++ b/pkg/proc/eval_go118.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package proc
 

--- a/pkg/proc/gdbserial/gdbserver_unix.go
+++ b/pkg/proc/gdbserial/gdbserver_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd
-// +build linux darwin freebsd
 
 package gdbserial
 

--- a/pkg/proc/internal/ebpf/bpf/dummy.go
+++ b/pkg/proc/internal/ebpf/bpf/dummy.go
@@ -1,4 +1,3 @@
 //go:build dummy
-// +build dummy
 
 package ebpf

--- a/pkg/proc/internal/ebpf/bpf/include/dummy.go
+++ b/pkg/proc/internal/ebpf/bpf/include/dummy.go
@@ -1,4 +1,3 @@
 //go:build dummy
-// +build dummy
 
 package ebpf

--- a/pkg/proc/internal/ebpf/dummy.go
+++ b/pkg/proc/internal/ebpf/dummy.go
@@ -1,5 +1,4 @@
 //go:build dummy
-// +build dummy
 
 // This file is part of a workaround for `go mod vendor` which won't
 // vendor C files if there are no Go files in the same directory.

--- a/pkg/proc/internal/ebpf/helpers.go
+++ b/pkg/proc/internal/ebpf/helpers.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64 && go1.16
-// +build linux,amd64,go1.16
 
 package ebpf
 

--- a/pkg/proc/internal/ebpf/helpers_disabled.go
+++ b/pkg/proc/internal/ebpf/helpers_disabled.go
@@ -1,5 +1,4 @@
 //go:build !linux || !amd64 || !go1.16
-// +build !linux !amd64 !go1.16
 
 package ebpf
 

--- a/pkg/proc/internal/ebpf/helpers_test.go
+++ b/pkg/proc/internal/ebpf/helpers_test.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64 && cgo && go1.16
-// +build linux,amd64,cgo,go1.16
 
 package ebpf
 

--- a/pkg/proc/internal/ebpf/testhelper/testhelper.go
+++ b/pkg/proc/internal/ebpf/testhelper/testhelper.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64 && cgo && go1.16
-// +build linux,amd64,cgo,go1.16
 
 package testhelper
 

--- a/pkg/proc/macutil/rosetta_other.go
+++ b/pkg/proc/macutil/rosetta_other.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package macutil
 

--- a/pkg/proc/native/dump_linux_other.go
+++ b/pkg/proc/native/dump_linux_other.go
@@ -1,5 +1,4 @@
 //go:build linux && !amd64
-// +build linux,!amd64
 
 package native
 

--- a/pkg/proc/native/dump_other.go
+++ b/pkg/proc/native/dump_other.go
@@ -1,5 +1,4 @@
 //go:build darwin || (windows && arm64)
-// +build darwin windows,arm64
 
 package native
 

--- a/pkg/proc/native/followexec_other.go
+++ b/pkg/proc/native/followexec_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package native
 

--- a/pkg/proc/native/hwbreak_other.go
+++ b/pkg/proc/native/hwbreak_other.go
@@ -1,5 +1,4 @@
 //go:build (linux && 386) || (darwin && arm64) || (windows && arm64) || (linux && ppc64le)
-// +build linux,386 darwin,arm64 windows,arm64 linux,ppc64le
 
 package native
 

--- a/pkg/proc/native/nonative_darwin.go
+++ b/pkg/proc/native/nonative_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin && !macnative
-// +build darwin,!macnative
 
 package native
 

--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin && macnative
-// +build darwin,macnative
 
 package native
 

--- a/pkg/proc/native/proc_ebpf_linux.go
+++ b/pkg/proc/native/proc_ebpf_linux.go
@@ -1,5 +1,4 @@
 //go:build linux && amd64 && cgo && go1.16
-// +build linux,amd64,cgo,go1.16
 
 package native
 

--- a/pkg/proc/native/proc_no_ebpf_linux.go
+++ b/pkg/proc/native/proc_no_ebpf_linux.go
@@ -1,5 +1,4 @@
 //go:build !linux || !amd64 || !go1.16 || !cgo
-// +build !linux !amd64 !go1.16 !cgo
 
 package native
 

--- a/pkg/proc/native/proc_unix.go
+++ b/pkg/proc/native/proc_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package native
 

--- a/pkg/proc/native/ptrace_darwin.go
+++ b/pkg/proc/native/ptrace_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin && macnative
-// +build darwin,macnative
 
 package native
 

--- a/pkg/proc/native/ptrace_linux_64bit.go
+++ b/pkg/proc/native/ptrace_linux_64bit.go
@@ -1,5 +1,4 @@
 //go:build (linux && amd64) || (linux && arm64) || (linux && ppc64le)
-// +build linux,amd64 linux,arm64 linux,ppc64le
 
 package native
 

--- a/pkg/proc/native/registers_darwin_amd64.go
+++ b/pkg/proc/native/registers_darwin_amd64.go
@@ -1,5 +1,4 @@
 //go:build darwin && macnative
-// +build darwin,macnative
 
 package native
 

--- a/pkg/proc/native/support_sentinel.go
+++ b/pkg/proc/native/support_sentinel.go
@@ -1,6 +1,5 @@
-// This file is used to detect build on unsupported GOOS/GOARCH combinations.
-
 //go:build !linux && !darwin && !windows && !freebsd
-// +build !linux,!darwin,!windows,!freebsd
+
+// This file is used to detect build on unsupported GOOS/GOARCH combinations.
 
 package your_operating_system_is_not_supported_by_delve

--- a/pkg/proc/native/support_sentinel_darwin.go
+++ b/pkg/proc/native/support_sentinel_darwin.go
@@ -1,6 +1,5 @@
-// This file is used to detect build on unsupported GOOS/GOARCH combinations.
-
 //go:build darwin && !amd64 && !arm64
-// +build darwin,!amd64,!arm64
+
+// This file is used to detect build on unsupported GOOS/GOARCH combinations.
 
 package your_darwin_architectur_is_not_supported_by_delve

--- a/pkg/proc/native/support_sentinel_freebsd.go
+++ b/pkg/proc/native/support_sentinel_freebsd.go
@@ -1,6 +1,5 @@
-// This file is used to detect build on unsupported GOOS/GOARCH combinations.
-
 //go:build freebsd && !amd64
-// +build freebsd,!amd64
+
+// This file is used to detect build on unsupported GOOS/GOARCH combinations.
 
 package your_freebsd_architecture_is_not_supported_by_delve

--- a/pkg/proc/native/support_sentinel_linux.go
+++ b/pkg/proc/native/support_sentinel_linux.go
@@ -1,10 +1,5 @@
-// This file is used to detect build on unsupported GOOS/GOARCH combinations.
-
 //go:build linux && !amd64 && !arm64 && !386 && !(ppc64le && exp.linuxppc64le)
-// +build linux
-// +build !amd64
-// +build !arm64
-// +build !386
-// +build !ppc64le !exp.linuxppc64le
+
+// This file is used to detect build on unsupported GOOS/GOARCH combinations.
 
 package your_linux_architecture_is_not_supported_by_delve

--- a/pkg/proc/native/support_sentinel_windows.go
+++ b/pkg/proc/native/support_sentinel_windows.go
@@ -1,8 +1,5 @@
-// This file is used to detect build on unsupported GOOS/GOARCH combinations.
-
 //go:build windows && !amd64 && !(arm64 && exp.winarm64)
-// +build windows
-// +build !amd64
-// +build !arm64 !exp.winarm64
+
+// This file is used to detect build on unsupported GOOS/GOARCH combinations.
 
 package your_windows_architecture_is_not_supported_by_delve

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin && macnative
-// +build darwin,macnative
 
 package native
 

--- a/pkg/proc/proc_unix_test.go
+++ b/pkg/proc/proc_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package proc_test
 

--- a/pkg/proc/redirector_other.go
+++ b/pkg/proc/redirector_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package proc
 

--- a/pkg/proc/redirector_windows.go
+++ b/pkg/proc/redirector_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package proc
 

--- a/pkg/terminal/out_unix.go
+++ b/pkg/terminal/out_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd
-// +build linux darwin freebsd
 
 package terminal
 

--- a/pkg/terminal/terminal_other.go
+++ b/pkg/terminal/terminal_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package terminal
 

--- a/pkg/version/buildinfo.go
+++ b/pkg/version/buildinfo.go
@@ -1,5 +1,4 @@
 //go:build go1.12
-// +build go1.12
 
 package version
 

--- a/pkg/version/fixbuild.go
+++ b/pkg/version/fixbuild.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 package version
 

--- a/service/debugger/debugger_unix_test.go
+++ b/service/debugger/debugger_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package debugger
 

--- a/service/internal/sameuser/sameuser.go
+++ b/service/internal/sameuser/sameuser.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package sameuser
 

--- a/service/internal/sameuser/sameuser_linux.go
+++ b/service/internal/sameuser/sameuser_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package sameuser
 

--- a/service/internal/sameuser/sameuser_linux_test.go
+++ b/service/internal/sameuser/sameuser_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package sameuser
 


### PR DESCRIPTION
This PR removes all `// +build` comments because they have been obsolete since Go 1.17. From the [doc](https://pkg.go.dev/cmd/go#hdr-Build_constraints):

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

