### PR TITLE
service/dap: support waitfor option for 'dap attach' only

### DIFF
--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -181,7 +181,7 @@ func waitForSearchProcess(pfx string, seen map[int]struct{}) (int, error) {
 		seen[int(proc.ki_pid)] = struct{}{}
 
 		argv := strings.Join(getCmdLineInternal(ps, proc), " ")
-		log.Debugf("waitfor: new process %q", argv)
+		log.Debugf("waitfor: new process:\n\tpid=%d\n\tcmdline=%q", int(proc.ki_pid), argv)
 		if strings.HasPrefix(argv, pfx) {
 			return int(proc.ki_pid), nil
 		}

--- a/pkg/proc/native/proc_linux.go
+++ b/pkg/proc/native/proc_linux.go
@@ -216,7 +216,7 @@ func waitForSearchProcess(pfx string, seen map[int]struct{}) (int, error) {
 				buf[i] = ' '
 			}
 		}
-		log.Debugf("waitfor: new process %q", string(buf))
+		log.Debugf("waitfor: new process:\n\tpid=%d\n\tcmdline=%q", pid, string(buf))
 		if strings.HasPrefix(string(buf), pfx) {
 			return pid, nil
 		}

--- a/pkg/proc/native/proc_windows.go
+++ b/pkg/proc/native/proc_windows.go
@@ -248,7 +248,7 @@ func waitForSearchProcess(pfx string, seen map[int]struct{}) (int, error) {
 		cmdline := getCmdLine(syscall.Handle(hProcess))
 		sys.CloseHandle(hProcess)
 
-		log.Debugf("waitfor: new process %q", cmdline)
+		log.Debugf("waitfor: new process:\n\tpid=%d\n\tcmdline=%q", int(entry.ProcessID), cmdline)
 		if strings.HasPrefix(cmdline, pfx) {
 			return int(entry.ProcessID), nil
 		}

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -237,6 +237,7 @@ func (m *SubstitutePath) UnmarshalJSON(data []byte) error {
 }
 
 // AttachConfig is the collection of attach request attributes recognized by DAP implementation.
+// 'processId' and 'waitFor' are mutually exclusive, and can't be specified at the same time.
 type AttachConfig struct {
 	// Acceptable values are:
 	//   "local": attaches to the local process with the given ProcessID.
@@ -245,8 +246,11 @@ type AttachConfig struct {
 	// Default is "local".
 	Mode string `json:"mode"`
 
-	// The numeric ID of the process to be debugged. Required and must not be 0.
+	// The numeric ID of the process to be debugged.
 	ProcessID int `json:"processId,omitempty"`
+
+	// Wait for a process with a name beginning with this prefix.
+	AttachWaitFor string `json:"waitFor,omitempty"`
 
 	LaunchAttachCommonConfig
 }


### PR DESCRIPTION
add a waitfor option for 'dap attach' that waits for a process with a given name to appear before attaching to it.