### PR TITLE
tests: fix tests on Go 1.23

### DIFF
--- a/_scripts/rtype-out.txt
+++ b/_scripts/rtype-out.txt
@@ -27,7 +27,7 @@ type g struct {
 	waitsince int64
 	waitreason waitReason (optional)
 	stack stack
-	atomicstatus uint32|runtime/internal/atomic.Uint32
+	atomicstatus uint32|runtime/internal/atomic.Uint32|internal/runtime/atomic.Uint32
 }
 
 type gobuf struct {
@@ -54,10 +54,6 @@ type moduledata struct {
 	types uintptr
 }
 
-type runtime/internal/atomic.Uint32 struct {
-	value uint32
-}
-
 type stack struct {
 	hi uintptr
 	lo uintptr
@@ -67,11 +63,11 @@ const emptyOne = 1
 
 const emptyRest = 0
 
-const kindDirectIface = 32
+const kindDirectIface|internal/abi.KindDirectIface = 32
 
-const kindGCProg = 64
+const kindGCProg|internal/abi.KindGCProg = 64
 
-const kindMask = 31
+const kindMask|internal/abi.KindMask = 31
 
 const minTopHash = 4
 or const minTopHash = 5

--- a/_scripts/rtype.go
+++ b/_scripts/rtype.go
@@ -619,7 +619,7 @@ func check() {
 	for _, C := range Cs {
 		rules := checkConstValRules[C]
 		pos := fset.Position(rules[0].pos)
-		def := lookupPackage(pkgmap, "runtime").Types.Scope().Lookup(C)
+		def := findConst(pkgmap, C)
 		if def == nil {
 			fmt.Fprintf(os.Stderr, "%s:%d: could not find constant %s\n", pos.Filename, pos.Line, C)
 			allok = false
@@ -650,6 +650,21 @@ func fieldTypeByName(typ *types.Struct, name string) types.Type {
 		field := typ.Field(i)
 		if field.Name() == name {
 			return field.Type()
+		}
+	}
+	return nil
+}
+
+func findConst(pkgmap map[string]*packages.Package, Cs string) types.Object {
+	for _, C := range strings.Split(Cs, "|") {
+		pkg := lookupPackage(pkgmap, "runtime")
+		if dot := strings.Index(C, "."); dot >= 0 {
+			pkg = lookupPackage(pkgmap, C[:dot])
+			C = C[dot+1:]
+		}
+		def := pkg.Types.Scope().Lookup(C)
+		if def != nil {
+			return def
 		}
 	}
 	return nil

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -15,10 +15,10 @@ import (
 // some extra flags defined here.
 // See equivalent declaration in $GOROOT/src/reflect/type.go
 const (
-	kindDirectIface = 1 << 5 // +rtype kindDirectIface
-	kindGCProg      = 1 << 6 // +rtype kindGCProg
+	kindDirectIface = 1 << 5 // +rtype kindDirectIface|internal/abi.KindDirectIface
+	kindGCProg      = 1 << 6 // +rtype kindGCProg|internal/abi.KindGCProg
 	kindNoPointers  = 1 << 7
-	kindMask        = (1 << 5) - 1 // +rtype kindMask
+	kindMask        = (1 << 5) - 1 // +rtype kindMask|internal/abi.KindMask
 )
 
 type runtimeTypeDIE struct {

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -930,11 +930,11 @@ func (v *Variable) parseG() (*G, error) {
 	}
 
 	status := uint64(0)
-	if atomicStatus := v.loadFieldNamed("atomicstatus"); /* +rtype uint32|runtime/internal/atomic.Uint32 */ atomicStatus != nil {
+	if atomicStatus := v.loadFieldNamed("atomicstatus"); /* +rtype uint32|runtime/internal/atomic.Uint32|internal/runtime/atomic.Uint32 */ atomicStatus != nil {
 		if constant.Val(atomicStatus.Value) != nil {
 			status, _ = constant.Uint64Val(atomicStatus.Value)
 		} else {
-			atomicStatus := atomicStatus              // +rtype runtime/internal/atomic.Uint32
+			atomicStatus := atomicStatus              // +rtype runtime/internal/atomic.Uint32|internal/runtime/atomic.Uint32
 			vv := atomicStatus.fieldVariable("value") // +rtype uint32
 			if vv == nil {
 				unreadable = true

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1848,9 +1848,7 @@ func TestScopesAndVariablesRequests2(t *testing.T) {
 					if ref > 0 {
 						client.VariablesRequest(ref)
 						ch1 := client.ExpectVariablesResponse(t)
-						checkChildren(t, ch1, "ch1", 11)
 						checkVarExact(t, ch1, 0, "qcount", "ch1.qcount", "4 = 0x4", "uint", noChildren)
-						checkVarRegex(t, ch1, 10, "lock", "ch1.lock", `runtime\.mutex {.*key: 0.*}`, `runtime\.mutex`, hasChildren)
 						validateEvaluateName(t, client, ch1, 0)
 						validateEvaluateName(t, client, ch1, 10)
 					}


### PR DESCRIPTION
* Adjust rtype.go script to handle constants moved to internal/abi from
runtime
* Remove tests in service/dap/server_test that relied on knowledge of
the internal layout of channels.
