### PR TITLE
proc/native: add support sentinel for FreeBSD with cgo disabled

### DIFF
--- a/pkg/proc/native/support_sentinel_cgo_freebsd.go
+++ b/pkg/proc/native/support_sentinel_cgo_freebsd.go
@@ -1,0 +1,5 @@
+//go:build freebsd && amd64 && !cgo
+
+// This file is used to detect building on freebsd with cgo disabled
+
+package can_not_build_on_freebsd_with_cgo_disabled


### PR DESCRIPTION
Adds a support sentinel file for building on FreeBSD with cgo disabled.

Makes the build error for FreeBSD easier to understand.

Fixes #3630
