### PR TITLE
pkg/proc: add inline function support for stripped binaries

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -12,17 +12,17 @@ Tests skipped by each supported backend:
 	* 2 broken - cgo stacktraces
 * darwin/lldb skipped = 1
 	* 1 upstream issue
-* freebsd skipped = 9
+* freebsd skipped = 10
 	* 2 flaky
 	* 2 follow exec not implemented on freebsd
 	* 4 not implemented
-	* 1 not working on freebsd
-* linux/386/pie skipped = 2
+	* 2 not working on freebsd
+* linux/386/pie skipped = 3
 	* 1 broken
-	* 1 not working on linux/386 with PIE
-* linux/ppc64le skipped = 2
+	* 2 not working on linux/386 with PIE
+* linux/ppc64le skipped = 3
 	* 1 broken - cgo stacktraces
-	* 1 not working on linux/ppc64le when -gcflags=-N -l is passed
+	* 2 not working on linux/ppc64le when -gcflags=-N -l is passed
 * linux/ppc64le/native skipped = 1
 	* 1 broken in linux ppc64le
 * linux/ppc64le/native/pie skipped = 3
@@ -33,9 +33,9 @@ Tests skipped by each supported backend:
 	* 6 broken
 	* 1 broken - global variable symbolication
 	* 4 not implemented
-* windows skipped = 5
+* windows skipped = 6
 	* 1 broken
-	* 1 not working on windows
+	* 2 not working on windows
 	* 3 see https://github.com/go-delve/delve/issues/2768
 * windows/arm64 skipped = 5
 	* 3 broken

--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -17,9 +17,10 @@ Tests skipped by each supported backend:
 	* 2 follow exec not implemented on freebsd
 	* 4 not implemented
 	* 1 not working on freebsd
-* linux/386/pie skipped = 2
+* linux/386 skipped = 1
+	* 1 not working on linux/386
+* linux/386/pie skipped = 1
 	* 1 broken
-	* 1 not working on linux/386 with PIE
 * linux/ppc64le skipped = 2
 	* 1 broken - cgo stacktraces
 	* 1 not working on linux/ppc64le when -gcflags=-N -l is passed

--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -5,7 +5,8 @@ Tests skipped by each supported backend:
 	* 3 not implemented
 * arm64 skipped = 1
 	* 1 broken - global variable symbolication
-* darwin skipped = 3
+* darwin skipped = 4
+	* 1 broken on darwin/amd64/pie
 	* 2 follow exec not implemented on macOS
 	* 1 waitfor implementation is delegated to debugserver
 * darwin/arm64 skipped = 2

--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -5,25 +5,24 @@ Tests skipped by each supported backend:
 	* 3 not implemented
 * arm64 skipped = 1
 	* 1 broken - global variable symbolication
-* darwin skipped = 4
-	* 1 broken on darwin/amd64/pie
+* darwin skipped = 3
 	* 2 follow exec not implemented on macOS
 	* 1 waitfor implementation is delegated to debugserver
 * darwin/arm64 skipped = 2
 	* 2 broken - cgo stacktraces
 * darwin/lldb skipped = 1
 	* 1 upstream issue
-* freebsd skipped = 10
+* freebsd skipped = 9
 	* 2 flaky
 	* 2 follow exec not implemented on freebsd
 	* 4 not implemented
-	* 2 not working on freebsd
-* linux/386/pie skipped = 3
+	* 1 not working on freebsd
+* linux/386/pie skipped = 2
 	* 1 broken
-	* 2 not working on linux/386 with PIE
-* linux/ppc64le skipped = 3
+	* 1 not working on linux/386 with PIE
+* linux/ppc64le skipped = 2
 	* 1 broken - cgo stacktraces
-	* 2 not working on linux/ppc64le when -gcflags=-N -l is passed
+	* 1 not working on linux/ppc64le when -gcflags=-N -l is passed
 * linux/ppc64le/native skipped = 1
 	* 1 broken in linux ppc64le
 * linux/ppc64le/native/pie skipped = 3
@@ -34,9 +33,9 @@ Tests skipped by each supported backend:
 	* 6 broken
 	* 1 broken - global variable symbolication
 	* 4 not implemented
-* windows skipped = 6
+* windows skipped = 5
 	* 1 broken
-	* 2 not working on windows
+	* 1 not working on windows
 	* 3 see https://github.com/go-delve/delve/issues/2768
 * windows/arm64 skipped = 5
 	* 3 broken

--- a/_fixtures/inlinestripped.go
+++ b/_fixtures/inlinestripped.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func callme(i int) int {
+	return i * i
+}
+
+func main() {
+	j := 0
+	j += callme(2)
+	fmt.Println(j)
+	fmt.Println(j + 1)
+	fmt.Println(j + 2)
+}

--- a/pkg/internal/gosym/additions.go
+++ b/pkg/internal/gosym/additions.go
@@ -1,0 +1,510 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gosym
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+const (
+	funcSymNameGo119Lower string = "go.func.*"
+	funcSymNameGo120      string = "go:func.*"
+)
+
+// Additions to the original package from cmd/internal/objabi/funcdata.go
+const (
+	pcdata_InlTreeIndex = 2
+	funcdata_InlTree    = 3
+)
+
+var (
+	// Regexp for matching go tags. The groups are:
+	// 1  the major.minor version
+	// 2  the patch version, or empty if none
+	// 3  the entire prerelease, if present
+	// 4  the prerelease type ("beta" or "rc")
+	// 5  the prerelease number
+	tagRegexp = regexp.MustCompile(`^go(\d+\.\d+)(\.\d+|)((beta|rc|-pre)(\d+))?$`)
+)
+
+// parsed returns the parsed form of a semantic version string.
+type parsed struct {
+	major      string
+	minor      string
+	patch      string
+	short      string
+	prerelease string
+	build      string
+}
+
+func parsePrerelease(v string) (t, rest string, ok bool) {
+	// "A pre-release version MAY be denoted by appending a hyphen and
+	// a series of dot separated identifiers immediately following the patch version.
+	// Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+	// Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes."
+	if v == "" || v[0] != '-' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) && v[i] != '+' {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i || isBadNum(v[start:i]) {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i || isBadNum(v[start:i]) {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+// This is a modified copy of pkgsite/internal/stdlib:VersionForTag.
+func GoTagToSemver(tag string) string {
+	if tag == "" {
+		return ""
+	}
+	tag = strings.Fields(tag)[0]
+	// Special cases for go1.
+	if tag == "go1" {
+		return "v1.0.0"
+	}
+	if tag == "go1.0" {
+		return ""
+	}
+	m := tagRegexp.FindStringSubmatch(tag)
+	if m == nil {
+		return ""
+	}
+	version := "v" + m[1]
+	if m[2] != "" {
+		version += m[2]
+	} else {
+		version += ".0"
+	}
+	if m[3] != "" {
+		if !strings.HasPrefix(m[4], "-") {
+			version += "-"
+		}
+		version += m[4] + "." + m[5]
+	}
+	return version
+}
+
+func parseBuild(v string) (t, rest string, ok bool) {
+	if v == "" || v[0] != '+' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i {
+		return
+	}
+	return v[:i], v[i:], true
+}
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}
+func isIdentChar(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '-'
+}
+
+func parse(v string) (p parsed, ok bool) {
+	if v == "" || v[0] != 'v' {
+		return
+	}
+	p.major, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if v == "" {
+		p.minor = "0"
+		p.patch = "0"
+		p.short = ".0.0"
+		return
+	}
+	if v[0] != '.' {
+		ok = false
+		return
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if v == "" {
+		p.patch = "0"
+		p.short = ".0"
+		return
+	}
+	if v[0] != '.' {
+		ok = false
+		return
+	}
+	p.patch, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if len(v) > 0 && v[0] == '-' {
+		p.prerelease, v, ok = parsePrerelease(v)
+		if !ok {
+			return
+		}
+	}
+	if len(v) > 0 && v[0] == '+' {
+		p.build, v, ok = parseBuild(v)
+		if !ok {
+			return
+		}
+	}
+	if v != "" {
+		ok = false
+		return
+	}
+	ok = true
+	return
+}
+
+func isBadNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v) && i > 1 && v[0] == '0'
+}
+func nextIdent(x string) (dx, rest string) {
+	i := 0
+	for i < len(x) && x[i] != '.' {
+		i++
+	}
+	return x[:i], x[i:]
+}
+func isNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v)
+}
+
+// MajorMinor returns the major.minor version prefix of the semantic version v.
+// For example, MajorMinor("v2.1.0") == "v2.1".
+// If v is an invalid semantic version string, MajorMinor returns the empty string.
+func MajorMinor(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	i := 1 + len(pv.major)
+	if j := i + 1 + len(pv.minor); j <= len(v) && v[i] == '.' && v[i+1:j] == pv.minor {
+		return v[:j]
+	}
+	return v[:i] + "." + pv.minor
+}
+
+func compareInt(x, y string) int {
+	if x == y {
+		return 0
+	}
+	if len(x) < len(y) {
+		return -1
+	}
+	if len(x) > len(y) {
+		return +1
+	}
+	if x < y {
+		return -1
+	} else {
+		return +1
+	}
+}
+func comparePrerelease(x, y string) int {
+	// "When major, minor, and patch are equal, a pre-release version has
+	// lower precedence than a normal version.
+	// Example: 1.0.0-alpha < 1.0.0.
+	// Precedence for two pre-release versions with the same major, minor,
+	// and patch version MUST be determined by comparing each dot separated
+	// identifier from left to right until a difference is found as follows:
+	// identifiers consisting of only digits are compared numerically and
+	// identifiers with letters or hyphens are compared lexically in ASCII
+	// sort order. Numeric identifiers always have lower precedence than
+	// non-numeric identifiers. A larger set of pre-release fields has a
+	// higher precedence than a smaller set, if all of the preceding
+	// identifiers are equal.
+	// Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta <
+	// 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0."
+	if x == y {
+		return 0
+	}
+	if x == "" {
+		return +1
+	}
+	if y == "" {
+		return -1
+	}
+	for x != "" && y != "" {
+		x = x[1:] // skip - or .
+		y = y[1:] // skip - or .
+		var dx, dy string
+		dx, x = nextIdent(x)
+		dy, y = nextIdent(y)
+		if dx != dy {
+			ix := isNum(dx)
+			iy := isNum(dy)
+			if ix != iy {
+				if ix {
+					return -1
+				} else {
+					return +1
+				}
+			}
+			if ix {
+				if len(dx) < len(dy) {
+					return -1
+				}
+				if len(dx) > len(dy) {
+					return +1
+				}
+			}
+			if dx < dy {
+				return -1
+			} else {
+				return +1
+			}
+		}
+	}
+	if x == "" {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+// Compare returns an integer comparing two versions according to
+// semantic version precedence.
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+//
+// An invalid semantic version string is considered less than a valid one.
+// All invalid semantic version strings compare equal to each other.
+func Compare(v, w string) int {
+	pv, ok1 := parse(v)
+	pw, ok2 := parse(w)
+	if !ok1 && !ok2 {
+		return 0
+	}
+	if !ok1 {
+		return -1
+	}
+	if !ok2 {
+		return +1
+	}
+	if c := compareInt(pv.major, pw.major); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.minor, pw.minor); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.patch, pw.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(pv.prerelease, pw.prerelease)
+}
+
+// InlineTree returns the inline tree for Func f as a sequence of InlinedCalls.
+// goFuncValue is the value of the gosym.FuncSymName symbol.
+// baseAddr is the address of the memory region (ELF Prog) containing goFuncValue.
+// progReader is a ReaderAt positioned at the start of that region.
+func (t *LineTable) InlineTree(f *Func, goFuncValue, baseAddr uint64, progReader io.ReaderAt) ([]InlinedCall, error) {
+	if f.inlineTreeCount == 0 {
+		return nil, nil
+	}
+	if f.inlineTreeOffset == ^uint32(0) {
+		return nil, errors.New("error inlTreeOffset\n")
+	}
+	var offset int64
+	if t.version >= ver118 {
+		offset = int64(goFuncValue - baseAddr + uint64(f.inlineTreeOffset))
+	} else {
+		offset = int64(uint64(f.inlineTreeOffset) - baseAddr)
+	}
+	r := io.NewSectionReader(progReader, offset, 1<<32) // pick a size larger than we need
+	var ics []InlinedCall
+	for i := 0; i < f.inlineTreeCount; i++ {
+		if t.version >= ver120 {
+			var ric rawInlinedCall120
+			if err := binary.Read(r, t.binary, &ric); err != nil {
+				return nil, fmt.Errorf("error reading into rawInlinedCall: %#v", err)
+			}
+			ics = append(ics, InlinedCall{
+				FuncID:   ric.FuncID,
+				Name:     t.funcName(uint32(ric.NameOff)),
+				ParentPC: ric.ParentPC,
+			})
+		} else {
+			var ric rawInlinedCall112
+			if err := binary.Read(r, t.binary, &ric); err != nil {
+				return nil, err
+			}
+			ics = append(ics, InlinedCall{
+				FuncID:   ric.FuncID,
+				Name:     t.funcName(uint32(ric.Func_)),
+				ParentPC: ric.ParentPC,
+			})
+		}
+	}
+	return ics, nil
+}
+
+// FuncSymName returns symbol name for Go functions used in binaries
+// based on Go version. Supported Go versions are 1.18 and greater.
+// If the go version is unreadable it assumes that it is a newer version
+// and returns the symbol name for go version 1.20 or greater.
+func FuncSymName(goVersion string) string {
+	// Support devel goX.Y...
+	v := strings.TrimPrefix(goVersion, "devel ")
+	v = GoTagToSemver(v)
+	mm := MajorMinor(v)
+	if Compare(mm, "v1.20") >= 0 || mm == "" {
+		return funcSymNameGo120
+	} else if Compare(mm, "v1.18") >= 0 {
+		return funcSymNameGo119Lower
+	}
+	return ""
+}
+
+func GetFuncSymName() string {
+	return funcSymNameGo120
+}
+
+// InlinedCall describes a call to an inlined function.
+type InlinedCall struct {
+	FuncID   uint8  // type of the called function
+	Name     string // name of called function
+	ParentPC int32  // position of an instruction whose source position is the call site (offset from entry)
+}
+
+// rawInlinedCall112 is the encoding of entries in the FUNCDATA_InlTree table
+// from Go 1.12 through 1.19. It is equivalent to runtime.inlinedCall.
+type rawInlinedCall112 struct {
+	Parent   int16 // index of parent in the inltree, or < 0
+	FuncID   uint8 // type of the called function
+	_        byte
+	File     int32 // perCU file index for inlined call. See cmd/link:pcln.go
+	Line     int32 // line number of the call site
+	Func_    int32 // offset into pclntab for name of called function
+	ParentPC int32 // position of an instruction whose source position is the call site (offset from entry)
+}
+
+// rawInlinedCall120 is the encoding of entries in the FUNCDATA_InlTree table
+// from Go 1.20. It is equivalent to runtime.inlinedCall.
+type rawInlinedCall120 struct {
+	FuncID    uint8 // type of the called function
+	_         [3]byte
+	NameOff   int32 // offset into pclntab for name of called function
+	ParentPC  int32 // position of an instruction whose source position is the call site (offset from entry)
+	StartLine int32 // line number of start of function (func keyword/TEXT directive)
+}
+
+func (f funcData) npcdata() uint32 { return f.field(7) }
+func (f funcData) nfuncdata(numFuncFields uint32) uint32 {
+	return uint32(f.data[f.fieldOffset(numFuncFields-1)+3])
+}
+
+func (f funcData) funcdataOffset(i uint8, numFuncFields uint32) uint32 {
+	if uint32(i) >= f.nfuncdata(numFuncFields) {
+		return ^uint32(0)
+	}
+	var off uint32
+	if f.t.version >= ver118 {
+		off = f.fieldOffset(numFuncFields) + // skip fixed part of _func
+			f.npcdata()*4 + // skip pcdata
+			uint32(i)*4 // index of i'th FUNCDATA
+	} else {
+		off = f.fieldOffset(numFuncFields) + // skip fixed part of _func
+			f.npcdata()*4
+		off += uint32(i) * f.t.ptrsize
+	}
+	return f.t.binary.Uint32(f.data[off:])
+}
+
+func (f funcData) fieldOffset(n uint32) uint32 {
+	// In Go 1.18, the first field of _func changed
+	// from a uintptr entry PC to a uint32 entry offset.
+	sz0 := f.t.ptrsize
+	if f.t.version >= ver118 {
+		sz0 = 4
+	}
+	return sz0 + (n-1)*4 // subsequent fields are 4 bytes each
+}
+
+func (f funcData) pcdataOffset(i uint8, numFuncFields uint32) uint32 {
+	if uint32(i) >= f.npcdata() {
+		return ^uint32(0)
+	}
+	off := f.fieldOffset(numFuncFields) + // skip fixed part of _func
+		uint32(i)*4 // index of i'th PCDATA
+	return f.t.binary.Uint32(f.data[off:])
+}
+
+// maxInlineTreeIndexValue returns the maximum value of the inline tree index
+// pc-value table in info. This is the only way to determine how many
+// IndexedCalls are in an inline tree, since the data of the tree itself is not
+// delimited in any way.
+func (t *LineTable) maxInlineTreeIndexValue(info funcData, numFuncFields uint32) int {
+	if info.npcdata() <= pcdata_InlTreeIndex {
+		return -1
+	}
+	off := info.pcdataOffset(pcdata_InlTreeIndex, numFuncFields)
+	p := t.pctab[off:]
+	val := int32(-1)
+	max := int32(-1)
+	var pc uint64
+	for t.step(&p, &pc, &val, pc == 0) {
+		if val > max {
+			max = val
+		}
+	}
+	return int(max)
+}
+
+type inlTree struct {
+	inlineTreeOffset uint32 // offset from go.func.* symbol
+	inlineTreeCount  int    // number of entries in inline tree
+}

--- a/pkg/internal/gosym/additions.go
+++ b/pkg/internal/gosym/additions.go
@@ -6,7 +6,6 @@ package gosym
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -72,7 +71,7 @@ func parsePrerelease(v string) (t, rest string, ok bool) {
 	return v[:i], v[i:], true
 }
 
-// This is a modified copy of pkgsite/internal/stdlib:VersionForTag.
+// GoTagToSemver is a modified copy of pkgsite/internal/stdlib:VersionForTag.
 func GoTagToSemver(tag string) string {
 	if tag == "" {
 		return ""
@@ -356,7 +355,7 @@ func (t *LineTable) InlineTree(f *Func, goFuncValue, baseAddr uint64, progReader
 		return nil, nil
 	}
 	if f.inlineTreeOffset == ^uint32(0) {
-		return nil, errors.New("error inlTreeOffset\n")
+		return nil, nil
 	}
 	var offset int64
 	if t.version >= ver118 {

--- a/pkg/internal/gosym/pclntab.go
+++ b/pkg/internal/gosym/pclntab.go
@@ -1,0 +1,671 @@
+package gosym
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sort"
+	"sync"
+)
+
+// version of the pclntab
+type version int
+
+const (
+	verUnknown version = iota
+	ver11
+	ver12
+	ver116
+	ver118
+	ver120
+)
+
+// A LineTable is a data structure mapping program counters to line numbers.
+//
+// In Go 1.1 and earlier, each function (represented by a Func) had its own LineTable,
+// and the line number corresponded to a numbering of all source lines in the
+// program, across all files. That absolute line number would then have to be
+// converted separately to a file name and line number within the file.
+//
+// In Go 1.2, the format of the data changed so that there is a single LineTable
+// for the entire program, shared by all Funcs, and there are no absolute line
+// numbers, just line numbers within specific files.
+//
+// For the most part, LineTable's methods should be treated as an internal
+// detail of the package; callers should use the methods on Table instead.
+type LineTable struct {
+	Data []byte
+	PC   uint64
+	Line int
+	// This mutex is used to keep parsing of pclntab synchronous.
+	mu sync.Mutex
+	// Contains the version of the pclntab section.
+	version version
+	// Go 1.2/1.16/1.18 state
+	binary      binary.ByteOrder
+	quantum     uint32
+	ptrsize     uint32
+	textStart   uint64 // address of runtime.text symbol (1.18+)
+	funcnametab []byte
+	cutab       []byte
+	funcdata    []byte
+	functab     []byte
+	nfunctab    uint32
+	filetab     []byte
+	pctab       []byte // points to the pctables.
+	nfiletab    uint32
+	funcNames   map[uint32]string // cache the function names
+	strings     map[uint32]string // interned substrings of Data, keyed by offset
+	// fileMap varies depending on the version of the object file.
+	// For ver12, it maps the name to the index in the file table.
+	// For ver116, it maps the name to the offset in filetab.
+	fileMap map[string]uint32
+}
+
+// NOTE(rsc): This is wrong for GOARCH=arm, which uses a quantum of 4,
+// but we have no idea whether we're using arm or not. This only
+// matters in the old (pre-Go 1.2) symbol table format, so it's not worth
+// fixing.
+const oldQuantum = 1
+
+func (t *LineTable) parse(targetPC uint64, targetLine int) (b []byte, pc uint64, line int) {
+	// The PC/line table can be thought of as a sequence of
+	//  <pc update>* <line update>
+	// batches. Each update batch results in a (pc, line) pair,
+	// where line applies to every PC from pc up to but not
+	// including the pc of the next pair.
+	//
+	// Here we process each update individually, which simplifies
+	// the code, but makes the corner cases more confusing.
+	b, pc, line = t.Data, t.PC, t.Line
+	for pc <= targetPC && line != targetLine && len(b) > 0 {
+		code := b[0]
+		b = b[1:]
+		switch {
+		case code == 0:
+			if len(b) < 4 {
+				b = b[0:0]
+				break
+			}
+			val := binary.BigEndian.Uint32(b)
+			b = b[4:]
+			line += int(val)
+		case code <= 64:
+			line += int(code)
+		case code <= 128:
+			line -= int(code - 64)
+		default:
+			pc += oldQuantum * uint64(code-128)
+			continue
+		}
+		pc += oldQuantum
+	}
+	return b, pc, line
+}
+func (t *LineTable) slice(pc uint64) *LineTable {
+	data, pc, line := t.parse(pc, -1)
+	return &LineTable{Data: data, PC: pc, Line: line}
+}
+
+// PCToLine returns the line number for the given program counter.
+//
+// Deprecated: Use Table's PCToLine method instead.
+func (t *LineTable) PCToLine(pc uint64) int {
+	if t.isGo12() {
+		return t.go12PCToLine(pc)
+	}
+	_, _, line := t.parse(pc, -1)
+	return line
+}
+
+// LineToPC returns the program counter for the given line number,
+// considering only program counters before maxpc.
+//
+// Deprecated: Use Table's LineToPC method instead.
+func (t *LineTable) LineToPC(line int, maxpc uint64) uint64 {
+	if t.isGo12() {
+		return 0
+	}
+	_, pc, line1 := t.parse(maxpc, line)
+	if line1 != line {
+		return 0
+	}
+	// Subtract quantum from PC to account for post-line increment
+	return pc - oldQuantum
+}
+
+// NewLineTable returns a new PC/line table
+// corresponding to the encoded data.
+// Text must be the start address of the
+// corresponding text segment.
+func NewLineTable(data []byte, text uint64) *LineTable {
+	return &LineTable{Data: data, PC: text, Line: 0, funcNames: make(map[uint32]string), strings: make(map[uint32]string)}
+}
+
+// Go 1.2 symbol table format.
+// See golang.org/s/go12symtab.
+//
+// A general note about the methods here: rather than try to avoid
+// index out of bounds errors, we trust Go to detect them, and then
+// we recover from the panics and treat them as indicative of a malformed
+// or incomplete table.
+//
+// The methods called by symtab.go, which begin with "go12" prefixes,
+// are expected to have that recovery logic.
+// isGo12 reports whether this is a Go 1.2 (or later) symbol table.
+func (t *LineTable) isGo12() bool {
+	t.parsePclnTab()
+	return t.version >= ver12
+}
+
+const (
+	go12magic  = 0xfffffffb
+	go116magic = 0xfffffffa
+	go118magic = 0xfffffff0
+	go120magic = 0xfffffff1
+)
+
+// uintptr returns the pointer-sized value encoded at b.
+// The pointer size is dictated by the table being read.
+func (t *LineTable) uintptr(b []byte) uint64 {
+	if t.ptrsize == 4 {
+		return uint64(t.binary.Uint32(b))
+	}
+	return t.binary.Uint64(b)
+}
+
+// parsePclnTab parses the pclntab, setting the version.
+func (t *LineTable) parsePclnTab() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.version != verUnknown {
+		return
+	}
+	// Note that during this function, setting the version is the last thing we do.
+	// If we set the version too early, and parsing failed (likely as a panic on
+	// slice lookups), we'd have a mistaken version.
+	//
+	// Error paths through this code will default the version to 1.1.
+	t.version = ver11
+	if !disableRecover {
+		defer func() {
+			// If we panic parsing, assume it's a Go 1.1 pclntab.
+			_ = recover()
+		}()
+	}
+	// Check header: 4-byte magic, two zeros, pc quantum, pointer size.
+	if len(t.Data) < 16 || t.Data[4] != 0 || t.Data[5] != 0 ||
+		(t.Data[6] != 1 && t.Data[6] != 2 && t.Data[6] != 4) || // pc quantum
+		(t.Data[7] != 4 && t.Data[7] != 8) { // pointer size
+		return
+	}
+	var possibleVersion version
+	leMagic := binary.LittleEndian.Uint32(t.Data)
+	beMagic := binary.BigEndian.Uint32(t.Data)
+	switch {
+	case leMagic == go12magic:
+		t.binary, possibleVersion = binary.LittleEndian, ver12
+	case beMagic == go12magic:
+		t.binary, possibleVersion = binary.BigEndian, ver12
+	case leMagic == go116magic:
+		t.binary, possibleVersion = binary.LittleEndian, ver116
+	case beMagic == go116magic:
+		t.binary, possibleVersion = binary.BigEndian, ver116
+	case leMagic == go118magic:
+		t.binary, possibleVersion = binary.LittleEndian, ver118
+	case beMagic == go118magic:
+		t.binary, possibleVersion = binary.BigEndian, ver118
+	case leMagic == go120magic:
+		t.binary, possibleVersion = binary.LittleEndian, ver120
+	case beMagic == go120magic:
+		t.binary, possibleVersion = binary.BigEndian, ver120
+	default:
+		return
+	}
+	t.version = possibleVersion
+	// quantum and ptrSize are the same between 1.2, 1.16, and 1.18
+	t.quantum = uint32(t.Data[6])
+	t.ptrsize = uint32(t.Data[7])
+	offset := func(word uint32) uint64 {
+		return t.uintptr(t.Data[8+word*t.ptrsize:])
+	}
+	data := func(word uint32) []byte {
+		return t.Data[offset(word):]
+	}
+	switch possibleVersion {
+	case ver118, ver120:
+		t.nfunctab = uint32(offset(0))
+		t.nfiletab = uint32(offset(1))
+		t.textStart = t.PC // use the start PC instead of reading from the table, which may be unrelocated
+		t.funcnametab = data(3)
+		t.cutab = data(4)
+		t.filetab = data(5)
+		t.pctab = data(6)
+		t.funcdata = data(7)
+		t.functab = data(7)
+		functabsize := (int(t.nfunctab)*2 + 1) * t.functabFieldSize()
+		t.functab = t.functab[:functabsize]
+	case ver116:
+		t.nfunctab = uint32(offset(0))
+		t.nfiletab = uint32(offset(1))
+		t.funcnametab = data(2)
+		t.cutab = data(3)
+		t.filetab = data(4)
+		t.pctab = data(5)
+		t.funcdata = data(6)
+		t.functab = data(6)
+		functabsize := (int(t.nfunctab)*2 + 1) * t.functabFieldSize()
+		t.functab = t.functab[:functabsize]
+	case ver12:
+		t.nfunctab = uint32(t.uintptr(t.Data[8:]))
+		t.funcdata = t.Data
+		t.funcnametab = t.Data
+		t.functab = t.Data[8+t.ptrsize:]
+		t.pctab = t.Data
+		functabsize := (int(t.nfunctab)*2 + 1) * t.functabFieldSize()
+		fileoff := t.binary.Uint32(t.functab[functabsize:])
+		t.functab = t.functab[:functabsize]
+		t.filetab = t.Data[fileoff:]
+		t.nfiletab = t.binary.Uint32(t.filetab)
+		t.filetab = t.filetab[:t.nfiletab*4]
+	default:
+		panic("unreachable")
+	}
+}
+
+// go12Funcs returns a slice of Funcs derived from the Go 1.2+ pcln table.
+func (t *LineTable) go12Funcs() []Func {
+	// Assume it is malformed and return nil on error.
+	if !disableRecover {
+		defer func() {
+			_ = recover()
+		}()
+	}
+	ft := t.funcTab()
+	funcs := make([]Func, ft.Count())
+	syms := make([]Sym, len(funcs))
+	for i := range funcs {
+		f := &funcs[i]
+		f.Entry = ft.pc(i)
+		f.End = ft.pc(i + 1)
+		info := t.funcData(uint32(i))
+		f.LineTable = t
+		f.FrameSize = int(info.deferreturn())
+		// Additions:
+		// numFuncField is the number of (32 bit) fields in _func (src/runtime/runtime2.go)
+		// Note that the last 4 fields are 32 bits combined. This number is 11 for go1.20,
+		// 10 for earlier versions down to go1.16, and 9 before that.
+		var numFuncFields uint32 = 11
+		if t.version < ver116 {
+			numFuncFields = 9
+		} else if t.version < ver120 {
+			numFuncFields = 10
+		}
+		f.inlineTreeOffset = info.funcdataOffset(funcdata_InlTree, numFuncFields)
+		f.inlineTreeCount = 1 + t.maxInlineTreeIndexValue(info, numFuncFields)
+		syms[i] = Sym{
+			Value:     f.Entry,
+			Type:      'T',
+			Name:      t.funcName(info.nameOff()),
+			GoType:    0,
+			Func:      f,
+			goVersion: t.version,
+		}
+		f.Sym = &syms[i]
+	}
+	return funcs
+}
+
+// findFunc returns the funcData corresponding to the given program counter.
+func (t *LineTable) findFunc(pc uint64) funcData {
+	ft := t.funcTab()
+	if pc < ft.pc(0) || pc >= ft.pc(ft.Count()) {
+		return funcData{}
+	}
+	idx := sort.Search(int(t.nfunctab), func(i int) bool {
+		return ft.pc(i) > pc
+	})
+	idx--
+	return t.funcData(uint32(idx))
+}
+
+// readvarint reads, removes, and returns a varint from *pp.
+func (t *LineTable) readvarint(pp *[]byte) uint32 {
+	var v, shift uint32
+	p := *pp
+	for shift = 0; ; shift += 7 {
+		b := p[0]
+		p = p[1:]
+		v |= (uint32(b) & 0x7F) << shift
+		if b&0x80 == 0 {
+			break
+		}
+	}
+	*pp = p
+	return v
+}
+
+// funcName returns the name of the function found at off.
+func (t *LineTable) funcName(off uint32) string {
+	if s, ok := t.funcNames[off]; ok {
+		return s
+	}
+	i := bytes.IndexByte(t.funcnametab[off:], 0)
+	s := string(t.funcnametab[off : off+uint32(i)])
+	t.funcNames[off] = s
+	return s
+}
+
+// stringFrom returns a Go string found at off from a position.
+func (t *LineTable) stringFrom(arr []byte, off uint32) string {
+	if s, ok := t.strings[off]; ok {
+		return s
+	}
+	i := bytes.IndexByte(arr[off:], 0)
+	s := string(arr[off : off+uint32(i)])
+	t.strings[off] = s
+	return s
+}
+
+// string returns a Go string found at off.
+func (t *LineTable) string(off uint32) string {
+	return t.stringFrom(t.funcdata, off)
+}
+
+// functabFieldSize returns the size in bytes of a single functab field.
+func (t *LineTable) functabFieldSize() int {
+	if t.version >= ver118 {
+		return 4
+	}
+	return int(t.ptrsize)
+}
+
+// funcTab returns t's funcTab.
+func (t *LineTable) funcTab() funcTab {
+	return funcTab{LineTable: t, sz: t.functabFieldSize()}
+}
+
+// funcTab is memory corresponding to a slice of functab structs, followed by an invalid PC.
+// A functab struct is a PC and a func offset.
+type funcTab struct {
+	*LineTable
+	sz int // cached result of t.functabFieldSize
+}
+
+// Count returns the number of func entries in f.
+func (f funcTab) Count() int {
+	return int(f.nfunctab)
+}
+
+// pc returns the PC of the i'th func in f.
+func (f funcTab) pc(i int) uint64 {
+	u := f.uint(f.functab[2*i*f.sz:])
+	if f.version >= ver118 {
+		u += f.textStart
+	}
+	return u
+}
+
+// funcOff returns the funcdata offset of the i'th func in f.
+func (f funcTab) funcOff(i int) uint64 {
+	return f.uint(f.functab[(2*i+1)*f.sz:])
+}
+
+// uint returns the uint stored at b.
+func (f funcTab) uint(b []byte) uint64 {
+	if f.sz == 4 {
+		return uint64(f.binary.Uint32(b))
+	}
+	return f.binary.Uint64(b)
+}
+
+// funcData is memory corresponding to an _func struct.
+type funcData struct {
+	t    *LineTable // LineTable this data is a part of
+	data []byte     // raw memory for the function
+}
+
+// funcData returns the ith funcData in t.functab.
+func (t *LineTable) funcData(i uint32) funcData {
+	data := t.funcdata[t.funcTab().funcOff(int(i)):]
+	return funcData{t: t, data: data}
+}
+
+// IsZero reports whether f is the zero value.
+func (f funcData) IsZero() bool {
+	return f.t == nil && f.data == nil
+}
+
+// entryPC returns the func's entry PC.
+func (f *funcData) entryPC() uint64 {
+	// In Go 1.18, the first field of _func changed
+	// from a uintptr entry PC to a uint32 entry offset.
+	if f.t.version >= ver118 {
+		// TODO: support multiple text sections.
+		// See runtime/symtab.go:(*moduledata).textAddr.
+		return uint64(f.t.binary.Uint32(f.data)) + f.t.textStart
+	}
+	return f.t.uintptr(f.data)
+}
+func (f funcData) nameOff() uint32     { return f.field(1) }
+func (f funcData) deferreturn() uint32 { return f.field(3) }
+func (f funcData) pcfile() uint32      { return f.field(5) }
+func (f funcData) pcln() uint32        { return f.field(6) }
+func (f funcData) cuOffset() uint32    { return f.field(8) }
+
+// field returns the nth field of the _func struct.
+// It panics if n == 0 or n > 9; for n == 0, call f.entryPC.
+// Most callers should use a named field accessor (just above).
+func (f funcData) field(n uint32) uint32 {
+	if n == 0 || n > 9 {
+		panic("bad funcdata field")
+	}
+	// Addition: some code deleted here to support inlining.
+	off := f.fieldOffset(n)
+	data := f.data[off:]
+	return f.t.binary.Uint32(data)
+}
+
+// step advances to the next pc, value pair in the encoded table.
+func (t *LineTable) step(p *[]byte, pc *uint64, val *int32, first bool) bool {
+	uvdelta := t.readvarint(p)
+	if uvdelta == 0 && !first {
+		return false
+	}
+	if uvdelta&1 != 0 {
+		uvdelta = ^(uvdelta >> 1)
+	} else {
+		uvdelta >>= 1
+	}
+	vdelta := int32(uvdelta)
+	pcdelta := t.readvarint(p) * t.quantum
+	*pc += uint64(pcdelta)
+	*val += vdelta
+	return true
+}
+
+// pcvalue reports the value associated with the target pc.
+// off is the offset to the beginning of the pc-value table,
+// and entry is the start PC for the corresponding function.
+func (t *LineTable) pcvalue(off uint32, entry, targetpc uint64) int32 {
+	p := t.pctab[off:]
+	val := int32(-1)
+	pc := entry
+	for t.step(&p, &pc, &val, pc == entry) {
+		if targetpc < pc {
+			return val
+		}
+	}
+	return -1
+}
+
+// findFileLine scans one function in the binary looking for a
+// program counter in the given file on the given line.
+// It does so by running the pc-value tables mapping program counter
+// to file number. Since most functions come from a single file, these
+// are usually short and quick to scan. If a file match is found, then the
+// code goes to the expense of looking for a simultaneous line number match.
+func (t *LineTable) findFileLine(entry uint64, filetab, linetab uint32, filenum, line int32, cutab []byte) uint64 {
+	if filetab == 0 || linetab == 0 {
+		return 0
+	}
+	fp := t.pctab[filetab:]
+	fl := t.pctab[linetab:]
+	fileVal := int32(-1)
+	filePC := entry
+	lineVal := int32(-1)
+	linePC := entry
+	fileStartPC := filePC
+	for t.step(&fp, &filePC, &fileVal, filePC == entry) {
+		fileIndex := fileVal
+		if t.version == ver116 || t.version == ver118 || t.version == ver120 {
+			fileIndex = int32(t.binary.Uint32(cutab[fileVal*4:]))
+		}
+		if fileIndex == filenum && fileStartPC < filePC {
+			// fileIndex is in effect starting at fileStartPC up to
+			// but not including filePC, and it's the file we want.
+			// Run the PC table looking for a matching line number
+			// or until we reach filePC.
+			lineStartPC := linePC
+			for linePC < filePC && t.step(&fl, &linePC, &lineVal, linePC == entry) {
+				// lineVal is in effect until linePC, and lineStartPC < filePC.
+				if lineVal == line {
+					if fileStartPC <= lineStartPC {
+						return lineStartPC
+					}
+					if fileStartPC < linePC {
+						return fileStartPC
+					}
+				}
+				lineStartPC = linePC
+			}
+		}
+		fileStartPC = filePC
+	}
+	return 0
+}
+
+// go12PCToLine maps program counter to line number for the Go 1.2+ pcln table.
+func (t *LineTable) go12PCToLine(pc uint64) (line int) {
+	defer func() {
+		if !disableRecover && recover() != nil {
+			line = -1
+		}
+	}()
+	f := t.findFunc(pc)
+	if f.IsZero() {
+		return -1
+	}
+	entry := f.entryPC()
+	linetab := f.pcln()
+	return int(t.pcvalue(linetab, entry, pc))
+}
+
+// go12PCToFile maps program counter to file name for the Go 1.2+ pcln table.
+func (t *LineTable) go12PCToFile(pc uint64) (file string) {
+	defer func() {
+		if !disableRecover && recover() != nil {
+			file = ""
+		}
+	}()
+	f := t.findFunc(pc)
+	if f.IsZero() {
+		return ""
+	}
+	entry := f.entryPC()
+	filetab := f.pcfile()
+	fno := t.pcvalue(filetab, entry, pc)
+	if t.version == ver12 {
+		if fno <= 0 {
+			return ""
+		}
+		return t.string(t.binary.Uint32(t.filetab[4*fno:]))
+	}
+	// Go ≥ 1.16
+	if fno < 0 { // 0 is valid for ≥ 1.16
+		return ""
+	}
+	cuoff := f.cuOffset()
+	if fnoff := t.binary.Uint32(t.cutab[(cuoff+uint32(fno))*4:]); fnoff != ^uint32(0) {
+		return t.stringFrom(t.filetab, fnoff)
+	}
+	return ""
+}
+
+// go12LineToPC maps a (file, line) pair to a program counter for the Go 1.2+ pcln table.
+func (t *LineTable) go12LineToPC(file string, line int) (pc uint64) {
+	defer func() {
+		if !disableRecover && recover() != nil {
+			pc = 0
+		}
+	}()
+	t.initFileMap()
+	filenum, ok := t.fileMap[file]
+	if !ok {
+		return 0
+	}
+	// Scan all functions.
+	// If this turns out to be a bottleneck, we could build a map[int32][]int32
+	// mapping file number to a list of functions with code from that file.
+	var cutab []byte
+	for i := uint32(0); i < t.nfunctab; i++ {
+		f := t.funcData(i)
+		entry := f.entryPC()
+		filetab := f.pcfile()
+		linetab := f.pcln()
+		if t.version == ver116 || t.version == ver118 || t.version == ver120 {
+			if f.cuOffset() == ^uint32(0) {
+				// skip functions without compilation unit (not real function, or linker generated)
+				continue
+			}
+			cutab = t.cutab[f.cuOffset()*4:]
+		}
+		pc := t.findFileLine(entry, filetab, linetab, int32(filenum), int32(line), cutab)
+		if pc != 0 {
+			return pc
+		}
+	}
+	return 0
+}
+
+// initFileMap initializes the map from file name to file number.
+func (t *LineTable) initFileMap() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.fileMap != nil {
+		return
+	}
+	m := make(map[string]uint32)
+	if t.version == ver12 {
+		for i := uint32(1); i < t.nfiletab; i++ {
+			s := t.string(t.binary.Uint32(t.filetab[4*i:]))
+			m[s] = i
+		}
+	} else {
+		var pos uint32
+		for i := uint32(0); i < t.nfiletab; i++ {
+			s := t.stringFrom(t.filetab, pos)
+			m[s] = pos
+			pos += uint32(len(s) + 1)
+		}
+	}
+	t.fileMap = m
+}
+
+// go12MapFiles adds to m a key for every file in the Go 1.2 LineTable.
+// Every key maps to obj. That's not a very interesting map, but it provides
+// a way for callers to obtain the list of files in the program.
+func (t *LineTable) go12MapFiles(m map[string]*Obj, obj *Obj) {
+	if !disableRecover {
+		defer func() {
+			_ = recover()
+		}()
+	}
+	t.initFileMap()
+	for file := range t.fileMap {
+		m[file] = obj
+	}
+}
+
+// disableRecover causes this package not to swallow panics.
+// This is useful when making changes.
+const disableRecover = true

--- a/pkg/internal/gosym/symtab.go
+++ b/pkg/internal/gosym/symtab.go
@@ -1,0 +1,763 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// Package gosym implements access to the Go symbol
+// and line number tables embedded in Go binaries generated
+// by the gc compilers.
+package gosym
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+/*
+ * Symbols
+ */
+// A Sym represents a single symbol table entry.
+type Sym struct {
+	Value  uint64
+	Type   byte
+	Name   string
+	GoType uint64
+	// If this symbol is a function symbol, the corresponding Func
+	Func      *Func
+	goVersion version
+}
+
+// Static reports whether this symbol is static (not visible outside its file).
+func (s *Sym) Static() bool { return s.Type >= 'a' }
+
+// nameWithoutInst returns s.Name if s.Name has no brackets (does not reference an
+// instantiated type, function, or method). If s.Name contains brackets, then it
+// returns s.Name with all the contents between (and including) the outermost left
+// and right bracket removed. This is useful to ignore any extra slashes or dots
+// inside the brackets from the string searches below, where needed.
+func (s *Sym) nameWithoutInst() string {
+	start := strings.Index(s.Name, "[")
+	if start < 0 {
+		return s.Name
+	}
+	end := strings.LastIndex(s.Name, "]")
+	if end < 0 {
+		// Malformed name, should contain closing bracket too.
+		return s.Name
+	}
+	return s.Name[0:start] + s.Name[end+1:]
+}
+
+// PackageName returns the package part of the symbol name,
+// or the empty string if there is none.
+func (s *Sym) PackageName() string {
+	name := s.nameWithoutInst()
+	// Since go1.20, a prefix of "type:" and "go:" is a compiler-generated symbol,
+	// they do not belong to any package.
+	//
+	// See cmd/compile/internal/base/link.go:ReservedImports variable.
+	if s.goVersion >= ver120 && (strings.HasPrefix(name, "go:") || strings.HasPrefix(name, "type:")) {
+		return ""
+	}
+	// For go1.18 and below, the prefix are "type." and "go." instead.
+	if s.goVersion <= ver118 && (strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.")) {
+		return ""
+	}
+	pathend := strings.LastIndex(name, "/")
+	if pathend < 0 {
+		pathend = 0
+	}
+	if i := strings.Index(name[pathend:], "."); i != -1 {
+		return name[:pathend+i]
+	}
+	return ""
+}
+
+// ReceiverName returns the receiver type name of this symbol,
+// or the empty string if there is none.  A receiver name is only detected in
+// the case that s.Name is fully-specified with a package name.
+func (s *Sym) ReceiverName() string {
+	name := s.nameWithoutInst()
+	// If we find a slash in name, it should precede any bracketed expression
+	// that was removed, so pathend will apply correctly to name and s.Name.
+	pathend := strings.LastIndex(name, "/")
+	if pathend < 0 {
+		pathend = 0
+	}
+	// Find the first dot after pathend (or from the beginning, if there was
+	// no slash in name).
+	l := strings.Index(name[pathend:], ".")
+	// Find the last dot after pathend (or the beginning).
+	r := strings.LastIndex(name[pathend:], ".")
+	if l == -1 || r == -1 || l == r {
+		// There is no receiver if we didn't find two distinct dots after pathend.
+		return ""
+	}
+	// Given there is a trailing '.' that is in name, find it now in s.Name.
+	// pathend+l should apply to s.Name, because it should be the dot in the
+	// package name.
+	r = strings.LastIndex(s.Name[pathend:], ".")
+	return s.Name[pathend+l+1 : pathend+r]
+}
+
+// BaseName returns the symbol name without the package or receiver name.
+func (s *Sym) BaseName() string {
+	name := s.nameWithoutInst()
+	if i := strings.LastIndex(name, "."); i != -1 {
+		if s.Name != name {
+			brack := strings.Index(s.Name, "[")
+			if i > brack {
+				// BaseName is a method name after the brackets, so
+				// recalculate for s.Name. Otherwise, i applies
+				// correctly to s.Name, since it is before the
+				// brackets.
+				i = strings.LastIndex(s.Name, ".")
+			}
+		}
+		return s.Name[i+1:]
+	}
+	return s.Name
+}
+
+// A Func collects information about a single function.
+type Func struct {
+	Entry uint64
+	*Sym
+	End       uint64
+	Params    []*Sym // nil for Go 1.3 and later binaries
+	Locals    []*Sym // nil for Go 1.3 and later binaries
+	FrameSize int
+	LineTable *LineTable
+	Obj       *Obj
+	// Addition: extra data to support inlining.
+	inlTree
+}
+
+func (T *Table) GetInlineTree(f *Func, goFuncVal, baseaddr uint64, progReader io.ReaderAt) ([]InlinedCall, error) {
+	//func (T *Table) GetInlineTree(f* Func, s *elf.Symbol, baseaddr uint64, progReader io.ReaderAt) ([]InlinedCall, error) {
+	//strver := fmt.Sprint(s.goVersion)
+	//goFuncValue := FuncSymName(strver)
+	//return T.go12line.InlineTree(f,goFuncValue,baseaddr,progReader)
+	return T.go12line.InlineTree(f, goFuncVal, baseaddr, progReader)
+
+}
+func ProgContaining(elfFile *elf.File, addr uint64) *elf.Prog {
+	for _, p := range elfFile.Progs {
+		if addr >= p.Vaddr && addr < p.Vaddr+p.Filesz {
+			return p
+		}
+	}
+	return nil
+}
+
+// An Obj represents a collection of functions in a symbol table.
+//
+// The exact method of division of a binary into separate Objs is an internal detail
+// of the symbol table format.
+//
+// In early versions of Go each source file became a different Obj.
+//
+// In Go 1 and Go 1.1, each package produced one Obj for all Go sources
+// and one Obj per C source file.
+//
+// In Go 1.2, there is a single Obj for the entire program.
+type Obj struct {
+	// Funcs is a list of functions in the Obj.
+	Funcs []Func
+	// In Go 1.1 and earlier, Paths is a list of symbols corresponding
+	// to the source file names that produced the Obj.
+	// In Go 1.2, Paths is nil.
+	// Use the keys of Table.Files to obtain a list of source files.
+	Paths []Sym // meta
+}
+
+/*
+ * Symbol tables
+ */
+// Table represents a Go symbol table. It stores all of the
+// symbols decoded from the program and provides methods to translate
+// between symbols, names, and addresses.
+type Table struct {
+	Syms     []Sym // nil for Go 1.3 and later binaries
+	Funcs    []Func
+	Files    map[string]*Obj // for Go 1.2 and later all files map to one Obj
+	Objs     []Obj           // for Go 1.2 and later only one Obj in slice
+	go12line *LineTable      // Go 1.2 line number table
+}
+type sym struct {
+	value  uint64
+	gotype uint64
+	typ    byte
+	name   []byte
+}
+
+var (
+	littleEndianSymtab    = []byte{0xFD, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}
+	bigEndianSymtab       = []byte{0xFF, 0xFF, 0xFF, 0xFD, 0x00, 0x00, 0x00}
+	oldLittleEndianSymtab = []byte{0xFE, 0xFF, 0xFF, 0xFF, 0x00, 0x00}
+)
+
+func walksymtab(data []byte, fn func(sym) error) error {
+	if len(data) == 0 { // missing symtab is okay
+		return nil
+	}
+	var order binary.ByteOrder = binary.BigEndian
+	newTable := false
+	switch {
+	case bytes.HasPrefix(data, oldLittleEndianSymtab):
+		// Same as Go 1.0, but little endian.
+		// Format was used during interim development between Go 1.0 and Go 1.1.
+		// Should not be widespread, but easy to support.
+		data = data[6:]
+		order = binary.LittleEndian
+	case bytes.HasPrefix(data, bigEndianSymtab):
+		newTable = true
+	case bytes.HasPrefix(data, littleEndianSymtab):
+		newTable = true
+		order = binary.LittleEndian
+	}
+	var ptrsz int
+	if newTable {
+		if len(data) < 8 {
+			//return &DecodingError{len(data), "unexpected EOF", nil}
+			return &DecodingError{len(data), "unexpected EOF", 0}
+		}
+		ptrsz = int(data[7])
+		if ptrsz != 4 && ptrsz != 8 {
+			return &DecodingError{7, "invalid pointer size", ptrsz}
+		}
+		data = data[8:]
+	}
+	var s sym
+	p := data
+	for len(p) >= 4 {
+		var typ byte
+		if newTable {
+			// Symbol type, value, Go type.
+			typ = p[0] & 0x3F
+			wideValue := p[0]&0x40 != 0
+			goType := p[0]&0x80 != 0
+			if typ < 26 {
+				typ += 'A'
+			} else {
+				typ += 'a' - 26
+			}
+			s.typ = typ
+			p = p[1:]
+			if wideValue {
+				if len(p) < ptrsz {
+					//return &DecodingError{len(data), "unexpected EOF", nil}
+					return &DecodingError{len(data), "unexpected EOF", 0}
+				}
+				// fixed-width value
+				if ptrsz == 8 {
+					s.value = order.Uint64(p[0:8])
+					p = p[8:]
+				} else {
+					s.value = uint64(order.Uint32(p[0:4]))
+					p = p[4:]
+				}
+			} else {
+				// varint value
+				s.value = 0
+				shift := uint(0)
+				for len(p) > 0 && p[0]&0x80 != 0 {
+					s.value |= uint64(p[0]&0x7F) << shift
+					shift += 7
+					p = p[1:]
+				}
+				if len(p) == 0 {
+					//return &DecodingError{len(data), "unexpected EOF", nil}
+					return &DecodingError{len(data), "unexpected EOF", 0}
+				}
+				s.value |= uint64(p[0]) << shift
+				p = p[1:]
+			}
+			if goType {
+				if len(p) < ptrsz {
+					//return &DecodingError{len(data), "unexpected EOF", nil}
+					return &DecodingError{len(data), "unexpected EOF", 0}
+				}
+				// fixed-width go type
+				if ptrsz == 8 {
+					s.gotype = order.Uint64(p[0:8])
+					p = p[8:]
+				} else {
+					s.gotype = uint64(order.Uint32(p[0:4]))
+					p = p[4:]
+				}
+			}
+		} else {
+			// Value, symbol type.
+			s.value = uint64(order.Uint32(p[0:4]))
+			if len(p) < 5 {
+				//return &DecodingError{len(data), "unexpected EOF", nil}
+				return &DecodingError{len(data), "unexpected EOF", 0}
+			}
+			typ = p[4]
+			if typ&0x80 == 0 {
+				return &DecodingError{len(data) - len(p) + 4, "bad symbol type", int(typ)}
+			}
+			typ &^= 0x80
+			s.typ = typ
+			p = p[5:]
+		}
+		// Name.
+		var i int
+		var nnul int
+		for i = 0; i < len(p); i++ {
+			if p[i] == 0 {
+				nnul = 1
+				break
+			}
+		}
+		switch typ {
+		case 'z', 'Z':
+			p = p[i+nnul:]
+			for i = 0; i+2 <= len(p); i += 2 {
+				if p[i] == 0 && p[i+1] == 0 {
+					nnul = 2
+					break
+				}
+			}
+		}
+		if len(p) < i+nnul {
+			//return &DecodingError{len(data), "unexpected EOF", nil}
+			return &DecodingError{len(data), "unexpected EOF", 0}
+		}
+		s.name = p[0:i]
+		i += nnul
+		p = p[i:]
+		if !newTable {
+			if len(p) < 4 {
+				//return &DecodingError{len(data), "unexpected EOF", nil}
+				return &DecodingError{len(data), "unexpected EOF", 0}
+			}
+			// Go type.
+			s.gotype = uint64(order.Uint32(p[:4]))
+			p = p[4:]
+		}
+		_ = fn(s)
+	}
+	return nil
+}
+
+// NewTable decodes the Go symbol table (the ".gosymtab" section in ELF),
+// returning an in-memory representation.
+// Starting with Go 1.3, the Go symbol table no longer includes symbol data.
+func NewTable(symtab []byte, pcln *LineTable) (*Table, error) {
+	var n int
+	err := walksymtab(symtab, func(s sym) error {
+		n++
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	var t Table
+	if pcln.isGo12() {
+		t.go12line = pcln
+	}
+	fname := make(map[uint16]string)
+	t.Syms = make([]Sym, 0, n)
+	nf := 0
+	nz := 0
+	lasttyp := uint8(0)
+	err = walksymtab(symtab, func(s sym) error {
+		n := len(t.Syms)
+		t.Syms = t.Syms[0 : n+1]
+		ts := &t.Syms[n]
+		ts.Type = s.typ
+		ts.Value = s.value
+		ts.GoType = s.gotype
+		ts.goVersion = pcln.version
+		switch s.typ {
+		default:
+			// rewrite name to use . instead of · (c2 b7)
+			w := 0
+			b := s.name
+			for i := 0; i < len(b); i++ {
+				if b[i] == 0xc2 && i+1 < len(b) && b[i+1] == 0xb7 {
+					i++
+					b[i] = '.'
+				}
+				b[w] = b[i]
+				w++
+			}
+			ts.Name = string(s.name[0:w])
+		case 'z', 'Z':
+			if lasttyp != 'z' && lasttyp != 'Z' {
+				nz++
+			}
+			for i := 0; i < len(s.name); i += 2 {
+				eltIdx := binary.BigEndian.Uint16(s.name[i : i+2])
+				elt, ok := fname[eltIdx]
+				if !ok {
+					return &DecodingError{-1, "bad filename code", int(eltIdx)}
+				}
+				if n := len(ts.Name); n > 0 && ts.Name[n-1] != '/' {
+					ts.Name += "/"
+				}
+				ts.Name += elt
+			}
+		}
+		switch s.typ {
+		case 'T', 't', 'L', 'l':
+			nf++
+		case 'f':
+			fname[uint16(s.value)] = ts.Name
+		}
+		lasttyp = s.typ
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	t.Funcs = make([]Func, 0, nf)
+	t.Files = make(map[string]*Obj)
+	var obj *Obj
+	if t.go12line != nil {
+		// Put all functions into one Obj.
+		t.Objs = make([]Obj, 1)
+		obj = &t.Objs[0]
+		t.go12line.go12MapFiles(t.Files, obj)
+	} else {
+		t.Objs = make([]Obj, 0, nz)
+	}
+	// Count text symbols and attach frame sizes, parameters, and
+	// locals to them. Also, find object file boundaries.
+	lastf := 0
+	for i := 0; i < len(t.Syms); i++ {
+		sym := &t.Syms[i]
+		switch sym.Type {
+		case 'Z', 'z': // path symbol
+			if t.go12line != nil {
+				// Go 1.2 binaries have the file information elsewhere. Ignore.
+				break
+			}
+			// Finish the current object
+			if obj != nil {
+				obj.Funcs = t.Funcs[lastf:]
+			}
+			lastf = len(t.Funcs)
+			// Start new object
+			n := len(t.Objs)
+			t.Objs = t.Objs[0 : n+1]
+			obj = &t.Objs[n]
+			// Count & copy path symbols
+			var end int
+			for end = i + 1; end < len(t.Syms); end++ {
+				if c := t.Syms[end].Type; c != 'Z' && c != 'z' {
+					break
+				}
+			}
+			obj.Paths = t.Syms[i:end]
+			i = end - 1 // loop will i++
+			// Record file names
+			depth := 0
+			for j := range obj.Paths {
+				s := &obj.Paths[j]
+				if s.Name == "" {
+					depth--
+				} else {
+					if depth == 0 {
+						t.Files[s.Name] = obj
+					}
+					depth++
+				}
+			}
+		case 'T', 't', 'L', 'l': // text symbol
+			if n := len(t.Funcs); n > 0 {
+				t.Funcs[n-1].End = sym.Value
+			}
+			if sym.Name == "runtime.etext" || sym.Name == "etext" {
+				continue
+			}
+			// Count parameter and local (auto) syms
+			var np, na int
+			var end int
+		countloop:
+			for end = i + 1; end < len(t.Syms); end++ {
+				switch t.Syms[end].Type {
+				case 'T', 't', 'L', 'l', 'Z', 'z':
+					break countloop
+				case 'p':
+					np++
+				case 'a':
+					na++
+				}
+			}
+			// Fill in the function symbol
+			n := len(t.Funcs)
+			t.Funcs = t.Funcs[0 : n+1]
+			fn := &t.Funcs[n]
+			sym.Func = fn
+			fn.Params = make([]*Sym, 0, np)
+			fn.Locals = make([]*Sym, 0, na)
+			fn.Sym = sym
+			fn.Entry = sym.Value
+			fn.Obj = obj
+			if t.go12line != nil {
+				// All functions share the same line table.
+				// It knows how to narrow down to a specific
+				// function quickly.
+				fn.LineTable = t.go12line
+			} else if pcln != nil {
+				fn.LineTable = pcln.slice(fn.Entry)
+				pcln = fn.LineTable
+			}
+			for j := i; j < end; j++ {
+				s := &t.Syms[j]
+				switch s.Type {
+				case 'm':
+					fn.FrameSize = int(s.Value)
+				case 'p':
+					n := len(fn.Params)
+					fn.Params = fn.Params[0 : n+1]
+					fn.Params[n] = s
+				case 'a':
+					n := len(fn.Locals)
+					fn.Locals = fn.Locals[0 : n+1]
+					fn.Locals[n] = s
+				}
+			}
+			i = end - 1 // loop will i++
+		}
+	}
+	if t.go12line != nil && nf == 0 {
+		t.Funcs = t.go12line.go12Funcs()
+	}
+	if obj != nil {
+		obj.Funcs = t.Funcs[lastf:]
+	}
+	return &t, nil
+}
+
+// PCToFunc returns the function containing the program counter pc,
+// or nil if there is no such function.
+func (t *Table) PCToFunc(pc uint64) *Func {
+	funcs := t.Funcs
+	for len(funcs) > 0 {
+		m := len(funcs) / 2
+		fn := &funcs[m]
+		switch {
+		case pc < fn.Entry:
+			funcs = funcs[0:m]
+		case fn.Entry <= pc && pc < fn.End:
+			return fn
+		default:
+			funcs = funcs[m+1:]
+		}
+	}
+	return nil
+}
+
+// PCToLine looks up line number information for a program counter.
+// If there is no information, it returns fn == nil.
+func (t *Table) PCToLine(pc uint64) (file string, line int, fn *Func) {
+	if fn = t.PCToFunc(pc); fn == nil {
+		return
+	}
+	if t.go12line != nil {
+		file = t.go12line.go12PCToFile(pc)
+		line = t.go12line.go12PCToLine(pc)
+	} else {
+		file, line = fn.Obj.lineFromAline(fn.LineTable.PCToLine(pc))
+	}
+	return
+}
+
+// LineToPC looks up the first program counter on the given line in
+// the named file. It returns UnknownPathError or UnknownLineError if
+// there is an error looking up this line.
+func (t *Table) LineToPC(file string, line int) (pc uint64, fn *Func, err error) {
+	obj, ok := t.Files[file]
+	if !ok {
+		return 0, nil, UnknownFileError(file)
+	}
+	if t.go12line != nil {
+		pc := t.go12line.go12LineToPC(file, line)
+		if pc == 0 {
+			return 0, nil, &UnknownLineError{file, line}
+		}
+		return pc, t.PCToFunc(pc), nil
+	}
+	abs, err := obj.alineFromLine(file, line)
+	if err != nil {
+		return
+	}
+	for i := range obj.Funcs {
+		f := &obj.Funcs[i]
+		pc := f.LineTable.LineToPC(abs, f.End)
+		if pc != 0 {
+			return pc, f, nil
+		}
+	}
+	return 0, nil, &UnknownLineError{file, line}
+}
+
+// LookupSym returns the text, data, or bss symbol with the given name,
+// or nil if no such symbol is found.
+func (t *Table) LookupSym(name string) *Sym {
+	// TODO(austin) Maybe make a map
+	for i := range t.Syms {
+		s := &t.Syms[i]
+		switch s.Type {
+		case 'T', 't', 'L', 'l', 'D', 'd', 'B', 'b':
+			if s.Name == name {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+// LookupFunc returns the text, data, or bss symbol with the given name,
+// or nil if no such symbol is found.
+func (t *Table) LookupFunc(name string) *Func {
+	for i := range t.Funcs {
+		f := &t.Funcs[i]
+		if f.Sym.Name == name {
+			return f
+		}
+	}
+	return nil
+}
+
+// SymByAddr returns the text, data, or bss symbol starting at the given address.
+func (t *Table) SymByAddr(addr uint64) *Sym {
+	for i := range t.Syms {
+		s := &t.Syms[i]
+		switch s.Type {
+		case 'T', 't', 'L', 'l', 'D', 'd', 'B', 'b':
+			if s.Value == addr {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+/*
+ * Object files
+ */
+// This is legacy code for Go 1.1 and earlier, which used the
+// Plan 9 format for pc-line tables. This code was never quite
+// correct. It's probably very close, and it's usually correct, but
+// we never quite found all the corner cases.
+//
+// Go 1.2 and later use a simpler format, documented at golang.org/s/go12symtab.
+func (o *Obj) lineFromAline(aline int) (string, int) {
+	type stackEnt struct {
+		path   string
+		start  int
+		offset int
+		prev   *stackEnt
+	}
+	noPath := &stackEnt{"", 0, 0, nil}
+	tos := noPath
+pathloop:
+	for _, s := range o.Paths {
+		val := int(s.Value)
+		switch {
+		case val > aline:
+			break pathloop
+		case val == 1:
+			// Start a new stack
+			tos = &stackEnt{s.Name, val, 0, noPath}
+		case s.Name == "":
+			// Pop
+			if tos == noPath {
+				return "<malformed symbol table>", 0
+			}
+			tos.prev.offset += val - tos.start
+			tos = tos.prev
+		default:
+			// Push
+			tos = &stackEnt{s.Name, val, 0, tos}
+		}
+	}
+	if tos == noPath {
+		return "", 0
+	}
+	return tos.path, aline - tos.start - tos.offset + 1
+}
+func (o *Obj) alineFromLine(path string, line int) (int, error) {
+	if line < 1 {
+		return 0, &UnknownLineError{path, line}
+	}
+	for i, s := range o.Paths {
+		// Find this path
+		if s.Name != path {
+			continue
+		}
+		// Find this line at this stack level
+		depth := 0
+		var incstart int
+		line += int(s.Value)
+	pathloop:
+		for _, s := range o.Paths[i:] {
+			val := int(s.Value)
+			switch {
+			case depth == 1 && val >= line:
+				return line - 1, nil
+			case s.Name == "":
+				depth--
+				if depth == 0 {
+					break pathloop
+				} else if depth == 1 {
+					line += val - incstart
+				}
+			default:
+				if depth == 1 {
+					incstart = val
+				}
+				depth++
+			}
+		}
+		return 0, &UnknownLineError{path, line}
+	}
+	return 0, UnknownFileError(path)
+}
+
+/*
+ * Errors
+ */
+// UnknownFileError represents a failure to find the specific file in
+// the symbol table.
+type UnknownFileError string
+
+func (e UnknownFileError) Error() string { return "unknown file: " + string(e) }
+
+// UnknownLineError represents a failure to map a line to a program
+// counter, either because the line is beyond the bounds of the file
+// or because there is no code on the given line.
+type UnknownLineError struct {
+	File string
+	Line int
+}
+
+func (e *UnknownLineError) Error() string {
+	return "no code at " + e.File + ":" + strconv.Itoa(e.Line)
+}
+
+// DecodingError represents an error during the decoding of
+// the symbol table.
+type DecodingError struct {
+	off int
+	msg string
+	val int
+}
+
+func (e *DecodingError) Error() string {
+	msg := e.msg
+	//if e.val != nil {
+	if e.val != 0 {
+		msg += fmt.Sprintf(" '%v'", e.val)
+	}
+	msg += fmt.Sprintf(" at byte %#x", e.off)
+	return msg
+}

--- a/pkg/internal/gosym/symtab.go
+++ b/pkg/internal/gosym/symtab.go
@@ -16,10 +16,7 @@ import (
 	"strings"
 )
 
-/*
- * Symbols
- */
-// A Sym represents a single symbol table entry.
+// Sym represents a single symbol table entry.
 type Sym struct {
 	Value  uint64
 	Type   byte
@@ -174,9 +171,6 @@ type Obj struct {
 	Paths []Sym // meta
 }
 
-/*
- * Symbol tables
- */
 // Table represents a Go symbol table. It stores all of the
 // symbols decoded from the program and provides methods to translate
 // between symbols, names, and addresses.
@@ -723,9 +717,6 @@ func (o *Obj) alineFromLine(path string, line int) (int, error) {
 	return 0, UnknownFileError(path)
 }
 
-/*
- * Errors
- */
 // UnknownFileError represents a failure to find the specific file in
 // the symbol table.
 type UnknownFileError string

--- a/pkg/internal/moduledata/moduledata.go
+++ b/pkg/internal/moduledata/moduledata.go
@@ -1,0 +1,86 @@
+// This package implements the parsing and usage of the moduledata
+// structs from a binary.
+// This code is mostly taken and adapted from https://github.com/goretk/gore.
+package moduledata
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+)
+
+// GetGoFuncValue is used to acquire the value of the
+// "go:func.*" symbol in stripped binaries.
+// TODO(derekparker) support Mach-O, PE.
+func GetGoFuncValue(f *elf.File, pclntabAddr uint64) (uint64, error) {
+	s := f.Section(".noptrdata")
+	if s == nil {
+		return 0, errors.New("unable to find .noptrdata section")
+	}
+	data, err := s.Data()
+	if err != nil {
+		return 0, err
+	}
+	buf := new(bytes.Buffer)
+	err = binary.Write(buf, binary.LittleEndian, &pclntabAddr)
+	if err != nil {
+		return 0, err
+	}
+	off := bytes.Index(data, buf.Bytes()[:8])
+
+	var md moduledata2064
+	err = binary.Read(bytes.NewReader(data[off:off+0x340]), f.ByteOrder, &md)
+	if err != nil {
+		return 0, err
+	}
+	return md.GoFunc, nil
+}
+
+type moduledata2064 struct {
+	PcHeader                                    uint64
+	Funcnametab, Funcnametablen, Funcnametabcap uint64
+	Cutab, Cutablen, Cutabcap                   uint64
+	Filetab, Filetablen, Filetabcap             uint64
+	Pctab, Pctablen, Pctabcap                   uint64
+	Pclntable, Pclntablelen, Pclntablecap       uint64
+	Ftab, Ftablen, Ftabcap                      uint64
+	Findfunctab                                 uint64
+	Minpc, Maxpc                                uint64
+
+	Text, Etext           uint64
+	Noptrdata, Enoptrdata uint64
+	Data, Edata           uint64
+	Bss, Ebss             uint64
+	Noptrbss, Enoptrbss   uint64
+	Covctrs, Ecovctrs     uint64
+	End, Gcdata, Gcbss    uint64
+	Types, Etypes         uint64
+	RData                 uint64
+	GoFunc                uint64
+
+	Textsectmap, Textsectmaplen, Textsectmapcap uint64
+	Typelinks, Typelinkslen, Typelinkscap       uint64 // offsets from types
+	Itablinks, Itablinkslen, Itablinkscap       uint64
+
+	Ptab, Ptablen, Ptabcap uint64
+
+	Pluginpath, Pluginpathlen             uint64
+	Pkghashes, Pkghasheslen, Pkghashescap uint64
+
+	Modulename, Modulenamelen                      uint64
+	Modulehashes, Modulehasheslen, Modulehashescap uint64
+
+	/*	These fields we are not planning to use so skipping the parsing of them.
+
+		hasmain uint8 // 1 if module contains the main function, 0 otherwise
+
+		gcdatamask, gcbssmask bitvector
+
+		typemap map[typeOff]*_type // offset to *_rtype in previous module
+
+		bad bool // module failed to load and should be ignored
+
+		next *moduledata
+	*/
+}

--- a/pkg/internal/moduledata/moduledata_test.go
+++ b/pkg/internal/moduledata/moduledata_test.go
@@ -1,0 +1,59 @@
+package moduledata
+
+import (
+	"debug/elf"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestGetGoFuncValue(t *testing.T) {
+	bin := "getgofuncvaltestbin"
+
+	err := exec.Command("go", "build", "-o", bin, "../../../_fixtures/traceprog.go").Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(name string) {
+		err := os.Remove(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}(bin)
+
+	file, err := elf.Open(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := file.Section(".gopclntab")
+
+	goFuncValue, err := GetGoFuncValue(file, s.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	goFuncSymValue := getGoFuncSymValue(file, t)
+	if goFuncSymValue == 0 {
+		t.Fatal("unable to find value for go:func.* symbol")
+	}
+
+	t.Logf("gofuncVal: %#v goFuncSymValue: %#v\n", goFuncValue, goFuncSymValue)
+
+	if goFuncValue != goFuncSymValue {
+		t.Fatalf("expected goFuncValue %#v to equal goFuncSymValue %#v", goFuncValue, goFuncSymValue)
+	}
+}
+
+func getGoFuncSymValue(f *elf.File, t *testing.T) uint64 {
+	syms, err := f.Symbols()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range syms {
+		if syms[i].Name == "go:func.*" {
+			return syms[i].Value
+		}
+	}
+	return 0
+}

--- a/pkg/internal/moduledata/moduledata_test.go
+++ b/pkg/internal/moduledata/moduledata_test.go
@@ -4,10 +4,14 @@ import (
 	"debug/elf"
 	"os"
 	"os/exec"
+	"runtime"
 	"testing"
 )
 
 func TestGetGoFuncValue(t *testing.T) {
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skipf("skipping since not linux/amd64")
+	}
 	bin := "getgofuncvaltestbin"
 
 	err := exec.Command("go", "build", "-o", bin, "../../../_fixtures/traceprog.go").Run()

--- a/pkg/internal/moduledata/moduledata_test.go
+++ b/pkg/internal/moduledata/moduledata_test.go
@@ -2,6 +2,7 @@ package moduledata
 
 import (
 	"debug/elf"
+	"github.com/go-delve/delve/pkg/goversion"
 	"os"
 	"os/exec"
 	"runtime"
@@ -11,6 +12,9 @@ import (
 func TestGetGoFuncValue(t *testing.T) {
 	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
 		t.Skipf("skipping since not linux/amd64")
+	}
+	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 20) {
+		t.Skip("temporarily disabled on Go versions < 1.20")
 	}
 	bin := "getgofuncvaltestbin"
 

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"debug/dwarf"
 	"debug/elf"
-	"debug/gosym"
 	"debug/macho"
 	"debug/pe"
 	"encoding/binary"
@@ -31,6 +30,8 @@ import (
 	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/dwarf/reader"
 	"github.com/go-delve/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/internal/gosym"
+	"github.com/go-delve/delve/pkg/internal/moduledata"
 	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/go-delve/delve/pkg/proc/debuginfod"
 	"github.com/hashicorp/golang-lru/simplelru"
@@ -1455,20 +1456,53 @@ func loadBinaryInfoElf(bi *BinaryInfo, image *Image, path string, addr uint64, w
 			if len(bi.Images) <= 1 {
 				fmt.Fprintln(os.Stderr, "Warning: no debug info found, some functionality will be missing such as stack traces and variable evaluation.")
 			}
-			symTable, err := readPcLnTableElf(elfFile, path)
+			cu := &compileUnit{}
+			cu.image = image
+			symTable, pcLnTabAddr, err := readPcLnTableElf(elfFile, path)
 			if err != nil {
 				return fmt.Errorf("could not read debug info (%v) and could not read go symbol table (%v)", dwerr, err)
 			}
 			image.symTable = symTable
+			goFuncVal, err := moduledata.GetGoFuncValue(elfFile, pcLnTabAddr)
+			if err != nil {
+				return err
+			}
+			prog := gosym.ProgContaining(elfFile, goFuncVal)
+			inlFuncs := make(map[string]*Function)
 			for _, f := range image.symTable.Funcs {
+				fnEntry := f.Entry + image.StaticBase
+				inlCalls, err := image.symTable.GetInlineTree(&f, goFuncVal, prog.Vaddr, prog.ReaderAt)
+				if err != nil {
+					return err
+				}
+				for _, inlfn := range inlCalls {
+					newInlinedCall := InlinedCall{cu: cu, LowPC: fnEntry + uint64(inlfn.ParentPC)}
+					if fn, ok := inlFuncs[inlfn.Name]; ok {
+						fn.InlinedCalls = append(fn.InlinedCalls, newInlinedCall)
+					} else {
+						inlFuncs[inlfn.Name] = &Function{
+							Name:  inlfn.Name,
+							Entry: 0, End: 0,
+							cu: cu,
+							InlinedCalls: []InlinedCall{
+								newInlinedCall,
+							}}
+					}
+				}
 				cu := &compileUnit{}
 				cu.image = image
-				fn := Function{Name: f.Name, Entry: f.Entry + image.StaticBase, End: f.End + image.StaticBase, cu: cu}
+				fn := Function{Name: f.Name, Entry: fnEntry, End: f.End + image.StaticBase, cu: cu}
 				bi.Functions = append(bi.Functions, fn)
 			}
+			for i := range inlFuncs {
+				bi.Functions = append(bi.Functions, *inlFuncs[i])
+			}
+			sort.Sort(functionsDebugInfoByEntry(bi.Functions))
 			for f := range image.symTable.Files {
 				bi.Sources = append(bi.Sources, f)
 			}
+			sort.Strings(bi.Sources)
+			bi.Sources = uniq(bi.Sources)
 			return nil
 		}
 		image.sepDebugCloser = sepFile

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -899,7 +899,7 @@ func (dbp *nativeProcess) SetUProbe(fnName string, goidOffset int64, args []ebpf
 
 	fns := dbp.bi.LookupFunc()[fnName]
 	if len(fns) != 1 {
-		return fmt.Errorf("could not find function: %s", fnName)
+		return &proc.ErrFunctionNotFound{FuncName: fnName}
 	}
 	fn := fns[0]
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3233,8 +3233,9 @@ func TestDebugStripped(t *testing.T) {
 }
 
 func TestDebugStripped2(t *testing.T) {
-	// Currently only implemented for Linux ELF and macOS Mach-O executables.
+	// Currently only implemented for Linux ELF executables.
 	// TODO(derekparker): Add support for PE.
+	skipOn(t, "broken on darwin/amd64/pie", "darwin")
 	skipOn(t, "not working on windows", "windows")
 	skipOn(t, "not working on freebsd", "freebsd")
 	skipOn(t, "not working on linux/386 with PIE", "linux", "386", "pie")

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3234,12 +3234,14 @@ func TestDebugStripped(t *testing.T) {
 
 func TestDebugStripped2(t *testing.T) {
 	// Currently only implemented for Linux ELF executables.
-	// TODO(derekparker): Add support for PE.
-	skipOn(t, "broken on darwin/amd64/pie", "darwin")
-	skipOn(t, "not working on windows", "windows")
-	skipOn(t, "not working on freebsd", "freebsd")
-	skipOn(t, "not working on linux/386 with PIE", "linux", "386", "pie")
-	skipOn(t, "not working on linux/ppc64le when -gcflags=-N -l is passed", "linux", "ppc64le")
+	// TODO(derekparker): Add support for Mach-O and PE.
+	skipUnlessOn(t, "linux/amd64 only", "linux", "amd64")
+	ver, _ := goversion.Parse(runtime.Version())
+	if ver.Major > 0 && !ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 20, Rev: -1}) {
+	}
+	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 20) {
+		t.Skip("temporarily disabled on Go versions < 1.20")
+	}
 	withTestProcessArgs("inlinestripped", t, "", []string{}, protest.EnableInlining|protest.LinkStrip, func(p *proc.Target, grp *proc.TargetGroup, f protest.Fixture) {
 		setFunctionBreakpointAll(p, t, "fmt.Println")
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3216,7 +3216,7 @@ func TestShadowedFlag(t *testing.T) {
 }
 
 func TestDebugStripped(t *testing.T) {
-	// Currently only implemented for Linux ELF executables.
+	// Currently only implemented for Linux ELF and macOS Mach-O executables.
 	// TODO(derekparker): Add support for PE.
 	skipOn(t, "not working on windows", "windows")
 	skipOn(t, "not working on freebsd", "freebsd")
@@ -3229,6 +3229,24 @@ func TestDebugStripped(t *testing.T) {
 		assertLineNumber(p, t, 37, "first continue")
 		assertNoError(grp.Next(), t, "Next")
 		assertLineNumber(p, t, 38, "after next")
+	})
+}
+
+func TestDebugStripped2(t *testing.T) {
+	// Currently only implemented for Linux ELF and macOS Mach-O executables.
+	// TODO(derekparker): Add support for PE.
+	skipOn(t, "not working on windows", "windows")
+	skipOn(t, "not working on freebsd", "freebsd")
+	skipOn(t, "not working on linux/386 with PIE", "linux", "386", "pie")
+	skipOn(t, "not working on linux/ppc64le when -gcflags=-N -l is passed", "linux", "ppc64le")
+	withTestProcessArgs("inlinestripped", t, "", []string{}, protest.EnableInlining|protest.LinkStrip, func(p *proc.Target, grp *proc.TargetGroup, f protest.Fixture) {
+		setFunctionBreakpointAll(p, t, "fmt.Println")
+
+		for i, line := range []int{12, 13, 14} {
+			assertNoError(grp.Continue(), t, "Continue")
+			assertCurrentLocationFunction(p, t, "main.main")
+			assertLineNumber(p, t, line, fmt.Sprintf("continue %d", i))
+		}
 	})
 }
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3236,9 +3236,6 @@ func TestDebugStripped2(t *testing.T) {
 	// Currently only implemented for Linux ELF executables.
 	// TODO(derekparker): Add support for Mach-O and PE.
 	skipUnlessOn(t, "linux/amd64 only", "linux", "amd64")
-	ver, _ := goversion.Parse(runtime.Version())
-	if ver.Major > 0 && !ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 20, Rev: -1}) {
-	}
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 20) {
 		t.Skip("temporarily disabled on Go versions < 1.20")
 	}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3220,7 +3220,7 @@ func TestDebugStripped(t *testing.T) {
 	// TODO(derekparker): Add support for PE.
 	skipOn(t, "not working on windows", "windows")
 	skipOn(t, "not working on freebsd", "freebsd")
-	skipOn(t, "not working on linux/386 with PIE", "linux", "386", "pie")
+	skipOn(t, "not working on linux/386", "linux", "386")
 	skipOn(t, "not working on linux/ppc64le when -gcflags=-N -l is passed", "linux", "ppc64le")
 	withTestProcessArgs("testnextprog", t, "", []string{}, protest.LinkStrip, func(p *proc.Target, grp *proc.TargetGroup, f protest.Fixture) {
 		setFunctionBreakpoint(p, t, "main.main")


### PR DESCRIPTION
This patch adds support for listing and setting breakpoints on inlined functions within stripped binaries. It uses a forked version of `debug/gosym` copied from golang.org/x/vuln/internal/vulncheck/internal/gosym which adds support for parsing the inline tree of the pclntab section. Parsing this section requires knowing the offset of the "go:func.*" symbol, which is not present in stripped binaries via the `.symtab` section so instead, we search the `.noptrdata` section which contains `runtime.moduledatap` which contains the value of that missing symbol, which we then can use to find the inline tree for a given function.

Given all this we parse the inline tree for each function we find, and then add that information the the appropriate `Function` contained in `bi.Functions`, using a relatively empty `Function` struct as what would be the abstract origin.

The forked version of `debug/gosym` is in an internal package because it is expected that this functionality will be exposed in the future and this package will be removed. Making it internal prevents anyone from relying on it outside this project, allowing us to remove it at will.

Currently this only supports Go 1.20+ 64-bit targets, however follow up commits can add module data support for older Go versions and 32-bit support. The parsing of the moduledata was taken and adapted from https://github.com/goretk/gore. It is my intention to contribute the necessary changes Delve requires and then simply use that as a dependency, so it is also internal.

Finally, thanks to my colleague @archanaravindar whom I worked together with on this feature.