### PR TITLE
pkg/terminal: clear erroneous name setting on postfix if

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1858,6 +1858,7 @@ func setBreakpoint(t *Term, ctx callContext, tracepoint bool, argstr string) ([]
 	if findLocErr != nil {
 		r := regexp.MustCompile(`^if | if `)
 		if match := r.FindStringIndex(argstr); match != nil {
+			requestedBp.Name = ""
 			cond = argstr[match[1]:]
 			argstr = argstr[:match[0]]
 			args = config.Split2PartsBySpace(argstr)

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1438,8 +1438,12 @@ func TestCreateBreakpointByLocExpr(t *testing.T) {
 func TestCreateBreakpointWithCondition(t *testing.T) {
 	withTestTerminal("break", t, func(term *FakeTerminal) {
 		term.MustExec("break bp1 main.main:4 if i == 3")
+		out := term.MustExec("breakpoints")
+		if !strings.Contains(out, "Breakpoint bp1") {
+			t.Fatal("incorrect breakpoint name")
+		}
 		listIsAt(t, term, "continue", 7, -1, -1)
-		out := term.MustExec("print i")
+		out = term.MustExec("print i")
 		t.Logf("%q", out)
 		if !strings.Contains(out, "3\n") {
 			t.Fatalf("wrong value of i")
@@ -1451,8 +1455,12 @@ func TestCreateBreakpointWithCondition2(t *testing.T) {
 	withTestTerminal("break", t, func(term *FakeTerminal) {
 		term.MustExec("continue main.main:4")
 		term.MustExec("break if i == 3")
+		out := term.MustExec("breakpoints")
+		if strings.Contains(out, "Breakpoint if") {
+			t.Fatal("incorrect breakpoint name, should be ID")
+		}
 		listIsAt(t, term, "continue", 7, -1, -1)
-		out := term.MustExec("print i")
+		out = term.MustExec("print i")
 		t.Logf("%q", out)
 		if !strings.Contains(out, "3\n") {
 			t.Fatalf("wrong value of i")


### PR DESCRIPTION
When a breakpoint was set on the current line via `break if i ==3` style condition setting, we would erroneously set the breakpoint name to be 'if'.