### PR TITLE
goversion: include pre-releases in VersionAfterOrEqual check

### DIFF
--- a/pkg/goversion/go_version.go
+++ b/pkg/goversion/go_version.go
@@ -209,7 +209,7 @@ func Installed() (GoVersion, bool) {
 // or go version) is major.minor or a later version, or a development
 // version.
 func VersionAfterOrEqual(version string, major, minor int) bool {
-	return VersionAfterOrEqualRev(version, major, minor, -1)
+	return VersionAfterOrEqualRev(version, major, minor, betaEnd)
 }
 
 // VersionAfterOrEqualRev checks that version (as returned by runtime.Version()


### PR DESCRIPTION
Change VersionAfterOrEqual(x, A, B) to return true for pre-releases of
version A.B. This is what it did before, it was broken when goversion
was changed to support the new version format.
