### PR TITLE
goversion: add 1.23 to supported versions, update test matrix

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -41,25 +41,25 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2023.05"
 
 val targets = arrayOf(
-        "linux/amd64/1.20",
         "linux/amd64/1.21",
         "linux/amd64/1.22",
+        "linux/amd64/1.23"
         "linux/amd64/tip",
 
-        "linux/386/1.22",
+        "linux/386/1.23",
 
-        "linux/arm64/1.22",
+        "linux/arm64/1.23",
         "linux/arm64/tip",
 
-        "linux/ppc64le/1.22",
+        "linux/ppc64le/1.23",
 
-        "windows/amd64/1.22",
+        "windows/amd64/1.23",
         "windows/amd64/tip",
 
-        "mac/amd64/1.22",
+        "mac/amd64/1.23",
         "mac/amd64/tip",
 
-        "mac/arm64/1.22",
+        "mac/arm64/1.23",
         "mac/arm64/tip"
 )
 

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -8,9 +8,9 @@ import (
 
 var (
 	MinSupportedVersionOfGoMajor = 1
-	MinSupportedVersionOfGoMinor = 19
+	MinSupportedVersionOfGoMinor = 21
 	MaxSupportedVersionOfGoMajor = 1
-	MaxSupportedVersionOfGoMinor = 22
+	MaxSupportedVersionOfGoMinor = 23
 	goTooOldErr                  = fmt.Sprintf("Go version %%s is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	goTooOldWarn                 = fmt.Sprintf("WARNING: undefined behavior - Go version %%s is too old for this version of Delve (minimum supported version %d.%d)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Sprintf("Version of Delve is too old for Go version %%s (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)


### PR DESCRIPTION
Add 1.23 to supported versions and to test matrix, remove 1.19 and 1.20
from supported versions (1.19 should have been removed long ago, but we
forgot to do it on release).
