### PR TITLE
terminal: add color highlighting to stacktraces

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,12 @@ type Config struct {
 	// Source list tab color, as a terminal escape sequence.
 	SourceListTabColor string `yaml:"source-list-tab-color"`
 
+	// Color for function names in the stack trace.
+	StackTraceFunctionColor string `yaml:"stacktrace-function-color"`
+
+	// Color for the base name in paths in the stack trace.
+	StackTraceBasenameColor string `yaml:"stacktrace-basename-color"`
+
 	// number of lines to list above and below cursor when printfile() is
 	// called (i.e. when execution stops, listCommand is used, etc)
 	SourceListLineCount *int `yaml:"source-list-line-count,omitempty"`

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2639,7 +2639,7 @@ func digits(n int) int {
 }
 
 func printStack(t *Term, out io.Writer, stack []api.Stackframe, ind string, offsets bool) {
-	api.PrintStack(t.formatPath, out, stack, ind, offsets, func(api.Stackframe) bool { return true })
+	api.PrintStack(t.formatPath, out, stack, ind, offsets, t.stackTraceColors, func(api.Stackframe) bool { return true })
 }
 
 func printcontext(t *Term, state *api.DebuggerState) {

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -60,6 +60,8 @@ type Term struct {
 	displays []displayEntry
 	oldPid   int
 
+	stackTraceColors api.StackTraceColors
+
 	historyFile *os.File
 
 	starlarkEnv *starbind.Env
@@ -160,6 +162,17 @@ func (t *Term) updateColorScheme() {
 	case nil:
 		t.stdout.colorEscapes[colorize.LineNoStyle] = fmt.Sprintf(terminalHighlightEscapeCode, ansiBlue)
 	}
+
+	wd2 := func(s, defaultStr string) string {
+		if s == "" {
+			return defaultStr
+		}
+		return s
+	}
+
+	t.stackTraceColors.FunctionColor = wd2(conf.StackTraceFunctionColor, "\033[1m")
+	t.stackTraceColors.BasenameColor = wd2(conf.StackTraceBasenameColor, "\033[1m")
+	t.stackTraceColors.NormalColor = terminalResetEscapeCode
 }
 
 func (t *Term) updateTab() {

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -564,7 +564,13 @@ func digits(n int) int {
 	return int(math.Floor(math.Log10(float64(n)))) + 1
 }
 
-func PrintStack(formatPath func(string) string, out io.Writer, stack []Stackframe, ind string, offsets bool, include func(Stackframe) bool) {
+type StackTraceColors struct {
+	FunctionColor string
+	BasenameColor string
+	NormalColor   string
+}
+
+func PrintStack(formatPath func(string) string, out io.Writer, stack []Stackframe, ind string, offsets bool, stc StackTraceColors, include func(Stackframe) bool) {
 	if len(stack) == 0 {
 		return
 	}
@@ -577,8 +583,22 @@ func PrintStack(formatPath func(string) string, out io.Writer, stack []Stackfram
 		extranl = extranl || (len(stack[i].Defers) > 0) || (len(stack[i].Arguments) > 0) || (len(stack[i].Locals) > 0)
 	}
 
+	fileLine := func(file string, line int) string {
+		file = formatPath(file)
+		if stc.BasenameColor == "" {
+			return fmt.Sprintf("%s:%d", file, line)
+		}
+		slash := strings.LastIndex(file, "/")
+		if slash < 0 {
+			slash = 0
+		} else {
+			slash++
+		}
+		return fmt.Sprintf("%s%s%s:%d%s", file[:slash], stc.BasenameColor, file[slash:], line, stc.NormalColor)
+	}
+
 	d := digits(len(stack) - 1)
-	fmtstr := "%s%" + strconv.Itoa(d) + "d  0x%016x in %s\n"
+	fmtstr := "%s%" + strconv.Itoa(d) + "d  0x%016x in " + stc.FunctionColor + "%s" + stc.NormalColor + "\n"
 	s := ind + strings.Repeat(" ", d+2+len(ind))
 
 	for i := range stack {
@@ -590,7 +610,7 @@ func PrintStack(formatPath func(string) string, out io.Writer, stack []Stackfram
 			continue
 		}
 		fmt.Fprintf(out, fmtstr, ind, i, stack[i].PC, stack[i].Function.Name())
-		fmt.Fprintf(out, "%sat %s:%d\n", s, formatPath(stack[i].File), stack[i].Line)
+		fmt.Fprintf(out, "%sat %s\n", s, fileLine(stack[i].File, stack[i].Line))
 
 		if offsets {
 			fmt.Fprintf(out, "%sframe: %+#x frame pointer %+#x\n", s, stack[i].FrameOffset, stack[i].FramePointerOffset)
@@ -603,9 +623,9 @@ func PrintStack(formatPath func(string) string, out io.Writer, stack []Stackfram
 				fmt.Fprintf(out, "%s(unreadable defer: %s)\n", deferHeader, d.Unreadable)
 				continue
 			}
-			fmt.Fprintf(out, "%s%#016x in %s\n", deferHeader, d.DeferredLoc.PC, d.DeferredLoc.Function.Name())
+			fmt.Fprintf(out, "%s%#016x in %s%s%s\n", deferHeader, d.DeferredLoc.PC, stc.FunctionColor, d.DeferredLoc.Function.Name(), stc.NormalColor)
 			fmt.Fprintf(out, "%sat %s:%d\n", s2, formatPath(d.DeferredLoc.File), d.DeferredLoc.Line)
-			fmt.Fprintf(out, "%sdeferred by %s at %s:%d\n", s2, d.DeferLoc.Function.Name(), formatPath(d.DeferLoc.File), d.DeferLoc.Line)
+			fmt.Fprintf(out, "%sdeferred by %s at %s\n", s2, d.DeferLoc.Function.Name(), fileLine(d.DeferLoc.File, d.DeferLoc.Line))
 		}
 
 		for j := range stack[i].Arguments {

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -3458,7 +3458,7 @@ func (s *Session) stacktrace(goroutineID int64, g *proc.G) (string, error) {
 	fmt.Fprintln(&buf, "Stack:")
 	userLoc := g.UserCurrent()
 	userFuncPkg := fnPackageName(&userLoc)
-	api.PrintStack(s.toClientPath, &buf, apiFrames, "\t", false, func(s api.Stackframe) bool {
+	api.PrintStack(s.toClientPath, &buf, apiFrames, "\t", false, api.StackTraceColors{}, func(s api.Stackframe) bool {
 		// Include all stack frames if the stack trace is for a system goroutine,
 		// otherwise, skip runtime stack frames.
 		if userFuncPkg == "runtime" {


### PR DESCRIPTION
Adds configurable highlighting for function names and filenames in stack traces.

Fixes #720
