### PR TITLE
service/dap: fix close on closed channel panic

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -3453,7 +3453,7 @@ func TestHaltPreventsAutoResume(t *testing.T) {
 						// Send a halt request when trying to resume the program after being
 						// interrupted. This should allow the log message to be processed,
 						// but keep the process from continuing beyond the line.
-						resumeOnceAndCheckStop = func(s *Session, command string, allowNextStateChange chan struct{}) (*api.DebuggerState, error) {
+						resumeOnceAndCheckStop = func(s *Session, command string, allowNextStateChange *syncflag) (*api.DebuggerState, error) {
 							// This should trigger after the log message is sent, but before
 							// execution is resumed.
 							if command == api.DirectionCongruentContinue {


### PR DESCRIPTION
Fixes close on closed channel panic that happens sporadically on many
of the dap tests (for example 1 ~ 3% of the times on
TestStepInstruction).
