### PR TITLE
proc: use .closureptr for stepping through range-over-func statements

### DIFF
--- a/_fixtures/rangeoverfunc.go
+++ b/_fixtures/rangeoverfunc.go
@@ -228,6 +228,20 @@ B:
 	fmt.Println(result)
 }
 
+func TestRecur(n int) {
+	result := []int{}
+	if n > 0 {
+		TestRecur(n - 1)
+	}
+	for _, x := range OfSliceIndex([]int{10, 20, 30}) {
+		result = append(result, x)
+		if n == 3 {
+			TestRecur(0)
+		}
+	}
+	fmt.Println(result)
+}
+
 func main() {
 	TestTrickyIterAll()
 	TestTrickyIterAll2()
@@ -240,47 +254,27 @@ func main() {
 	TestLongReturnWrapper()
 	TestGotoA1()
 	TestGotoB1()
+	TestRecur(3)
 }
 
 type Seq[T any] func(yield func(T) bool)
 type Seq2[T1, T2 any] func(yield func(T1, T2) bool)
 
 type TrickyIterator struct {
-	yield func(int, int) bool
-}
-
-func (ti *TrickyIterator) iterEcho(s []int) Seq2[int, int] {
-	return func(yield func(int, int) bool) {
-		for i, v := range s {
-			if !yield(i, v) {
-				ti.yield = yield
-				return
-			}
-			if ti.yield != nil && !ti.yield(i, v) {
-				return
-			}
-		}
-		ti.yield = yield
-		return
-	}
+	yield func()
 }
 
 func (ti *TrickyIterator) iterAll(s []int) Seq2[int, int] {
 	return func(yield func(int, int) bool) {
-		ti.yield = yield // Save yield for future abuse
+		// NOTE: storing the yield func in the iterator has been removed because
+		// it make the closure escape to the heap which breaks the .closureptr
+		// heuristic. Eventually we will need to figure out what to do when that
+		// happens.
 		for i, v := range s {
 			if !yield(i, v) {
 				return
 			}
 		}
-		return
-	}
-}
-
-func (ti *TrickyIterator) iterZero(s []int) Seq2[int, int] {
-	return func(yield func(int, int) bool) {
-		ti.yield = yield // Save yield for future abuse
-		// Don't call it at all, maybe it won't escape
 		return
 	}
 }

--- a/pkg/proc/evalop/evalcompile.go
+++ b/pkg/proc/evalop/evalcompile.go
@@ -218,6 +218,9 @@ func (ctx *compileCtx) compileAST(t ast.Expr) error {
 			case x.Name == "runtime" && node.Sel.Name == "threadid":
 				ctx.pushOp(&PushThreadID{})
 
+			case x.Name == "runtime" && node.Sel.Name == "rangeParentOffset":
+				ctx.pushOp(&PushRangeParentOffset{})
+
 			default:
 				ctx.pushOp(&PushPackageVarOrSelect{Name: x.Name, Sel: node.Sel.Name})
 			}

--- a/pkg/proc/evalop/ops.go
+++ b/pkg/proc/evalop/ops.go
@@ -30,6 +30,12 @@ type PushThreadID struct {
 
 func (*PushThreadID) depthCheck() (npop, npush int) { return 0, 1 }
 
+// PushRangeParentOffset pushes the frame offset of the range-over-func closure body parent.
+type PushRangeParentOffset struct {
+}
+
+func (*PushRangeParentOffset) depthCheck() (npop, npush int) { return 0, 1 }
+
 // PushConst pushes a constant on the stack.
 type PushConst struct {
 	Value constant.Value

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -6268,11 +6268,21 @@ func TestRangeOverFuncNext(t *testing.T) {
 		t.Skip("N/A")
 	}
 
+	var bp *proc.Breakpoint
+
 	funcBreak := func(t *testing.T, fnname string) seqTest {
 		return seqTest{
 			contNothing,
 			func(p *proc.Target) {
-				setFunctionBreakpoint(p, t, fnname)
+				bp = setFunctionBreakpoint(p, t, fnname)
+			}}
+	}
+
+	clearBreak := func(t *testing.T) seqTest {
+		return seqTest{
+			contNothing,
+			func(p *proc.Target) {
+				assertNoError(p.ClearBreakpoint(bp.Addr), t, "ClearBreakpoint")
 			}}
 	}
 
@@ -6359,6 +6369,19 @@ func TestRangeOverFuncNext(t *testing.T) {
 							t.Errorf("Wrong value for %q, got %q expected %q", expr, out, tgt)
 						}
 					}
+				}
+			},
+		}
+	}
+
+	assertFunc := func(t *testing.T, fname string) seqTest {
+		return seqTest{
+			contNothing,
+			func(p *proc.Target) {
+				pc := currentPC(p, t)
+				fn := p.BinInfo().PCToFunc(pc)
+				if fn.Name != fname {
+					t.Errorf("Wrong function name, expected %s got %s", fname, fn.Name)
 				}
 			},
 		}
@@ -6803,6 +6826,33 @@ func TestRangeOverFuncNext(t *testing.T) {
 				nx(228), // fmt.Println
 			})
 		})
+
+		t.Run("TestRecur", func(t *testing.T) {
+			testseq2intl(t, fixture, grp, p, nil, []seqTest{
+				funcBreak(t, "main.TestRecur"),
+				{contContinue, 231},
+				clearBreak(t),
+				nx(232), // result := []int{}
+				assertEval(t, "n", "3"),
+				nx(233), // if n > 0 {
+				nx(234), // TestRecur
+
+				nx(236), // for _, x := range (x == 10)
+				assertFunc(t, "main.TestRecur"),
+				assertEval(t, "n", "3"),
+				nx(236),
+				assertFunc(t, "main.TestRecur-range1"),
+				assertEval(t, "x", "10", "n", "3"),
+				nx(237), // result = ...
+				nx(238), // if n == 3
+				nx(239), // TestRecur(0)
+				nx(241),
+
+				nx(236), // for _, x := range (x == 20)
+				nx(237), // result = ...
+				assertEval(t, "x", "20", "n", "3"),
+			})
+		})
 	})
 }
 
@@ -6813,7 +6863,7 @@ func TestRangeOverFuncStepOut(t *testing.T) {
 
 	testseq2(t, "rangeoverfunc", "", []seqTest{
 		{contContinue, 97},
-		{contStepout, 237},
+		{contStepout, 251},
 	})
 }
 
@@ -6822,11 +6872,21 @@ func TestRangeOverFuncNextInlined(t *testing.T) {
 		t.Skip("N/A")
 	}
 
+	var bp *proc.Breakpoint
+
 	funcBreak := func(t *testing.T, fnname string) seqTest {
 		return seqTest{
 			contNothing,
 			func(p *proc.Target) {
-				setFunctionBreakpoint(p, t, fnname)
+				bp = setFunctionBreakpoint(p, t, fnname)
+			}}
+	}
+
+	clearBreak := func(t *testing.T) seqTest {
+		return seqTest{
+			contNothing,
+			func(p *proc.Target) {
+				assertNoError(p.ClearBreakpoint(bp.Addr), t, "ClearBreakpoint")
 			}}
 	}
 
@@ -6883,6 +6943,19 @@ func TestRangeOverFuncNextInlined(t *testing.T) {
 							t.Errorf("Wrong value for %q, got %q expected %q", expr, out, tgt)
 						}
 					}
+				}
+			},
+		}
+	}
+
+	assertFunc := func(t *testing.T, fname string) seqTest {
+		return seqTest{
+			contNothing,
+			func(p *proc.Target) {
+				pc := currentPC(p, t)
+				fn := p.BinInfo().PCToFunc(pc)
+				if fn.Name != fname {
+					t.Errorf("Wrong function name, expected %s got %s", fname, fn.Name)
 				}
 			},
 		}
@@ -7338,6 +7411,33 @@ func TestRangeOverFuncNextInlined(t *testing.T) {
 				nx(225),
 				nx(227), // result = append(result, 999)
 				nx(228), // fmt.Println
+			})
+		})
+
+		t.Run("TestRecur", func(t *testing.T) {
+			testseq2intl(t, fixture, grp, p, nil, []seqTest{
+				funcBreak(t, "main.TestRecur"),
+				{contContinue, 231},
+				clearBreak(t),
+				nx(232), // result := []int{}
+				assertEval(t, "n", "3"),
+				nx(233), // if n > 0 {
+				nx(234), // TestRecur
+
+				nx(236), // for _, x := range (x == 10)
+				assertFunc(t, "main.TestRecur"),
+				assertEval(t, "n", "3"),
+				nx(236),
+				assertFunc(t, "main.TestRecur-range1"),
+				assertEval(t, "x", "10", "n", "3"),
+				nx(237), // result = ...
+				nx(238), // if n == 3
+				nx(239), // TestRecur(0)
+				nx(241),
+
+				nx(236), // for _, x := range (x == 20)
+				nx(237), // result = ...
+				assertEval(t, "x", "20", "n", "3"),
 			})
 		})
 	})

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -65,6 +65,11 @@ type Stackframe struct {
 	// Use this value to determine active lexical scopes for the stackframe.
 	lastpc uint64
 
+	// closurePtr is the value of .closureptr, if present. This variable is
+	// used to correlated range-over-func closure bodies with their enclosing
+	// function.
+	closurePtr int64
+
 	// TopmostDefer is the defer that would be at the top of the stack when a
 	// panic unwind would get to this call frame, in other words it's the first
 	// deferred function that will  be called if the runtime unwinds past this
@@ -93,6 +98,13 @@ func (frame *Stackframe) FramePointerOffset() int64 {
 		return int64(frame.Regs.BP())
 	}
 	return int64(frame.Regs.BP()) - int64(frame.stackHi)
+}
+
+// contains returns true if off is between CFA and SP
+func (frame *Stackframe) contains(off int64) bool {
+	p := uint64(off + int64(frame.stackHi))
+	//TODO: check that this is the right order!!!
+	return frame.Regs.SP() < p && p <= uint64(frame.Regs.CFA)
 }
 
 // ThreadStacktrace returns the stack trace for thread.
@@ -350,6 +362,19 @@ func (it *stackIterator) newStackframe(ret, retaddr uint64) Stackframe {
 			r.Call.File, r.Call.Line = r.Current.Fn.cu.lineInfo.PCToLine(r.Current.Fn.Entry, it.pc-1)
 		}
 	}
+	if fn != nil && !fn.cu.image.Stripped() && !r.SystemStack && it.g != nil {
+		dwarfTree, _ := fn.cu.image.getDwarfTree(fn.offset)
+		if dwarfTree != nil {
+			c := readLocalPtrVar(dwarfTree, goClosurePtr, it.target, it.bi, fn.cu.image, r.Regs, it.mem)
+			if c != 0 {
+				if c >= it.g.stack.lo && c < it.g.stack.hi {
+					r.closurePtr = int64(c) - int64(it.g.stack.hi)
+				} else {
+					r.closurePtr = int64(c)
+				}
+			}
+		}
+	}
 	return r
 }
 
@@ -436,6 +461,7 @@ func (it *stackIterator) appendInlineCalls(callback func(Stackframe) bool, frame
 			SystemStack: frame.SystemStack,
 			Inlined:     true,
 			lastpc:      frame.lastpc,
+			closurePtr:  frame.closurePtr,
 		})
 
 		frame.Call.File = filepath
@@ -909,9 +935,40 @@ func rangeFuncStackTrace(tgt *Target, g *G) ([]Stackframe, error) {
 	stage := 0
 	var rangeParent *Function
 	nonMonotonicSP := false
-	it.stacktraceFunc(func(fr Stackframe) bool {
-		//TODO(range-over-func): this is a heuristic, we should use .closureptr instead
+	var closurePtr int64
 
+	ap := func(fr Stackframe) {
+		frames = append(frames, fr)
+		if fr.closurePtr != 0 {
+			closurePtr = fr.closurePtr
+		}
+	}
+
+	closureptrok := func(fr *Stackframe) bool {
+		if fr.SystemStack {
+			return false
+		}
+		if closurePtr < 0 {
+			// closure is stack allocated, check that it is on this frame
+			return fr.contains(closurePtr)
+		}
+		// otherwise closurePtr is a heap allocated variable, so we need to check
+		// all closure body variables in scope in this frame
+		scope := FrameToScope(tgt, it.mem, it.g, 0, *fr)
+		yields, _ := scope.simpleLocals(localsNoDeclLineCheck|localsOnlyRangeBodyClosures, "")
+		for _, yield := range yields {
+			if yield.Kind != reflect.Func {
+				continue
+			}
+			addr := yield.funcvalAddr()
+			if int64(addr) == closurePtr {
+				return true
+			}
+		}
+		return false
+	}
+
+	it.stacktraceFunc(func(fr Stackframe) bool {
 		if len(frames) > 0 {
 			prev := &frames[len(frames)-1]
 			if fr.Regs.SP() < prev.Regs.SP() {
@@ -922,20 +979,25 @@ func rangeFuncStackTrace(tgt *Target, g *G) ([]Stackframe, error) {
 
 		switch stage {
 		case 0:
-			frames = append(frames, fr)
+			ap(fr)
 			rangeParent = fr.Call.Fn.extra(tgt.BinInfo()).rangeParent
 			stage++
-			if rangeParent == nil {
+			if rangeParent == nil || closurePtr == 0 {
 				frames = nil
 				stage = 3
 				return false
 			}
 		case 1:
-			if fr.Call.Fn.offset == rangeParent.offset {
-				frames = append(frames, fr)
+			if fr.Call.Fn.offset == rangeParent.offset && closureptrok(&fr) {
+				ap(fr)
 				stage++
-			} else if fr.Call.Fn.extra(tgt.BinInfo()).rangeParent == rangeParent {
-				frames = append(frames, fr)
+			} else if fr.Call.Fn.extra(tgt.BinInfo()).rangeParent == rangeParent && closureptrok(&fr) {
+				ap(fr)
+				if closurePtr == 0 {
+					frames = nil
+					stage = 3
+					return false
+				}
 			}
 		case 2:
 			frames = append(frames, fr)


### PR DESCRIPTION
Uses special variables .closureptr and #yieldN to correctly identify
the parent frame of a range-over-func body closure call.

Updates #3733
