### PR TITLE
ci: remove go 1.20

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -41,7 +41,6 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2023.05"
 
 val targets = arrayOf(
-        "linux/amd64/1.20",
         "linux/amd64/1.21",
         "linux/amd64/1.22",
         "linux/amd64/tip",


### PR DESCRIPTION
https://github.com/go-delve/delve/commit/d8ed28ff35d6b23c222e6e0fc11bb61f153786db bumps the version requirement to 1.21