### PR TITLE
proc: add regression test for issue #3548

### DIFF
--- a/_fixtures/issue3548.go
+++ b/_fixtures/issue3548.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+)
+
+type Thing struct {
+	str string
+}
+
+func (d *Thing) Test() bool {
+	return d != nil
+}
+
+func callit(f func()) {
+	f()
+}
+
+func main() {
+	cases := []struct {
+		name  string
+		thing Thing
+	}{
+		{
+			name:  "Success",
+			thing: Thing{str: "hello"},
+		},
+	}
+
+	for _, c := range cases {
+		callit(func() {
+			fmt.Println("hello", c.thing.Test())
+		})
+	}
+}


### PR DESCRIPTION
Issue #3548 describes a bug in the compiler which was fixed by commit
505e50b. But this case wasn't covered by our current tests (obviously)
and the fix in the compiler looks accidental so it's worth adding a
test for it.

Fixes #3548
