### PR TITLE
pkg/terminal: do not use deprecated strings.Title

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -3522,7 +3522,7 @@ func formatBreakpointName(bp *api.Breakpoint, upcase bool) string {
 		thing = "watchpoint"
 	}
 	if upcase {
-		thing = strings.Title(thing)
+		thing = strings.ToUpper(string(thing[0])) + thing[1:]
 	}
 	id := bp.Name
 	if id == "" {


### PR DESCRIPTION
The PR removes usage of deprecated [`strings.Title`](https://pkg.go.dev/strings#Title).

In our case, for titling three words `breakpoint, tracepoint, watchpoint` the `strings.Title` is perfectly fine. But I decided to remove it anyway.