### PR TITLE
pkg/terminal: remove deprecated starlark global options

### DIFF
--- a/pkg/terminal/starbind/conv_test.go
+++ b/pkg/terminal/starbind/conv_test.go
@@ -1,8 +1,9 @@
 package starbind
 
 import (
-	"go.starlark.net/starlark"
 	"testing"
+
+	"go.starlark.net/starlark"
 )
 
 func TestConv(t *testing.T) {
@@ -10,7 +11,7 @@ func TestConv(t *testing.T) {
 # A list global that we'll unmarshal into a slice.
 x = [1,2]
 `
-	globals, err := starlark.ExecFile(&starlark.Thread{}, "test.star", script, nil)
+	globals, err := execFileOptions(nil, &starlark.Thread{}, "test.star", script, nil)
 	starlarkVal, ok := globals["x"]
 	if !ok {
 		t.Fatal("missing global 'x'")

--- a/pkg/terminal/starbind/repl.go
+++ b/pkg/terminal/starbind/repl.go
@@ -116,7 +116,7 @@ func rep(rl *liner.State, thread *starlark.Thread, globals starlark.StringDict, 
 	if expr := soleExpr(f); expr != nil {
 		//TODO: check for 'exit'
 		// eval
-		v, err := starlark.EvalExpr(thread, expr, globals)
+		v, err := evalExprOptions(nil, thread, expr, globals)
 		if err != nil {
 			printError(err)
 			return nil
@@ -194,7 +194,7 @@ func MakeLoad() func(thread *starlark.Thread, module string) (starlark.StringDic
 
 			// Load it.
 			thread := &starlark.Thread{Name: "exec " + module, Load: thread.Load}
-			globals, err := starlark.ExecFile(thread, module, nil, nil)
+			globals, err := execFileOptions(nil, thread, module, nil, nil)
 			e = &entry{globals, err}
 
 			// Update the cache.


### PR DESCRIPTION
This PR removes usage of [starlark global variable options](https://pkg.go.dev/go.starlark.net/resolve#pkg-variables), see https://github.com/google/starlark-go/issues/435. Changes:

- Remove `resolve.AllowNestedDef, resolve.AllowLambda, resolve.AllowFloat, resolve.AllowBitwise` because this obsolete flags has no effect.
- Use `starlark.ExecFileOptions` instead of deprecated [`starlark.ExecFile`](https://pkg.go.dev/go.starlark.net/starlark#ExecFile).
- Use `starlark.EvalOptions` instead of deprecated [`starlark.Eval`](https://pkg.go.dev/go.starlark.net/starlark#Eval).
- Use `starlark.EvalExprOptions` instead of deprecated [`starlark.EvalExpr`](https://pkg.go.dev/go.starlark.net/starlark#EvalExpr).