### PR TITLE
gdbserial: fixes for rr 5.7.0

### DIFF
--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -217,9 +217,10 @@ type rrInit struct {
 
 const (
 	rrGdbCommandLegacyPrefix = "  gdb "
-	rrGdbCommandPrefix = "  'gdb' "
-	rrGdbLaunchPrefix  = "Launch gdb with"
-	targetCmd          = "target extended-remote "
+	rrGdbCommandPrefix       = "  'gdb' "
+	rrGdbLaunchLegacyPrefix  = "Launch gdb with"
+	rrGdbLaunchPrefix        = "Launch debugger with"
+	targetCmd                = "target extended-remote "
 )
 
 func rrStderrParser(stderr io.ReadCloser, initch chan<- rrInit, quiet bool) {
@@ -245,7 +246,7 @@ func rrStderrParser(stderr io.ReadCloser, initch chan<- rrInit, quiet bool) {
 			break
 		}
 
-		if strings.HasPrefix(line, rrGdbLaunchPrefix) {
+		if strings.HasPrefix(line, rrGdbLaunchPrefix) || strings.HasPrefix(line, rrGdbLaunchLegacyPrefix) {
 			continue
 		}
 


### PR DESCRIPTION
The following fixes have been applied to make delve work with rr 5.7.0

* added a new launch prefix to exclude from stderr output
* allow the thread selection packet to be sent for 'c' commands even
when the stub supports thread suffixes, because the specification is
unclear over what should be done with bc and bs packets with thread
suffixes.

* changed the way qRRCmd are escaped and added a thread selector to
them to match changes to rr codebase
