### PR TITLE
proc: do not ignore error return of funcCallEvalFuncExpr

### DIFF
--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -981,7 +981,10 @@ func callInjectionComplete2(callScope *EvalScope, bi *BinaryInfo, fncall *functi
 func (scope *EvalScope) evalCallInjectionSetTarget(op *evalop.CallInjectionSetTarget, stack *evalStack, thread Thread) {
 	fncall := stack.fncallPeek()
 	if !fncall.hasDebugPinner && (fncall.fn == nil || fncall.receiver != nil || fncall.closureAddr != 0) {
-		funcCallEvalFuncExpr(scope, stack, fncall)
+		stack.err = funcCallEvalFuncExpr(scope, stack, fncall)
+		if stack.err != nil {
+			return
+		}
 	}
 	stack.pop() // target function, consumed by funcCallEvalFuncExpr either above or in evalop.CallInjectionStart
 


### PR DESCRIPTION
This is probably the cause of the panic such as in issue #3848 and
other similar issues, it is hard to be sure because we never get a
proper reproducer but judging from the stack traces it should be this.

Also it doesn't affect versions of Go that have the debug pinner.

Fixes #3848
