### PR TITLE
*: mark riscv64 port as experimental

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -83,23 +83,15 @@ func projectRoot() string {
 
 func TestBuild(t *testing.T) {
 	const listenAddr = "127.0.0.1:40573"
-	var err error
 
-	cmd := exec.Command("go", "run", "_scripts/make.go", "build")
-	cmd.Dir = projectRoot()
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("makefile error: %v\noutput %s\n", err, string(out))
-	}
-
-	dlvbin := filepath.Join(cmd.Dir, "dlv")
+	dlvbin := getDlvBin(t)
 	defer os.Remove(dlvbin)
 
 	fixtures := protest.FindFixturesDir()
 
 	buildtestdir := filepath.Join(fixtures, "buildtest")
 
-	cmd = exec.Command(dlvbin, "debug", "--headless=true", "--listen="+listenAddr, "--api-version=2", "--backend="+testBackend, "--log", "--log-output=debugger,rpc")
+	cmd := exec.Command(dlvbin, "debug", "--headless=true", "--listen="+listenAddr, "--api-version=2", "--backend="+testBackend, "--log", "--log-output=debugger,rpc")
 	cmd.Dir = buildtestdir
 	stderr, err := cmd.StderrPipe()
 	assertNoError(err, t, "stderr pipe")
@@ -214,6 +206,9 @@ func getDlvBin(t *testing.T) string {
 	}
 	if runtime.GOOS == "linux" && runtime.GOARCH == "ppc64le" {
 		tags = "-tags=exp.linuxppc64le"
+	}
+	if runtime.GOOS == "linux" && runtime.GOARCH == "riscv64" {
+		tags = "-tags=exp.linuxriscv64"
 	}
 	return getDlvBinInternal(t, tags)
 }
@@ -1483,23 +1478,14 @@ func TestUnixDomainSocket(t *testing.T) {
 
 	listenPath := filepath.Join(tmpdir, "delve_test")
 
-	var err error
-
-	cmd := exec.Command("go", "run", "_scripts/make.go", "build")
-	cmd.Dir = projectRoot()
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("makefile error: %v\noutput %s\n", err, string(out))
-	}
-
-	dlvbin := filepath.Join(cmd.Dir, "dlv")
+	dlvbin := getDlvBin(t)
 	defer os.Remove(dlvbin)
 
 	fixtures := protest.FindFixturesDir()
 
 	buildtestdir := filepath.Join(fixtures, "buildtest")
 
-	cmd = exec.Command(dlvbin, "debug", "--headless=true", "--listen=unix:"+listenPath, "--api-version=2", "--backend="+testBackend, "--log", "--log-output=debugger,rpc")
+	cmd := exec.Command(dlvbin, "debug", "--headless=true", "--listen=unix:"+listenPath, "--api-version=2", "--backend="+testBackend, "--log", "--log-output=debugger,rpc")
 	cmd.Dir = buildtestdir
 	stderr, err := cmd.StderrPipe()
 	assertNoError(err, t, "stderr pipe")

--- a/pkg/proc/native/support_sentinel_linux.go
+++ b/pkg/proc/native/support_sentinel_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !amd64 && !arm64 && !386 && !(ppc64le && exp.linuxppc64le) && !riscv64
+//go:build linux && !amd64 && !arm64 && !386 && !(ppc64le && exp.linuxppc64le) && !(riscv64 && exp.linuxriscv64)
 
 // This file is used to detect build on unsupported GOOS/GOARCH combinations.
 

--- a/pkg/proc/riscv64_arch.go
+++ b/pkg/proc/riscv64_arch.go
@@ -26,7 +26,7 @@ func RISCV64Arch(goos string) *Arch {
 		altBreakpointInstruction:         riscv64BreakInstruction,
 		breakInstrMovesPC:                false,
 		derefTLS:                         false,
-		prologues:                        prologuesRISCV64,
+		prologues:                        nil,
 		fixFrameUnwindContext:            riscv64FixFrameUnwindContext,
 		switchStack:                      riscv64SwitchStack,
 		regSize:                          riscv64RegSize,

--- a/pkg/proc/riscv64_disasm.go
+++ b/pkg/proc/riscv64_disasm.go
@@ -116,35 +116,6 @@ func resolveCallArgRISCV64(inst *riscv64asm.Inst, instAddr uint64, currentGorout
 	return &Location{PC: pc, File: file, Line: line, Fn: fn}
 }
 
-// Possible stacksplit prologues are inserted by stacksplit in
-// $GOROOT/src/cmd/internal/obj/riscv/obj.go.
-var prologuesRISCV64 []opcodeSeq
-
-func init() {
-	var tinyStacksplit = opcodeSeq{uint64(riscv64asm.ADDI)}
-	var smallStacksplit = opcodeSeq{}
-	var bigStacksplit = opcodeSeq{uint64(riscv64asm.LUI),
-		uint64(riscv64asm.ADDIW),
-		uint64(riscv64asm.BLTU),
-		uint64(riscv64asm.LUI),
-		uint64(riscv64asm.ADDIW),
-		uint64(riscv64asm.ADD)}
-
-	var unixGetG = opcodeSeq{uint64(riscv64asm.LD)}
-	var tailPrologues = opcodeSeq{uint64(riscv64asm.BLTU),
-		uint64(riscv64asm.JAL),
-		uint64(riscv64asm.JAL)}
-
-	prologuesRISCV64 = make([]opcodeSeq, 0, 3)
-	for _, stacksplit := range []opcodeSeq{tinyStacksplit, smallStacksplit, bigStacksplit} {
-		prologue := make(opcodeSeq, 0, len(unixGetG)+len(stacksplit)+len(tailPrologues))
-		prologue = append(prologue, unixGetG...)
-		prologue = append(prologue, stacksplit...)
-		prologue = append(prologue, tailPrologues...)
-		prologuesRISCV64 = append(prologuesRISCV64, prologue)
-	}
-}
-
 type riscv64ArchInst riscv64asm.Inst
 
 func (inst *riscv64ArchInst) Text(flavour AssemblyFlavour, pc uint64, symLookup func(uint64) (string, uint64)) string {


### PR DESCRIPTION
Delete non-working prologue detection code and mark port as experimental.

Updates #3832
