### PR TITLE
proc: generalize escapeCheck and allocString

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1163,12 +1163,9 @@ func (scope *EvalScope) evalJump(op *evalop.Jump, stack *evalStack) {
 	case evalop.JumpIfFalse:
 		v = false
 	case evalop.JumpIfAllocStringChecksFail:
-		if !(x.Kind == reflect.String && x.Addr == 0 && (x.Flags&VariableConstant) != 0 && x.Len > 0) {
-			stack.opidx = op.Target - 1
-			return
-		}
-		if scope.callCtx == nil {
-			// do not complain here, setValue will if no other errors happen
+		stringChecksFailed := x.Kind != reflect.String || x.Addr != 0 || x.Flags&VariableConstant == 0 || x.Len <= 0
+		nilCallCtx := scope.callCtx == nil // do not complain here, setValue will if no other errors happen
+		if stringChecksFailed || nilCallCtx {
 			stack.opidx = op.Target - 1
 			return
 		}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1045,6 +1045,10 @@ func (stack *evalStack) executeOp() {
 		}
 		stack.push(v)
 
+	case *evalop.PushLen:
+		v := stack.peek()
+		stack.push(newConstant(constant.MakeInt64(v.Len), scope.Mem))
+
 	case *evalop.Select:
 		scope.evalStructSelector(op, stack)
 
@@ -1112,8 +1116,11 @@ func (stack *evalStack) executeOp() {
 		stack.fncallPeek().undoInjection = nil
 		stack.callInjectionContinue = true
 
-	case *evalop.CallInjectionAllocString:
-		stack.callInjectionContinue = scope.allocString(op.Phase, stack, curthread)
+	case *evalop.CallInjectionStartSpecial:
+		stack.callInjectionContinue = scope.callInjectionStartSpecial(stack, op, curthread)
+
+	case *evalop.ConvertAllocToString:
+		scope.convertAllocToString(stack)
 
 	case *evalop.SetValue:
 		lhv := stack.pop()
@@ -1155,6 +1162,17 @@ func (scope *EvalScope) evalJump(op *evalop.Jump, stack *evalStack) {
 		v = true
 	case evalop.JumpIfFalse:
 		v = false
+	case evalop.JumpIfAllocStringChecksFail:
+		if !(x.Kind == reflect.String && x.Addr == 0 && (x.Flags&VariableConstant) != 0 && x.Len > 0) {
+			stack.opidx = op.Target - 1
+			return
+		}
+		if scope.callCtx == nil {
+			// do not complain here, setValue will if no other errors happen
+			stack.opidx = op.Target - 1
+			return
+		}
+		return
 	}
 
 	if x.Kind != reflect.Bool {


### PR DESCRIPTION
Generalizes the function for checking for escaping pointers so that it
can be used to iterate on all pointers of a variable.

Also generalizes the string allocation opcodes so that in the future we
can use it to call other special runtime functions (for example: map
access, channel send/receive, etc)

