### PR TITLE
proc: for optimized functions allow .closureptr to not exist

### DIFF
--- a/_fixtures/setiterator.go
+++ b/_fixtures/setiterator.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"iter"
+	"strconv"
+	"time"
+)
+
+func main() {
+	set := New[string]()
+	for i := 10; i < 100; i++ {
+		set.Add(strconv.Itoa(i))
+	}
+	PrintAllElements[string](set)
+}
+
+// Set holds a set of elements.
+type Set[E comparable] struct {
+	m map[E]struct{}
+}
+
+// New returns a new [Set].
+func New[E comparable]() *Set[E] {
+	return &Set[E]{m: make(map[E]struct{})}
+}
+
+// All is an iterator over the elements of s.
+func (s *Set[E]) All() iter.Seq[E] {
+	return func(yield func(E) bool) {
+		for v := range s.m {
+			tmp := make([]byte, 1024)
+			str := string(tmp)
+			if !yield(v) {
+				return
+			}
+			go func() { println(str) }()
+		}
+	}
+}
+
+func (s *Set[E]) Add(v E) {
+	s.m[v] = struct{}{}
+}
+
+func PrintAllElements[E comparable](s *Set[E]) {
+	for v := range s.All() {
+		time.Sleep(100 * time.Second)
+		fmt.Println(v)
+	}
+}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -390,7 +390,9 @@ func (scope *EvalScope) setupRangeFrames() error {
 	if err != nil {
 		return err
 	}
-	scope.rangeFrames = scope.rangeFrames[2:] // skip the first frame and its return frame
+	if len(scope.rangeFrames) > 0 {
+		scope.rangeFrames = scope.rangeFrames[2:] // skip the first frame and its return frame
+	}
 	scope.enclosingRangeScopes = make([]*EvalScope, len(scope.rangeFrames)/2)
 	return nil
 }

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -71,6 +71,10 @@ const (
 	// If localsOnlyRangeBodyClosures is set simpleLocals only returns
 	// variables containing the range body closure.
 	localsOnlyRangeBodyClosures
+
+	// If localsIsRangeBody is set DW_AT_formal_parameter variables will be
+	// considered local variables.
+	localsIsRangeBody
 )
 
 // ConvertEvalScope returns a new EvalScope in the context of the
@@ -319,7 +323,12 @@ func (scope *EvalScope) Locals(flags localsFlags, wantedName string) ([]*Variabl
 		return vars2
 	}
 
-	vars0, err := scope.simpleLocals(flags, wantedName)
+	rangeBodyFlags := localsFlags(0)
+	if scope.Fn != nil && scope.Fn.rangeParentName() != "" {
+		rangeBodyFlags = localsFlags(localsIsRangeBody)
+	}
+
+	vars0, err := scope.simpleLocals(flags|rangeBodyFlags, wantedName)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +353,11 @@ func (scope *EvalScope) Locals(flags localsFlags, wantedName string) ([]*Variabl
 			scope2 = FrameToScope(scope.target, scope.target.Memory(), scope.g, scope.threadID, scope.rangeFrames[2*i:]...)
 			scope.enclosingRangeScopes[i] = scope2
 		}
-		vars, err := scope2.simpleLocals(flags, wantedName)
+		rangeBodyFlags := localsFlags(localsIsRangeBody)
+		if i == len(scope.enclosingRangeScopes)-1 {
+			rangeBodyFlags = 0
+		}
+		vars, err := scope2.simpleLocals(flags|rangeBodyFlags, wantedName)
 		if err != nil {
 			return nil, err
 		}
@@ -455,7 +468,7 @@ func (scope *EvalScope) simpleLocals(flags localsFlags, wantedName string) ([]*V
 		}
 		vars = append(vars, val)
 		depth := entry.Depth
-		if entry.Tag == dwarf.TagFormalParameter {
+		if (flags&localsIsRangeBody == 0) && (entry.Tag == dwarf.TagFormalParameter) {
 			if depth <= 1 {
 				depth = 0
 			}

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -573,7 +573,7 @@ func funcCallArgs(fn *Function, bi *BinaryInfo, includeRet bool) (argFrameSize i
 		return 0, nil, fmt.Errorf("DWARF read error: %v", err)
 	}
 
-	if bi.regabi && fn.cu.optimized {
+	if bi.regabi && fn.Optimized() {
 		if runtimeWhitelist[fn.Name] {
 			runtimeOptimizedWorkaround(bi, fn.cu.image, dwarfTree)
 		} else {

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1841,3 +1841,22 @@ func TestCapturedVariable(t *testing.T) {
 		})
 	})
 }
+
+func TestSetupRangeFramesCrash(t *testing.T) {
+	// See issue #3806
+	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
+		t.Skip("N/A")
+	}
+	withTestProcess("setiterator", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+		setFileBreakpoint(p, t, fixture.Source, 48)
+		assertNoError(grp.Continue(), t, "Continue")
+		scope, err := evalScope(p)
+		assertNoError(err, t, "EvalScope")
+		v, err := scope.LocalVariables(normalLoadConfig)
+		assertNoError(err, t, "LocalVariables")
+		t.Logf("%#v", v)
+		if len(v) != 1 {
+			t.Fatalf("wrong number of variables")
+		}
+	})
+}

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1836,8 +1836,9 @@ func TestCapturedVariable(t *testing.T) {
 		assertVariable(t, v, varTest{
 			name:         "c",
 			preserveName: true,
-			value:        "struct { main.name string; main.thing main.Thing } {name: \"Success\", thing: main.Thing {str: \"hello\"}}",
-			varType:      "struct { main.name string; main.thing main.Thing }",
+
+			value:   "struct { main.name string; main.thing main.Thing } {name: \"Success\", thing: main.Thing {str: \"hello\"}}",
+			varType: "struct { main.name string; main.thing main.Thing }",
 		})
 	})
 }
@@ -1847,16 +1848,19 @@ func TestSetupRangeFramesCrash(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
 		t.Skip("N/A")
 	}
-	withTestProcess("setiterator", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
-		setFileBreakpoint(p, t, fixture.Source, 48)
-		assertNoError(grp.Continue(), t, "Continue")
-		scope, err := evalScope(p)
-		assertNoError(err, t, "EvalScope")
-		v, err := scope.LocalVariables(normalLoadConfig)
-		assertNoError(err, t, "LocalVariables")
-		t.Logf("%#v", v)
-		if len(v) != 1 {
-			t.Fatalf("wrong number of variables")
-		}
-	})
+
+	for _, options := range []protest.BuildFlags{0, protest.EnableInlining | protest.EnableOptimization} {
+		withTestProcessArgs("setiterator", t, ".", []string{}, options, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+			setFileBreakpoint(p, t, fixture.Source, 48)
+			assertNoError(grp.Continue(), t, "Continue")
+			scope, err := evalScope(p)
+			assertNoError(err, t, "EvalScope")
+			v, err := scope.LocalVariables(normalLoadConfig)
+			assertNoError(err, t, "LocalVariables")
+			t.Logf("%#v", v)
+			if len(v) != 1 {
+				t.Fatalf("wrong number of variables")
+			}
+		})
+	}
 }


### PR DESCRIPTION
### proc: for optimized functions allow .closureptr to not exist

For optimized functions .closureptr is sometimes omitted from DWARF,
allow it to be 0 and try to recover the range-over-func stack by best
effort.

Fixes #3806

### proc: flag variables correctly when range-over-func stmts are used

Argument variables of a range-over-func body closure should be returned
flagged as normal local variables, not as function arguments.

Updates #3806
