### PR TITLE
proc: fix TestRangeOverFuncNext

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -588,7 +588,11 @@ func testseq2intl(t *testing.T, fixture protest.Fixture, grp *proc.TargetGroup, 
 		_, _, fn := p.BinInfo().PCToLine(pc)
 
 		if traceTestseq2 {
-			t.Logf("at %#x (%s) %s:%d", pc, fn.Name, f, ln)
+			fnname := "?"
+			if fn != nil {
+				fnname = fn.Name
+			}
+			t.Logf("at %#x (%s) %s:%d", pc, fnname, f, ln)
 			//fmt.Printf("at %#x %s:%d\n", pc, f, ln)
 		}
 		switch pos := tc.pos.(type) {
@@ -604,6 +608,8 @@ func testseq2intl(t *testing.T, fixture protest.Fixture, grp *proc.TargetGroup, 
 			}
 		case func(*proc.Target):
 			pos(p)
+		case func(*proc.TargetGroup, *proc.Target):
+			pos(grp, p)
 		default:
 			panic(fmt.Errorf("unexpected type %T", pos))
 		}
@@ -6282,6 +6288,26 @@ func TestRangeOverFuncNext(t *testing.T) {
 		return seqTest{contNext, n}
 	}
 
+	nx2 := func(t *testing.T, n int) seqTest {
+		return seqTest{contNothing, func(grp *proc.TargetGroup, p *proc.Target) {
+			_, ln1 := currentLineNumber(p, t)
+			assertNoError(grp.Next(), t, "Next() returned an error")
+			f, ln2 := currentLineNumber(p, t)
+			if ln2 == n {
+				return
+			}
+			if ln2 != ln1 {
+				t.Fatalf("Program did not continue to correct next location (expected %d or %d) was %s:%d", ln1, n, f, ln2)
+			}
+			assertNoError(grp.Next(), t, "Next() returned an error")
+			f, ln2 = currentLineNumber(p, t)
+			if ln2 != n {
+				t.Fatalf("Program did not continue to correct next location (expected %d) was %s:%d", n, f, ln2)
+
+			}
+		}}
+	}
+
 	withTestProcessArgs("rangeoverfunc", t, ".", []string{}, 0, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 
 		t.Run("TestTrickyIterAll1", func(t *testing.T) {
@@ -6503,20 +6529,20 @@ func TestRangeOverFuncNext(t *testing.T) {
 				nx(118), // if z == 4
 				nx(121),
 
-				nx(116), // for _, z := range (z == 2)
-				nx(117), // result = append(result, z)
-				nx(118), // if z == 4
+				nx(116),     // for _, z := range (z == 2)
+				nx2(t, 117), // result = append(result, z)
+				nx(118),     // if z == 4
 				nx(121),
 
-				nx(116), // for _, z := range (z == 3)
-				nx(117), // result = append(result, z)
-				nx(118), // if z == 4
+				nx(116),     // for _, z := range (z == 3)
+				nx2(t, 117), // result = append(result, z)
+				nx(118),     // if z == 4
 				nx(121),
 
-				nx(116), // for _, z := range (z == 4)
-				nx(117), // result = append(result, z)
-				nx(118), // if z == 4
-				nx(119), // break
+				nx(116),     // for _, z := range (z == 4)
+				nx2(t, 117), // result = append(result, z)
+				nx(118),     // if z == 4
+				nx(119),     // break
 
 				nx(112), // defer func()
 				nx(113), // r := recover()
@@ -6617,14 +6643,14 @@ func TestRangeOverFuncNext(t *testing.T) {
 				nx(203), // result = append(result, y)
 				nx(204),
 
-				nx(199), // for _, y := range (y == 2)
-				nx(200), // if y == 3
-				nx(203), // result = append(result, y)
+				nx(199),     // for _, y := range (y == 2)
+				nx2(t, 200), // if y == 3
+				nx(203),     // result = append(result, y)
 				nx(204),
 
-				nx(199), // for _, y := range (y == 3)
-				nx(200), // if y == 3
-				nx(201), // goto A
+				nx(199),     // for _, y := range (y == 3)
+				nx2(t, 200), // if y == 3
+				nx(201),     // goto A
 				nx(204),
 				nx(206), // result = append(result, x)
 				nx(207),
@@ -6653,14 +6679,14 @@ func TestRangeOverFuncNext(t *testing.T) {
 				nx(222), // result = append(result, y)
 				nx(223),
 
-				nx(218), // for _, y := range (y == 2)
-				nx(219), // if y == 3
-				nx(222), // result = append(result, y)
+				nx(218),     // for _, y := range (y == 2)
+				nx2(t, 219), // if y == 3
+				nx(222),     // result = append(result, y)
 				nx(223),
 
-				nx(218), // for _, y := range (y == 3)
-				nx(219), // if y == 3
-				nx(220), // goto B
+				nx(218),     // for _, y := range (y == 3)
+				nx2(t, 219), // if y == 3
+				nx(220),     // goto B
 				nx(223),
 				nx(225),
 				nx(227), // result = append(result, 999)

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -911,7 +911,7 @@ func rangeFuncStackTrace(tgt *Target, g *G) ([]Stackframe, error) {
 
 		if len(frames) > 0 {
 			prev := &frames[len(frames)-1]
-			if fr.Regs.SP() <= prev.Regs.SP() {
+			if fr.Regs.SP() < prev.Regs.SP() {
 				nonMonotonicSP = true
 				return false
 			}


### PR DESCRIPTION
Fix TestRangeOverFuncNext on non-linux operating systems, on arm64 and
when the build mode is PIE.
