### PR TITLE
proc: fix TestIssue1101 flake

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3690,7 +3690,7 @@ func TestIssue1101(t *testing.T) {
 				// Also it seems that sometimes on linux/386 we will not receive the
 				// exit status. This happens if the process exits at the same time as it
 				// receives a signal.
-				t.Fatalf("process exited status %d (expected 2)", pexit.Status)
+				t.Fatalf("process exited status %d (expected 2) (last command = %s) (%#v)", pexit.Status, lastCmd, pexit)
 			}
 		} else {
 			assertNoError(exitErr, t, lastCmd)


### PR DESCRIPTION
If the target process exits and receives a signal at the same time and
we receive the signal first we should call waitpid again to read the
target's exit status.

This also fixes a nil pointer dereference when trapWaitInternal returns
an error, this fix is probably incomplete but I wasn't able to
reproduce its circumstances after 30000 runs of TestIssue1101 to
properly address it.
