### PR TITLE
proc: support stepping through range-over-func statements with inlining

### DIFF
--- a/pkg/dwarf/reader/variables.go
+++ b/pkg/dwarf/reader/variables.go
@@ -33,15 +33,15 @@ const (
 // returned. If the VariablesSkipInlinedSubroutines is set, variables from
 // inlined subroutines will be skipped.
 func Variables(root *godwarf.Tree, pc uint64, line int, flags VariablesFlags) []Variable {
-	return variablesInternal(nil, root, 0, pc, line, flags)
+	return variablesInternal(nil, root, 0, pc, line, flags, true)
 }
 
 // variablesInternal appends to 'v' variables from 'root'. The function calls
 // itself with an incremented scope for all sub-blocks in 'root'.
-func variablesInternal(v []Variable, root *godwarf.Tree, depth int, pc uint64, line int, flags VariablesFlags) []Variable {
+func variablesInternal(v []Variable, root *godwarf.Tree, depth int, pc uint64, line int, flags VariablesFlags, first bool) []Variable {
 	switch root.Tag {
 	case dwarf.TagInlinedSubroutine:
-		if flags&VariablesSkipInlinedSubroutines != 0 {
+		if !first && flags&VariablesSkipInlinedSubroutines != 0 {
 			return v
 		}
 		fallthrough
@@ -50,7 +50,7 @@ func variablesInternal(v []Variable, root *godwarf.Tree, depth int, pc uint64, l
 		// pc (or if we don't care about visibility).
 		if (flags&VariablesOnlyVisible == 0) || root.ContainsPC(pc) {
 			for _, child := range root.Children {
-				v = variablesInternal(v, child, depth+1, pc, line, flags)
+				v = variablesInternal(v, child, depth+1, pc, line, flags, false)
 			}
 		}
 		return v

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -394,7 +394,7 @@ func (scope *EvalScope) simpleLocals(flags localsFlags, wantedName string) ([]*V
 		return nil, err
 	}
 
-	variablesFlags := reader.VariablesOnlyVisible
+	variablesFlags := reader.VariablesOnlyVisible | reader.VariablesSkipInlinedSubroutines
 	if flags&localsNoDeclLineCheck != 0 {
 		variablesFlags = reader.VariablesNoDeclLineCheck
 	}

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -49,6 +49,8 @@ type Stackframe struct {
 	SystemStack bool
 	// Inlined is true if this frame is actually an inlined call.
 	Inlined bool
+	// hasInlines is true if this frame is a concrete function that is executing inlined calls (i.e. if there is at least one inlined call frame on top of this one).
+	hasInlines bool
 	// Bottom is true if this is the bottom of the stack
 	Bottom bool
 
@@ -403,6 +405,7 @@ func (it *stackIterator) appendInlineCalls(callback func(Stackframe) bool, frame
 	}
 
 	for _, entry := range reader.InlineStack(dwarfTree, callpc) {
+		frame.hasInlines = true
 		fnname, okname := entry.Val(dwarf.AttrName).(string)
 		fileidx, okfileidx := entry.Val(dwarf.AttrCallFile).(int64)
 		line, okline := entry.Val(dwarf.AttrCallLine).(int64)


### PR DESCRIPTION
Extends support for stepping through range-over-func statement to
programs compiled with inlining enabled.

Updates #3733
