### PR TITLE
test: Move statements from init to TestMain

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -33,10 +33,6 @@ import (
 var testBackend string
 var ldFlags string
 
-func init() {
-	ldFlags = os.Getenv("CGO_LDFLAGS")
-}
-
 func TestMain(m *testing.M) {
 	flag.StringVar(&testBackend, "backend", "", "selects backend")
 	flag.Parse()
@@ -49,6 +45,7 @@ func TestMain(m *testing.M) {
 			}
 		}
 	}
+	ldFlags = os.Getenv("CGO_LDFLAGS")
 	os.Exit(protest.RunTestsWithFixtures(m))
 }
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -42,12 +42,10 @@ import (
 var normalLoadConfig = proc.LoadConfig{true, 1, 64, 64, -1, 0}
 var testBackend, buildMode string
 
-func init() {
+func TestMain(m *testing.M) {
 	runtime.GOMAXPROCS(4)
 	os.Setenv("GOMAXPROCS", "4")
-}
 
-func TestMain(m *testing.M) {
 	flag.StringVar(&testBackend, "backend", "", "selects backend")
 	flag.StringVar(&buildMode, "test-buildmode", "", "selects build mode")
 	var logConf string

--- a/service/test/common_test.go
+++ b/service/test/common_test.go
@@ -35,10 +35,6 @@ func assertError(err error, t *testing.T, s string) {
 	}
 }
 
-func init() {
-	runtime.GOMAXPROCS(2)
-}
-
 type nextTest struct {
 	begin, end int
 }

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -40,6 +40,8 @@ var normalLoadConfig = api.LoadConfig{
 var testBackend, buildMode string
 
 func TestMain(m *testing.M) {
+	runtime.GOMAXPROCS(2)
+
 	flag.StringVar(&testBackend, "backend", "", "selects backend")
 	flag.StringVar(&buildMode, "test-buildmode", "", "selects build mode")
 	var logOutput string


### PR DESCRIPTION
This PR moves code from `init` to `TestMain` in tests to increase readability and maintenability.