### PR TITLE
_scripts: update staticcheck version

### DIFF
--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -54,7 +54,7 @@ export GOPATH
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 go version
 if [ "$arch" != "ppc64le" ]; then
-	go install honnef.co/go/tools/cmd/staticcheck@2023.1.6 || true
+	go install honnef.co/go/tools/cmd/staticcheck@2024.1.1 || true
 fi
 
 uname -a

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1410,9 +1410,6 @@ func TestVersion(t *testing.T) {
 }
 
 func TestStaticcheck(t *testing.T) {
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("staticcheck does not support go1.23 yet")
-	}
 	_, err := exec.LookPath("staticcheck")
 	if err != nil {
 		t.Skip("staticcheck not installed")


### PR DESCRIPTION
Update version of staticcheck and reenable for go1.23
