### PR TITLE
proc: simplify and generalize runtime.mallocgc workaround

### DIFF
--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -43,6 +43,7 @@ func AMD64Arch(goos string) *Arch {
 		RegnumToString:                   regnum.AMD64ToName,
 		debugCallMinStackSize:            256,
 		maxRegArgBytes:                   9*8 + 15*8,
+		argumentRegs:                     []int{regnum.AMD64_Rax, regnum.AMD64_Rbx, regnum.AMD64_Rcx},
 	}
 }
 

--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -55,6 +55,8 @@ type Arch struct {
 	// maxRegArgBytes is extra padding for ABI1 call injections, equivalent to
 	// the maximum space occupied by register arguments.
 	maxRegArgBytes int
+	// argumentRegs are function call injection registers for runtimeOptimizedWorkaround
+	argumentRegs []int
 
 	// asmRegisters maps assembly register numbers to dwarf registers.
 	asmRegisters map[int]asmRegister

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -53,6 +53,7 @@ func ARM64Arch(goos string) *Arch {
 		RegnumToString:                   regnum.ARM64ToName,
 		debugCallMinStackSize:            288,
 		maxRegArgBytes:                   16*8 + 16*8, // 16 int argument registers plus 16 float argument registers
+		argumentRegs:                     []int{regnum.ARM64_X0, regnum.ARM64_X0 + 1, regnum.ARM64_X0 + 2},
 	}
 }
 

--- a/pkg/proc/ppc64le_arch.go
+++ b/pkg/proc/ppc64le_arch.go
@@ -41,6 +41,7 @@ func PPC64LEArch(goos string) *Arch {
 		RegisterNameToDwarf:              nameToDwarfFunc(regnum.PPC64LENameToDwarf),
 		debugCallMinStackSize:            320,
 		maxRegArgBytes:                   13*8 + 13*8,
+		argumentRegs:                     []int{regnum.PPC64LE_R0 + 3, regnum.PPC64LE_R0 + 4, regnum.PPC64LE_R0 + 5},
 	}
 }
 


### PR DESCRIPTION
Instead of having a different version for each architecture have a
single version that uses an architecture specific list of registers.

Also generalize it so that, if we want, we can extend the workaround to
other runtime functions we might want to call (for example the channel
send/receive functions).
