### PR TITLE
*: remove redundant lines at the start/end of block

### DIFF
--- a/pkg/dwarf/frame/entries_test.go
+++ b/pkg/dwarf/frame/entries_test.go
@@ -38,8 +38,8 @@ func TestFDEForPC(t *testing.T) {
 		{300, frames[3]},
 		{309, frames[3]},
 		{310, nil},
-		{400, nil}} {
-
+		{400, nil},
+	} {
 		out, err := frames.FDEForPC(test.pc)
 		if test.fde != nil {
 			if err != nil {

--- a/pkg/dwarf/line/line_parser_test.go
+++ b/pkg/dwarf/line/line_parser_test.go
@@ -377,5 +377,4 @@ func TestDebugLineDwarf4(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/pkg/dwarf/line/state_machine_test.go
+++ b/pkg/dwarf/line/state_machine_test.go
@@ -238,7 +238,6 @@ func TestMultipleSequences(t *testing.T) {
 		if curline != testCase.line {
 			t.Errorf("Wrong line returned for %#x: got %d expected %d", testCase.pc, curline, testCase.line)
 		}
-
 	}
 
 	// Test that AllPCsBetween is correct for all three sequences

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -207,7 +207,6 @@ func FindFileLocation(p Process, filename string, lineno int) ([]uint64, error) 
 	selectedPCs := []uint64{}
 
 	for fn, pcs := range pcByFunc {
-
 		// 3. for each concrete function split instruction between the inlined functions it contains
 
 		if strings.Contains(fn.Name, "·dwrap·") || fn.trampoline {
@@ -1399,7 +1398,6 @@ func (bi *BinaryInfo) openSeparateDebugInfo(image *Image, exe *elf.File, debugIn
 					bi.logger.Errorf("gnu_debuglink CRC check failed for %s (want %x got %x)", debugFilePath, crc, computedCRC)
 					debugFilePath = ""
 				}
-
 			}
 		}
 	}

--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -368,7 +368,6 @@ func buildMemory(core, exeELF *elf.File, exe io.ReaderAt, notes []*note) proc.Me
 				}
 				memory.Add(r, entry.Start, entry.End-entry.Start)
 			}
-
 		}
 	}
 

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -370,7 +370,6 @@ func TestLocationCovers(t *testing.T) {
 	if fmt.Sprintf("%x", ranges) != "[[40100 40700] [40700 41000]]" {
 		t.Error("wrong value returned by LocationCover")
 	}
-
 }
 
 func TestIssue1636_InlineWithoutOrigin(t *testing.T) {

--- a/pkg/proc/evalop/evalcompile.go
+++ b/pkg/proc/evalop/evalcompile.go
@@ -266,7 +266,6 @@ func (ctx *compileCtx) compileAST(t ast.Expr) error {
 
 		default:
 			return ctx.compileUnary(node.X, &Select{node.Sel.Name})
-
 		}
 
 	case *ast.TypeAssertExpr: // <expression>.(<type>)

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1784,7 +1784,6 @@ func (t *gdbThread) writeRegisters() error {
 		} else {
 			return err
 		}
-
 	}
 	for _, r := range t.regs.regs {
 		if r.ignoreOnWrite {

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -38,7 +38,6 @@ func loadModuleData(bi *BinaryInfo, mem MemoryReadWriter) ([]moduleData, error) 
 			if err != nil {
 				return nil, err
 			}
-
 		}
 
 		var err error

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3325,7 +3325,6 @@ func logStacktrace(t *testing.T, p *proc.Target, frames []proc.Stackframe) {
 		fmt.Fprintf(w, "%#x\t%#x\t%#x\t%#x\t%#x\t%s\t%s:%d\t%s\t%s\t\n",
 			frame.Call.PC, frame.FrameOffset(), frame.FramePointerOffset(), frame.Current.PC, frame.Ret,
 			name, filepath.Base(frame.Call.File), frame.Call.Line, topmostdefer, defers)
-
 	}
 	w.Flush()
 }
@@ -5011,7 +5010,8 @@ func TestStepIntoWrapperForEmbeddedPointer(t *testing.T) {
 			{contStep, 22},
 			{contNext, 23},
 			{contNext, 23},
-			{contNext, 29}})
+			{contNext, 29},
+		})
 	} else {
 		testseq2(t, "ifaceembcall", "", []seqTest{
 			{contContinue, 28}, // main.main, the line calling iface.PtrReceiver()
@@ -5021,8 +5021,8 @@ func TestStepIntoWrapperForEmbeddedPointer(t *testing.T) {
 			{contContinueToBreakpoint, 29}, // main.main, the line calling iface.NonPtrReceiver()
 			{contStep, 22},
 			{contNext, 23},
-			{contNext, 29}})
-
+			{contNext, 29},
+		})
 	}
 }
 
@@ -5123,7 +5123,6 @@ func TestStepOutPreservesGoroutine(t *testing.T) {
 		} else {
 			pickg = candg[rand.Intn(len(candg))]
 			t.Logf("selected goroutine %d\n", pickg.ID)
-
 		}
 		goid := pickg.ID
 		assertNoError(p.SwitchGoroutine(pickg), t, "SwitchGoroutine")

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -114,7 +114,6 @@ func TestScope(t *testing.T) {
 			t.Errorf("breakpoint at line %d not hit", scopeChecks[i].line)
 		}
 	}
-
 }
 
 type scopeCheck struct {
@@ -288,7 +287,6 @@ func (varCheck *varCheck) checkInScope(line int, scope *proc.EvalScope, t *testi
 	v, err := scope.EvalExpression(varCheck.name, normalLoadConfig)
 	assertNoError(err, t, fmt.Sprintf("EvalVariable(%s)", varCheck.name))
 	varCheck.check(line, v, t, "EvalExpression")
-
 }
 
 func (varCheck *varCheck) check(line int, v *proc.Variable, t *testing.T, ctxt string) {

--- a/pkg/proc/stack_sigtramp.go
+++ b/pkg/proc/stack_sigtramp.go
@@ -429,7 +429,6 @@ func sigtrampContextFromExceptionPointers(mem MemoryReader, addr uint64) (uint64
 		return 0, err
 	}
 	return ((*exceptionpointers)(unsafe.Pointer(&buf[0]))).context, nil
-
 }
 
 func sigtrampContextWindowsAMD64(mem MemoryReader, addr uint64) (*op.DwarfRegisters, error) {

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -1354,7 +1354,6 @@ func stepOutReverse(p *Target, topframe, retframe Stackframe, sameGCond ast.Expr
 		if ok, pc := isDeferReturnCall(frames, deferReturns); ok && pc != 0 {
 			callpc = pc
 		}
-
 	}
 
 	_, err = allowDuplicateBreakpoint(p.SetBreakpoint(0, callpc, NextBreakpoint, sameGCond))

--- a/pkg/proc/variable_test.go
+++ b/pkg/proc/variable_test.go
@@ -35,7 +35,6 @@ func TestGoroutineCreationLocation(t *testing.T) {
 					t.Fatalf("goroutine creation line incorrect: %v", createdLocation.Line)
 				}
 			}
-
 		}
 
 		p.ClearBreakpoint(bp.Addr)

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -236,7 +236,6 @@ func TestSetVariable(t *testing.T) {
 				assertNoError(err, t, "EvalVariable()")
 				assertVariable(t, variable, varTest{tc.name, true, tc.finalVal, "", tc.typ, nil})
 			}
-
 		}
 	})
 }

--- a/pkg/terminal/docgen.go
+++ b/pkg/terminal/docgen.go
@@ -63,7 +63,6 @@ func (c *Commands) WriteMarkdown(w io.Writer) {
 			fmt.Fprintf(w, "[%s](#%s) | %s\n", cmd.aliases[0], cmd.aliases[0], h)
 		}
 		fmt.Fprint(w, "\n")
-
 	}
 
 	for _, cmd := range c.cmds {

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -242,7 +242,6 @@ func (t *Term) sigintGuard(ch <-chan os.Signal, multiClient bool) {
 			default:
 				fmt.Fprintln(t.stdout, "only p or q allowed")
 			}
-
 		} else {
 			fmt.Fprintf(t.stdout, "received SIGINT, stopping process (will not forward signal)\n")
 			_, err := t.client.Halt()

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -427,7 +427,6 @@ func ConvertRegisters(in *op.DwarfRegisters, dwarfRegisterToString func(int, *op
 			return a.DwarfNumber < b.DwarfNumber
 		}
 		return an < bn
-
 	})
 	return
 }

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -488,7 +488,6 @@ func (v *Variable) writeSliceOrArrayTo(buf io.Writer, flags prettyFlags, indent,
 // `format` specifies the data format (or data type), `size` specifies size of each data,
 // like 4byte integer, 1byte character, etc. `count` specifies the number of values.
 func PrettyExamineMemory(address uintptr, memArea []byte, isLittleEndian bool, format byte, size int) string {
-
 	var (
 		cols      int
 		colFormat string

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -3228,7 +3228,6 @@ func (s *Session) onDisassembleRequest(request *dap.DisassembleRequest) {
 			instructions[i] = invalidInstruction
 			instructions[i].Address = fmt.Sprintf("%#x", uint64(math.MaxUint64))
 			continue
-
 		}
 		instruction := api.ConvertAsmInstruction(procInstructions[i-offset], s.debugger.AsmInstructionText(&procInstructions[i-offset], proc.GoFlavour))
 		instructions[i] = dap.DisassembledInstruction{
@@ -3734,7 +3733,6 @@ func (s *Session) runUntilStopAndNotify(command string, allowNextStateChange *sy
 			stopped.Body.Reason = "pause"
 			stopped.Body.HitBreakpointIds = []int{}
 		}
-
 	} else {
 		s.exceptionErr = err
 		s.config.log.Error("runtime error: ", err)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4886,7 +4886,6 @@ func TestStepOutPreservesGoroutine(t *testing.T) {
 					} else if len(candg) > 0 {
 						goroutineId = candg[rand.Intn(len(candg))]
 						t.Logf("selected goroutine %d\n", goroutineId)
-
 					}
 
 					if goroutineId != 0 {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1919,7 +1919,6 @@ func (d *Debugger) convertDefers(defers []*proc.Defer) []api.Defer {
 				SP: defers[i].SP,
 			}
 		}
-
 	}
 
 	return r

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -511,7 +511,6 @@ func Test1ClientServer_traceContinue(t *testing.T) {
 			if state.Err != nil {
 				t.Fatalf("Unexpected error during continue: %v\n", state.Err)
 			}
-
 		}
 
 		if count != 3 {
@@ -550,7 +549,6 @@ func Test1ClientServer_traceContinue2(t *testing.T) {
 			if state.Err != nil {
 				t.Fatalf("Unexpected error during continue: %v\n", state.Err)
 			}
-
 		}
 
 		if countMain != 1 {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -891,7 +891,6 @@ func TestClientServer_traceContinue(t *testing.T) {
 			if state.Err != nil {
 				t.Fatalf("Unexpected error during continue: %v\n", state.Err)
 			}
-
 		}
 
 		if count != 3 {
@@ -931,7 +930,6 @@ func TestClientServer_traceContinue2(t *testing.T) {
 			if state.Err != nil {
 				t.Fatalf("Unexpected error during continue: %v\n", state.Err)
 			}
-
 		}
 
 		if countMain != 1 {


### PR DESCRIPTION
This PR removes excessive empty lines at the start and end of a block. They can be deleted without harming readability.