### PR TITLE
go.mod: Update version of go-delve/liner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/creack/pty v1.1.20
 	github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d
 	github.com/go-delve/gore v0.11.6
-	github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d
+	github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62
 	github.com/google/go-dap v0.11.0
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/mattn/go-colorable v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx
 github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/go-delve/gore v0.11.6 h1:MyP7xTNQO+dDiLBKxI/DKgkn74cMBjHZZxS8grtJ6G8=
 github.com/go-delve/gore v0.11.6/go.mod h1:6RBVnEUxVGkztpRY0UDUnEzS4GqETQjWrw8rhegmN4I=
-github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d h1:pxjSLshkZJGLVm0wv20f/H0oTWiq/egkoJQ2ja6LEvo=
-github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d/go.mod h1:biJCRbqp51wS+I92HMqn5H8/A0PAhxn2vyOT+JqhiGI=
+github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62 h1:IGtvsNyIuRjl04XAOFGACozgUD7A82UffYxZt4DWbvA=
+github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62/go.mod h1:biJCRbqp51wS+I92HMqn5H8/A0PAhxn2vyOT+JqhiGI=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-dap v0.11.0 h1:SpAZJL41rOOvd85PuLCCLE1dteTQOyKNnn0H3DBHywo=

--- a/vendor/github.com/go-delve/liner/signal_unix.go
+++ b/vendor/github.com/go-delve/liner/signal_unix.go
@@ -8,8 +8,9 @@ import (
 )
 
 func handleCtrlZ() {
-	p, err := os.FindProcess(os.Getpid())
+	pid := os.Getpid()
+	pgrp, err := syscall.Getpgid(pid)
 	if err == nil {
-		p.Signal(syscall.SIGTSTP)
+		syscall.Kill(-pgrp, syscall.SIGTSTP)
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/derekparker/trie
 # github.com/go-delve/gore v0.11.6
 ## explicit; go 1.21
 github.com/go-delve/gore
-# github.com/go-delve/liner v1.2.3-0.20220127212407-d32d89dd2a5d
+# github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62
 ## explicit
 github.com/go-delve/liner
 # github.com/google/go-dap v0.11.0


### PR DESCRIPTION
Update version of go-delve/liner to include the Ctrl-Z fix (SIGTSTP
should be sent to our process group instead of just sending it to
ourselves to correctly imitate a terminal).

Fixes #3605
