### PR TITLE
CI: update staticcheck version

### DIFF
--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -50,7 +50,7 @@ export GOPATH
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 go version
 if [ "$arch" != "ppc64le" ]; then
-	go install honnef.co/go/tools/cmd/staticcheck@2023.1 || true
+	go install honnef.co/go/tools/cmd/staticcheck@2023.1.6 || true
 fi
 
 uname -a

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1310,9 +1310,6 @@ func TestStaticcheck(t *testing.T) {
 	if err != nil {
 		t.Skip("staticcheck not installed")
 	}
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 22) {
-		t.Skip("broken with staticcheck@2023.1")
-	}
 	// default checks minus SA1019 which complains about deprecated identifiers, which change between versions of Go.
 	args := []string{"-tests=false", "-checks=all,-SA1019,-ST1000,-ST1003,-ST1016,-S1021,-ST1023", "github.com/go-delve/delve/..."}
 	// * SA1019 is disabled because new deprecations get added on every version


### PR DESCRIPTION
Update staticcheck version and re-enable TestStaticcheck on Go 1.22.
