### PR TITLE
all: remove redundant err declarations

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1414,8 +1414,6 @@ func TestUnixDomainSocket(t *testing.T) {
 
 	listenPath := filepath.Join(tmpdir, "delve_test")
 
-	var err error
-
 	dlvbin := protest.GetDlvBinary(t)
 	defer os.Remove(dlvbin)
 

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -304,7 +304,6 @@ func (bpstate *BreakpointState) checkCond(tgt *Target, breaklet *Breaklet, threa
 	case StepBreakpoint, NextBreakpoint, NextDeferBreakpoint:
 		nextDeferOk := true
 		if breaklet.Kind&NextDeferBreakpoint != 0 {
-			var err error
 			frames, err := ThreadStacktrace(tgt, thread, 2)
 			if err == nil {
 				nextDeferOk, _ = isPanicCall(frames)

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1316,7 +1316,6 @@ func (s *Session) stopDebugSession(killProcess bool) error {
 	if s.debugger == nil {
 		return nil
 	}
-	var err error
 	var exited error
 	// Halting will stop any debugger command that's pending on another
 	// per-request goroutine. Tell auto-resumer not to resume, so the

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1937,7 +1937,6 @@ func (d *Debugger) convertStacktrace(rawlocs []proc.Stackframe, cfg *proc.LoadCo
 			frame.Err = rawlocs[i].Err.Error()
 		}
 		if cfg != nil && rawlocs[i].Current.Fn != nil {
-			var err error
 			scope := proc.FrameToScope(d.target.Selected, d.target.Selected.Memory(), nil, 0, rawlocs[i:]...)
 			locals, err := scope.LocalVariables(*cfg)
 			if err != nil {

--- a/service/rpc1/server.go
+++ b/service/rpc1/server.go
@@ -317,7 +317,6 @@ type DisassembleRequest struct {
 }
 
 func (s *RPCServer) Disassemble(args DisassembleRequest, answer *api.AsmInstructions) error {
-	var err error
 	insts, err := s.debugger.Disassemble(args.Scope.GoroutineID, args.StartPC, args.EndPC)
 	if err != nil {
 		return err

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -201,7 +201,6 @@ func (s *RPCServer) Stacktrace(arg StacktraceIn, out *StacktraceOut) error {
 	if arg.Defers {
 		arg.Opts |= api.StacktraceReadDefers
 	}
-	var err error
 	rawlocs, err := s.debugger.Stacktrace(arg.Id, arg.Depth, arg.Opts)
 	if err != nil {
 		return err
@@ -781,7 +780,6 @@ type DisassembleOut struct {
 //
 // Disassemble will also try to calculate the destination address of an absolute indirect CALL if it happens to be the instruction the selected goroutine is stopped at.
 func (s *RPCServer) Disassemble(arg DisassembleIn, out *DisassembleOut) error {
-	var err error
 	insts, err := s.debugger.Disassemble(arg.Scope.GoroutineID, arg.StartPC, arg.EndPC)
 	if err != nil {
 		return err
@@ -828,7 +826,6 @@ type ListCheckpointsOut struct {
 }
 
 func (s *RPCServer) ListCheckpoints(arg ListCheckpointsIn, out *ListCheckpointsOut) error {
-	var err error
 	cps, err := s.debugger.Checkpoints()
 	if err != nil {
 		return err


### PR DESCRIPTION
The PR removes redundant `var err error` lines across the project.