### PR TITLE
proc,service/dap,proc/gdbserial: fixes for debugserver --unmask-signals

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -5044,7 +5044,13 @@ func TestRefreshCurThreadSelGAfterContinueOnceError(t *testing.T) {
 		setFileBreakpoint(p, t, fixture.Source, 4)
 		assertNoError(grp.Continue(), t, "Continue() (first)")
 		if grp.Continue() == nil {
-			t.Fatalf("Second continue did not return an error")
+			pc := currentPC(p, t)
+			f, l, fn := p.BinInfo().PCToLine(pc)
+			t.Logf("Second continue did not return an error %s:%d %#v", f, l, fn)
+			if fn != nil && fn.Name == "runtime.fatalpanic" {
+				// this is also ok, it just means this debugserver supports --unmask-signals and it's working as intented.
+				return
+			}
 		}
 		g := p.SelectedGoroutine()
 		if g.CurrentLoc.Line != 9 {


### PR DESCRIPTION
* fix TestRefreshCurThreadSelGAfterContinueOnceError and TestBadAccess
to work when debugserver has --unmask-signals
* when a fatal signal is received while singlestepping delay its
delivery until the subsequent continue, otherwise debugserver will get
stuck completely (fixes TestNilPtrDerefInBreakInstr)
