### PR TITLE
proc/gdbserial: add environment variables to configure rr invocation

### DIFF
--- a/Documentation/usage/dlv_backend.md
+++ b/Documentation/usage/dlv_backend.md
@@ -12,6 +12,11 @@ are:
 	lldb		Uses lldb-server or debugserver.
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
 
+Some backends can be configured using environment variables:
+
+* DELVE_DEBUGSERVER_PATH specifies the path of the debugserver executable for the lldb backend
+* DELVE_RR_RECORD_FLAGS specifies additional flags used when calling 'rr record'
+* DELVE_RR_REPLAY_FLAGS specifies additional flags used when calling 'rr replay'
 
 
 ### Options

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -456,6 +456,11 @@ are:
 	lldb		Uses lldb-server or debugserver.
 	rr		Uses mozilla rr (https://github.com/mozilla/rr).
 
+Some backends can be configured using environment variables:
+
+* DELVE_DEBUGSERVER_PATH specifies the path of the debugserver executable for the lldb backend
+* DELVE_RR_RECORD_FLAGS specifies additional flags used when calling 'rr record'
+* DELVE_RR_REPLAY_FLAGS specifies additional flags used when calling 'rr replay'
 `})
 
 	rootCommand.AddCommand(&cobra.Command{

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -15,6 +15,11 @@ import (
 	"github.com/go-delve/delve/pkg/proc"
 )
 
+const (
+	delveRecordFlagsEnvVar = "DELVE_RR_RECORD_FLAGS"
+	delveReplayFlagsEnvVar = "DELVE_RR_REPLAY_FLAGS"
+)
+
 // RecordAsync configures rr to record the execution of the specified
 // program. Returns a run function which will actually record the program, a
 // stop function which will prematurely terminate the recording of the
@@ -31,6 +36,7 @@ func RecordAsync(cmd []string, wd string, quiet bool, stdin string, stdout proc.
 
 	args := make([]string, 0, len(cmd)+2)
 	args = append(args, "record", "--print-trace-dir=3")
+	args = append(args, config.SplitQuotedFields(os.Getenv(delveRecordFlagsEnvVar), '"')...)
 	args = append(args, cmd...)
 	rrcmd := exec.Command("rr", args...)
 	var closefn func()
@@ -141,6 +147,7 @@ func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string,
 	if rrOnProcessPid != 0 {
 		args = append(args, fmt.Sprintf("--onprocess=%d", rrOnProcessPid))
 	}
+	args = append(args, config.SplitQuotedFields(os.Getenv(delveReplayFlagsEnvVar), '\'')...)
 	args = append(args, tracedir)
 
 	rrcmd := exec.Command("rr", args...)


### PR DESCRIPTION
Adds two environment variables to configure rr invocations.

Fixes #3670
