### PR TITLE
tests: calling os.Exit in TestMain is not required

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 			}
 		}
 	}
-	os.Exit(protest.RunTestsWithFixtures(m))
+	protest.RunTestsWithFixtures(m)
 }
 
 func assertNoError(err error, t testing.TB, s string) {

--- a/pkg/dwarf/line/line_parser_test.go
+++ b/pkg/dwarf/line/line_parser_test.go
@@ -25,7 +25,7 @@ var userTestFile string
 func TestMain(m *testing.M) {
 	flag.StringVar(&userTestFile, "user", "", "runs line parsing test on one extra file")
 	flag.Parse()
-	os.Exit(m.Run())
+	m.Run()
 }
 
 func grabDebugLineSection(p string, t *testing.T) []byte {

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "unknown build mode %q", buildMode)
 		os.Exit(1)
 	}
-	os.Exit(test.RunTestsWithFixtures(m))
+	test.RunTestsWithFixtures(m)
 }
 
 func assertNoError(err error, t testing.TB, s string) {

--- a/pkg/proc/gdbserial/rr_test.go
+++ b/pkg/proc/gdbserial/rr_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -21,7 +20,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&logConf, "log", "", "configures logging")
 	flag.Parse()
 	logflags.Setup(logConf != "", logConf, "")
-	os.Exit(protest.RunTestsWithFixtures(m))
+	protest.RunTestsWithFixtures(m)
 }
 
 func withTestRecording(name string, t testing.TB, fn func(grp *proc.TargetGroup, fixture protest.Fixture)) {

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	logflags.Setup(logConf != "", logConf, "")
-	os.Exit(protest.RunTestsWithFixtures(m))
+	protest.RunTestsWithFixtures(m)
 }
 
 func matchSkipConditions(conditions ...string) bool {

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -212,14 +212,14 @@ func BuildFixture(name string, flags BuildFlags) Fixture {
 	return fixtures[fk]
 }
 
-// RunTestsWithFixtures will pre-compile test fixtures before running test
-// methods. Test binaries are deleted before exiting.
-func RunTestsWithFixtures(m *testing.M) int {
+// RunTestsWithFixtures sets the flag runningWithFixtures to compile fixtures on demand and runs tests with m.Run().
+// After the tests are run, it removes the fixtures and paths from PathsToRemove.
+func RunTestsWithFixtures(m *testing.M) {
 	runningWithFixtures = true
 	defer func() {
 		runningWithFixtures = false
 	}()
-	status := m.Run()
+	m.Run()
 
 	// Remove the fixtures.
 	for _, f := range fixtures {
@@ -237,7 +237,6 @@ func RunTestsWithFixtures(m *testing.M) int {
 			os.Remove(p)
 		}
 	}
-	return status
 }
 
 var recordingAllowed = map[string]bool{}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	logflags.Setup(logConf != "", logConf, "")
-	os.Exit(test.RunTestsWithFixtures(m))
+	test.RunTestsWithFixtures(m)
 }
 
 type FakeTerminal struct {

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	logflags.Setup(logOutput != "", logOutput, "")
 	protest.DefaultTestBackend(&testBackend)
-	os.Exit(protest.RunTestsWithFixtures(m))
+	protest.RunTestsWithFixtures(m)
 }
 
 // name is for _fixtures/<name>.go

--- a/service/debugger/debugger_test.go
+++ b/service/debugger/debugger_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&logConf, "log", "", "configures logging")
 	flag.Parse()
 	logflags.Setup(logConf != "", logConf, "")
-	os.Exit(protest.RunTestsWithFixtures(m))
+	protest.RunTestsWithFixtures(m)
 }
 
 func TestDebugger_LaunchNoMain(t *testing.T) {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	logflags.Setup(logOutput != "", logOutput, "")
-	os.Exit(protest.RunTestsWithFixtures(m))
+	protest.RunTestsWithFixtures(m)
 }
 
 func withTestClient2(name string, t *testing.T, fn func(c service.Client)) {


### PR DESCRIPTION
This PR simplifies tests by removing `os.Exit` calls in `TestMain`. It's not needed from Go 1.15, see golang/go#34129.

Additionally, this PR updates the comment for `RunTestsWithFixtures`.