### PR TITLE
terminal,service: add raw examinemem dump

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -354,7 +354,7 @@ Examine memory:
 	examinemem [-fmt <format>] [-count|-len <count>] [-size <size>] <address>
 	examinemem [-fmt <format>] [-count|-len <count>] [-size <size>] -x <expression>
 
-Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal).
+Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal) and raw.
 Length is the number of bytes (default 1) and must be less than or equal to 1000.
 Address is the memory location of the target to examine. Please note '-len' is deprecated by '-count and -size'.
 Expression can be an integer expression or pointer value of the memory location to examine.

--- a/pkg/terminal/starbind/conv.go
+++ b/pkg/terminal/starbind/conv.go
@@ -97,6 +97,9 @@ func (v sliceAsStarlarkValue) Hash() (uint32, error) {
 }
 
 func (v sliceAsStarlarkValue) String() string {
+	if x, ok := v.v.Interface().([]byte); ok {
+		return string(x)
+	}
 	return fmt.Sprintf("%#v", v.v)
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -977,8 +977,10 @@ type ExaminedMemoryOut struct {
 	IsLittleEndian bool
 }
 
+const ExamineMemoryLengthLimit = 1 << 16
+
 func (s *RPCServer) ExamineMemory(arg ExamineMemoryIn, out *ExaminedMemoryOut) error {
-	if arg.Length > 1000 {
+	if arg.Length > ExamineMemoryLengthLimit {
 		return errors.New("len must be less than or equal to 1000")
 	}
 	Mem, err := s.debugger.ExamineMemory(arg.Address, arg.Length)


### PR DESCRIPTION
Change the examinemem command to have a new format 'raw' that just
prints the raw memory bytes.

Change the transcript command to add a new flag that disables prompt
echo to the output file.

Fixes #3706
