### PR TITLE
TeamCity: remove windows/arm64 builders from chain

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -50,8 +50,6 @@ val targets = arrayOf(
         "windows/amd64/1.21",
         "windows/amd64/tip",
 
-        "windows/arm64/1.21",
-
         "mac/amd64/1.21",
         "mac/amd64/tip",
 


### PR DESCRIPTION
We haven't had a builder for 2 months so it can be declared legally
dead.
