### PR TITLE
proc/evalop: remove no longer needed Go 1.17 files

### DIFF
--- a/pkg/proc/evalop/eval_go117.go
+++ b/pkg/proc/evalop/eval_go117.go
@@ -1,9 +1,0 @@
-//go:build !go1.18
-
-package evalop
-
-import "go/ast"
-
-type astIndexListExpr struct {
-	ast.Expr
-}

--- a/pkg/proc/evalop/eval_go118.go
+++ b/pkg/proc/evalop/eval_go118.go
@@ -1,7 +1,0 @@
-//go:build go1.18
-
-package evalop
-
-import "go/ast"
-
-type astIndexListExpr = ast.IndexListExpr

--- a/pkg/proc/evalop/evalcompile.go
+++ b/pkg/proc/evalop/evalcompile.go
@@ -359,7 +359,7 @@ func (ctx *compileCtx) compileTypeCastOrFuncCall(node *ast.CallExpr) error {
 		default:
 			return ctx.compileFunctionCall(node)
 		}
-	case *astIndexListExpr:
+	case *ast.IndexListExpr:
 		return ctx.compileTypeCast(node, nil)
 	default:
 		// All other expressions must be function calls


### PR DESCRIPTION
The PR cleans up code files that are needed to support compiling with Go 1.17. Since the https://github.com/go-delve/delve/pull/3589 these files are not used.