### PR TITLE
all: fix typos in CHANGELOG, comments and package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ This project adheres to Semantic Versioning.
 ### Changed
 
 - Type casts from slice to string and vice versa will now use the load configuration for the target type, which is more intuitive (#3596, @aarzilli)
-- Miscellaneous impreovements to documentation (#3531, #3555, #3556, #3562, #3564, #3575, #3576, @alexandear, @testwill)
+- Miscellaneous improvements to documentation (#3531, #3555, #3556, #3562, #3564, #3575, #3576, @alexandear, @testwill)
 
 ## [1.21.2] 2023-10-30
 
@@ -207,7 +207,7 @@ This project adheres to Semantic Versioning.
 - Add support for empty string in substitutePath (@RuijieC-dev)
 - Support gnu_debuglink section (@aarzilli)
 - Support exact matches in SubstitutePath (@eandre)
-- Add ability to show disassembly instead of source code (@aazilli)
+- Add ability to show disassembly instead of source code (@aarzilli)
 - Add -per-g-hitcount to breakpoint conditions (@yangxikun)
 
 ### Fixed
@@ -218,7 +218,7 @@ This project adheres to Semantic Versioning.
 - Do not panic reading bad G struct (@aarzilli)
 - Fix parsing DWARFv5 file table (@derekparker)
 - Improve trace subcommand output (@derekparker)
-- Fix documentation for examinemem (@aaarzilli)
+- Fix documentation for examinemem (@aarzilli)
 - Fix step instruction on 1 byte instruction with software breakpoint (@qmuntal)
 - Fix handling of function entry / return in ebpf tracing backend (@derekparker)
 - Fix size of ebpf type for fn_addr (@derekparker)
@@ -389,7 +389,7 @@ This project adheres to Semantic Versioning.
 ### Fixed
 
 * Correctly check for 1.17 and regabi (@aarzilli)
-* Print config output strings quouted (@aarzilli, @krobelus)
+* Print config output strings quoted (@aarzilli, @krobelus)
 * Update check for system goroutines (@suzmue)
 * DAP: Halt before detach in Stop (@polinasok)
 * DAP: Do not send halt request if debuggee is not running (@suzmue)

--- a/_fixtures/issue2896.go
+++ b/_fixtures/issue2896.go
@@ -6,7 +6,7 @@ type Vehicle interface {
 	Run()
 }
 
-// BMWS1000RR defines the motocycle bmw s1000rr
+// BMWS1000RR defines the motorcycle bmw s1000rr
 type BMWS1000RR struct {
 }
 

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -503,7 +503,7 @@ type Function struct {
 	// InlinedCalls lists all inlined calls to this function
 	InlinedCalls         []InlinedCall
 	rangeParentNameCache int // see rangeParentName
-	// extraCache contains informations about this function that is only needed for
+	// extraCache contains information about this function that is only needed for
 	// some operations and is expensive to compute or store for every function.
 	extraCache *functionExtra
 }
@@ -687,7 +687,7 @@ func (fn *Function) rangeParentName() string {
 	return fn.Name[:fn.rangeParentNameCache]
 }
 
-// extra loads informations about fn that is expensive to compute and we
+// extra loads information about fn that is expensive to compute and we
 // only need for a minority of the functions.
 func (fn *Function) extra(bi *BinaryInfo) *functionExtra {
 	if fn.extraCache != nil {

--- a/pkg/proc/native/support_sentinel_darwin.go
+++ b/pkg/proc/native/support_sentinel_darwin.go
@@ -2,4 +2,4 @@
 
 // This file is used to detect build on unsupported GOOS/GOARCH combinations.
 
-package your_darwin_architectur_is_not_supported_by_delve
+package your_darwin_architecture_is_not_supported_by_delve

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -901,7 +901,7 @@ func TestPrintContextParkedGoroutine(t *testing.T) {
 		frameout := strings.Split(term.MustExec("frame 0"), "\n")
 		t.Logf("frame 0 -> %q", frameout)
 		if strings.Contains(frameout[0], "stacktraceme") {
-			t.Fatal("bad output for `frame 0` command on a parked goorutine")
+			t.Fatal("bad output for `frame 0` command on a parked goroutine")
 		}
 
 		listout := strings.Split(term.MustExec("list"), "\n")

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -2286,7 +2286,7 @@ func TestVariablesLoading(t *testing.T) {
 						checkChildren(t, tm, "tm", 1)
 						ref = checkVarExact(t, tm, 0, "v", "tm.v", "[]map[string]main.astruct len: 1, cap: 1, [[...]]", "[]map[string]main.astruct", hasChildren)
 						if ref > 0 {
-							// Auto-loading of fully missing map chidlren happens here, but they get truncated at MaxArrayValues
+							// Auto-loading of fully missing map children happens here, but they get truncated at MaxArrayValues
 							client.VariablesRequest(ref)
 							tmV := client.ExpectVariablesResponse(t)
 							checkChildren(t, tmV, "tm.v", 1)
@@ -2315,7 +2315,7 @@ func TestVariablesLoading(t *testing.T) {
 							checkChildren(t, tm, "tm", 1)
 							ref = checkVarExact(t, tm, 0, "v", "", "[]map[string]main.astruct len: 1, cap: 1, [[...]]", "[]map[string]main.astruct", hasChildren)
 							if ref > 0 {
-								// Auto-loading of fully missing map chidlren happens here, but they get trancated at MaxArrayValues
+								// Auto-loading of fully missing map children happens here, but they get truncated at MaxArrayValues
 								client.VariablesRequest(ref)
 								tmV := client.ExpectVariablesResponse(t)
 								checkChildren(t, tmV, "tm.v", 1)

--- a/service/rpccallback.go
+++ b/service/rpccallback.go
@@ -9,7 +9,7 @@ type RPCCallback interface {
 	// receive other requests.
 	SetupDoneChan() chan struct{}
 
-	// DisconnectChan returns a channel that should be clised to signal that
+	// DisconnectChan returns a channel that should be closed to signal that
 	// the client that initially issued the command has been disconnected.
 	DisconnectChan() chan struct{}
 }


### PR DESCRIPTION
The PR corrects spelling issues:
- fix wrong username in CHANGELOG;
- fix package name;
- `information` do not use in plural;
- correct typos in comments.