### PR TITLE
pkg/terminal: add missing file.Close() call

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -3123,6 +3123,7 @@ func (c *Commands) onCmd(t *Term, ctx callContext, argstr string) error {
 			return err
 		}
 		defer func() {
+			_ = f.Close()
 			_ = os.Remove(f.Name())
 		}()
 		attrs := formatBreakpointAttrs("", ctx.Breakpoint, true)


### PR DESCRIPTION
The PR adds missing `f.Close()` call.

If `_, err = f.Write(...)` returns an error, the program doesn't call `f.Close()`:

```go
		f, err := os.CreateTemp("", "dlv-on-cmd-")
		if err != nil {
			return err
		}
		defer func() {
			_ = os.Remove(f.Name())
		}()
		// ...
		_, err = f.Write([]byte(strings.Join(attrs, "\n")))
		if err != nil {
			// missing f.Close() which is called below
			return err
		}
		err = f.Close()
		if err != nil {
			return err
		}
```