### PR TITLE
pkg/proc/core: Clean up some repetitive code

### DIFF
--- a/pkg/proc/core/core.go
+++ b/pkg/proc/core/core.go
@@ -168,14 +168,14 @@ type process struct {
 
 // thread represents a thread in the core file being debugged.
 type thread struct {
-	th     osThread
+	osThread
 	p      *process
 	common proc.CommonThread
 }
 
 type osThread interface {
-	registers() (proc.Registers, error)
-	pid() int
+	Registers() (proc.Registers, error)
+	ThreadID() int
 }
 
 var (
@@ -322,7 +322,7 @@ func (t *thread) ProcessMemory() proc.MemoryReadWriter {
 // Location returns the location of this thread based on
 // the value of the instruction pointer register.
 func (t *thread) Location() (*proc.Location, error) {
-	regs, err := t.th.registers()
+	regs, err := t.Registers()
 	if err != nil {
 		return nil, err
 	}
@@ -336,16 +336,6 @@ func (t *thread) Location() (*proc.Location, error) {
 // there are no breakpoints when debugging core files.
 func (t *thread) Breakpoint() *proc.BreakpointState {
 	return &proc.BreakpointState{}
-}
-
-// ThreadID returns the ID for this thread.
-func (t *thread) ThreadID() int {
-	return t.th.pid()
-}
-
-// Registers returns the current value of the registers for this thread.
-func (t *thread) Registers() (proc.Registers, error) {
-	return t.th.registers()
 }
 
 // RestoreRegisters will only return an error for core files,

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -213,8 +213,13 @@ func withCoreFile(t *testing.T, name, args string) *proc.TargetGroup {
 	case err != nil || len(cores) > 1:
 		t.Fatalf("Got %v, wanted one file named core* in %v", cores, tempDir)
 	case len(cores) == 0:
-		t.Skipf("core file was not produced, could not run test")
-		return nil
+		cores = []string{fix.Path + ".dump"}
+		err := exec.Command("coredumpctl", "--output="+cores[0], "dump", fix.Path).Run()
+		if err != nil {
+			t.Skipf("core file was not produced, could not run test, coredumpctl error: %v", err)
+			return nil
+		}
+		test.PathsToRemove = append(test.PathsToRemove, cores[0])
 	}
 	corePath := cores[0]
 

--- a/pkg/proc/core/delve_core.go
+++ b/pkg/proc/core/delve_core.go
@@ -130,11 +130,11 @@ type delveThread struct {
 	regs *delveRegisters
 }
 
-func (th *delveThread) pid() int {
+func (th *delveThread) ThreadID() int {
 	return int(th.id)
 }
 
-func (th *delveThread) registers() (proc.Registers, error) {
+func (th *delveThread) Registers() (proc.Registers, error) {
 	return th.regs, nil
 }
 

--- a/pkg/proc/core/windows_amd64_minidump.go
+++ b/pkg/proc/core/windows_amd64_minidump.go
@@ -57,10 +57,10 @@ type windowsAMD64Thread struct {
 	th *minidump.Thread
 }
 
-func (th *windowsAMD64Thread) pid() int {
+func (th *windowsAMD64Thread) ThreadID() int {
 	return int(th.th.ID)
 }
 
-func (th *windowsAMD64Thread) registers() (proc.Registers, error) {
+func (th *windowsAMD64Thread) Registers() (proc.Registers, error) {
 	return winutil.NewAMD64Registers(&th.th.Context, th.th.TEB), nil
 }


### PR DESCRIPTION
Cleans up repetitive code in pkg/proc/core and also adds coredumpctl
support to our test suite.
