### PR TITLE
service/dap,rpc1,rpc2: refactor creating RPC clients

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -123,7 +123,7 @@ func TestBuild(t *testing.T) {
 		}
 	}()
 
-	client := rpc2.NewClient(listenAddr)
+	client := rpc2.NewTestClient(t, listenAddr)
 	state := <-client.Continue()
 
 	if !state.Exited {
@@ -273,7 +273,7 @@ func TestUnattendedBreakpoint(t *testing.T) {
 	}
 
 	// and detach from and kill the headless instance
-	client := rpc2.NewClient(listenAddr)
+	client := rpc2.NewTestClient(t, listenAddr)
 	if err := client.Detach(true); err != nil {
 		t.Fatalf("error detaching from headless instance: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestContinue(t *testing.T) {
 	}
 
 	// and detach from and kill the headless instance
-	client := rpc2.NewClient(listenAddr)
+	client := rpc2.NewTestClient(t, listenAddr)
 	if err := client.Detach(true); err != nil {
 		t.Fatalf("error detaching from headless instance: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestRedirect(t *testing.T) {
 	}
 
 	// and detach from and kill the headless instance
-	client := rpc2.NewClient(listenAddr)
+	client := rpc2.NewTestClient(t, listenAddr)
 	client.Detach(true)
 	cmd.Wait()
 }
@@ -673,7 +673,7 @@ func TestDAPCmd(t *testing.T) {
 	}()
 
 	// Connect a client and request shutdown.
-	client := daptest.NewClient(listenAddr)
+	client := daptest.NewClient(t, listenAddr)
 	client.DisconnectRequest()
 	client.ExpectDisconnectResponse(t)
 	client.ExpectTerminatedEvent(t)
@@ -692,7 +692,7 @@ func TestDAPCmd(t *testing.T) {
 }
 
 func newDAPRemoteClient(t *testing.T, addr string, isDlvAttach bool, isMulti bool) *daptest.Client {
-	c := daptest.NewClient(addr)
+	c := daptest.NewClient(t, addr)
 	c.AttachRequest(map[string]interface{}{"mode": "remote", "stopOnEntry": true})
 	if isDlvAttach || isMulti {
 		c.ExpectCapabilitiesEventSupportTerminateDebuggee(t)
@@ -786,7 +786,7 @@ func TestRemoteDAPClientMulti(t *testing.T) {
 	}()
 
 	// Client 0 connects but with the wrong attach request
-	dapclient0 := daptest.NewClient(listenAddr)
+	dapclient0 := daptest.NewClient(t, listenAddr)
 	dapclient0.AttachRequest(map[string]interface{}{"mode": "local"})
 	dapclient0.ExpectErrorResponse(t)
 
@@ -809,13 +809,13 @@ func TestRemoteDAPClientMulti(t *testing.T) {
 	closeDAPRemoteMultiClient(t, dapclient2, "exited")
 
 	// Attach to exited processes is an error
-	dapclient3 := daptest.NewClient(listenAddr)
+	dapclient3 := daptest.NewClient(t, listenAddr)
 	dapclient3.AttachRequest(map[string]interface{}{"mode": "remote", "stopOnEntry": true})
 	dapclient3.ExpectErrorResponseWith(t, dap.FailedToAttach, `Process \d+ has exited with status 0`, true)
 	closeDAPRemoteMultiClient(t, dapclient3, "exited")
 
 	// But rpc clients can still connect and restart
-	rpcclient := rpc2.NewClient(listenAddr)
+	rpcclient := rpc2.NewTestClient(t, listenAddr)
 	if _, err := rpcclient.Restart(false); err != nil {
 		t.Errorf("error restarting with rpc client: %v", err)
 	}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -140,7 +140,7 @@ func withTestTerminalBuildFlags(name string, t testing.TB, buildFlags test.Build
 	if err := server.Run(); err != nil {
 		t.Fatal(err)
 	}
-	client := rpc2.NewClient(listener.Addr().String())
+	client := rpc2.NewTestClient(t, listener.Addr().String())
 	defer func() {
 		client.Detach(true)
 	}()

--- a/service/dap/daptest/client.go
+++ b/service/dap/daptest/client.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"path/filepath"
 	"reflect"
@@ -31,11 +30,11 @@ type Client struct {
 
 // NewClient creates a new Client over a TCP connection.
 // Call Close() to close the connection.
-func NewClient(addr string) *Client {
-	fmt.Println("Connecting to server at:", addr)
+func NewClient(t *testing.T, addr string) *Client {
+	t.Logf("Connecting to server at: %s", addr)
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
-		log.Fatal("dialing:", err)
+		t.Fatalf("dialing: %v", err)
 	}
 	return NewClientFromConn(conn)
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -77,7 +77,7 @@ func runTestBuildFlags(t *testing.T, name string, test func(c *daptest.Client, f
 
 func startDAPServerWithClient(t *testing.T, defaultDebugInfoDirs bool, serverStopped chan struct{}) *daptest.Client {
 	server, _ := startDAPServer(t, defaultDebugInfoDirs, serverStopped)
-	client := daptest.NewClient(server.config.Listener.Addr().String())
+	client := daptest.NewClient(t, server.config.Listener.Addr().String())
 	return client
 }
 
@@ -184,7 +184,7 @@ func TestStopNoTarget(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			serverStopped := make(chan struct{})
 			server, forceStop := startDAPServer(t, false, serverStopped)
-			client := daptest.NewClient(server.config.Listener.Addr().String())
+			client := daptest.NewClient(t, server.config.Listener.Addr().String())
 			defer client.Close()
 
 			client.InitializeRequest()
@@ -211,7 +211,7 @@ func TestStopWithTarget(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			serverStopped := make(chan struct{})
 			server, forceStop := startDAPServer(t, false, serverStopped)
-			client := daptest.NewClient(server.config.Listener.Addr().String())
+			client := daptest.NewClient(t, server.config.Listener.Addr().String())
 			defer client.Close()
 
 			client.InitializeRequest()
@@ -284,7 +284,7 @@ func TestSessionStop(t *testing.T) {
 				close(acceptDone)
 			}()
 			time.Sleep(10 * time.Millisecond) // give time to start listening
-			client := daptest.NewClient(listener.Addr().String())
+			client := daptest.NewClient(t, listener.Addr().String())
 			defer client.Close()
 			<-acceptDone
 			if err != nil {
@@ -315,7 +315,7 @@ func TestSessionStop(t *testing.T) {
 func TestForceStopWhileStopping(t *testing.T) {
 	serverStopped := make(chan struct{})
 	server, forceStop := startDAPServer(t, false, serverStopped)
-	client := daptest.NewClient(server.config.Listener.Addr().String())
+	client := daptest.NewClient(t, server.config.Listener.Addr().String())
 
 	client.InitializeRequest()
 	client.ExpectInitializeResponseAndCapabilities(t)
@@ -6782,7 +6782,7 @@ func attachDebuggerWithTargetHalted(t *testing.T, fixture string) (*exec.Cmd, *d
 func runTestWithDebugger(t *testing.T, dbg *debugger.Debugger, test func(c *daptest.Client)) {
 	serverStopped := make(chan struct{})
 	server, _ := startDAPServer(t, false, serverStopped)
-	client := daptest.NewClient(server.listener.Addr().String())
+	client := daptest.NewClient(t, server.listener.Addr().String())
 	time.Sleep(100 * time.Millisecond) // Give time for connection to be set as dap.Session
 	server.sessionMu.Lock()
 	if server.session == nil {
@@ -6913,7 +6913,7 @@ func NewMultiClientCloseServerMock(t *testing.T, fixture string) *MultiClientClo
 }
 
 func (s *MultiClientCloseServerMock) acceptNewClient(t *testing.T) *daptest.Client {
-	client := daptest.NewClient(s.impl.listener.Addr().String())
+	client := daptest.NewClient(t, s.impl.listener.Addr().String())
 	time.Sleep(100 * time.Millisecond) // Give time for connection to be set as dap.Session
 	s.impl.sessionMu.Lock()
 	if s.impl.session == nil {

--- a/service/rpc1/client.go
+++ b/service/rpc1/client.go
@@ -3,11 +3,10 @@ package rpc1
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/rpc"
 	"net/rpc/jsonrpc"
-
 	"sync"
+	"testing"
 
 	"github.com/go-delve/delve/service/api"
 )
@@ -22,11 +21,12 @@ type RPCClient struct {
 
 var errAPIUnsupported = errors.New("unsupported")
 
-// NewClient creates a new RPCClient.
-func NewClient(addr string) *RPCClient {
+// NewTestClient creates a new RPCClient.
+// Should be used only for tests.
+func NewTestClient(t testing.TB, addr string) *RPCClient {
 	client, err := jsonrpc.Dial("tcp", addr)
 	if err != nil {
-		log.Fatal("dialing:", err)
+		t.Fatalf("dialing: %v", err)
 	}
 	return &RPCClient{
 		addr:   addr,

--- a/service/rpc1/doc.go
+++ b/service/rpc1/doc.go
@@ -1,0 +1,5 @@
+// Package rpc1 implements version 1 of Delve's API and is only
+// kept for backwards compatibility.
+// client.go is the old client code used by Delve's frontend (delve/cmd/dlv),
+// it is only preserved for the backwards compatibility of integrations tests.
+package rpc1

--- a/service/rpc1/readme.txt
+++ b/service/rpc1/readme.txt
@@ -1,5 +1,0 @@
-This package implements version 1 of Delve's API and is only
-kept here for backwards compatibility. Client.go is the old
-client code used by Delve's frontend (delve/cmd/dlv), it is
-only preserved here for the backwards compatibility tests in
-service/test/integration1_test.go.

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -2,10 +2,10 @@ package rpc2
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
+	"testing"
 	"time"
 
 	"github.com/go-delve/delve/service"
@@ -22,11 +22,12 @@ type RPCClient struct {
 // Ensure the implementation satisfies the interface.
 var _ service.Client = &RPCClient{}
 
-// NewClient creates a new RPCClient.
-func NewClient(addr string) *RPCClient {
+// NewTestClient dials the given address and returns a new RPCClient.
+// Should be used only for tests.
+func NewTestClient(t testing.TB, addr string) *RPCClient {
 	client, err := jsonrpc.Dial("tcp", addr)
 	if err != nil {
-		log.Fatal("dialing:", err)
+		t.Fatalf("dialing: %v", err)
 	}
 	return newFromRPCClient(client)
 }

--- a/service/test/integration1_test.go
+++ b/service/test/integration1_test.go
@@ -51,7 +51,7 @@ func withTestClient1Extended(name string, t *testing.T, fn func(c *rpc1.RPCClien
 	if err := server.Run(); err != nil {
 		t.Fatal(err)
 	}
-	client := rpc1.NewClient(listener.Addr().String())
+	client := rpc1.NewTestClient(t, listener.Addr().String())
 	defer func() {
 		client.Detach(true)
 	}()

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2095,10 +2095,10 @@ func TestAcceptMulticlient(t *testing.T) {
 		<-disconnectChan
 		server.Stop()
 	}()
-	client1 := rpc2.NewClient(listener.Addr().String())
+	client1 := rpc2.NewTestClient(t, listener.Addr().String())
 	client1.Disconnect(false)
 
-	client2 := rpc2.NewClient(listener.Addr().String())
+	client2 := rpc2.NewTestClient(t, listener.Addr().String())
 	state := <-client2.Continue()
 	if state.CurrentThread.Function.Name() != "main.main" {
 		t.Fatalf("bad state after continue: %v\n", state)
@@ -2133,7 +2133,7 @@ func TestForceStopWhileContinue(t *testing.T) {
 		server.Stop()
 	}()
 
-	client := rpc2.NewClient(listener.Addr().String())
+	client := rpc2.NewTestClient(t, listener.Addr().String())
 	client.Disconnect(true /*continue*/)
 	time.Sleep(10 * time.Millisecond) // give server time to start running
 	close(disconnectChan)             // stop the server


### PR DESCRIPTION
The PR refactors RPC code for creating a Client:

- Rename `rpc2.NewClient` to `rpc2.NewTestClient` as it's being used only in tests.
- Rename `rpc1.NewClient` to `rpc1.NewTestClient` as it's being used only in tests.
- Move `dap.NewClient` to `daptest.NewClient`.
- Rename `rpc1/readme.txt` to `rpc1/doc.go`
- Use `t.Fatal` instead of `log.Fatal`