### PR TITLE
pkg/dwarf/line: use t.Logf instead of fmt.Printf in tests

### DIFF
--- a/pkg/dwarf/line/line_parser_test.go
+++ b/pkg/dwarf/line/line_parser_test.go
@@ -6,7 +6,6 @@ import (
 	"debug/macho"
 	"debug/pe"
 	"flag"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -272,7 +271,7 @@ func runTestPCToLine(t testing.TB, lineInfos DebugLines, entries []pctolineEntry
 		file, line := lineInfos[0].PCToLine(basePC, pc)
 		if pc == entries[i].pc {
 			if i%samples == 0 && log {
-				fmt.Printf("match %x / %x (%v)\n", pc, entries[len(entries)-1].pc, time.Since(t0)/samples)
+				t.Logf("match %x / %x (%v)\n", pc, entries[len(entries)-1].pc, time.Since(t0)/samples)
 				t0 = time.Now()
 			}
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -594,7 +594,6 @@ func testseq2intl(t *testing.T, fixture protest.Fixture, grp *proc.TargetGroup, 
 				fnname = fn.Name
 			}
 			t.Logf("at %#x (%s) %s:%d", pc, fnname, f, ln)
-			//fmt.Printf("at %#x %s:%d\n", pc, f, ln)
 		}
 		switch pos := tc.pos.(type) {
 		case int:


### PR DESCRIPTION
[`t.Logf`](https://pkg.go.dev/testing#T.Logf) is slightly better than `fmt.Printf` for tests:

> Logf formats its arguments according to the format, analogous to Printf, and records the text in the error log. A final newline is added if not provided. For tests, the text will be printed only if the test fails or the -test.v flag is set.