### PR TITLE
Shorten variable types

### DIFF
--- a/service/api/shorten_type.go
+++ b/service/api/shorten_type.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"strings"
+	"unicode"
+)
+
+func ShortenType(typ string) string {
+	out, ok := shortenTypeEx(typ)
+	if !ok {
+		return typ
+	}
+	return out
+}
+
+func shortenTypeEx(typ string) (string, bool) {
+	switch {
+	case strings.HasPrefix(typ, "["):
+		for i := range typ {
+			if typ[i] == ']' {
+				sub, ok := shortenTypeEx(typ[i+1:])
+				return typ[:i+1] + sub, ok
+			}
+		}
+		return "", false
+	case strings.HasPrefix(typ, "*"):
+		sub, ok := shortenTypeEx(typ[1:])
+		return "*" + sub, ok
+	case strings.HasPrefix(typ, "map["):
+		depth := 1
+		for i := 4; i < len(typ); i++ {
+			switch typ[i] {
+			case '[':
+				depth++
+			case ']':
+				depth--
+				if depth == 0 {
+					key, keyok := shortenTypeEx(typ[4:i])
+					val, valok := shortenTypeEx(typ[i+1:])
+					return "map[" + key + "]" + val, keyok && valok
+				}
+			}
+		}
+		return "", false
+	case typ == "interface {}" || typ == "interface{}":
+		return typ, true
+	case typ == "struct {}" || typ == "struct{}":
+		return typ, true
+	default:
+		if containsAnonymousType(typ) {
+			return "", false
+		}
+
+		if lbrk := strings.Index(typ, "["); lbrk >= 0 {
+			if typ[len(typ)-1] != ']' {
+				return "", false
+			}
+			typ0, ok := shortenTypeEx(typ[:lbrk])
+			if !ok {
+				return "", false
+			}
+			args := strings.Split(typ[lbrk+1:len(typ)-1], ",")
+			for i := range args {
+				var ok bool
+				args[i], ok = shortenTypeEx(strings.TrimSpace(args[i]))
+				if !ok {
+					return "", false
+				}
+			}
+			return typ0 + "[" + strings.Join(args, ", ") + "]", true
+		}
+
+		slashnum := 0
+		slash := -1
+		for i, ch := range typ {
+			if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) && ch != '_' && ch != '.' && ch != '/' && ch != '@' && ch != '%' && ch != '-' {
+				return "", false
+			}
+			if ch == '/' {
+				slash = i
+				slashnum++
+			}
+		}
+		if slashnum <= 1 || slash < 0 {
+			return typ, true
+		}
+		return typ[slash+1:], true
+	}
+}
+
+func containsAnonymousType(typ string) bool {
+	for _, thing := range []string{"interface {", "interface{", "struct {", "struct{", "func (", "func("} {
+		idx := strings.Index(typ, thing)
+		if idx >= 0 && idx+len(thing) < len(typ) {
+			ch := typ[idx+len(thing)]
+			if ch != '}' && ch != ')' {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/service/api/shorten_type_test.go
+++ b/service/api/shorten_type_test.go
@@ -1,0 +1,36 @@
+package api
+
+import "testing"
+
+func TestShortenType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"long/package/path/pkg.A", "pkg.A"},
+		{"[]long/package/path/pkg.A", "[]pkg.A"},
+		{"map[long/package/path/pkg.A]long/package/path/pkg.B", "map[pkg.A]pkg.B"},
+		{"map[long/package/path/pkg.A]interface {}", "map[pkg.A]interface {}"},
+		{"map[long/package/path/pkg.A]interface{}", "map[pkg.A]interface{}"},
+		{"map[long/package/path/pkg.A]struct {}", "map[pkg.A]struct {}"},
+		{"map[long/package/path/pkg.A]struct{}", "map[pkg.A]struct{}"},
+		{"map[long/package/path/pkg.A]map[long/package/path/pkg.B]long/package/path/pkg.C", "map[pkg.A]map[pkg.B]pkg.C"},
+		{"map[long/package/path/pkg.A][]long/package/path/pkg.B", "map[pkg.A][]pkg.B"},
+		{"map[uint64]*github.com/aarzilli/dwarf5/dwarf.typeUnit", "map[uint64]*dwarf.typeUnit"},
+		{"uint8", "uint8"},
+		{"encoding/binary", "encoding/binary"},
+		{"*github.com/go-delve/delve/pkg/proc.Target", "*proc.Target"},
+		{"long/package/path/pkg.Parametric[long/package/path/pkg.A, map[long/package/path/pkg.B]long/package/path/pkg.A]", "pkg.Parametric[pkg.A, map[pkg.B]pkg.A]"},
+		{"[]long/package/path/pkg.Parametric[long/package/path/pkg.A]", "[]pkg.Parametric[pkg.A]"},
+		{"[24]long/package/path/pkg.A", "[24]pkg.A"},
+		{"chan func()", "chan func()"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ShortenType(tt.input)
+			if result != tt.expected {
+				t.Errorf("shortenTypeEx() got = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2579,7 +2579,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		}
 		return s.variableHandles.create(&fullyQualifiedVariable{v, qualifiedNameOrExpr, false /*not a scope*/, 0})
 	}
-	value = api.ConvertVar(v).SinglelineString()
+	value = api.ConvertVar(v).SinglelineStringWithShortTypes()
 	if v.Unreadable != nil {
 		return value, 0
 	}
@@ -2593,7 +2593,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		// TODO(polina): Get *proc.Variable object from debugger instead. Export a function to set v.loaded to false
 		// and call v.loadValue gain with a different load config. It's more efficient, and it's guaranteed to keep
 		// working with generics.
-		value = api.ConvertVar(v).SinglelineString()
+		value = api.ConvertVar(v).SinglelineStringWithShortTypes()
 		typeName := api.PrettyTypeName(v.DwarfType)
 		loadExpr := fmt.Sprintf("*(*%q)(%#x)", typeName, v.Addr)
 		s.config.log.Debugf("loading %s (type %s) with %s", qualifiedNameOrExpr, typeName, loadExpr)
@@ -2607,7 +2607,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		} else {
 			v.Children = vLoaded.Children
 			v.Value = vLoaded.Value
-			value = api.ConvertVar(v).SinglelineString()
+			value = api.ConvertVar(v).SinglelineStringWithShortTypes()
 		}
 		return value
 	}
@@ -2639,7 +2639,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 					} else {
 						cLoaded.Name = v.Children[0].Name // otherwise, this will be the pointer expression
 						v.Children = []proc.Variable{*cLoaded}
-						value = api.ConvertVar(v).SinglelineString()
+						value = api.ConvertVar(v).SinglelineStringWithShortTypes()
 					}
 				} else {
 					value = reloadVariable(v, qualifiedNameOrExpr)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2502,7 +2502,7 @@ func TestGlobalScopeAndVariables(t *testing.T) {
 					client.VariablesRequest(globalsScope)
 					globals := client.ExpectVariablesResponse(t)
 					checkChildren(t, globals, "Globals", 1)
-					ref := checkVarExact(t, globals, 0, "SomeVar", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeVar", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeType {X: 0}", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeType", hasChildren)
+					ref := checkVarExact(t, globals, 0, "SomeVar", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeVar", "pkg.SomeType {X: 0}", "github.com/go-delve/delve/_fixtures/internal/dir0/pkg.SomeType", hasChildren)
 
 					if ref > 0 {
 						client.VariablesRequest(ref)


### PR DESCRIPTION
The variables view in VS Code is a lot easier to read if long type names are
shortened in much the same way as we shorten them for functions in the call
stack view.

We only shorten them in the value strings; the Type field of dap.Variable is
kept as is. Since this only appears in a tooltip, it isn't a problem to have the
full type visible there.

Fixes #3516.