### PR TITLE
pkg/proc,service/debugger: fix debuginfod-find source

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2346,7 +2346,12 @@ func (d *Debugger) TargetGroup() *proc.TargetGroup {
 }
 
 func (d *Debugger) BuildID() string {
-	return d.target.Selected.BinInfo().BuildID
+	loc, err := d.target.Selected.CurrentThread().Location()
+	if err != nil {
+		return ""
+	}
+	img := d.target.Selected.BinInfo().PCToImage(loc.PC)
+	return img.BuildID
 }
 
 func (d *Debugger) AttachPid() int {


### PR DESCRIPTION
Fixes bug where the incorrect Build ID could be used to try and download the source for a binary. This is because the Build ID was stored on the BinInfo object for a target and not the image itself.