### PR TITLE
cmds/commands: Update 'client-addr' to support Unix domain sockets

### DIFF
--- a/Documentation/usage/dlv_dap.md
+++ b/Documentation/usage/dlv_dap.md
@@ -33,7 +33,7 @@ dlv dap [flags]
 ### Options
 
 ```
-      --client-addr string   host:port where the DAP client is waiting for the DAP server to dial in
+      --client-addr string   Address where the DAP client is waiting for the DAP server to dial in. Prefix with 'unix:' to use a unix domain socket.
   -h, --help                 help for dap
 ```
 

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -398,7 +398,7 @@ Currently supports linux/amd64 and linux/arm64 core files, windows/amd64 minidum
 	rootCommand.AddCommand(coreCommand)
 
 	// 'version' subcommand.
-	var versionVerbose bool
+	var versionVerbose = false
 	versionCommand := &cobra.Command{
 		Use:   "version",
 		Short: "Prints version.",
@@ -668,7 +668,7 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 		var processArgs []string
 
 		dlvArgs, targetArgs := splitArgs(cmd, args)
-		dlvArgsLen := len(dlvArgs)
+		var dlvArgsLen = len(dlvArgs)
 		switch dlvArgsLen {
 		case 0:
 			fmt.Fprintf(os.Stderr, "you must supply a regexp for functions to trace\n")

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -30,10 +30,8 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-var (
-	testBackend string
-	ldFlags     string
-)
+var testBackend string
+var ldFlags string
 
 func init() {
 	ldFlags = os.Getenv("CGO_LDFLAGS")
@@ -398,11 +396,11 @@ func diffMaybe(t *testing.T, filename string, generated []byte) {
 // updated.
 func TestGeneratedDoc(t *testing.T) {
 	if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" {
-		// TODO(qmuntal): investigate further when the Windows ARM64 backend is more stable.
+		//TODO(qmuntal): investigate further when the Windows ARM64 backend is more stable.
 		t.Skip("skipping test on Windows in CI")
 	}
 	if runtime.GOOS == "linux" && runtime.GOARCH == "ppc64le" {
-		// TODO(alexsaezm): finish CI integration
+		//TODO(alexsaezm): finish CI integration
 		t.Skip("skipping test on Linux/PPC64LE in CI")
 	}
 	// Checks gen-cli-docs.go


### PR DESCRIPTION
This change updates the '--client-addr' flag to accept Unix domain sockets (UDS). Currently, the --listen flag supports UDS, but --client-addr does not. This modification ensures consistency across the APIs and improves support for vscode-go, which uses reverse mode (via client-addr) to connect to DAP.

Fixes #3814

See - https://github.com/golang/vscode-go/issues/3216