### PR TITLE
pkg: refactor to .WriteString() instead of .Write([]byte())

### DIFF
--- a/_scripts/gen-faq-toc.go
+++ b/_scripts/gen-faq-toc.go
@@ -50,12 +50,12 @@ func spliceDocs(docpath string, docs []byte, outpath string) {
 	footer := v[1]
 
 	outbuf := bytes.NewBuffer(make([]byte, 0, len(header)+len(docs)+len(footer)+len(startOfToc)+len(endOfToc)+1))
-	outbuf.Write([]byte(header))
-	outbuf.Write([]byte(startOfToc))
+	outbuf.WriteString(header)
+	outbuf.WriteString(startOfToc)
 	outbuf.WriteByte('\n')
 	outbuf.Write(docs)
-	outbuf.Write([]byte(endOfToc))
-	outbuf.Write([]byte(footer))
+	outbuf.WriteString(endOfToc)
+	outbuf.WriteString(footer)
 
 	if outpath != "-" {
 		err = os.WriteFile(outpath, outbuf.Bytes(), 0o664)

--- a/pkg/dwarf/dwarfbuilder/info.go
+++ b/pkg/dwarf/dwarfbuilder/info.go
@@ -137,7 +137,7 @@ func (b *Builder) Attr(attr dwarf.Attr, val interface{}) dwarf.Offset {
 	switch x := val.(type) {
 	case string:
 		tag.form = append(tag.form, DW_FORM_string)
-		b.info.Write([]byte(x))
+		b.info.WriteString(x)
 		b.info.WriteByte(0)
 	case uint8:
 		tag.form = append(tag.form, DW_FORM_data1)

--- a/pkg/proc/dump.go
+++ b/pkg/proc/dump.go
@@ -273,7 +273,7 @@ func (t *Target) dumpThreadNotes(notes []elfwriter.Note, state *DumpState, th Th
 
 	for _, reg := range regsv {
 		binary.Write(buf, binary.LittleEndian, uint16(len(reg.Name)))
-		buf.Write([]byte(reg.Name))
+		buf.WriteString(reg.Name)
 		if reg.Reg.Bytes != nil {
 			binary.Write(buf, binary.LittleEndian, uint16(len(reg.Reg.Bytes)))
 			buf.Write(reg.Reg.Bytes)

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -258,7 +258,7 @@ func rrStderrParser(stderr io.ReadCloser, initch chan<- rrInit, quiet bool) {
 		}
 
 		if !quiet {
-			os.Stderr.Write([]byte(line))
+			os.Stderr.WriteString(line)
 		}
 	}
 

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -3126,7 +3126,7 @@ func (c *Commands) onCmd(t *Term, ctx callContext, argstr string) error {
 			_ = os.Remove(f.Name())
 		}()
 		attrs := formatBreakpointAttrs("", ctx.Breakpoint, true)
-		_, err = f.Write([]byte(strings.Join(attrs, "\n")))
+		_, err = f.WriteString(strings.Join(attrs, "\n"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The PR refactors code to `.WriteString(...)` instead of `.Write([]byte(...))`, both for `File` and `Buffer`.

[`File.WriteString(...)`](https://cs.opensource.google/go/go/+/refs/tags/go1.22.5:src/os/file.go;l=293) may be more efficient than `File.Write([]byte(...))` because it utilizes `unsafe` under the hood to convert a `string` to `[]byte` without allocation.