### PR TITLE
Documentation: fix autogenerated markdown documentation

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -112,26 +112,26 @@ Sets a breakpoint.
 
 Locspec is a location specifier in the form of:
 
-  * *<address> Specifies the location of memory address address. address can be specified as a decimal, hexadecimal or octal number
-  * <filename>:<line> Specifies the line in filename. filename can be the partial path to a file or even just the base name as long as the expression remains unambiguous.
-  * <line> Specifies the line in the current file
-  * +<offset> Specifies the line offset lines after the current one
-  * -<offset> Specifies the line offset lines before the current one
-  * <function>[:<line>] Specifies the line inside function.
-      The full syntax for function is <package>.(*<receiver type>).<function name> however the only required element is the function name,
+  * *&lt;address> Specifies the location of memory address address. address can be specified as a decimal, hexadecimal or octal number
+  * &lt;filename>:&lt;line> Specifies the line in filename. filename can be the partial path to a file or even just the base name as long as the expression remains unambiguous.
+  * &lt;line> Specifies the line in the current file
+  * +&lt;offset> Specifies the line offset lines after the current one
+  * -&lt;offset> Specifies the line offset lines before the current one
+  * &lt;function>[:&lt;line>] Specifies the line inside function.
+      The full syntax for function is &lt;package>.(*&lt;receiver type>).&lt;function name> however the only required element is the function name,
       everything else can be omitted as long as the expression remains unambiguous. For setting a breakpoint on an init function (ex: main.init),
-      the <filename>:<line> syntax should be used to break in the correct init function at the correct location.
-  * /<regex>/ Specifies the location of all the functions matching regex
+      the &lt;filename>:&lt;line> syntax should be used to break in the correct init function at the correct location.
+  * /&lt;regex>/ Specifies the location of all the functions matching regex
 
 If locspec is omitted a breakpoint will be set on the current line.
 
 If you would like to assign a name to the breakpoint you can do so with the form:
 
-  break mybpname main.go:4
+	break mybpname main.go:4
 
 Finally, you can assign a condition to the newly created breakpoint by using the 'if' postfix form, like so:
 
-  break main.go:55 if i == 5
+	break main.go:55 if i == 5
 
 Alternatively you can set a condition on a breakpoint after created by using the 'on' command.
 
@@ -265,7 +265,7 @@ See also [Documentation/cli/substitutepath.md](//github.com/go-delve/delve/tree/
 	config alias <command> <alias>
 	config alias <alias>
 
-Defines <alias> as an alias to <command> or removes an alias.
+Defines &lt;alias> as an alias to &lt;command> or removes an alias.
 
 	config debug-info-directories -add <path>
 	config debug-info-directories -rm <path>
@@ -326,7 +326,7 @@ Move the current frame down.
 	down [<m>]
 	down [<m>] <command>
 
-Move the current frame down by <m>. The second form runs the command on the given frame.
+Move the current frame down by &lt;m>. The second form runs the command on the given frame.
 
 
 ## dump
@@ -564,7 +564,7 @@ To convert a breakpoint into a tracepoint use:
 	
 	on <breakpoint name or id> trace
 
-The command 'on <bp> cond <cond-arguments>' is equivalent to 'cond <bp> <cond-arguments>'.
+The command 'on &lt;bp> cond &lt;cond-arguments>' is equivalent to 'cond &lt;bp> &lt;cond-arguments>'.
 
 The command 'on x -edit' can be used to edit the list of commands executed when the breakpoint is hit.
 
@@ -724,7 +724,7 @@ Print out info for every traced thread.
 ## toggle
 Toggles on or off a breakpoint.
 
-toggle <breakpoint name or id>
+	toggle <breakpoint name or id>
 
 
 ## trace
@@ -763,7 +763,7 @@ Move the current frame up.
 	up [<m>]
 	up [<m>] <command>
 
-Move the current frame up by <m>. The second form runs the command on the given frame.
+Move the current frame up by &lt;m>. The second form runs the command on the given frame.
 
 
 ## vars

--- a/pkg/locspec/locations.go
+++ b/pkg/locspec/locations.go
@@ -179,9 +179,7 @@ func parseFuncLocationSpec(in string) *FuncLocationSpec {
 		v = strings.Split(in, ".")
 	} else {
 		v = strings.Split(in[pathend:], ".")
-		if len(v) > 0 {
-			v[0] = in[:pathend] + v[0]
-		}
+		v[0] = in[:pathend] + v[0]
 	}
 
 	var spec FuncLocationSpec

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -141,11 +141,11 @@ If locspec is omitted a breakpoint will be set on the current line.
 
 If you would like to assign a name to the breakpoint you can do so with the form:
 
-  break mybpname main.go:4
+	break mybpname main.go:4
 
 Finally, you can assign a condition to the newly created breakpoint by using the 'if' postfix form, like so:
 
-  break main.go:55 if i == 5
+	break main.go:55 if i == 5
 
 Alternatively you can set a condition on a breakpoint after created by using the 'on' command.
 
@@ -248,7 +248,7 @@ Current limitations:
 If called with the locspec argument it will delete all the breakpoints matching the locspec. If locspec is omitted all breakpoints are deleted.`},
 		{aliases: []string{"toggle"}, group: breakCmds, cmdFn: toggle, helpMsg: `Toggles on or off a breakpoint.
 
-toggle <breakpoint name or id>`},
+	toggle <breakpoint name or id>`},
 		{aliases: []string{"goroutines", "grs"}, group: goroutineCmds, cmdFn: c.goroutines, helpMsg: `List program goroutines.
 
 	goroutines [-u|-r|-g|-s] [-t [depth]] [-l] [-with loc expr] [-without loc expr] [-group argument] [-chan expr] [-exec command]

--- a/pkg/terminal/docgen.go
+++ b/pkg/terminal/docgen.go
@@ -38,6 +38,16 @@ func replaceDocPath(s string) string {
 	}
 }
 
+func fixLessThan(s string) string {
+	v := strings.Split(s, "\n")
+	for i := range v {
+		if len(v[i]) == 0 || v[i][0] != '\t' {
+			v[i] = strings.ReplaceAll(v[i], "<", "&lt;")
+		}
+	}
+	return strings.Join(v, "\n")
+}
+
 func (c *Commands) WriteMarkdown(w io.Writer) {
 	fmt.Fprint(w, "# Configuration and Command History\n\n")
 	fmt.Fprint(w, "If `$XDG_CONFIG_HOME` is set, then configuration and command history files are located in `$XDG_CONFIG_HOME/dlv`. ")
@@ -66,7 +76,7 @@ func (c *Commands) WriteMarkdown(w io.Writer) {
 	}
 
 	for _, cmd := range c.cmds {
-		fmt.Fprintf(w, "## %s\n%s\n\n", cmd.aliases[0], replaceDocPath(cmd.helpMsg))
+		fmt.Fprintf(w, "## %s\n%s\n\n", cmd.aliases[0], fixLessThan(replaceDocPath(cmd.helpMsg)))
 		if len(cmd.aliases) > 1 {
 			fmt.Fprint(w, "Aliases:")
 			for _, alias := range cmd.aliases[1:] {


### PR DESCRIPTION
Changes < to &lt; in autogenerated documentation for CLI commands so that markdown does not interpret them as HTML tags.

Supersedes #3830
Fixes #3829
