### PR TITLE
proc: refactor identifier evaluation for range-over-func support

### DIFF
--- a/pkg/proc/evalop/ops.go
+++ b/pkg/proc/evalop/ops.go
@@ -45,26 +45,29 @@ type PushLocal struct {
 
 func (*PushLocal) depthCheck() (npop, npush int) { return 0, 1 }
 
+// PushIdent pushes a local or global variable or a predefined identifier
+// (true, false, etc) or the value of a register on the stack.
+type PushIdent struct {
+	Name string
+}
+
+func (*PushIdent) depthCheck() (npop, npush int) { return 0, 1 }
+
+// PushPackageVarOrSelect pushes the value of Name.Sel on the stack, which
+// could either be a global variable (with the package name specified), or a
+// field of a local variable.
+type PushPackageVarOrSelect struct {
+	Name, Sel    string
+	NameIsString bool
+}
+
+func (*PushPackageVarOrSelect) depthCheck() (npop, npush int) { return 0, 1 }
+
 // PushNil pushes an untyped nil on the stack.
 type PushNil struct {
 }
 
 func (*PushNil) depthCheck() (npop, npush int) { return 0, 1 }
-
-// PushRegister pushes the CPU register Regnum on the stack.
-type PushRegister struct {
-	Regnum  int
-	Regname string
-}
-
-func (*PushRegister) depthCheck() (npop, npush int) { return 0, 1 }
-
-// PushPackageVar pushes a package variable on the stack.
-type PushPackageVar struct {
-	PkgName, Name string // if PkgName == "" use current function's package
-}
-
-func (*PushPackageVar) depthCheck() (npop, npush int) { return 0, 1 }
 
 // PushLen pushes the length of the variable at the top of the stack into
 // the stack.

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -143,6 +143,7 @@ func dataAtAddr(thread proc.MemoryReadWriter, addr uint64) ([]byte, error) {
 }
 
 func assertNoError(err error, t testing.TB, s string) {
+	t.Helper()
 	if err != nil {
 		_, file, line, _ := runtime.Caller(1)
 		fname := filepath.Base(file)
@@ -1254,6 +1255,7 @@ func evalVariableOrError(p *proc.Target, symbol string) (*proc.Variable, error) 
 }
 
 func evalVariable(p *proc.Target, t testing.TB, symbol string) *proc.Variable {
+	t.Helper()
 	v, err := evalVariableOrError(p, symbol)
 	if err != nil {
 		_, file, line, _ := runtime.Caller(1)

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -820,9 +820,9 @@ func getEvalExpressionTestCases() []varTest {
 		{"afunc(2)", false, "", "", "", errors.New("function calls not allowed without using 'call'")},
 		{"(afunc)(2)", false, "", "", "", errors.New("function calls not allowed without using 'call'")},
 		{"(*afunc)(2)", false, "", "", "", errors.New("expression \"afunc\" (func()) can not be dereferenced")},
-		{"unknownthing(2)", false, "", "", "", errors.New("could not evaluate function or type unknownthing: could not find symbol value for unknownthing")},
-		{"(*unknownthing)(2)", false, "", "", "", errors.New("could not evaluate function or type (*unknownthing): could not find symbol value for unknownthing")},
-		{"(*strings.Split)(2)", false, "", "", "", errors.New("could not evaluate function or type (*strings.Split): could not find symbol value for strings")},
+		{"unknownthing(2)", false, "", "", "", errors.New("could not find symbol value for unknownthing")},
+		{"(*unknownthing)(2)", false, "", "", "", errors.New("could not find symbol value for unknownthing")},
+		{"(*strings.Split)(2)", false, "", "", "", errors.New("could not find symbol value for strings")},
 
 		// pretty printing special types
 		{"tim1", false, `time.Time(1977-05-25T18:00:00Z)…`, `time.Time(1977-05-25T18:00:00Z)…`, "time.Time", nil},
@@ -1195,7 +1195,7 @@ func TestCallFunction(t *testing.T) {
 		{`stringsJoin(nil, "")`, []string{`:string:""`}, nil},
 		{`stringsJoin(stringslice, comma)`, []string{`:string:"one,two,three"`}, nil},
 		{`stringsJoin(stringslice, "~~")`, []string{`:string:"one~~two~~three"`}, nil},
-		{`stringsJoin(s1, comma)`, nil, errors.New(`error evaluating "s1" as argument 1 in function stringsJoin: could not find symbol value for s1`)},
+		{`stringsJoin(s1, comma)`, nil, errors.New(`could not find symbol value for s1`)},
 		{`stringsJoin(intslice, comma)`, nil, errors.New("can not convert value of type []int to []string")},
 		{`noreturncall(2)`, nil, nil},
 
@@ -1295,11 +1295,11 @@ func TestCallFunction(t *testing.T) {
 	}
 
 	var testcasesBefore114After112 = []testCaseCallFunction{
-		{`strings.Join(s1, comma)`, nil, errors.New(`error evaluating "s1" as argument 1 in function strings.Join: could not find symbol value for s1`)},
+		{`strings.Join(s1, comma)`, nil, errors.New(`could not find symbol value for s1`)},
 	}
 
 	var testcases114 = []testCaseCallFunction{
-		{`strings.Join(s1, comma)`, nil, errors.New(`error evaluating "s1" as argument 1 in function strings.Join: could not find symbol value for s1`)},
+		{`strings.Join(s1, comma)`, nil, errors.New(`could not find symbol value for s1`)},
 	}
 
 	var testcases117 = []testCaseCallFunction{


### PR DESCRIPTION
Because of how range-over-func is implemented it is difficult to
determine the set of visible local variables during expression
compilation (i.e. it is difficulto to keep the HasLocal function
correct).

This commit moves that logic from expression compilation to expression
evaluation.

Updates #3733
