### PR TITLE
pkg/astutil,pkg/elfwriter: fix package doc

### DIFF
--- a/pkg/astutil/astutil.go
+++ b/pkg/astutil/astutil.go
@@ -1,6 +1,5 @@
 // This package contains utility functions used by pkg/proc to generate
 // ast.Expr expressions.
-
 package astutil
 
 import (

--- a/pkg/elfwriter/writer.go
+++ b/pkg/elfwriter/writer.go
@@ -3,7 +3,6 @@
 // This package is incomplete, only features needed to write core files are
 // implemented, notably missing:
 // - program headers at the beginning of the file
-
 package elfwriter
 
 import (


### PR DESCRIPTION
The PR fixes the Go reference documentation for the `astutil` and `elfwriter` packages.

Before (https://pkg.go.dev/github.com/go-delve/delve):
<img width="400" alt="image" src="https://github.com/go-delve/delve/assets/3228886/ef6669c4-b6ee-4394-bb1b-c2d3228c7677">


After:
<img width="400" alt="image" src="https://github.com/go-delve/delve/assets/3228886/fb91782f-4e8d-4bbc-8129-6cf69e633a57">
