### PR TITLE
service/rpc1: add Go Reference doc

### DIFF
--- a/service/rpc1/doc.go
+++ b/service/rpc1/doc.go
@@ -1,0 +1,5 @@
+// Package rpc1 implements version 1 of Delve's API and is only
+// kept for backwards compatibility.
+// client.go is the old client code used by Delve's frontend (delve/cmd/dlv) and
+// is preserved for backwards compatibility with integration tests.
+package rpc1

--- a/service/rpc1/readme.txt
+++ b/service/rpc1/readme.txt
@@ -1,5 +1,0 @@
-This package implements version 1 of Delve's API and is only
-kept here for backwards compatibility. Client.go is the old
-client code used by Delve's frontend (delve/cmd/dlv), it is
-only preserved here for the backwards compatibility tests in
-service/test/integration1_test.go.


### PR DESCRIPTION
This page https://pkg.go.dev/github.com/go-delve/delve/service@v1.22.1

- before:
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/1a9a47c6-143d-47fc-980e-8e0b966f5e50">


- after:
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/4cf8a4e0-c8dd-41a5-94df-af9085a03761">
