### PR TITLE
service/test: use t.Setenv instead of os.Setenv

### DIFF
--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3178,9 +3178,7 @@ func TestGuessSubstitutePath(t *testing.T) {
 	}
 
 	guess := func(t *testing.T, goflags string) [][2]string {
-		oldgoflags := os.Getenv("GOFLAGS")
-		os.Setenv("GOFLAGS", goflags)
-		defer os.Setenv("GOFLAGS", oldgoflags)
+		t.Setenv("GOFLAGS", goflags)
 
 		dlvbin := protest.GetDlvBinary(t)
 		defer os.Remove(dlvbin)
@@ -3206,9 +3204,9 @@ func TestGuessSubstitutePath(t *testing.T) {
 
 		switch runtime.GOARCH {
 		case "ppc64le":
-			os.Setenv("GOFLAGS", "-tags=exp.linuxppc64le")
+			t.Setenv("GOFLAGS", "-tags=exp.linuxppc64le")
 		case "riscv64":
-			os.Setenv("GOFLAGS", "-tags=exp.linuxriscv64")
+			t.Setenv("GOFLAGS", "-tags=exp.linuxriscv64")
 		}
 
 		gsp, err := client.GuessSubstitutePath()


### PR DESCRIPTION
This PR refactors tests to use [`T.Setenv`](https://pkg.go.dev/testing#T.Setenv) instead of `os.Setenv`.

`T.Setenv` calls `os.Setenv(key, value)` and uses `T.Cleanup` to restore the environment variable to its original value after the test. So, the test doesn't need to restore the environment by itself.

Similar changes to #3503