### PR TITLE
proc/native: wherever we check for exited we should also check detached

### DIFF
--- a/pkg/proc/native/proc_darwin.go
+++ b/pkg/proc/native/proc_darwin.go
@@ -183,7 +183,7 @@ func Attach(pid int, waitFor *proc.WaitFor, _ []string) (*proc.TargetGroup, erro
 
 // Kill kills the process.
 func (procgrp *processGroup) kill(dbp *nativeProcess) (err error) {
-	if dbp.exited {
+	if ok, _ := dbp.Valid(); !ok {
 		return nil
 	}
 	err = sys.Kill(-dbp.pid, sys.SIGKILL)
@@ -449,8 +449,8 @@ func (procgrp *processGroup) stop(cctx *proc.ContinueOnceContext, trapthread *na
 }
 
 func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
-	if dbp.exited {
-		return nil, proc.ErrProcessExited{Pid: dbp.pid}
+	if ok, err := dbp.Valid(); !ok {
+		return nil, err
 	}
 	for _, th := range dbp.threads {
 		if !th.Stopped() {

--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -206,7 +206,7 @@ func initialize(dbp *nativeProcess) (string, error) {
 
 // kill kills the target process.
 func (procgrp *processGroup) kill(dbp *nativeProcess) (err error) {
-	if dbp.exited {
+	if ok, _ := dbp.Valid(); !ok {
 		return nil
 	}
 	dbp.execPtraceFunc(func() {
@@ -508,8 +508,8 @@ func (procgrp *processGroup) stop(cctx *proc.ContinueOnceContext, trapthread *na
 }
 
 func (dbp *nativeProcess) stop(trapthread *nativeThread) (*nativeThread, error) {
-	if dbp.exited {
-		return nil, proc.ErrProcessExited{Pid: dbp.pid}
+	if ok, err := dbp.Valid(); !ok {
+		return nil, err
 	}
 
 	var err error

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -261,7 +261,7 @@ func (dbp *nativeProcess) GetBufferedTracepoints() []ebpf.RawUProbeParams {
 
 // kill kills the target process.
 func (procgrp *processGroup) kill(dbp *nativeProcess) error {
-	if dbp.exited {
+	if ok, _ := dbp.Valid(); !ok {
 		return nil
 	}
 	if !dbp.threads[dbp.pid].Stopped() {
@@ -680,7 +680,7 @@ func (procgrp *processGroup) stop(cctx *proc.ContinueOnceContext, trapthread *na
 	}
 
 	for _, dbp := range procgrp.procs {
-		if dbp.exited {
+		if ok, _ := dbp.Valid(); !ok {
 			continue
 		}
 		for _, th := range dbp.threads {
@@ -703,7 +703,7 @@ func (procgrp *processGroup) stop(cctx *proc.ContinueOnceContext, trapthread *na
 
 	// stop all threads that are still running
 	for _, dbp := range procgrp.procs {
-		if dbp.exited {
+		if ok, _ := dbp.Valid(); !ok {
 			continue
 		}
 		for _, th := range dbp.threads {
@@ -724,7 +724,7 @@ func (procgrp *processGroup) stop(cctx *proc.ContinueOnceContext, trapthread *na
 	for {
 		allstopped := true
 		for _, dbp := range procgrp.procs {
-			if dbp.exited {
+			if ok, _ := dbp.Valid(); !ok {
 				continue
 			}
 			for _, th := range dbp.threads {
@@ -746,7 +746,7 @@ func (procgrp *processGroup) stop(cctx *proc.ContinueOnceContext, trapthread *na
 	switchTrapthread := false
 
 	for _, dbp := range procgrp.procs {
-		if dbp.exited {
+		if ok, _ := dbp.Valid(); !ok {
 			continue
 		}
 		err := stop1(cctx, dbp, trapthread, &switchTrapthread)
@@ -759,7 +759,7 @@ func (procgrp *processGroup) stop(cctx *proc.ContinueOnceContext, trapthread *na
 		trapthreadID := trapthread.ID
 		trapthread = nil
 		for _, dbp := range procgrp.procs {
-			if dbp.exited {
+			if ok, _ := dbp.Valid(); !ok {
 				continue
 			}
 			for _, th := range dbp.threads {

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -259,7 +259,7 @@ func waitForSearchProcess(pfx string, seen map[int]struct{}) (int, error) {
 
 // kill kills the process.
 func (procgrp *processGroup) kill(dbp *nativeProcess) error {
-	if dbp.exited {
+	if ok, _ := dbp.Valid(); !ok {
 		return nil
 	}
 

--- a/pkg/proc/native/threads_darwin.go
+++ b/pkg/proc/native/threads_darwin.go
@@ -93,8 +93,8 @@ func (t *nativeThread) Stopped() bool {
 }
 
 func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
-	if t.dbp.exited {
-		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	if ok, err := t.dbp.Valid(); !ok {
+		return 0, err
 	}
 	if len(data) == 0 {
 		return 0, nil
@@ -111,8 +111,8 @@ func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
 }
 
 func (t *nativeThread) ReadMemory(buf []byte, addr uint64) (int, error) {
-	if t.dbp.exited {
-		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	if ok, err := t.dbp.Valid(); !ok {
+		return 0, err
 	}
 	if len(buf) == 0 {
 		return 0, nil

--- a/pkg/proc/native/threads_freebsd.go
+++ b/pkg/proc/native/threads_freebsd.go
@@ -77,8 +77,8 @@ func (t *nativeThread) restoreRegisters(savedRegs proc.Registers) error {
 }
 
 func (t *nativeThread) WriteMemory(addr uint64, data []byte) (written int, err error) {
-	if t.dbp.exited {
-		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	if ok, err := t.dbp.Valid(); !ok {
+		return 0, err
 	}
 	if len(data) == 0 {
 		return 0, nil
@@ -88,8 +88,8 @@ func (t *nativeThread) WriteMemory(addr uint64, data []byte) (written int, err e
 }
 
 func (t *nativeThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
-	if t.dbp.exited {
-		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	if ok, err := t.dbp.Valid(); !ok {
+		return 0, err
 	}
 	if len(data) == 0 {
 		return 0, nil

--- a/pkg/proc/native/threads_linux.go
+++ b/pkg/proc/native/threads_linux.go
@@ -88,8 +88,8 @@ func (procgrp *processGroup) singleStep(t *nativeThread) (err error) {
 }
 
 func (t *nativeThread) WriteMemory(addr uint64, data []byte) (written int, err error) {
-	if t.dbp.exited {
-		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	if ok, err := t.dbp.Valid(); !ok {
+		return 0, err
 	}
 	if len(data) == 0 {
 		return
@@ -106,8 +106,8 @@ func (t *nativeThread) WriteMemory(addr uint64, data []byte) (written int, err e
 }
 
 func (t *nativeThread) ReadMemory(data []byte, addr uint64) (n int, err error) {
-	if t.dbp.exited {
-		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	if ok, err := t.dbp.Valid(); !ok {
+		return 0, err
 	}
 	if len(data) == 0 {
 		return

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -5,8 +5,6 @@ import (
 	"syscall"
 
 	sys "golang.org/x/sys/windows"
-
-	"github.com/go-delve/delve/pkg/proc"
 )
 
 const enableHardwareBreakpoints = false // see https://github.com/go-delve/delve/issues/2768
@@ -106,8 +104,8 @@ func (procgrp *processGroup) singleStep(t *nativeThread) error {
 }
 
 func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
-	if t.dbp.exited {
-		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	if ok, err := t.dbp.Valid(); !ok {
+		return 0, err
 	}
 	if len(data) == 0 {
 		return 0, nil
@@ -123,8 +121,8 @@ func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
 var ErrShortRead = errors.New("short read")
 
 func (t *nativeThread) ReadMemory(buf []byte, addr uint64) (int, error) {
-	if t.dbp.exited {
-		return 0, proc.ErrProcessExited{Pid: t.dbp.pid}
+	if ok, err := t.dbp.Valid(); !ok {
+		return 0, err
 	}
 	if len(buf) == 0 {
 		return 0, nil


### PR DESCRIPTION
Only Linux and Windows are affected but it's better to do this for all
platforms for consistency.
