### PR TITLE
pkg/proc: simplify tests by using errors.As

### DIFF
--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -1,6 +1,7 @@
 package gdbserial_test
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -76,7 +77,7 @@ func TestRestartAfterExit(t *testing.T) {
 		loc, err := p.CurrentThread().Location()
 		assertNoError(err, t, "CurrentThread().Location()")
 		err = grp.Continue()
-		if _, isexited := err.(proc.ErrProcessExited); err == nil || !isexited {
+		if !errors.As(err, &proc.ErrProcessExited{}) {
 			t.Fatalf("program did not exit: %v", err)
 		}
 
@@ -89,7 +90,7 @@ func TestRestartAfterExit(t *testing.T) {
 			t.Fatalf("stopped at %d (expected %d)", loc2.Line, loc.Line)
 		}
 		err = grp.Continue()
-		if _, isexited := err.(proc.ErrProcessExited); err == nil || !isexited {
+		if !errors.As(err, &proc.ErrProcessExited{}) {
 			t.Fatalf("program did not exit (after exit): %v", err)
 		}
 	})
@@ -113,7 +114,7 @@ func TestRestartDuringStop(t *testing.T) {
 			t.Fatalf("stopped at %d (expected %d)", loc2.Line, loc.Line)
 		}
 		err = grp.Continue()
-		if _, isexited := err.(proc.ErrProcessExited); err == nil || !isexited {
+		if !errors.As(err, &proc.ErrProcessExited{}) {
 			t.Fatalf("program did not exit (after exit): %v", err)
 		}
 	})

--- a/pkg/proc/scope_test.go
+++ b/pkg/proc/scope_test.go
@@ -1,6 +1,7 @@
 package proc_test
 
 import (
+	"errors"
 	"fmt"
 	"go/constant"
 	"go/parser"
@@ -80,12 +81,11 @@ func TestScope(t *testing.T) {
 		t.Logf("%d breakpoints set", len(scopeChecks))
 
 		for {
-			if err := grp.Continue(); err != nil {
-				if _, exited := err.(proc.ErrProcessExited); exited {
-					break
-				}
-				assertNoError(err, t, "Continue()")
+			err := grp.Continue()
+			if errors.As(err, &proc.ErrProcessExited{}) {
+				break
 			}
+			assertNoError(err, t, "Continue()")
 			bp := p.CurrentThread().Breakpoint()
 
 			scopeCheck := findScopeCheck(scopeChecks, bp.Line)
@@ -104,7 +104,7 @@ func TestScope(t *testing.T) {
 			}
 
 			scopeCheck.ok = true
-			err := p.ClearBreakpoint(bp.Addr)
+			err = p.ClearBreakpoint(bp.Addr)
 			assertNoError(err, t, "ClearBreakpoint")
 		}
 	})


### PR DESCRIPTION
The PR refactors tests that check for `proc.ErrProcessExited` by using `errors.As`.