### PR TITLE
pkg/terminal: remove duplicated word

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -113,11 +113,11 @@ Sets a breakpoint.
 Locspec is a location specifier in the form of:
 
   * *<address> Specifies the location of memory address address. address can be specified as a decimal, hexadecimal or octal number
-  * <filename>:<line> Specifies the line line in filename. filename can be the partial path to a file or even just the base name as long as the expression remains unambiguous.
-  * <line> Specifies the line line in the current file
+  * <filename>:<line> Specifies the line in filename. filename can be the partial path to a file or even just the base name as long as the expression remains unambiguous.
+  * <line> Specifies the line in the current file
   * +<offset> Specifies the line offset lines after the current one
   * -<offset> Specifies the line offset lines before the current one
-  * <function>[:<line>] Specifies the line line inside function. 
+  * <function>[:<line>] Specifies the line inside function.
       The full syntax for function is <package>.(*<receiver type>).<function name> however the only required element is the function name,
       everything else can be omitted as long as the expression remains unambiguous. For setting a breakpoint on an init function (ex: main.init),
       the <filename>:<line> syntax should be used to break in the correct init function at the correct location.

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -127,11 +127,11 @@ Type "help" followed by the name of a command for more information about it.`},
 Locspec is a location specifier in the form of:
 
   * *<address> Specifies the location of memory address address. address can be specified as a decimal, hexadecimal or octal number
-  * <filename>:<line> Specifies the line line in filename. filename can be the partial path to a file or even just the base name as long as the expression remains unambiguous.
-  * <line> Specifies the line line in the current file
+  * <filename>:<line> Specifies the line in filename. filename can be the partial path to a file or even just the base name as long as the expression remains unambiguous.
+  * <line> Specifies the line in the current file
   * +<offset> Specifies the line offset lines after the current one
   * -<offset> Specifies the line offset lines before the current one
-  * <function>[:<line>] Specifies the line line inside function. 
+  * <function>[:<line>] Specifies the line inside function.
       The full syntax for function is <package>.(*<receiver type>).<function name> however the only required element is the function name,
       everything else can be omitted as long as the expression remains unambiguous. For setting a breakpoint on an init function (ex: main.init),
       the <filename>:<line> syntax should be used to break in the correct init function at the correct location.


### PR DESCRIPTION
The PR removes the duplicated word `line` from the `break` command help.