### PR TITLE
terminal/starbind: fix starlark conversion of named consts

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -11,8 +11,23 @@ import (
 	"unsafe"
 )
 
-type Byte byte
-type String string
+type (
+	Byte    byte
+	String  string
+	Uint32  uint32
+	Int64   int64
+	Bool    bool
+	Float64 float64
+)
+
+const (
+	ByteConst   Byte    = 255
+	StringConst String  = "hi"
+	UintConst   Uint32  = 42
+	IntConst    Int64   = 9001
+	BoolConst   Bool    = true
+	FloatConst  Float64 = 3.14
+)
 
 type astruct struct {
 	A int
@@ -394,6 +409,13 @@ func main() {
 	var ptrinf2 pptr
 	ptrinf2 = &ptrinf2
 
+	enum1 := ByteConst
+	enum2 := StringConst
+	enum3 := UintConst
+	enum4 := IntConst
+	enum5 := BoolConst
+	enum6 := FloatConst
+
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
@@ -404,5 +426,5 @@ func main() {
 	longslice := make([]int, 100, 100)
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice)
+	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice, enum1, enum2, enum3, enum4, enum5, enum6)
 }

--- a/pkg/terminal/starbind/conv.go
+++ b/pkg/terminal/starbind/conv.go
@@ -228,10 +228,10 @@ func (env *Env) variableValueToStarlarkValue(v *api.Variable, top bool) (starlar
 	case reflect.String:
 		return starlark.String(v.Value), nil
 	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
-		n, _ := strconv.ParseInt(v.Value, 0, 64)
+		n, _ := strconv.ParseInt(api.ExtractIntValue(v.Value), 0, 64)
 		return starlark.MakeInt64(n), nil
 	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint, reflect.Uintptr:
-		n, _ := strconv.ParseUint(v.Value, 0, 64)
+		n, _ := strconv.ParseUint(api.ExtractIntValue(v.Value), 0, 64)
 		return starlark.MakeUint64(n), nil
 	case reflect.Bool:
 		n, _ := strconv.ParseBool(v.Value)

--- a/pkg/terminal/starlark_test.go
+++ b/pkg/terminal/starlark_test.go
@@ -145,6 +145,14 @@ func TestStarlarkVariable(t *testing.T) {
 			{`v = eval(cur_scope(), "as1").Variable; print(v.Value.A)`, "1"},
 			{`v = eval(None, "as1", default_load_config()).Variable; print(v.Value.A)`, "1"},
 
+			// named constant values
+			{`v = eval(None, "enum1").Variable; print(v.Value)`, "255"},
+			{`v = eval(None, "enum2").Variable; print(v.Value)`, "hi"},
+			{`v = eval(None, "enum3").Variable; print(v.Value)`, "42"},
+			{`v = eval(None, "enum4").Variable; print(v.Value)`, "9001"},
+			{`v = eval(None, "enum5").Variable; print(v.Value)`, "True"},
+			{`v = eval(None, "enum6").Variable; print(v.Value)`, "3.14"},
+
 			// From starlark.md's examples
 			{`v = eval(None, "s2").Variable; print(v.Value[0])`, "main.astruct {A: 1, B: 2}"},
 			{`v = eval(None, "s2").Variable; print(v.Value[1].A)`, "3"},


### PR DESCRIPTION
If a value of a derived integer type matches a named constant, Delve will wrap the string representation of the value with the name of the constant, causing ParseInt/ParseUint to fail. This change removes the wrapping before attempting to parse the value before sending it to Starlark.

Fixes  #3801