### PR TITLE
Documentation: Add dape to list of plugins

### DIFF
--- a/Documentation/EditorIntegration.md
+++ b/Documentation/EditorIntegration.md
@@ -8,6 +8,7 @@ The following editor plugins for delve are available:
 **Emacs**
 * [Emacs plugin](https://github.com/benma/go-dlv.el/)
 * [dap-mode](https://github.com/emacs-lsp/dap-mode#go-1)
+* [dape](https://github.com/svaante/dape?tab=readme-ov-file#go---dlv)
 
 **Goland**
 * [JetBrains Goland](https://www.jetbrains.com/go)


### PR DESCRIPTION
Hi, this patch mentions dape in the list of editor plugins for Emacs.