### PR TITLE
TeamCity: speed up ppc64le CI

### DIFF
--- a/pkg/proc/proc_linux_test.go
+++ b/pkg/proc/proc_linux_test.go
@@ -14,7 +14,15 @@ import (
 	protest "github.com/go-delve/delve/pkg/proc/test"
 )
 
+func mustHaveObjcopy(t *testing.T) {
+	t.Helper()
+	if objcopyPath, _ := exec.LookPath("objcopy"); objcopyPath == "" {
+		t.Skip("no objcopy in path")
+	}
+}
+
 func TestLoadingExternalDebugInfo(t *testing.T) {
+	mustHaveObjcopy(t)
 	fixture := protest.BuildFixture("locationsprog", 0)
 	defer os.Remove(fixture.Path)
 	stripAndCopyDebugInfo(fixture, t)
@@ -26,6 +34,7 @@ func TestLoadingExternalDebugInfo(t *testing.T) {
 }
 
 func TestGnuDebuglink(t *testing.T) {
+	mustHaveObjcopy(t)
 	// build math.go and make a copy of the executable
 	fixture := protest.BuildFixture("math", 0)
 	buf, err := os.ReadFile(fixture.Path)

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4449,6 +4449,7 @@ func findSource(source string, sources []string) bool {
 }
 
 func TestListImages(t *testing.T) {
+	protest.MustHaveCgo(t)
 	pluginFixtures := protest.WithPlugins(t, protest.AllNonOptimized, "plugin1/", "plugin2/")
 
 	withTestProcessArgs("plugintest", t, ".", []string{pluginFixtures[0].Path, pluginFixtures[1].Path}, protest.AllNonOptimized, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
@@ -4596,6 +4597,7 @@ func TestCallConcurrent(t *testing.T) {
 }
 
 func TestPluginStepping(t *testing.T) {
+	protest.MustHaveCgo(t)
 	pluginFixtures := protest.WithPlugins(t, protest.AllNonOptimized, "plugin1/", "plugin2/")
 
 	testseq2Args(".", []string{pluginFixtures[0].Path, pluginFixtures[1].Path}, protest.AllNonOptimized, t, "plugintest2", "", []seqTest{

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -7489,6 +7489,7 @@ func TestFindInstructions(t *testing.T) {
 func TestDisassembleCgo(t *testing.T) {
 	// Test that disassembling a program containing cgo code does not create problems.
 	// See issue #3040
+	protest.MustHaveCgo(t)
 	runTestBuildFlags(t, "cgodisass", func(client *daptest.Client, fixture protest.Fixture) {
 		runDebugSessionWithBPs(t, client, "launch",
 			// Launch

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2789,6 +2789,9 @@ func TestNonGoDebug(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip()
 	}
+	if objcopyPath, _ := exec.LookPath("cc"); objcopyPath == "" {
+		t.Skip("no C compiler in path")
+	}
 	dir := protest.FindFixturesDir()
 	path := protest.TempFile("testc")
 	cmd := exec.Command("cc", "-g", "-o", path, filepath.Join(dir, "test.c"))


### PR DESCRIPTION
The builder is currently spending 15 to 20 minutes installing gcc and
upgrading packages every time we run the tests.

Because of this the build fails sometimes by running out of time.

This change reduces that to 5 minutes by:

* switching from curl to wget (which seems to have fewer dependencies)
* not installing gcc on ppc64le
* skipping tests that depend on gcc or other binutils
