### PR TITLE
proc: cache module data

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -104,6 +104,8 @@ type BinaryInfo struct {
 	// dwrapUnwrapCache caches unwrapping of defer wrapper functions (dwrap)
 	dwrapUnwrapCache map[uint64]*Function
 
+	moduleDataCache []ModuleData
+
 	// Go 1.17 register ABI is enabled.
 	regabi bool
 

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -260,6 +260,7 @@ func (t *Target) SupportsFunctionCalls() bool {
 func (t *Target) ClearCaches() {
 	t.clearFakeMemory()
 	t.gcache.Clear()
+	t.BinInfo().moduleDataCache = nil
 	for _, thread := range t.ThreadList() {
 		thread.Common().g = nil
 	}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -149,9 +149,15 @@ func resolveParametricType(bi *BinaryInfo, mem MemoryReadWriter, t godwarf.Type,
 	}
 	_type := newVariable("", rtypeAddr, runtimeType, bi, mem)
 
-	mds, err := LoadModuleData(bi, _type.mem)
-	if err != nil {
-		return ptyp.TypedefType.Type, fmt.Errorf("error loading module data: %v", err)
+	var mds []ModuleData
+	if bi.moduleDataCache != nil {
+		mds = bi.moduleDataCache
+	} else {
+		mds, err = LoadModuleData(bi, _type.mem)
+		if err != nil {
+			return ptyp.TypedefType.Type, fmt.Errorf("error loading module data: %v", err)
+		}
+		bi.moduleDataCache = mds
 	}
 
 	typ, _, err := RuntimeTypeToDIE(_type, 0, mds)


### PR DESCRIPTION
Cache module data so that we don't reload it every time we look up a
variable with a generic type.
