### PR TITLE
proc: adds pointer pinning to call injection

### DIFF
--- a/pkg/proc/dwarf_export_test.go
+++ b/pkg/proc/dwarf_export_test.go
@@ -30,3 +30,14 @@ func NewCompositeMemory(p *Target, pieces []op.Piece, base uint64) (*compositeMe
 func IsJNZ(inst archInst) bool {
 	return inst.(*x86Inst).Op == x86asm.JNE
 }
+
+// HasDebugPinner returns true if the target has runtime.debugPinner.
+func (bi *BinaryInfo) HasDebugPinner() bool {
+	return bi.hasDebugPinner()
+}
+
+// DebugPinCount returns the number of addresses pinned during the last
+// function call injection.
+func DebugPinCount() int {
+	return debugPinCount
+}

--- a/pkg/proc/mem.go
+++ b/pkg/proc/mem.go
@@ -43,14 +43,25 @@ func (m *memCache) contains(addr uint64, size int) bool {
 	return addr >= m.cacheAddr && end <= m.cacheAddr+uint64(len(m.cache))
 }
 
+func (m *memCache) load() error {
+	if m.loaded {
+		return nil
+	}
+	_, err := m.mem.ReadMemory(m.cache, m.cacheAddr)
+	if err != nil {
+		return err
+	}
+	m.loaded = true
+	return nil
+}
+
 func (m *memCache) ReadMemory(data []byte, addr uint64) (n int, err error) {
 	if m.contains(addr, len(data)) {
 		if !m.loaded {
-			_, err := m.mem.ReadMemory(m.cache, m.cacheAddr)
+			err := m.load()
 			if err != nil {
 				return 0, err
 			}
-			m.loaded = true
 		}
 		copy(data, m.cache[addr-m.cacheAddr:])
 		return len(data), nil

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -159,7 +159,7 @@ func (grp *TargetGroup) Continue() error {
 					log.Debugf("\t%d PC=%#x", th.ThreadID(), regs.PC())
 				}
 			}
-			callInjectionDoneThis, callErrThis := callInjectionProtocol(dbp, threads)
+			callInjectionDoneThis, callErrThis := callInjectionProtocol(dbp, trapthread, threads)
 			callInjectionDone = callInjectionDone || callInjectionDoneThis
 			if callInjectionDoneThis {
 				dbp.StopReason = StopCallReturned

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -206,7 +206,10 @@ func dwarfToRuntimeType(bi *BinaryInfo, mem MemoryReadWriter, typ godwarf.Type) 
 	if kindv == nil || kindv.Unreadable != nil || kindv.Kind != reflect.Uint {
 		kindv = _type.loadFieldNamed("Kind_")
 	}
-	if kindv == nil || kindv.Unreadable != nil || kindv.Kind != reflect.Uint {
+	if kindv == nil {
+		return 0, 0, false, fmt.Errorf("unreadable interace type (no kind field)")
+	}
+	if kindv.Unreadable != nil || kindv.Kind != reflect.Uint {
 		return 0, 0, false, fmt.Errorf("unreadable interface type: %v", kindv.Unreadable)
 	}
 	typeKind, _ = constant.Uint64Val(kindv.Value)


### PR DESCRIPTION
This commit adds a new mode to call injection. If the runtime.debugPinner
function is available in the target executable it obtains a pinner by
calling it and then uses it to pin the pointers in the results of call
injection.

This allows the code for call injection to be refactored to execute the
calls in the normal order, since it doesn't need to be concerned with having
space on the target's memory to store intermediate values.

Updates #3310
