### PR TITLE
goversion: parse version for development builds

### DIFF
--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -21,7 +21,7 @@ var (
 // this version of delve.
 func Compatible(producer string, warnonly bool) error {
 	ver := ParseProducer(producer)
-	if ver.IsDevel() {
+	if ver.IsOldDevel() {
 		return nil
 	}
 	if !ver.AfterOrEqual(GoVersion{MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor, betaRev(0), "", ""}) {

--- a/pkg/goversion/version_test.go
+++ b/pkg/goversion/version_test.go
@@ -54,7 +54,7 @@ func TestParseVersionStringAfterOrEqual(t *testing.T) {
 	if !ok {
 		t.Fatalf("Could not parse devel version string")
 	}
-	if !ver.IsDevel() {
+	if !ver.IsOldDevel() {
 		t.Fatalf("Devel version string not correctly recognized")
 	}
 
@@ -77,6 +77,7 @@ func TestParseVersionStringEqual(t *testing.T) {
 	versionEqual(t, "go1.16.4b7", GoVersion{1, 16, 4, "", ""})
 	versionEqual(t, "go1.21.1-something", GoVersion{1, 21, 1, "", "something"})
 	versionEqual(t, "devel +17efbfc Tue Jul 28 17:39:19 2015 +0000 linux/amd64", GoVersion{Major: -1})
+	versionEqual(t, "devel go1.24-1bb6f19a25 Mon Oct 14 15:17:20 2024 -0400 linux/amd64", GoVersion{1, 24, versionedDevel, "", ""})
 }
 
 func TestRoundtrip(t *testing.T) {

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -2081,7 +2081,7 @@ func (bi *BinaryInfo) macOSDebugFrameBugWorkaround() {
 		}
 	} else {
 		prod := goversion.ParseProducer(bi.Producer())
-		if !prod.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 19, Rev: 3}) && !prod.IsDevel() {
+		if !prod.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 19, Rev: 3}) && !prod.IsOldDevel() {
 			bi.logger.Infof("debug_frame workaround not needed (version %q on %s)", bi.Producer(), bi.Arch.Name)
 			return
 		}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2780,7 +2780,7 @@ func TestDebugStripped(t *testing.T) {
 	skipOn(t, "not working on linux/386", "linux", "386")
 	skipOn(t, "not working on linux/ppc64le when -gcflags=-N -l is passed", "linux", "ppc64le")
 	ver, _ := goversion.Parse(runtime.Version())
-	if ver.IsDevel() {
+	if ver.IsDevelBuild() {
 		t.Skip("not supported")
 	}
 	withTestProcessArgs("testnextprog", t, "", []string{}, protest.LinkStrip, func(p *proc.Target, grp *proc.TargetGroup, f protest.Fixture) {
@@ -2810,7 +2810,7 @@ func TestDebugStripped2(t *testing.T) {
 	skipOn(t, "not working on linux/ppc64le when -gcflags=-N -l is passed", "linux", "ppc64le")
 	skipOn(t, "not working on linux/riscv64", "linux", "riscv64")
 	ver, _ := goversion.Parse(runtime.Version())
-	if ver.IsDevel() {
+	if ver.IsDevelBuild() {
 		t.Skip("not supported")
 	}
 	if ver.Major > 0 && ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 22, Rev: -1}) {

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -158,7 +158,7 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	if flags&BuildModeExternalLinker != 0 {
 		buildFlags = append(buildFlags, "-ldflags=-linkmode=external")
 	}
-	if ver.IsDevel() || ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 11, Rev: -1}) {
+	if ver.IsOldDevel() || ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 11, Rev: -1}) {
 		if flags&EnableDWZCompression != 0 {
 			buildFlags = append(buildFlags, "-ldflags=-compressdwarf=false")
 		}


### PR DESCRIPTION
Once upon a time Go version strings for development builds did not
reference the major/minor version they belonged to, therefore the best
we could do was to always assume that a development build belonged to
the most recently released version of Go.

This commit changes pkg/goversion so that the new style of development
version string is fully parsed.
