### PR TITLE
test: use math/rand/v2 instead of deprecated math/rand.Seed

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -10,7 +10,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"os"
@@ -5061,7 +5061,6 @@ func TestRequestManualStopWhileStopped(t *testing.T) {
 
 func TestStepOutPreservesGoroutine(t *testing.T) {
 	// Checks that StepOut preserves the currently selected goroutine.
-	rand.Seed(time.Now().Unix())
 	withTestProcess("issue2113", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		assertNoError(grp.Continue(), t, "Continue()")
 
@@ -5102,10 +5101,10 @@ func TestStepOutPreservesGoroutine(t *testing.T) {
 		}
 		var pickg *proc.G
 		if len(bestg) > 0 {
-			pickg = bestg[rand.Intn(len(bestg))]
+			pickg = bestg[rand.IntN(len(bestg))]
 			t.Logf("selected goroutine %d (best)\n", pickg.ID)
 		} else {
-			pickg = candg[rand.Intn(len(candg))]
+			pickg = candg[rand.IntN(len(candg))]
 			t.Logf("selected goroutine %d\n", pickg.ID)
 
 		}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"os/exec"
@@ -4838,7 +4838,6 @@ func testNextParkedHelper(t *testing.T, client *daptest.Client, fixture protest.
 // and checks that StepOut preserves the currently selected goroutine.
 func TestStepOutPreservesGoroutine(t *testing.T) {
 	// Checks that StepOut preserves the currently selected goroutine.
-	rand.Seed(time.Now().Unix())
 	runTest(t, "issue2113", func(client *daptest.Client, fixture protest.Fixture) {
 		runDebugSessionWithBPs(t, client, "launch",
 			// Launch
@@ -4881,10 +4880,10 @@ func TestStepOutPreservesGoroutine(t *testing.T) {
 					}
 					var goroutineId int
 					if len(bestg) > 0 {
-						goroutineId = bestg[rand.Intn(len(bestg))]
+						goroutineId = bestg[rand.IntN(len(bestg))]
 						t.Logf("selected goroutine %d (best)\n", goroutineId)
 					} else if len(candg) > 0 {
-						goroutineId = candg[rand.Intn(len(candg))]
+						goroutineId = candg[rand.IntN(len(candg))]
 						t.Logf("selected goroutine %d\n", goroutineId)
 
 					}

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -2,7 +2,7 @@ package service_test
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"path/filepath"
 	"runtime"
@@ -1024,8 +1024,7 @@ func Test1Issue419(t *testing.T) {
 	// try to read 'runtime.g' and debug/dwarf.Data.Type is not thread safe
 	withTestClient1("issue419", t, func(c *rpc1.RPCClient) {
 		go func() {
-			rand.Seed(time.Now().Unix())
-			d := time.Duration(rand.Intn(4) + 1)
+			d := time.Duration(rand.IntN(4) + 1)
 			time.Sleep(d * time.Second)
 			_, err := c.Halt()
 			assertNoError(err, t, "RequestManualStop()")

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3,7 +3,7 @@ package service_test
 import (
 	"flag"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
@@ -1593,8 +1593,7 @@ func TestIssue419(t *testing.T) {
 	withTestClient2("issue419", t, func(c service.Client) {
 		go func() {
 			defer close(finish)
-			rand.Seed(time.Now().Unix())
-			d := time.Duration(rand.Intn(4) + 1)
+			d := time.Duration(rand.IntN(4) + 1)
 			time.Sleep(d * time.Second)
 			t.Logf("halt")
 			_, err := c.Halt()


### PR DESCRIPTION
This PR removes usages of [`rand.Seed`](https://pkg.go.dev/math/rand@go1.21#Seed) in tests. This function is deprecated since Go 1.20. We can replace `rand.Seed + rand.Intn` by using just `rand.IntN` from the package `math/rand/v2`.