### PR TITLE
service/dap: make TestEvaluateCallFunction independent of line numbers

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1576,7 +1576,7 @@ func (s *Session) onSetFunctionBreakpointsRequest(request *dap.SetFunctionBreakp
 		if len(locs) == 0 {
 			return nil, err
 		}
-		if len(locs) > 0 {
+		if len(locs) > 1 {
 			s.config.log.Debugf("multiple locations found for %s", want.Name)
 		}
 


### PR DESCRIPTION
_fixtures/fncall.go was made to support TestCallFunction in pkg/proc
and new things must be added to fncall.go to test new features. Having
a test depend on precise line numbers makes the process tedious.
