### PR TITLE
Cirrus-CI: update FreeBSD version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ env:
   GOFLAGS: -mod=vendor
 
 freebsd_instance:
-  image_family: freebsd-12-3
+  image_family: freebsd-13-2
 
 test_task:
   install_script: pkg install -y go gcc git


### PR DESCRIPTION
It looks like FreeBSD 12 is no longer available
