### PR TITLE
pkg/proc: fix 404 links and change to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Delve](https://raw.githubusercontent.com/go-delve/delve/master/assets/delve_horizontal.png)
 
-[![license](http://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/go-delve/delve/master/LICENSE)
+[![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/go-delve/delve/master/LICENSE)
 [![GoDoc](https://godoc.org/github.com/go-delve/delve?status.svg)](https://godoc.org/github.com/go-delve/delve)
 [![Build Status](https://delve.teamcity.com/app/rest/builds/buildType:(id:Delve_AggregatorBuild)/statusIcon.svg)](https://delve.teamcity.com/viewType.html?buildTypeId=Delve_AggregatorBuild&guest=1)
 

--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -36,7 +36,7 @@ const _NT_AUXV elf.NType = 0x6
 const _NT_FPREGSET elf.NType = 0x2
 
 // Fetch architecture using exeELF.Machine from core file
-// Refer http://man7.org/linux/man-pages/man5/elf.5.html
+// Refer https://man7.org/linux/man-pages/man5/elf.5.html
 const (
 	_EM_AARCH64          = 183
 	_EM_X86_64           = 62
@@ -89,9 +89,9 @@ func linuxThreadsFromNotes(p *process, notes []*note, machineType elf.Machine) p
 // readLinuxOrPlatformIndependentCore reads a core file from corePath
 // corresponding to the executable at exePath. For details on the Linux ELF
 // core format, see:
-// http://www.gabriel.urdhr.fr/2015/05/29/core-file/,
-// http://uhlo.blogspot.fr/2012/05/brief-look-into-core-dumps.html,
-// elf_core_dump in http://lxr.free-electrons.com/source/fs/binfmt_elf.c,
+// https://www.gabriel.urdhr.fr/2015/05/29/core-file/,
+// https://uhlo.blogspot.com/2012/05/brief-look-into-core-dumps.html,
+// elf_core_dump in https://elixir.bootlin.com/linux/v4.20.17/source/fs/binfmt_elf.c,
 // and, if absolutely desperate, readelf.c from the binutils source.
 func readLinuxOrPlatformIndependentCore(corePath, exePath string) (*process, proc.Thread, error) {
 	coreFile, err := elf.Open(corePath)
@@ -256,7 +256,7 @@ func readNotes(core *elf.File, machineType elf.Machine) ([]*note, bool, error) {
 // readNote reads a single note from r, decoding the descriptor if possible.
 func readNote(r io.ReadSeeker, machineType elf.Machine) (*note, error) {
 	// Notes are laid out as described in the SysV ABI:
-	// http://www.sco.com/developers/gabi/latest/ch5.pheader.html#note_section
+	// https://www.sco.com/developers/gabi/latest/ch5.pheader.html#note_section
 	note := &note{}
 	hdr := &elfNotesHdr{}
 
@@ -406,7 +406,7 @@ func findEntryPoint(notes []*note, ptrSize int) uint64 {
 // LinuxPrPsInfo has various structures from the ELF spec and the Linux kernel.
 // AMD64 specific primarily because of unix.PtraceRegs, but also
 // because some of the fields are word sized.
-// See http://lxr.free-electrons.com/source/include/uapi/linux/elfcore.h
+// See https://elixir.bootlin.com/linux/v4.20.17/source/include/uapi/linux/elfcore.h
 type linuxPrPsInfo struct {
 	State                uint8
 	Sname                int8

--- a/pkg/proc/linutil/dynamic.go
+++ b/pkg/proc/linutil/dynamic.go
@@ -138,7 +138,7 @@ func readCString(p proc.Process, addr uint64) (string, error) {
 // ElfUpdateSharedObjects reads the list of dynamic libraries loaded by the
 // dynamic linker from the .dynamic section and uses it to update p.BinInfo().
 // See the SysV ABI for a description of how the .dynamic section works:
-// http://www.sco.com/developers/gabi/latest/contents.html
+// https://www.sco.com/developers/gabi/latest/contents.html
 func ElfUpdateSharedObjects(p proc.Process) error {
 	bi := p.BinInfo()
 	if bi.ElfDynamicSection.Addr == 0 {

--- a/pkg/proc/native/proc_darwin.c
+++ b/pkg/proc/native/proc_darwin.c
@@ -159,7 +159,7 @@ mach_port_wait(mach_port_t port_set, task_t *task, int nonblocking) {
 	switch (msg.hdr.msgh_id) {
 		case 2401: { // Exception
 			// 2401 is the exception_raise event, defined in:
-			// http://opensource.apple.com/source/xnu/xnu-2422.1.72/osfmk/mach/exc.defs?txt
+			// https://opensource.apple.com/source/xnu/xnu-2422.1.72/osfmk/mach/exc.defs?txt
 			// compile this file with mig to get the C version of the description
 			
 			mach_msg_body_t *bod = (mach_msg_body_t*)(&msg.hdr + 1);

--- a/pkg/proc/native/ptrace_linux_386.go
+++ b/pkg/proc/native/ptrace_linux_386.go
@@ -43,7 +43,7 @@ func ptraceGetRegset(tid int) (regset amd64util.AMD64Xstate, err error) {
 }
 
 // ptraceGetTls return the addr of tls by PTRACE_GET_THREAD_AREA for specify thread.
-// See http://man7.org/linux/man-pages/man2/ptrace.2.html for detail about PTRACE_GET_THREAD_AREA.
+// See https://man7.org/linux/man-pages/man2/ptrace.2.html for detail about PTRACE_GET_THREAD_AREA.
 // struct user_desc at https://golang.org/src/runtime/sys_linux_386.s
 //
 //	type UserDesc struct {

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1479,7 +1479,7 @@ func convertToEface(srcv, dstv *Variable) error {
 
 func readStringInfo(mem MemoryReadWriter, arch *Arch, addr uint64, typ *godwarf.StringType) (uint64, int64, error) {
 	// string data structure is always two ptrs in size. Addr, followed by len
-	// http://research.swtch.com/godata
+	// https://research.swtch.com/godata
 
 	mem = cacheMemory(mem, addr, arch.PtrSize()*2)
 


### PR DESCRIPTION
The PR edits links in comments:

- Replace `http://` with `https://`.
- Fix not existent links:
  - Replace `http://lxr.free-electrons.com/source/include/uapi/linux/elfcore.h` with the latest available `https://elixir.bootlin.com/linux/v4.20.17/source/fs/binfmt_elf.c`
  - Replace `http://uhlo.blogspot.fr` with `https://uhlo.blogspot.com`