### PR TITLE
pkg,service: Remove redundant build constraints

### DIFF
--- a/pkg/proc/redirector_windows.go
+++ b/pkg/proc/redirector_windows.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package proc
 
 import (

--- a/pkg/version/buildinfo.go
+++ b/pkg/version/buildinfo.go
@@ -1,5 +1,3 @@
-//go:build go1.12
-
 package version
 
 import (

--- a/service/internal/sameuser/sameuser_linux.go
+++ b/service/internal/sameuser/sameuser_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package sameuser
 
 import (

--- a/service/internal/sameuser/sameuser_linux_test.go
+++ b/service/internal/sameuser/sameuser_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package sameuser
 
 import (


### PR DESCRIPTION
This PR removes some `//go:build` constraints.
We can remove OS-specific build constrains like `//go:build windows` if a file name ending with `_windows.go` (according to the [doc](https://pkg.go.dev/cmd/go#hdr-Build_constraints)).
`//go:build go1.12` is redundant for delve because the minimum supported version is Go 1.17.