### PR TITLE
proc: initial support for expressions with range-over-func

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -960,7 +960,7 @@ func (rbpi *returnBreakpointInfo) Collect(t *Target, thread Thread) []*Variable 
 		return returnInfoError("could not read function entry", err, thread.ProcessMemory())
 	}
 
-	vars, err := scope.Locals(0)
+	vars, err := scope.Locals(0, "")
 	if err != nil {
 		return returnInfoError("could not evaluate return variables", err, thread.ProcessMemory())
 	}

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -855,7 +855,7 @@ func funcCallStep(callScope *EvalScope, stack *evalStack, thread Thread) bool {
 			flags |= localsTrustArgOrder
 		}
 
-		fncall.retvars, err = retScope.Locals(flags)
+		fncall.retvars, err = retScope.Locals(flags, "")
 		if err != nil {
 			fncall.err = fmt.Errorf("could not get return values: %v", err)
 			break

--- a/pkg/proc/stack_sigtramp.go
+++ b/pkg/proc/stack_sigtramp.go
@@ -18,7 +18,7 @@ func (it *stackIterator) readSigtrampgoContext() (*op.DwarfRegisters, error) {
 	bi := it.bi
 
 	findvar := func(name string) *Variable {
-		vars, _ := scope.Locals(0)
+		vars, _ := scope.Locals(0, name)
 		for i := range vars {
 			if vars[i].Name == name {
 				return vars[i]


### PR DESCRIPTION
Supports viewing local variables and evaluating expressions correctly
when range-over-func is used.

The same limitations that the previous commit on this line had still
apply (no inlining, wrong way to identify the range parent in some
cases).

Updates #3733
