### PR TITLE
Don't use a fixed width for s when parsing /proc/net/tcp lines

### DIFF
--- a/service/internal/sameuser/sameuser_linux.go
+++ b/service/internal/sameuser/sameuser_linux.go
@@ -42,10 +42,11 @@ func sameUserForHexLocalAddr(filename, localAddr, remoteAddr string) (bool, erro
 			retransmit                    int
 			remoteUID                     uint
 		)
-		// Note that we must use %d where the kernel format uses %5u:
-		// %u is not understood by the fmt package (%U is something else),
-		// %5d cuts off longer uids (e.g. 149098 on gLinux).
-		n, err := fmt.Sscanf(line, "%4d: %s %s %02X %s %s %08X %d",
+		// Note that we must use %d where the kernel format uses %4d or %5u:
+		// - %4d fails to parse for large number of entries (len(sl) > 4)
+		// - %u is not understood by the fmt package (%U is something else)
+		// - %5d cuts off longer uids (e.g. 149098 on gLinux)
+		n, err := fmt.Sscanf(line, "%d: %s %s %02X %s %s %08X %d",
 			&sl, &readLocalAddr, &readRemoteAddr, &state, &queue, &timer, &retransmit, &remoteUID)
 		if n != 8 || err != nil {
 			continue // invalid line (e.g. header line)


### PR DESCRIPTION
If /proc/net/tcp contains a large number of entries (>9999), parsing lines with len(sl) > 4 fails with the fixed width pattern. In that case the lines are silently ignored.