### PR TITLE
pkg/proc,service/debugger: do not disable unsatisfiable breakpoints

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -1540,10 +1540,7 @@ func TestCondBreakpointError(t *testing.T) {
 func TestHitCondBreakpointEQ(t *testing.T) {
 	withTestProcess("break", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 7)
-		bp.Logical.HitCond = &struct {
-			Op  token.Token
-			Val int
-		}{token.EQL, 3}
+		grp.ChangeBreakpointCondition(bp.Logical, "", "== 3", false)
 
 		assertNoError(grp.Continue(), t, "Continue()")
 		ivar := evalVariable(p, t, "i")
@@ -1564,10 +1561,7 @@ func TestHitCondBreakpointGEQ(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("break", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 7)
-		bp.Logical.HitCond = &struct {
-			Op  token.Token
-			Val int
-		}{token.GEQ, 3}
+		grp.ChangeBreakpointCondition(bp.Logical, "", ">= 3", false)
 
 		for it := 3; it <= 10; it++ {
 			assertNoError(grp.Continue(), t, "Continue()")
@@ -1587,10 +1581,7 @@ func TestHitCondBreakpointREM(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestProcess("break", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 7)
-		bp.Logical.HitCond = &struct {
-			Op  token.Token
-			Val int
-		}{token.REM, 2}
+		grp.ChangeBreakpointCondition(bp.Logical, "", "% 2", false)
 
 		for it := 2; it <= 10; it += 2 {
 			assertNoError(grp.Continue(), t, "Continue()")
@@ -5123,8 +5114,9 @@ func TestFollowExec(t *testing.T) {
 		grp.LogicalBreakpoints[2] = &proc.LogicalBreakpoint{LogicalID: 2, Set: proc.SetBreakpoint{FunctionName: "main.traceme2"}, HitCount: make(map[int64]uint64)}
 		grp.LogicalBreakpoints[3] = &proc.LogicalBreakpoint{LogicalID: 3, Set: proc.SetBreakpoint{FunctionName: "main.traceme3"}, HitCount: make(map[int64]uint64)}
 
-		assertNoError(grp.EnableBreakpoint(grp.LogicalBreakpoints[1]), t, "EnableBreakpoint(main.traceme1)")
-		assertNoError(grp.EnableBreakpoint(grp.LogicalBreakpoints[3]), t, "EnableBreakpoint(main.traceme3)")
+		assertNoError(grp.SetBreakpointEnabled(grp.LogicalBreakpoints[1], true), t, "EnableBreakpoint(main.traceme1)")
+		assertNoError(grp.SetBreakpointEnabled(grp.LogicalBreakpoints[2], true), t, "EnableBreakpoint(main.traceme2)")
+		assertNoError(grp.SetBreakpointEnabled(grp.LogicalBreakpoints[3], true), t, "EnableBreakpoint(main.traceme3)")
 
 		assertNoError(grp.FollowExec(true, ""), t, "FollowExec")
 
@@ -5297,8 +5289,9 @@ func TestFollowExecRegexFilter(t *testing.T) {
 		grp.LogicalBreakpoints[2] = &proc.LogicalBreakpoint{LogicalID: 2, Set: proc.SetBreakpoint{FunctionName: "main.traceme2"}, HitCount: make(map[int64]uint64)}
 		grp.LogicalBreakpoints[3] = &proc.LogicalBreakpoint{LogicalID: 3, Set: proc.SetBreakpoint{FunctionName: "main.traceme3"}, HitCount: make(map[int64]uint64)}
 
-		assertNoError(grp.EnableBreakpoint(grp.LogicalBreakpoints[1]), t, "EnableBreakpoint(main.traceme1)")
-		assertNoError(grp.EnableBreakpoint(grp.LogicalBreakpoints[3]), t, "EnableBreakpoint(main.traceme3)")
+		assertNoError(grp.SetBreakpointEnabled(grp.LogicalBreakpoints[1], true), t, "EnableBreakpoint(main.traceme1)")
+		assertNoError(grp.SetBreakpointEnabled(grp.LogicalBreakpoints[2], true), t, "EnableBreakpoint(main.traceme2)")
+		assertNoError(grp.SetBreakpointEnabled(grp.LogicalBreakpoints[3], true), t, "EnableBreakpoint(main.traceme3)")
 
 		assertNoError(grp.FollowExec(true, "spawn.* child C1"), t, "FollowExec")
 

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -78,6 +78,11 @@ func (grp *TargetGroup) Continue() error {
 		}
 	}()
 	for {
+		err := grp.manageUnsatisfiableBreakpoints()
+		if err != nil {
+			return err
+		}
+
 		if grp.cctx.CheckAndClearManualStopRequest() {
 			grp.finishManualStop()
 			return nil

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1231,7 +1231,6 @@ func TestHitCondBreakpoint(t *testing.T) {
 		if !strings.Contains(out, "2\n") {
 			t.Fatalf("wrong value of j")
 		}
-		term.MustExec("toggle bp1")
 		listIsAt(t, term, "continue", 16, -1, -1)
 		// second g hit
 		out = term.MustExec("print j")

--- a/service/api/conversions.go
+++ b/service/api/conversions.go
@@ -1,11 +1,8 @@
 package api
 
 import (
-	"bytes"
 	"fmt"
 	"go/constant"
-	"go/printer"
-	"go/token"
 	"reflect"
 	"sort"
 	"strconv"
@@ -32,7 +29,7 @@ func ConvertLogicalBreakpoint(lbp *proc.LogicalBreakpoint) *Breakpoint {
 		LoadArgs:         LoadConfigFromProc(lbp.LoadArgs),
 		LoadLocals:       LoadConfigFromProc(lbp.LoadLocals),
 		TotalHitCount:    lbp.TotalHitCount,
-		Disabled:         !lbp.Enabled,
+		Disabled:         !lbp.Enabled(),
 		UserData:         lbp.UserData,
 		RootFuncName:     lbp.RootFuncName,
 		TraceFollowCalls: lbp.TraceFollowCalls,
@@ -43,14 +40,10 @@ func ConvertLogicalBreakpoint(lbp *proc.LogicalBreakpoint) *Breakpoint {
 		b.HitCount[strconv.FormatInt(idx, 10)] = lbp.HitCount[idx]
 	}
 
-	if lbp.HitCond != nil {
-		b.HitCond = fmt.Sprintf("%s %d", lbp.HitCond.Op.String(), lbp.HitCond.Val)
-		b.HitCondPerG = lbp.HitCondPerG
-	}
+	b.HitCond = lbp.HitCond()
+	b.HitCondPerG = lbp.HitCondPerG
 
-	var buf bytes.Buffer
-	printer.Fprint(&buf, token.NewFileSet(), lbp.Cond)
-	b.Cond = buf.String()
+	b.Cond = lbp.Cond()
 
 	return b
 }

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -7,8 +7,6 @@ import (
 	"debug/pe"
 	"errors"
 	"fmt"
-	"go/parser"
-	"go/token"
 	"io"
 	"os"
 	"os/exec"
@@ -18,7 +16,6 @@ import (
 	"runtime"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -768,10 +765,10 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string,
 		d.breakpointIDCounter = id
 	}
 
-	lbp := &proc.LogicalBreakpoint{LogicalID: id, HitCount: make(map[int64]uint64), Enabled: true}
+	lbp := &proc.LogicalBreakpoint{LogicalID: id, HitCount: make(map[int64]uint64)}
 	d.target.LogicalBreakpoints[id] = lbp
 
-	err = copyLogicalBreakpointInfo(lbp, requestedBp)
+	err = d.copyLogicalBreakpointInfo(lbp, requestedBp)
 	if err != nil {
 		return nil, err
 	}
@@ -790,7 +787,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string,
 		}
 	}
 
-	err = d.target.EnableBreakpoint(lbp)
+	err = d.target.SetBreakpointEnabled(lbp, true)
 	if err != nil {
 		if suspended {
 			logflags.DebuggerLogger().Debugf("could not enable new breakpoint: %v (breakpoint will be suspended)", err)
@@ -847,34 +844,18 @@ func (d *Debugger) amendBreakpoint(amend *api.Breakpoint) error {
 	if original == nil {
 		return fmt.Errorf("no breakpoint with ID %d", amend.ID)
 	}
-	enabledBefore := original.Enabled
-	err := copyLogicalBreakpointInfo(original, amend)
+	if d.isWatchpoint(original) && amend.Disabled {
+		return errors.New("can not disable watchpoints")
+	}
+	err := d.copyLogicalBreakpointInfo(original, amend)
 	if err != nil {
 		return err
 	}
-	original.Enabled = !amend.Disabled
-
-	switch {
-	case enabledBefore && !original.Enabled:
-		if d.isWatchpoint(original) {
-			return errors.New("can not disable watchpoints")
-		}
-		err = d.target.DisableBreakpoint(original)
-	case !enabledBefore && original.Enabled:
-		err = d.target.EnableBreakpoint(original)
-	}
+	err = d.target.SetBreakpointEnabled(original, !amend.Disabled)
 	if err != nil {
 		return err
 	}
 
-	t := proc.ValidTargets{Group: d.target}
-	for t.Next() {
-		for _, bp := range t.Breakpoints().M {
-			if bp.LogicalID() == amend.ID {
-				bp.UserBreaklet().Cond = original.Cond
-			}
-		}
-	}
 	return nil
 }
 
@@ -907,7 +888,7 @@ func (d *Debugger) CancelNext() error {
 	return d.target.ClearSteppingBreakpoints()
 }
 
-func copyLogicalBreakpointInfo(lbp *proc.LogicalBreakpoint, requested *api.Breakpoint) error {
+func (d *Debugger) copyLogicalBreakpointInfo(lbp *proc.LogicalBreakpoint, requested *api.Breakpoint) error {
 	lbp.Name = requested.Name
 	lbp.Tracepoint = requested.Tracepoint
 	lbp.TraceReturn = requested.TraceReturn
@@ -919,70 +900,8 @@ func copyLogicalBreakpointInfo(lbp *proc.LogicalBreakpoint, requested *api.Break
 	lbp.UserData = requested.UserData
 	lbp.RootFuncName = requested.RootFuncName
 	lbp.TraceFollowCalls = requested.TraceFollowCalls
-	lbp.Cond = nil
-	if requested.Cond != "" {
-		var err error
-		lbp.Cond, err = parser.ParseExpr(requested.Cond)
-		if err != nil {
-			return err
-		}
-	}
 
-	lbp.HitCond = nil
-	if requested.HitCond != "" {
-		opTok, val, err := parseHitCondition(requested.HitCond)
-		if err != nil {
-			return err
-		}
-		lbp.HitCond = &struct {
-			Op  token.Token
-			Val int
-		}{opTok, val}
-		lbp.HitCondPerG = requested.HitCondPerG
-	}
-
-	return nil
-}
-
-func parseHitCondition(hitCond string) (token.Token, int, error) {
-	// A hit condition can be in the following formats:
-	// - "number"
-	// - "OP number"
-	hitConditionRegex := regexp.MustCompile(`(([=><%!])+|)( |)((\d|_)+)`)
-
-	match := hitConditionRegex.FindStringSubmatch(strings.TrimSpace(hitCond))
-	if match == nil || len(match) != 6 {
-		return 0, 0, fmt.Errorf("unable to parse breakpoint hit condition: %q\nhit conditions should be of the form \"number\" or \"OP number\"", hitCond)
-	}
-
-	opStr := match[1]
-	var opTok token.Token
-	switch opStr {
-	case "==", "":
-		opTok = token.EQL
-	case ">=":
-		opTok = token.GEQ
-	case "<=":
-		opTok = token.LEQ
-	case ">":
-		opTok = token.GTR
-	case "<":
-		opTok = token.LSS
-	case "%":
-		opTok = token.REM
-	case "!=":
-		opTok = token.NEQ
-	default:
-		return 0, 0, fmt.Errorf("unable to parse breakpoint hit condition: %q\ninvalid operator: %q", hitCond, opStr)
-	}
-
-	numStr := match[4]
-	val, parseErr := strconv.Atoi(numStr)
-	if parseErr != nil {
-		return 0, 0, fmt.Errorf("unable to parse breakpoint hit condition: %q\ninvalid number: %q", hitCond, numStr)
-	}
-
-	return opTok, val, nil
+	return d.target.ChangeBreakpointCondition(lbp, requested.Cond, requested.HitCond, requested.HitCondPerG)
 }
 
 // ClearBreakpoint clears a breakpoint.
@@ -1000,7 +919,7 @@ func (d *Debugger) ClearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint
 	lbp := d.target.LogicalBreakpoints[requestedBp.ID]
 	clearedBp := d.convertBreakpoint(lbp)
 
-	err := d.target.DisableBreakpoint(lbp)
+	err := d.target.SetBreakpointEnabled(lbp, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1009,33 +928,6 @@ func (d *Debugger) ClearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint
 
 	d.log.Infof("cleared breakpoint: %#v", clearedBp)
 	return clearedBp, nil
-}
-
-// isBpHitCondNotSatisfiable returns true if the breakpoint bp has a hit
-// condition that is no more satisfiable.
-// The hit condition is considered no more satisfiable if it can no longer be
-// hit again, for example with {Op: "==", Val: 1} and TotalHitCount == 1.
-func isBpHitCondNotSatisfiable(bp *api.Breakpoint) bool {
-	if bp.HitCond == "" {
-		return false
-	}
-
-	tok, val, err := parseHitCondition(bp.HitCond)
-	if err != nil {
-		return false
-	}
-	switch tok {
-	case token.EQL, token.LEQ:
-		if int(bp.TotalHitCount) >= val {
-			return true
-		}
-	case token.LSS:
-		if int(bp.TotalHitCount) >= val-1 {
-			return true
-		}
-	}
-
-	return false
 }
 
 // Breakpoints returns the list of current breakpoints.
@@ -1335,10 +1227,6 @@ func (d *Debugger) Command(command *api.DebuggerCommand, resumeNotify chan struc
 				}
 			}
 		}
-	}
-	if bp := state.CurrentThread.Breakpoint; bp != nil && isBpHitCondNotSatisfiable(bp) {
-		bp.Disabled = true
-		d.amendBreakpoint(bp)
 	}
 
 	d.maybePrintUnattendedBreakpointWarning(d.target.Selected.StopReason, state.CurrentThread, clientStatusCh)


### PR DESCRIPTION
Previously breakpoints with hitcount conditions that became
unsatisfiable
would become disabled, this was done as an optimization so that the
continue loop would no longer need to stop on them and evaluate their
conditions.

As a side effect this meant that on restart these breakpoints would
remain disabled, even though their hit condition returned satisfiable.

This commit changes Delve behavior so that breakpoints with
unsatisifiable hitcount conditions are no longer disabled but the
associated physical breakpoints are removed anyway, preserving the
optimization.

Some refactoring is done to the way conditions are represented and the
enable status is managed so that in the future it will be possible to
use hitcount conditions to implement "chained" breakpoints (also known
as dependet breakpoints), i.e. breakpoints that become active only
after a second breakpoint has been hit.
