### PR TITLE
proc: support reading captured variables of closures

### DIFF
--- a/_fixtures/closurecontents.go
+++ b/_fixtures/closurecontents.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func makeAcc(scale int) func(x int) int {
+	a := 0
+	return func(x int) int {
+		a += x * scale
+		return a
+	}
+}
+
+func main() {
+	acc := makeAcc(3)
+	runtime.Breakpoint()
+	fmt.Println(acc(1))
+	runtime.Breakpoint()
+	fmt.Println(acc(2))
+	runtime.Breakpoint()
+	fmt.Println(acc(6))
+	runtime.Breakpoint()
+}

--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -27,6 +27,7 @@ const (
 	AttrGoRuntimeType   dwarf.Attr = 0x2904
 	AttrGoPackageName   dwarf.Attr = 0x2905
 	AttrGoDictIndex     dwarf.Attr = 0x2906
+	AttrGoClosureOffset dwarf.Attr = 0x2907
 )
 
 // Basic type encodings -- the value for AttrEncoding in a TagBaseType Entry.

--- a/pkg/dwarf/reader/variables.go
+++ b/pkg/dwarf/reader/variables.go
@@ -24,6 +24,7 @@ const (
 	VariablesSkipInlinedSubroutines
 	VariablesTrustDeclLine
 	VariablesNoDeclLineCheck
+	VariablesOnlyCaptured
 )
 
 // Variables returns a list of variables contained inside 'root'.

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -176,6 +176,15 @@ func (v *Variable) writeTo(buf io.Writer, flags prettyFlags, indent, fmtstr stri
 			fmt.Fprint(buf, "nil")
 		} else {
 			fmt.Fprintf(buf, "%s", v.Value)
+			if flags.newlines() && len(v.Children) > 0 {
+				fmt.Fprintf(buf, " {\n")
+				for i := range v.Children {
+					fmt.Fprintf(buf, "%s%s%s %s = ", indent, indentString, v.Children[i].Name, v.Children[i].typeStr(flags))
+					v.Children[i].writeTo(buf, flags.set(prettyTop, false).set(prettyIncludeType, false), indent+indentString, fmtstr)
+					fmt.Fprintf(buf, "\n")
+				}
+				fmt.Fprintf(buf, "%s}", indent)
+			}
 		}
 	default:
 		v.writeBasicType(buf, fmtstr)

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -321,12 +321,12 @@ type Variable struct {
 	// Function variables will store the name of the function in this field
 	Value string `json:"value"`
 
-	// Number of elements in an array or a slice, number of keys for a map, number of struct members for a struct, length of strings
+	// Number of elements in an array or a slice, number of keys for a map, number of struct members for a struct, length of strings, number of captured variables for functions
 	Len int64 `json:"len"`
 	// Cap value for slices
 	Cap int64 `json:"cap"`
 
-	// Array and slice elements, member fields of structs, key/value pairs of maps, value of complex numbers
+	// Array and slice elements, member fields of structs, key/value pairs of maps, value of complex numbers, captured variables of functions.
 	// The Name field in this slice will always be the empty string except for structs (when it will be the field name) and for complex numbers (when it will be "real" and "imaginary")
 	// For maps each map entry will have to items in this slice, even numbered items will represent map keys and odd numbered items will represent their values
 	// This field's length is capped at proc.maxArrayValues for slices and arrays and 2*proc.maxArrayValues for maps, in the circumstances where the cap takes effect len(Children) != Len

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2746,7 +2746,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 				variablesReference = maybeCreateVariableHandle(v)
 			}
 		}
-	case reflect.Struct:
+	case reflect.Struct, reflect.Func:
 		if v.Len > int64(len(v.Children)) { // Not fully loaded
 			if len(v.Children) == 0 { // Fully missing
 				value = reloadVariable(v, qualifiedNameOrExpr)
@@ -2771,7 +2771,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 			v.Children[1].Kind = reflect.Float64
 		}
 		fallthrough
-	default: // Complex, Scalar, Chan, Func
+	default: // Complex, Scalar, Chan
 		if len(v.Children) > 0 {
 			variablesReference = maybeCreateVariableHandle(v)
 		}


### PR DESCRIPTION
Supports showing captured variables for function closures on versions
of Go that export informations about the closure struct (Go >= 1.23)

Fixes #3612
