### PR TITLE
Upgrade github.com/google/go-dap to v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/creack/pty v1.1.20
 	github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d
 	github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62
-	github.com/google/go-dap v0.11.0
+	github.com/google/go-dap v0.12.0
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62 h1:IGtvsNyIuRjl04
 github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62/go.mod h1:biJCRbqp51wS+I92HMqn5H8/A0PAhxn2vyOT+JqhiGI=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-dap v0.11.0 h1:SpAZJL41rOOvd85PuLCCLE1dteTQOyKNnn0H3DBHywo=
-github.com/google/go-dap v0.11.0/go.mod h1:HAeyoSd2WIfTfg+0GRXcFrb+RnojAtGNh+k+XTIxJDE=
+github.com/google/go-dap v0.12.0 h1:rVcjv3SyMIrpaOoTAdFDyHs99CwVOItIJGKLQFQhNeM=
+github.com/google/go-dap v0.12.0/go.mod h1:tNjCASCm5cqePi/RVXXWEVqtnNLV1KTWtYOqu6rZNzc=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/vendor/github.com/google/go-dap/schematypes.go
+++ b/vendor/github.com/google/go-dap/schematypes.go
@@ -201,7 +201,7 @@ type TerminatedEvent struct {
 }
 
 type TerminatedEventBody struct {
-	Restart interface{} `json:"restart,omitempty"`
+	Restart json.RawMessage `json:"restart,omitempty"`
 }
 
 // ThreadEvent: The event indicates that a thread has started or exited.
@@ -224,14 +224,14 @@ type OutputEvent struct {
 }
 
 type OutputEventBody struct {
-	Category           string      `json:"category,omitempty"`
-	Output             string      `json:"output"`
-	Group              string      `json:"group,omitempty"`
-	VariablesReference int         `json:"variablesReference,omitempty"`
-	Source             *Source     `json:"source,omitempty"`
-	Line               int         `json:"line,omitempty"`
-	Column             int         `json:"column,omitempty"`
-	Data               interface{} `json:"data,omitempty"`
+	Category           string          `json:"category,omitempty"`
+	Output             string          `json:"output"`
+	Group              string          `json:"group,omitempty"`
+	VariablesReference int             `json:"variablesReference,omitempty"`
+	Source             *Source         `json:"source,omitempty"`
+	Line               int             `json:"line,omitempty"`
+	Column             int             `json:"column,omitempty"`
+	Data               json.RawMessage `json:"data,omitempty"`
 }
 
 // BreakpointEvent: The event indicates that some information about a breakpoint has changed.
@@ -388,12 +388,12 @@ type RunInTerminalRequest struct {
 
 // RunInTerminalRequestArguments: Arguments for `runInTerminal` request.
 type RunInTerminalRequestArguments struct {
-	Kind                        string                 `json:"kind,omitempty"`
-	Title                       string                 `json:"title,omitempty"`
-	Cwd                         string                 `json:"cwd"`
-	Args                        []string               `json:"args"`
-	Env                         map[string]interface{} `json:"env,omitempty"`
-	ArgsCanBeInterpretedByShell bool                   `json:"argsCanBeInterpretedByShell,omitempty"`
+	Kind                        string         `json:"kind,omitempty"`
+	Title                       string         `json:"title,omitempty"`
+	Cwd                         string         `json:"cwd"`
+	Args                        []string       `json:"args"`
+	Env                         map[string]any `json:"env,omitempty"`
+	ArgsCanBeInterpretedByShell bool           `json:"argsCanBeInterpretedByShell,omitempty"`
 }
 
 // RunInTerminalResponse: Response to `runInTerminal` request.
@@ -419,8 +419,8 @@ type StartDebuggingRequest struct {
 
 // StartDebuggingRequestArguments: Arguments for `startDebugging` request.
 type StartDebuggingRequestArguments struct {
-	Configuration map[string]interface{} `json:"configuration"`
-	Request       string                 `json:"request"`
+	Configuration map[string]any `json:"configuration"`
+	Request       string         `json:"request"`
 }
 
 // StartDebuggingResponse: Response to `startDebugging` request. This is just an acknowledgement, so no body field is required.
@@ -518,12 +518,7 @@ type AttachResponse struct {
 type RestartRequest struct {
 	Request
 
-	Arguments *RestartArguments `json:"arguments,omitempty"`
-}
-
-// RestartArguments: Arguments for `restart` request.
-type RestartArguments struct {
-	Arguments interface{} `json:"arguments,omitempty"`
+	Arguments json.RawMessage `json:"arguments"`
 }
 
 // RestartResponse: Response to `restart` request. This is just an acknowledgement, so no body field is required.
@@ -713,7 +708,7 @@ type DataBreakpointInfoResponse struct {
 }
 
 type DataBreakpointInfoResponseBody struct {
-	DataId      interface{}                `json:"dataId"`
+	DataId      any                        `json:"dataId"`
 	Description string                     `json:"description"`
 	AccessTypes []DataBreakpointAccessType `json:"accessTypes,omitempty"`
 	CanPersist  bool                       `json:"canPersist,omitempty"`
@@ -1511,16 +1506,16 @@ type ErrorMessage struct {
 //
 // To avoid an unnecessary proliferation of additional attributes with similar semantics but different names, we recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.
 type Module struct {
-	Id             interface{} `json:"id"`
-	Name           string      `json:"name"`
-	Path           string      `json:"path,omitempty"`
-	IsOptimized    bool        `json:"isOptimized,omitempty"`
-	IsUserCode     bool        `json:"isUserCode,omitempty"`
-	Version        string      `json:"version,omitempty"`
-	SymbolStatus   string      `json:"symbolStatus,omitempty"`
-	SymbolFilePath string      `json:"symbolFilePath,omitempty"`
-	DateTimeStamp  string      `json:"dateTimeStamp,omitempty"`
-	AddressRange   string      `json:"addressRange,omitempty"`
+	Id             any    `json:"id"`
+	Name           string `json:"name"`
+	Path           string `json:"path,omitempty"`
+	IsOptimized    bool   `json:"isOptimized,omitempty"`
+	IsUserCode     bool   `json:"isUserCode,omitempty"`
+	Version        string `json:"version,omitempty"`
+	SymbolStatus   string `json:"symbolStatus,omitempty"`
+	SymbolFilePath string `json:"symbolFilePath,omitempty"`
+	DateTimeStamp  string `json:"dateTimeStamp,omitempty"`
+	AddressRange   string `json:"addressRange,omitempty"`
 }
 
 // ColumnDescriptor: A `ColumnDescriptor` specifies what module attribute to show in a column of the modules view, how to format it,
@@ -1549,29 +1544,29 @@ type Thread struct {
 // Source: A `Source` is a descriptor for source code.
 // It is returned from the debug adapter as part of a `StackFrame` and it is used by clients when specifying breakpoints.
 type Source struct {
-	Name             string      `json:"name,omitempty"`
-	Path             string      `json:"path,omitempty"`
-	SourceReference  int         `json:"sourceReference,omitempty"`
-	PresentationHint string      `json:"presentationHint,omitempty"`
-	Origin           string      `json:"origin,omitempty"`
-	Sources          []Source    `json:"sources,omitempty"`
-	AdapterData      interface{} `json:"adapterData,omitempty"`
-	Checksums        []Checksum  `json:"checksums,omitempty"`
+	Name             string          `json:"name,omitempty"`
+	Path             string          `json:"path,omitempty"`
+	SourceReference  int             `json:"sourceReference,omitempty"`
+	PresentationHint string          `json:"presentationHint,omitempty"`
+	Origin           string          `json:"origin,omitempty"`
+	Sources          []Source        `json:"sources,omitempty"`
+	AdapterData      json.RawMessage `json:"adapterData,omitempty"`
+	Checksums        []Checksum      `json:"checksums,omitempty"`
 }
 
 // StackFrame: A Stackframe contains the source location.
 type StackFrame struct {
-	Id                          int         `json:"id"`
-	Name                        string      `json:"name"`
-	Source                      *Source     `json:"source,omitempty"`
-	Line                        int         `json:"line"`
-	Column                      int         `json:"column"`
-	EndLine                     int         `json:"endLine,omitempty"`
-	EndColumn                   int         `json:"endColumn,omitempty"`
-	CanRestart                  bool        `json:"canRestart,omitempty"`
-	InstructionPointerReference string      `json:"instructionPointerReference,omitempty"`
-	ModuleId                    interface{} `json:"moduleId,omitempty"`
-	PresentationHint            string      `json:"presentationHint,omitempty"`
+	Id                          int     `json:"id"`
+	Name                        string  `json:"name"`
+	Source                      *Source `json:"source,omitempty"`
+	Line                        int     `json:"line"`
+	Column                      int     `json:"column"`
+	EndLine                     int     `json:"endLine,omitempty"`
+	EndColumn                   int     `json:"endColumn,omitempty"`
+	CanRestart                  bool    `json:"canRestart,omitempty"`
+	InstructionPointerReference string  `json:"instructionPointerReference,omitempty"`
+	ModuleId                    any     `json:"moduleId,omitempty"`
+	PresentationHint            string  `json:"presentationHint,omitempty"`
 }
 
 // Scope: A `Scope` is a named container for variables. Optionally a scope can map to a source or a range within a source.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,8 +27,8 @@ github.com/derekparker/trie
 # github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62
 ## explicit
 github.com/go-delve/liner
-# github.com/google/go-dap v0.11.0
-## explicit; go 1.13
+# github.com/google/go-dap v0.12.0
+## explicit; go 1.18
 github.com/google/go-dap
 # github.com/hashicorp/golang-lru v1.0.2
 ## explicit; go 1.12


### PR DESCRIPTION
A new version of github.com/google/go-dap is available, update to latest.