### PR TITLE
proc: fix dynamic library loading with musl loader

### DIFF
--- a/pkg/proc/linutil/dynamic.go
+++ b/pkg/proc/linutil/dynamic.go
@@ -165,6 +165,8 @@ func ElfUpdateSharedObjects(p proc.Process) error {
 
 	libs := []string{}
 
+	first := true
+
 	for {
 		if r_map == 0 {
 			break
@@ -176,8 +178,13 @@ func ElfUpdateSharedObjects(p proc.Process) error {
 		if err != nil {
 			return err
 		}
-		bi.AddImage(lm.name, lm.addr)
+		if !first || lm.addr != 0 {
+			// First entry is the executable, we don't need to add it, and doing so
+			// can cause duplicate entries due to base address mismatches.
+			bi.AddImage(lm.name, lm.addr)
+		}
 		libs = append(libs, lm.name)
+		first = false
 		r_map = lm.next
 	}
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2622,7 +2622,7 @@ func libraries(t *Term, ctx callContext, args string) error {
 	for i := range libs {
 		fmt.Fprintf(t.stdout, "%"+strconv.Itoa(d)+"d. %#x %s\n", i, libs[i].Address, libs[i].Path)
 		if libs[i].LoadError != "" {
-			fmt.Fprintf(t.stdout, "    Load error: %s", libs[i].LoadError)
+			fmt.Fprintf(t.stdout, "    Load error: %s\n", libs[i].LoadError)
 		}
 	}
 	return nil


### PR DESCRIPTION
With the glibc loader the link map entry for the static executable has
an empty name field and address equal to 0x0. This case was already
handled by the check in bininfo.go AddImage for names to be valid
paths.

With the musl loader however the first entry, corresponding to the
static executable, has a valid path with address equal to 0x0, since we
record a real address for the image corresponding to the static
executable this results in having two entries for the executable when
musl is used to link go programs.

Change the code scanning the debug link map so that the first entry is
skipped if it has address equal to zero.

Fixes #3617
