### PR TITLE
pkg/proc: implement composite literals

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -252,6 +252,7 @@ func main() {
 	m2 := map[int]*astruct{1: &astruct{10, 11}}
 	m3 := map[astruct]int{{1, 1}: 42, {2, 2}: 43, {1, 0}: 44, {0, 1}: 45, {}: 46}
 	m4 := map[astruct]astruct{{1, 1}: {11, 11}, {2, 2}: {22, 22}}
+	var mint map[int]int
 	upnil := unsafe.Pointer(nil)
 	up1 := unsafe.Pointer(&i1)
 	i4 := 800
@@ -404,5 +405,5 @@ func main() {
 	longslice := make([]int, 100, 100)
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice)
+	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, mint, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice)
 }

--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -250,7 +250,7 @@ func main() {
 	}
 	var mnil map[string]astruct = nil
 	m2 := map[int]*astruct{1: &astruct{10, 11}}
-	m3 := map[astruct]int{{1, 1}: 42, {2, 2}: 43}
+	m3 := map[astruct]int{{1, 1}: 42, {2, 2}: 43, {1, 0}: 44, {0, 1}: 45, {}: 46}
 	m4 := map[astruct]astruct{{1, 1}: {11, 11}, {2, 2}: {22, 22}}
 	upnil := unsafe.Pointer(nil)
 	up1 := unsafe.Pointer(&i1)

--- a/pkg/proc/evalop/ops.go
+++ b/pkg/proc/evalop/ops.go
@@ -251,3 +251,10 @@ type SetValue struct {
 }
 
 func (*SetValue) depthCheck() (npop, npush int) { return 2, 0 }
+
+type CompositeLit struct {
+	DwarfType godwarf.Type
+	Count     int
+}
+
+func (v *CompositeLit) depthCheck() (npop, npush int) { return v.Count, 1 }

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -757,12 +757,22 @@ func getEvalExpressionTestCases() []varTest {
 		{"main.astruct{A: 1, B: 2}", false, "main.astruct {A: 1, B: 2}", "main.astruct {A: 1, B: 2}", "main.astruct", nil},
 		{"main.astruct{A: 1, 2}", false, "", "", "", fmt.Errorf("cannot mix positional and named values in a composite literal")},
 		{"main.astruct{A: 1}", false, "main.astruct {A: 1, B: 0}", "main.astruct {A: 1, B: 0}", "main.astruct", nil},
-		{"main.astruct{2}", false, "", "", "", fmt.Errorf("wrong number of fields for struct main.astruct: want 2, got 1")},
-		{"main.astruct{1, 2, 3}", false, "", "", "", fmt.Errorf("wrong number of fields for struct main.astruct: want 2, got 3")},
+		{"main.astruct{2}", false, "", "", "", fmt.Errorf("too few values for struct main.astruct: want 2, got 1")},
+		{"main.astruct{1, 2, 3}", false, "", "", "", fmt.Errorf("too many values for struct main.astruct: want 2, got 3")},
+
 		{"m3[main.astruct{A: 1, B: 1}]", false, "42", "42", "int", nil},
 		{"m3[main.astruct{A: 1}]", false, "44", "44", "int", nil},
 		{"m3[main.astruct{B: 1}]", false, "45", "45", "int", nil},
 		{"m3[main.astruct{}]", false, "46", "46", "int", nil},
+
+		{"[2]int{}", false, "[2]int [0,0]", "[2]int [0,0]", "[2]int", nil},
+		{"[2]int{1, 2}", false, "[2]int [1,2]", "[2]int [1,2]", "[2]int", nil},
+		{"[5]int{3: 1, 2}", false, "[5]int [0,0,0,1,2]", "[5]int [0,0,0,1,2]", "[5]int", nil},
+		{"[0]int{}", false, "[0]int []", "[0]int []", "[0]int", nil},
+		{"[]int{}", false, "[]int len: 0, cap: 0, nil", "[]int len: 0, cap: 0, nil", "[]int", nil},
+		{"[]int{1, 2}", false, "[]int len: 2, cap: 2, [1,2]", "[]int len: 2, cap: 2, [1,2]", "[]int", nil},
+		{"[]int{0: 1, 2}", false, "[]int len: 2, cap: 2, [1,2]", "[]int len: 2, cap: 2, [1,2]", "[]int", nil},
+		{"[]int{3: 1, 2}", false, "[]int len: 5, cap: 5, [0,0,0,1,2]", "[]int len: 5, cap: 5, [0,0,0,1,2]", "[]int", nil},
 
 		// misc
 		{"i1", true, "1", "1", "int", nil},

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -752,6 +752,18 @@ func getEvalExpressionTestCases() []varTest {
 		{"string(byteslice[0])", false, `"t"`, `"t"`, "string", nil},
 		{"string(runeslice[0])", false, `"t"`, `"t"`, "string", nil},
 
+		// composite literals
+		{"main.astruct{1, 2}", false, "main.astruct {A: 1, B: 2}", "main.astruct {A: 1, B: 2}", "main.astruct", nil},
+		{"main.astruct{A: 1, B: 2}", false, "main.astruct {A: 1, B: 2}", "main.astruct {A: 1, B: 2}", "main.astruct", nil},
+		{"main.astruct{A: 1, 2}", false, "", "", "", fmt.Errorf("cannot mix positional and named values in a composite literal")},
+		{"main.astruct{A: 1}", false, "main.astruct {A: 1, B: 0}", "main.astruct {A: 1, B: 0}", "main.astruct", nil},
+		{"main.astruct{2}", false, "", "", "", fmt.Errorf("wrong number of fields for struct main.astruct: want 2, got 1")},
+		{"main.astruct{1, 2, 3}", false, "", "", "", fmt.Errorf("wrong number of fields for struct main.astruct: want 2, got 3")},
+		{"m3[main.astruct{A: 1, B: 1}]", false, "42", "42", "int", nil},
+		{"m3[main.astruct{A: 1}]", false, "44", "44", "int", nil},
+		{"m3[main.astruct{B: 1}]", false, "45", "45", "int", nil},
+		{"m3[main.astruct{}]", false, "46", "46", "int", nil},
+
 		// misc
 		{"i1", true, "1", "1", "int", nil},
 		{"mainMenu", true, `main.Menu len: 3, cap: 3, [{Name: "home", Route: "/", Active: 1},{Name: "About", Route: "/about", Active: 1},{Name: "Login", Route: "/login", Active: 1}]`, `main.Menu len: 3, cap: 3, [...]`, "main.Menu", nil},

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -774,6 +774,8 @@ func getEvalExpressionTestCases() []varTest {
 		{"[]int{0: 1, 2}", false, "[]int len: 2, cap: 2, [1,2]", "[]int len: 2, cap: 2, [1,2]", "[]int", nil},
 		{"[]int{3: 1, 2}", false, "[]int len: 5, cap: 5, [0,0,0,1,2]", "[]int len: 5, cap: 5, [0,0,0,1,2]", "[]int", nil},
 
+		{"map[int]int{1: 2}", false, "map[int]int [1: 2, ]", "map[int]int [1: 2, ]", "map[int]int", nil},
+
 		// misc
 		{"i1", true, "1", "1", "int", nil},
 		{"mainMenu", true, `main.Menu len: 3, cap: 3, [{Name: "home", Route: "/", Active: 1},{Name: "About", Route: "/about", Active: 1},{Name: "Login", Route: "/login", Active: 1}]`, `main.Menu len: 3, cap: 3, [...]`, "main.Menu", nil},

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -6134,7 +6134,7 @@ func TestSetVariable(t *testing.T) {
 
 					// Args of foobar(baz string, bar FooBar)
 					checkVarExact(t, locals, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
-					tester.failSetVariable(localsScope, "bar", `main.FooBar {Baz: 42, Bur: "ipsum"}`, "*ast.CompositeLit not implemented")
+					tester.failSetVariable(localsScope, "bar", `main.FooBar {Baz: 42, Bur: "ipsum"}`, "can not set variables of type struct")
 
 					// Nested field.
 					barRef := checkVarExact(t, locals, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
@@ -6160,7 +6160,7 @@ func TestSetVariable(t *testing.T) {
 					tester.expectSetVariable(a4Ref, "[1]", "-7")
 					tester.evaluate("a4", "[2]int [1,-7]", hasChildren)
 
-					tester.failSetVariable(localsScope, "a4", "[2]int{3, 4}", "not implemented")
+					tester.failSetVariable(localsScope, "a4", "[2]int{3, 4}", "composite literals of [2]int not supported")
 
 					// slice of int
 					a5Ref := checkVarExact(t, locals, -1, "a5", "a5", "[]int len: 5, cap: 5, [1,2,3,4,5]", "[]int", hasChildren)
@@ -6258,7 +6258,7 @@ func TestSetVariable(t *testing.T) {
 					tester.evaluate(elem1.EvaluateName, "main.astruct {A: -9999, B: 10000}", hasChildren)
 
 					// map: struct -> int
-					m3Ref := checkVarExact(t, locals, -1, "m3", "m3", "map[main.astruct]int [{A: 1, B: 1}: 42, {A: 2, B: 2}: 43, ]", "map[main.astruct]int", hasChildren)
+					m3Ref := checkVarExact(t, locals, -1, "m3", "m3", "map[main.astruct]int [{A: 1, B: 1}: 42, {A: 2, B: 2}: 43, {A: 1, B: 0}: 44, {A: 0, B: 1}: 45, {A: 0, B: 0}: 46, ]", "map[main.astruct]int", hasChildren)
 					tester.expectSetVariable(m3Ref, "main.astruct {A: 1, B: 1}", "8888")
 					// note: updating keys is possible, but let's not promise anything.
 					tester.evaluateRegex("m3", `.*\[\{A: 1, B: 1\}: 8888,.*`, hasChildren)


### PR DESCRIPTION
This change implements composite literals for struct, slice, array, and map types.

Fixes #1465