### PR TITLE
proc: use CPUID to determine ZMM_Hi256 region offset

### DIFF
--- a/pkg/proc/amd64util/xsave_amd64.go
+++ b/pkg/proc/amd64util/xsave_amd64.go
@@ -28,3 +28,28 @@ func AMD64XstateMaxSize() int {
 	})
 	return xstateMaxSize
 }
+
+var xstateZMMHi256Offset int
+var loadXstateZMMHi256OffsetOnce sync.Once
+
+// AMD64XstateZMMHi256Offset probes ZMM_Hi256 offset of the current CPU.  Beware
+// that core dumps may be generated from a different CPU.
+func AMD64XstateZMMHi256Offset() int {
+	loadXstateZMMHi256OffsetOnce.Do(func() {
+		// See Intel 64 and IA-32 Architecture Software Developer's Manual, Vol. 1
+		// chapter 13.2 and Vol. 2A CPUID instruction for a description of all the
+		// magic constants.
+
+		_, _, cx, _ := cpuid(0x01, 0x00)
+
+		if cx&(1<<26) == 0 { // Vol. 2A, Table 3-10, XSAVE enabled bit check
+			// XSAVE not supported by this processor
+			xstateZMMHi256Offset = 0
+			return
+		}
+
+		_, bx, _, _ := cpuid(0x0d, 0x06) // ZMM_Hi256 is component #6
+		xstateZMMHi256Offset = int(bx)
+	})
+	return xstateZMMHi256Offset
+}

--- a/pkg/proc/amd64util/xsave_other.go
+++ b/pkg/proc/amd64util/xsave_other.go
@@ -5,3 +5,8 @@ package amd64util
 func AMD64XstateMaxSize() int {
 	return _XSTATE_MAX_KNOWN_SIZE
 }
+
+func AMD64XstateZMMHi256Offset() int {
+	// AVX-512 not supported
+	return 0
+}

--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -351,7 +351,7 @@ func readNote(r io.ReadSeeker, machineType elf.Machine) (*note, error) {
 	case _NT_X86_XSTATE:
 		if machineType == _EM_X86_64 {
 			var fpregs amd64util.AMD64Xstate
-			if err := amd64util.AMD64XstateRead(desc, true, &fpregs); err != nil {
+			if err := amd64util.AMD64XstateRead(desc, true, &fpregs, 0); err != nil {
 				return nil, err
 			}
 			note.Desc = &fpregs

--- a/pkg/proc/native/ptrace_freebsd_amd64.go
+++ b/pkg/proc/native/ptrace_freebsd_amd64.go
@@ -73,7 +73,7 @@ func ptraceGetRegset(id int) (*amd64util.AMD64Xstate, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset)
+	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, amd64util.AMD64XstateZMMHi256Offset())
 	return &regset, err
 }
 

--- a/pkg/proc/native/ptrace_linux_386.go
+++ b/pkg/proc/native/ptrace_linux_386.go
@@ -38,7 +38,7 @@ func ptraceGetRegset(tid int) (regset amd64util.AMD64Xstate, err error) {
 	}
 
 	regset.Xsave = xstateargs[:iov.Len]
-	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset)
+	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, amd64util.AMD64XstateZMMHi256Offset())
 	return
 }
 

--- a/pkg/proc/native/ptrace_linux_amd64.go
+++ b/pkg/proc/native/ptrace_linux_amd64.go
@@ -37,6 +37,6 @@ func ptraceGetRegset(tid int) (regset amd64util.AMD64Xstate, err error) {
 	}
 
 	regset.Xsave = xstateargs[:iov.Len]
-	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset)
+	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, amd64util.AMD64XstateZMMHi256Offset())
 	return
 }


### PR DESCRIPTION
The offset of state component i can be found via
CPUID.(EAX=0DH,ECX=i):EBX. The ZMM_Hi256 is state component 6, so we use CPUID to enumerate the offset instead of hardcoding.

Fixes #3827.