### PR TITLE
cmd: fix a bunch of linter warnings from GoLand

### DIFF
--- a/cmd/dlv/cmds/helphelpers/help.go
+++ b/cmd/dlv/cmds/helphelpers/help.go
@@ -6,10 +6,10 @@ import (
 )
 
 // Prepare prepares cmd flag set for the invocation of its usage function by
-// hiding flags that we want cobra to parse but we don't want to show to the
+// hiding flags that we want cobra to parse, but we don't want to show to the
 // user.
 // We do this because not all flags associated with the root command are
-// valid for all subcommands but we don't want to move them out of the root
+// valid for all subcommands, but we don't want to move them out of the root
 // command and into subcommands, since that would change how cobra parses
 // the command line.
 //

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -180,7 +180,7 @@ func testOutput(t *testing.T, dlvbin, output string, delveCmds []string) (stdout
 
 	// ignore "dlv debug" command error, it returns
 	// errors even after successful debug session.
-	_ = cmd.Wait()
+	cmd.Wait()
 	stdout, stderr = stdoutBuf.Bytes(), stderrBuf.Bytes()
 
 	_, err = os.Stat(debugbin)
@@ -308,7 +308,7 @@ func TestRedirect(t *testing.T) {
 
 	// and detach from and kill the headless instance
 	client := rpc2.NewClient(listenAddr)
-	_ = client.Detach(true)
+	client.Detach(true)
 	cmd.Wait()
 }
 
@@ -1352,8 +1352,8 @@ func TestDefaultBinary(t *testing.T) {
 	fmt.Fprintf(stdin1, "continue\nquit\n")
 	fmt.Fprintf(stdin2, "continue\nquit\n")
 
-	_ = wait1()
-	_ = wait2()
+	wait1()
+	wait2()
 
 	out1, out2 := stdoutBuf1.String(), stdoutBuf2.String()
 	t.Logf("%q", out1)

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -180,17 +180,17 @@ func testOutput(t *testing.T, dlvbin, output string, delveCmds []string) (stdout
 
 	// ignore "dlv debug" command error, it returns
 	// errors even after successful debug session.
-	cmd.Wait()
+	_ = cmd.Wait()
 	stdout, stderr = stdoutBuf.Bytes(), stderrBuf.Bytes()
 
 	_, err = os.Stat(debugbin)
 	if err == nil {
 		// Sometimes delve on Windows can't remove the built binary before
 		// exiting and gets an "Access is denied" error when trying.
-		// See: https://travis-ci.com/go-delve/delve/jobs/296325131)
+		// See: https://travis-ci.com/go-delve/delve/jobs/296325131.
 		// We have added a delay to gobuild.Remove, but to avoid any test
 		// flakiness, we guard against this failure here as well.
-		if runtime.GOOS != "windows" || !strings.Contains(err.Error(), "Access is denied") {
+		if runtime.GOOS != "windows" {
 			t.Errorf("running %q: file %v was not deleted\nstdout is %q, stderr is %q", delveCmds, debugbin, stdout, stderr)
 		}
 		return
@@ -204,7 +204,7 @@ func testOutput(t *testing.T, dlvbin, output string, delveCmds []string) (stdout
 
 func getDlvBin(t *testing.T) string {
 	// In case this was set in the environment
-	// from getDlvBinEBPF lets clear it here so
+	// from getDlvBinEBPF lets clear it here, so
 	// we can ensure we don't get build errors
 	// depending on the test ordering.
 	t.Setenv("CGO_LDFLAGS", ldFlags)
@@ -427,7 +427,7 @@ func TestExitInInit(t *testing.T) {
 	cmd.Dir = buildtestdir
 	out, err := cmd.CombinedOutput()
 	t.Logf("%q %v\n", string(out), err)
-	// dlv will exit anyway because stdin is not a tty but it will print the
+	// dlv will exit anyway because stdin is not a tty, but it will print the
 	// prompt once if the init file didn't call exit successfully.
 	if strings.Contains(string(out), "(dlv)") {
 		t.Fatal("init did not cause dlv to exit")
@@ -1352,8 +1352,8 @@ func TestDefaultBinary(t *testing.T) {
 	fmt.Fprintf(stdin1, "continue\nquit\n")
 	fmt.Fprintf(stdin2, "continue\nquit\n")
 
-	wait1()
-	wait2()
+	_ = wait1()
+	_ = wait2()
 
 	out1, out2 := stdoutBuf1.String(), stdoutBuf2.String()
 	t.Logf("%q", out1)

--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -18,13 +18,10 @@ func main() {
 
 	const cgoCflagsEnv = "CGO_CFLAGS"
 	if os.Getenv(cgoCflagsEnv) == "" {
-		err := os.Setenv(cgoCflagsEnv, "-O0 -g")
-		if err != nil {
-			logrus.WithFields(logrus.Fields{"layer": "dlv"}).Warnf("CGO_CFLAGS could not be set, Cgo code could be optimized: %v", err)
-		}
+		os.Setenv(cgoCflagsEnv, "-O0 -g")
 	} else {
 		logrus.WithFields(logrus.Fields{"layer": "dlv"}).Warnln("CGO_CFLAGS already set, Cgo code could be optimized.")
 	}
 
-	_ = cmds.New(false).Execute()
+	cmds.New(false).Execute()
 }

--- a/cmd/dlv/main.go
+++ b/cmd/dlv/main.go
@@ -15,11 +15,16 @@ func main() {
 	if Build != "" {
 		version.DelveVersion.Build = Build
 	}
+
 	const cgoCflagsEnv = "CGO_CFLAGS"
 	if os.Getenv(cgoCflagsEnv) == "" {
-		os.Setenv(cgoCflagsEnv, "-O0 -g")
+		err := os.Setenv(cgoCflagsEnv, "-O0 -g")
+		if err != nil {
+			logrus.WithFields(logrus.Fields{"layer": "dlv"}).Warnf("CGO_CFLAGS could not be set, Cgo code could be optimized: %v", err)
+		}
 	} else {
 		logrus.WithFields(logrus.Fields{"layer": "dlv"}).Warnln("CGO_CFLAGS already set, Cgo code could be optimized.")
 	}
-	cmds.New(false).Execute()
+
+	_ = cmds.New(false).Execute()
 }


### PR DESCRIPTION
Also fixes a potential nil pointer deref error in a test.