### PR TITLE
terminal: add prompt color option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,6 +76,9 @@ type Config struct {
 	// Source list comment color, as a terminal escape sequence.
 	SourceListCommentColor string `yaml:"source-list-comment-color"`
 
+	// Color for the prompt line.
+	PromptColor string `yaml:"prompt-color"`
+
 	// Source list tab color, as a terminal escape sequence.
 	SourceListTabColor string `yaml:"source-list-tab-color"`
 

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -423,6 +423,10 @@ func (t *Term) formatPath(path string) string {
 }
 
 func (t *Term) promptForInput() (string, error) {
+	if t.stdout.colorEscapes != nil && t.conf.PromptColor != "" {
+		fmt.Fprint(os.Stdout, t.conf.PromptColor)
+		defer fmt.Fprint(os.Stdout, terminalResetEscapeCode)
+	}
 	l, err := t.line.Prompt(t.prompt)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Add option to configure prompt color.

Fixes #3603
