### PR TITLE
tests: disable TestGeneratedDoc on 1.24 (tip)

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -403,6 +403,9 @@ func TestGeneratedDoc(t *testing.T) {
 		//TODO(alexsaezm): finish CI integration
 		t.Skip("skipping test on Linux/PPC64LE in CI")
 	}
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) {
+		t.Skip("disabled due to export format changes")
+	}
 	// Checks gen-cli-docs.go
 	var generatedBuf bytes.Buffer
 	commands := terminal.DebugCommands(nil)


### PR DESCRIPTION
The test is currently broken due to a change to the export format.
