### PR TITLE
proc: make some type casts less counterintuitive

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -344,6 +344,7 @@ func main() {
 	runearray := [4]rune{116, 232, 115, 116}
 
 	longstr := "very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"
+	longbyteslice := []byte(longstr)
 	m5 := map[C]int{{longstr}: 1}
 	m6 := map[string]int{longstr: 123}
 	m7 := map[C]C{{longstr}: {"hello"}}
@@ -403,5 +404,5 @@ func main() {
 	longslice := make([]int, 100, 100)
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan)
+	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice)
 }

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -770,21 +770,23 @@ func getEvalExpressionTestCases() []varTest {
 
 		{"ptrinf2", false, `**(main.pptr)(…`, `(main.pptr)(…`, "main.pptr", nil},
 
-		// conversions between string/[]byte/[]rune (issue #548)
+		// conversions between string/[]byte/[]rune (issue #548, #3595, #3539)
 		{"runeslice", true, `[]int32 len: 4, cap: 4, [116,232,115,116]`, `[]int32 len: 4, cap: 4, [...]`, "[]int32", nil},
 		{"byteslice", true, `[]uint8 len: 5, cap: 5, [116,195,168,115,116]`, `[]uint8 len: 5, cap: 5, [...]`, "[]uint8", nil},
-		{"[]byte(str1)", false, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, "[]uint8", nil},
-		{"[]uint8(str1)", false, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, "[]uint8", nil},
+		{"[]byte(str1)", false, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]uint8 len: 11, cap: 11, nil`, "[]uint8", nil},
+		{"[]uint8(str1)", false, `[]uint8 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]uint8 len: 11, cap: 11, nil`, "[]uint8", nil},
 		{"[]rune(str1)", false, `[]int32 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]int32 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, "[]int32", nil},
 		{"[]int32(str1)", false, `[]int32 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, `[]int32 len: 11, cap: 11, [48,49,50,51,52,53,54,55,56,57,48]`, "[]int32", nil},
-		{"string(byteslice)", false, `"tèst"`, `""`, "string", nil},
-		{"[]int32(string(byteslice))", false, `[]int32 len: 4, cap: 4, [116,232,115,116]`, `[]int32 len: 0, cap: 0, nil`, "[]int32", nil},
-		{"string(runeslice)", false, `"tèst"`, `""`, "string", nil},
-		{"[]byte(string(runeslice))", false, `[]uint8 len: 5, cap: 5, [116,195,168,115,116]`, `[]uint8 len: 0, cap: 0, nil`, "[]uint8", nil},
+		{"string(byteslice)", false, `"tèst"`, `"tèst"`, "string", nil},
+		{"[]int32(string(byteslice))", false, `[]int32 len: 4, cap: 4, [116,232,115,116]`, `[]int32 len: 4, cap: 4, [116,232,115,116]`, "[]int32", nil},
+		{"string(runeslice)", false, `"tèst"`, `"tèst"`, "string", nil},
+		{"[]byte(string(runeslice))", false, `[]uint8 len: 5, cap: 5, [116,195,168,115,116]`, `[]uint8 len: 5, cap: 5, [116,195,168,115,116]`, "[]uint8", nil},
 		{"*(*[5]byte)(uintptr(&byteslice[0]))", false, `[5]uint8 [116,195,168,115,116]`, `[5]uint8 [...]`, "[5]uint8", nil},
-		{"string(bytearray)", false, `"tèst"`, `""`, "string", nil},
-		{"string(runearray)", false, `"tèst"`, `""`, "string", nil},
+		{"string(bytearray)", false, `"tèst"`, `"tèst"`, "string", nil},
+		{"string(runearray)", false, `"tèst"`, `"tèst"`, "string", nil},
 		{"string(str1)", false, `"01234567890"`, `"01234567890"`, "string", nil},
+		{"len([]byte(longstr))", false, `137`, `137`, "", nil},
+		{"len(string(longbyteslice))", false, `137`, `137`, "", nil},
 
 		// access to channel field members
 		{"ch1.qcount", false, "4", "4", "uint", nil},
@@ -831,7 +833,7 @@ func getEvalExpressionTestCases() []varTest {
 		{`m6["very long string 0123456789a0123456789b0123456789c0123456789d0123456789e0123456789f0123456789g012345678h90123456789i0123456789j0123456789"]`, false, `123`, `123`, "int", nil},
 
 		// issue #1423 - special typecasts everywhere
-		{`string(byteslice) == "tèst"`, false, `true`, `false`, "", nil},
+		{`string(byteslice) == "tèst"`, false, `true`, `true`, "", nil},
 
 		// issue #3138 - typecast to *interface{} breaking
 		{`*(*interface {})(uintptr(&iface1))`, false, `interface {}(*main.astruct) *{A: 1, B: 2}`, `interface {}(*main.astruct)…`, "interface {}", nil},

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1514,3 +1514,24 @@ func TestSubstitutePathAndList(t *testing.T) {
 		}
 	})
 }
+
+func TestDisplay(t *testing.T) {
+	// Tests that display command works. See issue #3595.
+	type testCase struct{ in, tgt string }
+	withTestTerminal("testvariables2", t, func(term *FakeTerminal) {
+		term.MustExec("continue")
+
+		for _, tc := range []testCase{
+			{"string(byteslice)", `0: string(byteslice) = "tèst"`},
+			{"string(byteslice[1:])", `0: string(byteslice[1:]) = "èst"`},
+			{"%s string(byteslice)", `0: string(byteslice) = tèst`},
+		} {
+			out := term.MustExec("display -a " + tc.in)
+			t.Logf("%q -> %q", tc.in, out)
+			if !strings.Contains(out, tc.tgt) {
+				t.Errorf("wrong output for 'display -a %s':\n\tgot: %q\n\texpected: %q", tc.in, out, tc.tgt)
+			}
+			term.MustExec("display -d 0")
+		}
+	})
+}


### PR DESCRIPTION
The interaction of type casts with load configuration is sometimes
counterintuitive. This commit changes the way it is performed so that
when converting slices to strings and vice versa the maximum size
corresponding to the target type is used (i.e. MaxStringLen when
converting slices to strings and MaxArrayValues when converting slices
to strings).

This doesn't fully solve the problem (conversions to []rune are
problematic and multiple chained type casts will still be confusing)
but removes the problem for the majority of practical uses.

Fixes #3595, #3539
