### PR TITLE
pkg/terminal: allow postfix if for breakpoint conds 

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -108,9 +108,32 @@ If regex is specified only function arguments with a name matching it will be re
 ## break
 Sets a breakpoint.
 
-	break [name] [locspec]
+	break [name] [locspec] [if <condition>]
 
-See [Documentation/cli/locspec.md](//github.com/go-delve/delve/tree/master/Documentation/cli/locspec.md) for the syntax of locspec. If locspec is omitted a breakpoint will be set on the current line.
+Locspec is a location specifier in the form of:
+
+  * *<address> Specifies the location of memory address address. address can be specified as a decimal, hexadecimal or octal number
+  * <filename>:<line> Specifies the line line in filename. filename can be the partial path to a file or even just the base name as long as the expression remains unambiguous.
+  * <line> Specifies the line line in the current file
+  * +<offset> Specifies the line offset lines after the current one
+  * -<offset> Specifies the line offset lines before the current one
+  * <function>[:<line>] Specifies the line line inside function. 
+      The full syntax for function is <package>.(*<receiver type>).<function name> however the only required element is the function name,
+      everything else can be omitted as long as the expression remains unambiguous. For setting a breakpoint on an init function (ex: main.init),
+      the <filename>:<line> syntax should be used to break in the correct init function at the correct location.
+  * /<regex>/ Specifies the location of all the functions matching regex
+
+If locspec is omitted a breakpoint will be set on the current line.
+
+If you would like to assign a name to the breakpoint you can do so with the form:
+
+  break mybpname main.go:4
+
+Finally, you can assign a condition to the newly created breakpoint by using the 'if' postfix form, like so:
+
+  break main.go:55 if i == 5
+
+Alternatively you can set a condition on a breakpoint after created by using the 'on' command.
 
 See also: "help on", "help cond" and "help clear"
 

--- a/_fixtures/test if path/main.go
+++ b/_fixtures/test if path/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("here")
+}

--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -361,7 +361,6 @@ func (ale AmbiguousLocationError) Error() string {
 		for i := range ale.CandidatesLocation {
 			candidates = append(candidates, ale.CandidatesLocation[i].Function.Name())
 		}
-
 	} else {
 		candidates = ale.CandidatesString
 	}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1435,6 +1435,39 @@ func TestCreateBreakpointByLocExpr(t *testing.T) {
 	})
 }
 
+func TestCreateBreakpointWithCondition(t *testing.T) {
+	withTestTerminal("break", t, func(term *FakeTerminal) {
+		term.MustExec("break bp1 main.main:4 if i == 3")
+		listIsAt(t, term, "continue", 7, -1, -1)
+		out := term.MustExec("print i")
+		t.Logf("%q", out)
+		if !strings.Contains(out, "3\n") {
+			t.Fatalf("wrong value of i")
+		}
+	})
+}
+
+func TestCreateBreakpointWithCondition2(t *testing.T) {
+	withTestTerminal("break", t, func(term *FakeTerminal) {
+		term.MustExec("continue main.main:4")
+		term.MustExec("break if i == 3")
+		listIsAt(t, term, "continue", 7, -1, -1)
+		out := term.MustExec("print i")
+		t.Logf("%q", out)
+		if !strings.Contains(out, "3\n") {
+			t.Fatalf("wrong value of i")
+		}
+	})
+}
+
+func TestCreateBreakpointWithCondition3(t *testing.T) {
+	withTestTerminal("test if path/main", t, func(term *FakeTerminal) {
+		// We should not attempt to parse this as a condition.
+		term.MustExec(`break _fixtures/test if path/main.go:4`)
+		listIsAt(t, term, "continue", 4, -1, -1)
+	})
+}
+
 func TestRestartBreakpoints(t *testing.T) {
 	// Tests that breakpoints set using just a line number and with a line
 	// offset are preserved after restart. See issue #3423.


### PR DESCRIPTION
Allows for a user to specify the breakpoint condition directly
when creating the breakpoint. The new syntax looks like the
following:

```
break <name> <locspec> [if <expression>]
```

Also updates docs to include more examples and locspec description
instead of directing users to the online / source documentation.