### PR TITLE
Use a valid timezone in tested binary

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -374,7 +374,7 @@ func main() {
 
 	os.Setenv("TZ", "UTC")
 	tim1 := time.Unix(233431200, 0).UTC()
-	loc, _ := time.LoadLocation("Mexico/BajaSur")
+	loc, _ := time.LoadLocation("America/Mazatlan")
 	tim2, _ := time.ParseInLocation("2006-01-02 15:04:05", "2022-06-07 02:03:04", loc)
 	typedstringvar := String("blah")
 	namedA1 := astructName1{12, 45}


### PR DESCRIPTION
With recent changes to debian/ubuntu tzdata package, the Mexico/BajaSur is not valid anymore (not present by default). It is now present in the tzdata-legacy package, which is not a essential package. Without this timezone, the call to time.LoadLocation() will send a nil location, which will provoke a panic in time.ParseInLocation(). This change uses the underlying associated timezone America/Mazatlan.

Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1052030