### PR TITLE
TeamCity: move riscv64 backend testing to tip

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -53,7 +53,7 @@ val targets = arrayOf(
 
         "linux/ppc64le/1.23",
 
-        "linux/riscv64/1.23",
+        "linux/riscv64/tip",
 
         "windows/amd64/1.23",
         "windows/amd64/tip",

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -2,6 +2,7 @@ package goversion
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/go-delve/delve/pkg/logflags"
 )
@@ -23,6 +24,13 @@ func Compatible(producer string, warnonly bool) error {
 	ver := ParseProducer(producer)
 	if ver.IsOldDevel() {
 		return nil
+	}
+	if runtime.GOARCH == "riscv64" && !ver.AfterOrEqual(GoVersion{1, 24, versionedDevel, "", ""}) {
+		if warnonly {
+			logflags.WriteError(fmt.Sprintf(goTooOldWarn, ver.String()))
+			return nil
+		}
+		return fmt.Errorf(goTooOldErr, ver.String())
 	}
 	if !ver.AfterOrEqual(GoVersion{MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor, betaRev(0), "", ""}) {
 		if warnonly {


### PR DESCRIPTION
Updates #3832
