### PR TITLE
dwarfbuilder: fix makeAbbrevTable

### DIFF
--- a/pkg/dwarf/dwarfbuilder/info.go
+++ b/pkg/dwarf/dwarfbuilder/info.go
@@ -244,6 +244,8 @@ func (b *Builder) makeAbbrevTable() []byte {
 		leb128.EncodeUnsigned(&abbrev, 0)
 	}
 
+	leb128.EncodeUnsigned(&abbrev, uint64(0))
+
 	return abbrev.Bytes()
 }
 


### PR DESCRIPTION
It did not terminate the section with the required 0 byte.
