### PR TITLE
pkg/proc/gdbserial: optimize gdbwire backend

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1428,8 +1428,10 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopP
 	}
 
 	for _, th := range p.threads {
-		_, hasThread := jstopInfo[th.ID]
-		shouldQueryStopInfo := (jstopInfo != nil && hasThread) || p.threadStopInfo
+		shouldQueryStopInfo := p.threadStopInfo
+		if jstopInfo != nil {
+			_, shouldQueryStopInfo = jstopInfo[th.ID]
+		}
 		if shouldQueryStopInfo {
 			sp, err := p.conn.threadStopInfo(th.strID)
 			if err != nil {

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1431,7 +1431,7 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopP
 		_, hasThread := jstopInfo[th.ID]
 		shouldQueryStopInfo := (jstopInfo != nil && hasThread) || p.threadStopInfo
 		if shouldQueryStopInfo {
-			tsp, err := p.conn.threadStopInfo(th.strID)
+			sp, err := p.conn.threadStopInfo(th.strID)
 			if err != nil {
 				if isProtocolErrorUnsupported(err) {
 					p.threadStopInfo = false
@@ -1439,10 +1439,10 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopP
 				}
 				return err
 			}
-			th.setbp = (tsp.reason == "breakpoint" || (tsp.reason == "" && tsp.sig == breakpointSignal) || (tsp.watchAddr > 0) || (tsp.watchReg >= 0))
-			th.sig = tsp.sig
-			th.watchAddr = tsp.watchAddr
-			th.watchReg = tsp.watchReg
+			th.setbp = (sp.reason == "breakpoint" || (sp.reason == "" && sp.sig == breakpointSignal) || (sp.watchAddr > 0) || (sp.watchReg >= 0))
+			th.sig = sp.sig
+			th.watchAddr = sp.watchAddr
+			th.watchReg = sp.watchReg
 		} else {
 			th.sig = 0
 			th.watchAddr = 0

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1437,6 +1437,8 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopP
 	for _, th := range p.threads {
 		queryThreadInfo := true
 		if jstopInfo != nil {
+			// TODO(derekparker): Use jstopInfo directly, if present, instead of
+			// issuing another stop info request.
 			_, queryThreadInfo = jstopInfo[th.ID]
 		}
 		if p.threadStopInfo && queryThreadInfo {

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1431,11 +1431,15 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopP
 	}
 
 	for _, th := range p.threads {
-		shouldQueryStopInfo := p.threadStopInfo
+		th.clearBreakpointState()
+	}
+
+	for _, th := range p.threads {
+		queryThreadInfo := true
 		if jstopInfo != nil {
-			_, shouldQueryStopInfo = jstopInfo[th.ID]
+			_, queryThreadInfo = jstopInfo[th.ID]
 		}
-		if shouldQueryStopInfo {
+		if p.threadStopInfo && queryThreadInfo {
 			sp, err := p.conn.threadStopInfo(th.strID)
 			if err != nil {
 				if isProtocolErrorUnsupported(err) {
@@ -1448,10 +1452,6 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopP
 			th.sig = sp.sig
 			th.watchAddr = sp.watchAddr
 			th.watchReg = sp.watchReg
-		} else {
-			th.sig = 0
-			th.watchAddr = 0
-			th.watchReg = -1
 		}
 	}
 

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -726,7 +726,7 @@ func (p *gdbProcess) initialize(path, cmdline string, debugInfoDirs []string, st
 		}
 	}
 
-	err = p.updateThreadList(&threadUpdater{p: p})
+	err = p.updateThreadList(&threadUpdater{p: p}, nil)
 	if err != nil {
 		p.conn.conn.Close()
 		p.bi.Close()
@@ -877,10 +877,12 @@ func (p *gdbProcess) ContinueOnce(cctx *proc.ContinueOnceContext) (proc.Thread, 
 	var trapthread *gdbThread
 	var tu = threadUpdater{p: p}
 	var atstart bool
+	var sp stopPacket
 continueLoop:
 	for {
 		tu.Reset()
-		sp, err := p.conn.resume(cctx, p.threads, &tu)
+		var err error
+		sp, err = p.conn.resume(cctx, p.threads, &tu)
 		threadID = sp.threadID
 		if err != nil {
 			if _, exited := err.(proc.ErrProcessExited); exited {
@@ -895,7 +897,7 @@ continueLoop:
 		// NOTE: because debugserver will sometimes send two stop packets after a
 		// continue it is important that this is the very first thing we do after
 		// resume(). See comment in threadStopInfo for an explanation.
-		p.updateThreadList(&tu)
+		p.updateThreadList(&tu, sp.jstopInfo)
 
 		trapthread = p.findThreadByStrID(threadID)
 		if trapthread != nil && !p.threadStopInfo {
@@ -918,6 +920,7 @@ continueLoop:
 	}
 
 	p.clearThreadRegisters()
+	trapthread.reloadRegisters(sp.regs)
 
 	stopReason := proc.StopUnknown
 	if atstart {
@@ -1000,7 +1003,6 @@ func (p *gdbProcess) handleThreadSignals(cctx *proc.ContinueOnceContext, trapthr
 		// Unfortunately debugserver can not convert them into signals for the
 		// process so we must stop here.
 		case debugServerTargetExcBadAccess, debugServerTargetExcBadInstruction, debugServerTargetExcArithmetic, debugServerTargetExcEmulation, debugServerTargetExcSoftware, debugServerTargetExcBreakpoint:
-
 			trapthreadCandidate = th
 			shouldStop = true
 
@@ -1127,7 +1129,7 @@ func (p *gdbProcess) Restart(cctx *proc.ContinueOnceContext, pos string) (proc.T
 		return nil, err
 	}
 
-	err = p.updateThreadList(&threadUpdater{p: p})
+	err = p.updateThreadList(&threadUpdater{p: p}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1405,7 +1407,7 @@ func (tu *threadUpdater) Finish() {
 // Some stubs will return the list of running threads in the stop packet, if
 // this happens the threadUpdater will know that we have already updated the
 // thread list and the first step of updateThreadList will be skipped.
-func (p *gdbProcess) updateThreadList(tu *threadUpdater) error {
+func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopPacket) error {
 	if !tu.done {
 		first := true
 		for {
@@ -1426,8 +1428,13 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater) error {
 	}
 
 	for _, th := range p.threads {
-		if p.threadStopInfo {
-			sp, err := p.conn.threadStopInfo(th.strID)
+		var haveStopInfo bool
+		var tsp stopPacket
+		var err error
+		_, hasThread := jstopInfo[th.ID]
+		shouldQueryStopInfo := (jstopInfo != nil && hasThread) || p.threadStopInfo
+		if shouldQueryStopInfo {
+			tsp, err = p.conn.threadStopInfo(th.strID)
 			if err != nil {
 				if isProtocolErrorUnsupported(err) {
 					p.threadStopInfo = false
@@ -1435,10 +1442,13 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater) error {
 				}
 				return err
 			}
-			th.setbp = (sp.reason == "breakpoint" || (sp.reason == "" && sp.sig == breakpointSignal) || (sp.watchAddr > 0) || (sp.watchReg >= 0))
-			th.sig = sp.sig
-			th.watchAddr = sp.watchAddr
-			th.watchReg = sp.watchReg
+			haveStopInfo = true
+		}
+		if haveStopInfo {
+			th.setbp = (tsp.reason == "breakpoint" || (tsp.reason == "" && tsp.sig == breakpointSignal) || (tsp.watchAddr > 0) || (tsp.watchReg >= 0))
+			th.sig = tsp.sig
+			th.watchAddr = tsp.watchAddr
+			th.watchReg = tsp.watchReg
 		} else {
 			th.sig = 0
 			th.watchAddr = 0
@@ -1537,7 +1547,7 @@ func (t *gdbThread) ThreadID() int {
 // Registers returns the CPU registers for this thread.
 func (t *gdbThread) Registers() (proc.Registers, error) {
 	if t.regs.regs == nil {
-		if err := t.reloadRegisters(); err != nil {
+		if err := t.reloadRegisters(nil); err != nil {
 			return nil, err
 		}
 	}
@@ -1689,25 +1699,35 @@ func (regs *gdbRegisters) gdbRegisterNew(reginfo *gdbRegisterInfo) gdbRegister {
 // It will also load the address of the thread's G.
 // Loading the address of G can be done in one of two ways reloadGAlloc, if
 // the stub can allocate memory, or reloadGAtPC, if the stub can't.
-func (t *gdbThread) reloadRegisters() error {
+func (t *gdbThread) reloadRegisters(regs map[uint64]uint64) error {
 	if t.regs.regs == nil {
 		t.regs.init(t.p.conn.regsInfo, t.p.bi.Arch, t.p.regnames)
 	}
 
-	if t.p.gcmdok {
-		if err := t.p.conn.readRegisters(t.strID, t.regs.buf); err != nil {
-			gdberr, isProt := err.(*GdbProtocolError)
-			if isProtocolErrorUnsupported(err) || (t.p.conn.isDebugserver && isProt && gdberr.code == "E74") {
-				t.p.gcmdok = false
-			} else {
-				return err
+	if regs == nil {
+		if t.p.gcmdok {
+			if err := t.p.conn.readRegisters(t.strID, t.regs.buf); err != nil {
+				gdberr, isProt := err.(*GdbProtocolError)
+				if isProtocolErrorUnsupported(err) || (t.p.conn.isDebugserver && isProt && gdberr.code == "E74") {
+					t.p.gcmdok = false
+				} else {
+					return err
+				}
 			}
 		}
-	}
-	if !t.p.gcmdok {
-		for _, reginfo := range t.p.conn.regsInfo {
-			if err := t.p.conn.readRegister(t.strID, reginfo.Regnum, t.regs.regs[reginfo.Name].value); err != nil {
-				return err
+		if !t.p.gcmdok {
+			for _, reginfo := range t.p.conn.regsInfo {
+				if err := t.p.conn.readRegister(t.strID, reginfo.Regnum, t.regs.regs[reginfo.Name].value); err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		for _, r := range t.regs.regsInfo {
+			val := regs[uint64(r.Regnum)]
+			switch r.Bitsize / 8 {
+			case 8:
+				binary.BigEndian.PutUint64(t.regs.regs[r.Name].value, val)
 			}
 		}
 	}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1431,10 +1431,6 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopP
 	}
 
 	for _, th := range p.threads {
-		th.clearBreakpointState()
-	}
-
-	for _, th := range p.threads {
 		queryThreadInfo := true
 		if jstopInfo != nil {
 			// TODO(derekparker): Use jstopInfo directly, if present, instead of
@@ -1454,6 +1450,8 @@ func (p *gdbProcess) updateThreadList(tu *threadUpdater, jstopInfo map[int]stopP
 			th.sig = sp.sig
 			th.watchAddr = sp.watchAddr
 			th.watchReg = sp.watchReg
+		} else {
+			th.clearBreakpointState()
 		}
 	}
 

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -896,11 +896,7 @@ continueLoop:
 		// NOTE: because debugserver will sometimes send two stop packets after a
 		// continue it is important that this is the very first thing we do after
 		// resume(). See comment in threadStopInfo for an explanation.
-		var jstopinfo map[int]stopPacket
-		if p.conn.isDebugserver { // TODO(deparker): Can we support this on RR backend?
-			jstopinfo = sp.jstopInfo
-		}
-		p.updateThreadList(&tu, jstopinfo)
+		p.updateThreadList(&tu, sp.jstopInfo)
 
 		trapthread = p.findThreadByStrID(threadID)
 		if trapthread != nil && !p.threadStopInfo {

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1726,13 +1726,18 @@ func (t *gdbThread) reloadRegisters(regs map[uint64]uint64) error {
 			}
 		}
 	} else {
-		for _, r := range t.regs.regsInfo {
-			val := regs[uint64(r.Regnum)]
-			switch r.Bitsize / 8 {
-			case 8:
-				binary.BigEndian.PutUint64(t.regs.regs[r.Name].value, val)
-			case 4:
-				binary.BigEndian.PutUint32(t.regs.regs[r.Name].value, uint32(val))
+		for _, r := range t.p.conn.regsInfo {
+			if val, ok := regs[uint64(r.Regnum)]; ok {
+				switch r.Bitsize / 8 {
+				case 8:
+					binary.BigEndian.PutUint64(t.regs.regs[r.Name].value, val)
+				case 4:
+					binary.BigEndian.PutUint32(t.regs.regs[r.Name].value, uint32(val))
+				}
+			} else {
+				if err := t.p.conn.readRegister(t.strID, r.Regnum, t.regs.regs[r.Name].value); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -896,7 +896,11 @@ continueLoop:
 		// NOTE: because debugserver will sometimes send two stop packets after a
 		// continue it is important that this is the very first thing we do after
 		// resume(). See comment in threadStopInfo for an explanation.
-		p.updateThreadList(&tu, sp.jstopInfo)
+		var jstopinfo map[int]stopPacket
+		if p.conn.isDebugserver { // TODO(deparker): Can we support this on RR backend?
+			jstopinfo = sp.jstopInfo
+		}
+		p.updateThreadList(&tu, jstopinfo)
 
 		trapthread = p.findThreadByStrID(threadID)
 		if trapthread != nil && !p.threadStopInfo {
@@ -920,7 +924,10 @@ continueLoop:
 	}
 
 	p.clearThreadRegisters()
-	trapthread.reloadRegisters(trapThreadRegs)
+	// TODO(deparker): Can we support this optimization for the RR backend?
+	if p.conn.isDebugserver {
+		trapthread.reloadRegisters(trapThreadRegs)
+	}
 
 	stopReason := proc.StopUnknown
 	if atstart {


### PR DESCRIPTION
This change optimizes the gdbwire backend by reducing the number of
round trips we have to make to debugserver. It does this by using the
jstopinfo packet to only query threads which we know to have a stop
reason, and it also uses the registers returned by the 'T' packet
to avoid issuing a bunch of 'p' packets to get the register values.