### PR TITLE
proc: fix bug with range-over-func stepping

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -340,12 +340,8 @@ func (scope *EvalScope) Locals(flags localsFlags, wantedName string) ([]*Variabl
 		}
 	}
 	for i, scope2 := range scope.enclosingRangeScopes {
-		if i == len(scope.enclosingRangeScopes)-1 {
-			// Last one is the caller frame, we shouldn't check it
-			break
-		}
 		if scope2 == nil {
-			scope2 = FrameToScope(scope.target, scope.target.Memory(), scope.g, scope.threadID, scope.rangeFrames[i:]...)
+			scope2 = FrameToScope(scope.target, scope.target.Memory(), scope.g, scope.threadID, scope.rangeFrames[2*i:]...)
 			scope.enclosingRangeScopes[i] = scope2
 		}
 		vars, err := scope2.simpleLocals(flags, wantedName)
@@ -381,8 +377,8 @@ func (scope *EvalScope) setupRangeFrames() error {
 	if err != nil {
 		return err
 	}
-	scope.rangeFrames = scope.rangeFrames[1:]
-	scope.enclosingRangeScopes = make([]*EvalScope, len(scope.rangeFrames))
+	scope.rangeFrames = scope.rangeFrames[2:] // skip the first frame and its return frame
+	scope.enclosingRangeScopes = make([]*EvalScope, len(scope.rangeFrames)/2)
 	return nil
 }
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -6299,25 +6299,6 @@ func TestRangeOverFuncNext(t *testing.T) {
 		return seqTest{contNext, n}
 	}
 
-	nx2 := func(t *testing.T, n int) seqTest {
-		return seqTest{contNothing, func(grp *proc.TargetGroup, p *proc.Target) {
-			_, ln1 := currentLineNumber(p, t)
-			assertNoError(grp.Next(), t, "Next() returned an error")
-			f, ln2 := currentLineNumber(p, t)
-			if ln2 == n {
-				return
-			}
-			if ln2 != ln1 {
-				t.Fatalf("Program did not continue to correct next location (expected %d or %d) was %s:%d", ln1, n, f, ln2)
-			}
-			assertNoError(grp.Next(), t, "Next() returned an error")
-			f, ln2 = currentLineNumber(p, t)
-			if ln2 != n {
-				t.Fatalf("Program did not continue to correct next location (expected %d) was %s:%d", n, f, ln2)
-			}
-		}}
-	}
-
 	assertLocals := func(t *testing.T, varnames ...string) seqTest {
 		return seqTest{
 			contNothing,
@@ -6659,20 +6640,20 @@ func TestRangeOverFuncNext(t *testing.T) {
 				nx(118), // if z == 4
 				nx(121),
 
-				nx(116),     // for _, z := range (z == 2)
-				nx2(t, 117), // result = append(result, z)
-				nx(118),     // if z == 4
+				nx(116), // for _, z := range (z == 2)
+				nx(117), // result = append(result, z)
+				nx(118), // if z == 4
 				nx(121),
 
-				nx(116),     // for _, z := range (z == 3)
-				nx2(t, 117), // result = append(result, z)
-				nx(118),     // if z == 4
+				nx(116), // for _, z := range (z == 3)
+				nx(117), // result = append(result, z)
+				nx(118), // if z == 4
 				nx(121),
 
-				nx(116),     // for _, z := range (z == 4)
-				nx2(t, 117), // result = append(result, z)
-				nx(118),     // if z == 4
-				nx(119),     // break
+				nx(116), // for _, z := range (z == 4)
+				nx(117), // result = append(result, z)
+				nx(118), // if z == 4
+				nx(119), // break
 
 				nx(112), // defer func()
 				nx(113), // r := recover()
@@ -6773,14 +6754,14 @@ func TestRangeOverFuncNext(t *testing.T) {
 				nx(203), // result = append(result, y)
 				nx(204),
 
-				nx(199),     // for _, y := range (y == 2)
-				nx2(t, 200), // if y == 3
-				nx(203),     // result = append(result, y)
+				nx(199), // for _, y := range (y == 2)
+				nx(200), // if y == 3
+				nx(203), // result = append(result, y)
 				nx(204),
 
-				nx(199),     // for _, y := range (y == 3)
-				nx2(t, 200), // if y == 3
-				nx(201),     // goto A
+				nx(199), // for _, y := range (y == 3)
+				nx(200), // if y == 3
+				nx(201), // goto A
 				nx(204),
 				nx(206), // result = append(result, x)
 				nx(207),
@@ -6809,14 +6790,14 @@ func TestRangeOverFuncNext(t *testing.T) {
 				nx(222), // result = append(result, y)
 				nx(223),
 
-				nx(218),     // for _, y := range (y == 2)
-				nx2(t, 219), // if y == 3
-				nx(222),     // result = append(result, y)
+				nx(218), // for _, y := range (y == 2)
+				nx(219), // if y == 3
+				nx(222), // result = append(result, y)
 				nx(223),
 
-				nx(218),     // for _, y := range (y == 3)
-				nx2(t, 219), // if y == 3
-				nx(220),     // goto B
+				nx(218), // for _, y := range (y == 3)
+				nx(219), // if y == 3
+				nx(220), // goto B
 				nx(223),
 				nx(225),
 				nx(227), // result = append(result, 999)

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -119,6 +119,11 @@ func (grp *TargetGroup) Continue() error {
 				}
 				delete(it.Breakpoints().Logical, watchpoint.LogicalID())
 			}
+			// Clear inactivated breakpoints
+			err := it.clearInactivatedSteppingBreakpoint()
+			if err != nil {
+				logflags.DebuggerLogger().Errorf("could not clear inactivated stepping breakpoints: %v", err)
+			}
 		}
 
 		if contOnceErr != nil {
@@ -847,8 +852,10 @@ func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 
 	// Set step-out breakpoints for range-over-func body closures
 	if !stepInto && selg != nil && topframe.Current.Fn.extra(bi).rangeParent != nil && len(rangeFrames) > 0 {
-		for _, fr := range rangeFrames[:len(rangeFrames)-1] {
-			retframecond := astutil.And(sameGCond, frameoffCondition(&fr))
+		// Set step-out breakpoint for every range-over-func body currently on the stack so that we stop on them.
+		for i := 2; i < len(rangeFrames); i += 2 {
+			fr := &rangeFrames[i]
+			retframecond := astutil.And(sameGCond, frameoffCondition(fr))
 			if !fr.hasInlines {
 				dbp.SetBreakpoint(0, fr.Current.PC, NextBreakpoint, retframecond)
 			} else {
@@ -857,7 +864,7 @@ func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 				if err != nil {
 					return err
 				}
-				pcs, err = removeInlinedCalls(pcs, &fr, bi)
+				pcs, err = removeInlinedCalls(pcs, fr, bi)
 				if err != nil {
 					return err
 				}
@@ -866,6 +873,24 @@ func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 				}
 			}
 		}
+
+		// Set a step-out breakpoint for the first range-over-func body on the
+		// stack, this breakpoint will never cause a stop because the associated
+		// callback always returns false.
+		// Its purpose is to inactivate all the breakpoints for the current
+		// range-over-func body function so that if the iterator re-calls it we
+		// don't end up inside the prologue.
+		if !rangeFrames[0].Inlined {
+			bp, err := dbp.SetBreakpoint(0, rangeFrames[1].Call.PC, NextBreakpoint, astutil.And(sameGCond, frameoffCondition(&rangeFrames[1])))
+			if err == nil {
+				bplet := bp.Breaklets[len(bp.Breaklets)-1]
+				bplet.callback = func(th Thread, p *Target) (bool, error) {
+					rangeFrameInactivateNextBreakpoints(p, rangeFrames[0].Call.Fn)
+					return false, nil
+				}
+			}
+		}
+
 		topframe, retframe = rangeFrames[len(rangeFrames)-2], rangeFrames[len(rangeFrames)-1]
 	}
 
@@ -1656,4 +1681,27 @@ func (t *Target) handleHardcodedBreakpoints(grp *TargetGroup, trapthread Thread,
 		}
 	}
 	return nil
+}
+
+func rangeFrameInactivateNextBreakpoints(p *Target, fn *Function) {
+	pc, err := FirstPCAfterPrologue(p, fn, false)
+	if err != nil {
+		logflags.DebuggerLogger().Errorf("Error inactivating next breakpoints after exiting a range-over-func body: %v", err)
+		return
+	}
+
+	for _, bp := range p.Breakpoints().M {
+		if bp.Addr < fn.Entry || bp.Addr >= fn.End || bp.Addr == pc {
+			continue
+		}
+		for _, bplet := range bp.Breaklets {
+			if bplet.Kind != NextBreakpoint {
+				continue
+			}
+			// We set to NextInactivatedBreakpoint instead of deleting them because
+			// we can't delete breakpoints (or breakpointlets) while breakpoint
+			// conditions are being evaluated.
+			bplet.Kind = NextInactivatedBreakpoint
+		}
+	}
 }


### PR DESCRIPTION
Set a breakpoint on the return address of the current function, if it's
a range-over-func body, and clear the stepping breakpoints for the
current function (except the entry one) when its hit.

Without this what can happen is the following:

1. the range-over-func body finishes and returns to the iterator
2. the iterator calls back into the range-over-func body
3. a stepping breakpoint that's inside the prologue gets hit

Updates #3733
