### PR TITLE
dwarf/loclist: remove impossible condition

### DIFF
--- a/pkg/dwarf/loclist/dwarf5_loclist.go
+++ b/pkg/dwarf/loclist/dwarf5_loclist.go
@@ -118,10 +118,6 @@ func (it *loclistsIterator) next() bool {
 
 	case _DW_LLE_base_addressx:
 		baseIdx, _ := leb128.DecodeUnsigned(it.buf)
-		if err != nil {
-			it.err = err
-			return false
-		}
 		it.base, it.err = it.debugAddr.Get(baseIdx)
 		it.base += it.staticBase
 		it.onRange = false


### PR DESCRIPTION
The PR removes the redundant `err != nil` check because `err` cannot be `nil` in that context.

This was found by the [`nilness`](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/nilness/cmd/nilness) analyzer:
```sh
❯ go install golang.org/x/tools/go/analysis/passes/nilness/cmd/nilness@latest
❯ go vet -vettool=$(which nilness) ./...
# github.com/go-delve/delve/pkg/dwarf/loclist
# [github.com/go-delve/delve/pkg/dwarf/loclist]
pkg/dwarf/loclist/dwarf5_loclist.go:121:10: impossible condition: nil != nil
```