### PR TITLE
proc: fix stacktrace frame after runtime.sigpanic

### DIFF
--- a/_fixtures/panicline.go
+++ b/_fixtures/panicline.go
@@ -1,0 +1,8 @@
+package main
+
+import "os"
+
+func main() {
+	fi, _ := os.Lstat("/this/path/does/not/exist")
+	fi.Size()
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -6121,3 +6121,28 @@ func TestIssue3545(t *testing.T) {
 		}
 	})
 }
+
+func TestPanicLine(t *testing.T) {
+	withTestProcess("panicline", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+		err := grp.Continue()
+		if runtime.GOOS == "darwin" && err != nil && err.Error() == "bad access" {
+			// not supported
+			return
+		}
+		assertNoError(err, t, "Continue()")
+		frames, err := proc.ThreadStacktrace(p, p.CurrentThread(), 20)
+		assertNoError(err, t, "ThreadStacktrace")
+		logStacktrace(t, p, frames)
+
+		found := false
+		for _, frame := range frames {
+			if strings.HasSuffix(frame.Call.File, "panicline.go") && frame.Call.Line == 7 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("could not find panicline.go:6")
+		}
+	})
+}


### PR DESCRIPTION
The first frame after sigpanic didn't execute a call so we shouldn't
decrement the PC address to look up its location.

Fixes #3634
