### PR TITLE
TeamCity: reupgrade linux/386 builder to Go 1.21

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -40,7 +40,7 @@ val targets = arrayOf(
         "linux/amd64/1.21",
         "linux/amd64/tip",
 
-        "linux/386/1.20",
+        "linux/386/1.21",
 
         "linux/arm64/1.21",
         "linux/arm64/tip",

--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -1,6 +1,7 @@
 Tests skipped by each supported backend:
 
-* 386 skipped = 6
+* 386 skipped = 7
+	* 1 broken
 	* 3 broken - cgo stacktraces
 	* 3 not implemented
 * arm64 skipped = 1

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4683,8 +4683,8 @@ func TestCgoStacktrace2(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 21) {
 		skipOn(t, "upstream issue", "windows")
 		skipOn(t, "broken", "arm64")
-		skipOn(t, "broken", "386")
 	}
+	skipOn(t, "broken", "386")
 	skipOn(t, "broken - cgo stacktraces", "darwin", "arm64")
 	skipOn(t, "broken", "ppc64le")
 	protest.MustHaveCgo(t)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1282,7 +1282,7 @@ func TestFunctionNameFormattingInStackTrace(t *testing.T) {
 			[]onBreakpoint{{
 				// Stop at line 36
 				execute: func() {
-					if runtime.GOARCH == "386" && goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) {
+					if runtime.GOARCH == "386" && goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) && !goversion.VersionAfterOrEqual(runtime.Version(), 1, 21) {
 						client.StepInRequest(1)
 						client.ExpectStepInResponse(t)
 						client.ExpectStoppedEvent(t)
@@ -2463,7 +2463,7 @@ func TestGlobalScopeAndVariables(t *testing.T) {
 			[]onBreakpoint{{
 				// Stop at line 36
 				execute: func() {
-					if runtime.GOARCH == "386" && goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) {
+					if runtime.GOARCH == "386" && goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) && !goversion.VersionAfterOrEqual(runtime.Version(), 1, 21) {
 						client.StepInRequest(1)
 						client.ExpectStepInResponse(t)
 						client.ExpectStoppedEvent(t)
@@ -2538,7 +2538,7 @@ func TestRegistersScopeAndVariables(t *testing.T) {
 			[]onBreakpoint{{
 				// Stop at line 36
 				execute: func() {
-					if runtime.GOARCH == "386" && goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) {
+					if runtime.GOARCH == "386" && goversion.VersionAfterOrEqual(runtime.Version(), 1, 18) && !goversion.VersionAfterOrEqual(runtime.Version(), 1, 21) {
 						client.StepInRequest(1)
 						client.ExpectStepInResponse(t)
 						client.ExpectStoppedEvent(t)


### PR DESCRIPTION
The bug that prevented updating to linux/386 has been fixed upstream,
update linux/386 to 1.21 in the test matrix and fix some broken bugs.
