### PR TITLE
proc: expose breakpoint hitcounts in expressions

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -211,7 +211,7 @@ Set breakpoint condition.
 
 Specifies that the breakpoint, tracepoint or watchpoint should break only if the boolean expression is true.
 
-See [Documentation/cli/expr.md](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md) for a description of supported expressions.
+See [Documentation/cli/expr.md](//github.com/go-delve/delve/tree/master/Documentation/cli/expr.md) for a description of supported expressions and [Documentation/cli/cond.md](//github.com/go-delve/delve/tree/master/Documentation/cli/cond.md) for a description of how breakpoint conditions are evaluated.
 
 With the -hitcount option a condition on the breakpoint hit count can be set, the following operators are supported
 

--- a/Documentation/cli/cond.md
+++ b/Documentation/cli/cond.md
@@ -1,0 +1,15 @@
+# Breakpoint conditions
+
+Breakpoints have two conditions:
+
+* The normal condition, which is specified using the command `cond <breakpoint> <expr>` (or by setting the Cond field when amending a breakpoint via the API), is any [expression](expr.md) which evaluates to true or false.
+* The hitcount condition, which is specified `cond <breakpoint> -hitcount <operator> <number>` (or by setting the HitCond field when amending a breakpoint via the API), is a constraint on the number of times the breakpoint has been hit.
+
+When a breakpoint location is encountered during the execution of the program, the debugger will:
+
+* Evaluate the normal condition
+* Stop if there is an error while evaluating the normal condition
+* If the normal condition evaluates to true the hit count is incremented
+* Evaluate the hitcount condition
+* If the hitcount condition is also satisfied stop the execution at the breakpoint
+

--- a/Documentation/cli/expr.md
+++ b/Documentation/cli/expr.md
@@ -119,6 +119,7 @@ Delve defines two special variables:
 
 * `runtime.curg` evaluates to the 'g' struct for the current goroutine, in particular `runtime.curg.goid` is the goroutine id of the current goroutine.
 * `runtime.frameoff` is the offset of the frame's base address from the bottom of the stack.
+* `delve.bphitcount[X]` is the total hitcount for breakpoint X, which can be either an ID or the breakpoint name as a string.
 
 ## Access to variables from previous frames
 

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -340,3 +340,25 @@ var = eval(
         {"FollowPointers":True, "MaxVariableRecurse":2, "MaxStringLen":100, "MaxArrayValues":10, "MaxStructFields":100}
       )
 ```
+
+## Chain breakpoints
+
+Chain a number of breakpoints such that breakpoint n+1 is only hit after breakpoint n is hit:
+
+```python
+def command_breakchain(*args):
+	v = args.split(" ")
+	
+	bp = get_breakpoint(int(v[0]), "").Breakpoint
+	bp.HitCond = "== 1"
+	amend_breakpoint(bp)
+	
+	for i in range(1, len(v)):
+		bp = get_breakpoint(int(v[i]), "").Breakpoint
+		if i != len(v)-1:
+			bp.HitCond = "== 1"
+		bp.Cond = "delve.bphitcount[" + v[i-1] + "] > 0"
+		amend_breakpoint(bp)
+```
+
+To be used as `chain 1 2 3` where `1`, `2`, and `3` are IDs of breakpoints to chain together.

--- a/_fixtures/bphitcountchain.go
+++ b/_fixtures/bphitcountchain.go
@@ -1,0 +1,31 @@
+package main
+
+import "fmt"
+
+func breakfunc1() {
+	fmt.Println("breakfunc1")
+}
+
+func breakfunc2() {
+	fmt.Println("breakfunc2")
+}
+
+func breakfunc3() {
+	fmt.Println("breakfunc3")
+}
+
+func main() {
+	breakfunc2()
+	breakfunc3()
+
+	breakfunc1() // hit
+	breakfunc3()
+	breakfunc1()
+
+	breakfunc2() // hit
+	breakfunc1()
+
+	breakfunc3() // hit
+	breakfunc1()
+	breakfunc2()
+}

--- a/_fixtures/chain_breakpoints.star
+++ b/_fixtures/chain_breakpoints.star
@@ -1,0 +1,13 @@
+def command_chain(args):
+	v = args.split(" ")
+	
+	bp = get_breakpoint(int(v[0]), "").Breakpoint
+	bp.HitCond = "== 1"
+	amend_breakpoint(bp)
+	
+	for i in range(1, len(v)):
+		bp = get_breakpoint(int(v[i]), "").Breakpoint
+		if i != len(v)-1:
+			bp.HitCond = "== 1"
+		bp.Cond = "delve.bphitcount[" + v[i-1] + "] > 0"
+		amend_breakpoint(bp)

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -11,12 +11,14 @@ import (
 	"go/printer"
 	"go/token"
 	"reflect"
+	"strconv"
 
 	"github.com/go-delve/delve/pkg/astutil"
 	"github.com/go-delve/delve/pkg/dwarf/godwarf"
 	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/dwarf/reader"
 	"github.com/go-delve/delve/pkg/goversion"
+	"github.com/go-delve/delve/pkg/proc/evalop"
 	"github.com/go-delve/delve/pkg/proc/internal/ebpf"
 )
 
@@ -921,6 +923,24 @@ func (bpmap *BreakpointMap) HasHWBreakpoints() bool {
 	return false
 }
 
+func totalHitCountByName(lbpmap map[int]*LogicalBreakpoint, s string) (uint64, error) {
+	for _, bp := range lbpmap {
+		if bp.Name == s {
+			return bp.TotalHitCount, nil
+		}
+	}
+	return 0, fmt.Errorf("could not find breakpoint named %q", s)
+}
+
+func totalHitCountByID(lbpmap map[int]*LogicalBreakpoint, id int) (uint64, error) {
+	for _, bp := range lbpmap {
+		if bp.LogicalID == int(id) {
+			return bp.TotalHitCount, nil
+		}
+	}
+	return 0, fmt.Errorf("could not find breakpoint with ID = %d", id)
+}
+
 // BreakpointState describes the state of a breakpoint in a thread.
 type BreakpointState struct {
 	*Breakpoint
@@ -1064,6 +1084,8 @@ type LogicalBreakpoint struct {
 
 	// condSatisfiable is true when 'cond && hitCond' can potentially be true.
 	condSatisfiable bool
+	// condUsesHitCounts is true when 'cond' uses breakpoint hitcounts
+	condUsesHitCounts bool
 
 	UserData interface{} // Any additional information about the breakpoint
 	// Name of root function from where tracing needs to be done
@@ -1106,15 +1128,135 @@ func (lbp *LogicalBreakpoint) Cond() string {
 	return buf.String()
 }
 
-func breakpointConditionSatisfiable(lbp *LogicalBreakpoint) bool {
-	if lbp.hitCond == nil || lbp.HitCondPerG {
+func breakpointConditionSatisfiable(lbpmap map[int]*LogicalBreakpoint, lbp *LogicalBreakpoint) bool {
+	if lbp.hitCond != nil && !lbp.HitCondPerG {
+		switch lbp.hitCond.Op {
+		case token.EQL, token.LEQ:
+			if int(lbp.TotalHitCount) >= lbp.hitCond.Val {
+				return false
+			}
+		case token.LSS:
+			if int(lbp.TotalHitCount) >= lbp.hitCond.Val-1 {
+				return false
+			}
+		}
+	}
+	if !lbp.condUsesHitCounts {
 		return true
 	}
-	switch lbp.hitCond.Op {
-	case token.EQL, token.LEQ:
-		return int(lbp.TotalHitCount) < lbp.hitCond.Val
-	case token.LSS:
-		return int(lbp.TotalHitCount) < lbp.hitCond.Val-1
+
+	toint := func(x ast.Expr) (uint64, bool) {
+		lit, ok := x.(*ast.BasicLit)
+		if !ok || lit.Kind != token.INT {
+			return 0, false
+		}
+		n, err := strconv.Atoi(lit.Value)
+		return uint64(n), err == nil && n >= 0
 	}
-	return true
+
+	hitcountexpr := func(x ast.Expr) (uint64, bool) {
+		idx, ok := x.(*ast.IndexExpr)
+		if !ok {
+			return 0, false
+		}
+		selx, ok := idx.X.(*ast.SelectorExpr)
+		if !ok {
+			return 0, false
+		}
+		ident, ok := selx.X.(*ast.Ident)
+		if !ok || ident.Name != evalop.BreakpointHitCountVarNamePackage || selx.Sel.Name != evalop.BreakpointHitCountVarName {
+			return 0, false
+		}
+		lit, ok := idx.Index.(*ast.BasicLit)
+		if !ok {
+			return 0, false
+		}
+		switch lit.Kind {
+		case token.INT:
+			n, _ := strconv.Atoi(lit.Value)
+			thc, err := totalHitCountByID(lbpmap, n)
+			return thc, err == nil
+		case token.STRING:
+			v, _ := strconv.Unquote(lit.Value)
+			thc, err := totalHitCountByName(lbpmap, v)
+			return thc, err == nil
+		default:
+			return 0, false
+		}
+	}
+
+	var satisf func(n ast.Node) bool
+	satisf = func(n ast.Node) bool {
+		parexpr, ok := n.(*ast.ParenExpr)
+		if ok {
+			return satisf(parexpr.X)
+		}
+		binexpr, ok := n.(*ast.BinaryExpr)
+		if !ok {
+			return true
+		}
+		switch binexpr.Op {
+		case token.AND:
+			return satisf(binexpr.X) && satisf(binexpr.Y)
+		case token.OR:
+			if !satisf(binexpr.X) {
+				return false
+			}
+			if !satisf(binexpr.Y) {
+				return false
+			}
+			return true
+		case token.EQL, token.LEQ, token.LSS, token.NEQ, token.GTR, token.GEQ:
+		default:
+			return true
+		}
+
+		hitcount, ok1 := hitcountexpr(binexpr.X)
+		val, ok2 := toint(binexpr.Y)
+		if !ok1 || !ok2 {
+			return true
+		}
+
+		switch binexpr.Op {
+		case token.EQL:
+			return hitcount == val
+		case token.LEQ:
+			return hitcount <= val
+		case token.LSS:
+			return hitcount < val
+		case token.NEQ:
+			return hitcount != val
+		case token.GTR:
+			return hitcount > val
+		case token.GEQ:
+			return hitcount >= val
+		}
+		return true
+	}
+
+	return satisf(lbp.cond)
+}
+
+func breakpointConditionUsesHitCounts(lbp *LogicalBreakpoint) bool {
+	if lbp.cond == nil {
+		return false
+	}
+	r := false
+	ast.Inspect(lbp.cond, func(n ast.Node) bool {
+		if r {
+			return false
+		}
+		seln, ok := n.(*ast.SelectorExpr)
+		if ok {
+			ident, ok := seln.X.(*ast.Ident)
+			if ok {
+				if ident.Name == evalop.BreakpointHitCountVarNamePackage && seln.Sel.Name == evalop.BreakpointHitCountVarName {
+					r = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return r
 }

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1253,6 +1253,9 @@ func (stack *evalStack) executeOp() {
 	case *evalop.PushDebugPinner:
 		stack.push(stack.debugPinner)
 
+	case *evalop.PushBreakpointHitCount:
+		stack.push(newVariable(evalop.BreakpointHitCountVarNameQualified, fakeAddressUnresolv, godwarf.FakeSliceType(godwarf.FakeBasicType("uint", 64)), scope.BinInfo, scope.Mem))
+
 	default:
 		stack.err = fmt.Errorf("internal debugger error: unknown eval opcode: %#v", op)
 	}
@@ -2068,6 +2071,33 @@ func (scope *EvalScope) evalIndex(op *evalop.Index, stack *evalStack) {
 	xev := stack.pop()
 	if xev.Unreadable != nil {
 		stack.err = xev.Unreadable
+		return
+	}
+
+	if xev.Name == evalop.BreakpointHitCountVarNameQualified {
+		if idxev.Kind == reflect.String {
+			s := constant.StringVal(idxev.Value)
+			thc, err := totalHitCountByName(scope.target.Breakpoints().Logical, s)
+			if err == nil {
+				stack.push(newConstant(constant.MakeUint64(thc), scope.Mem))
+			}
+			stack.err = err
+			return
+		}
+		n, err := idxev.asInt()
+		if err != nil {
+			n2, err := idxev.asUint()
+			if err != nil {
+				stack.err = fmt.Errorf("can not index %s with %s", xev.Name, astutil.ExprToString(op.Node.Index))
+				return
+			}
+			n = int64(n2)
+		}
+		thc, err := totalHitCountByID(scope.target.Breakpoints().Logical, int(n))
+		if err == nil {
+			stack.push(newConstant(constant.MakeUint64(thc), scope.Mem))
+		}
+		stack.err = err
 		return
 	}
 

--- a/pkg/proc/evalop/evalcompile.go
+++ b/pkg/proc/evalop/evalcompile.go
@@ -17,8 +17,14 @@ import (
 )
 
 var (
-	ErrFuncCallNotAllowed   = errors.New("function calls not allowed without using 'call'")
-	DebugPinnerFunctionName = "runtime.debugPinnerV1"
+	ErrFuncCallNotAllowed = errors.New("function calls not allowed without using 'call'")
+)
+
+const (
+	BreakpointHitCountVarNamePackage   = "delve"
+	BreakpointHitCountVarName          = "bphitcount"
+	BreakpointHitCountVarNameQualified = BreakpointHitCountVarNamePackage + "." + BreakpointHitCountVarName
+	DebugPinnerFunctionName            = "runtime.debugPinnerV1"
 )
 
 type compileCtx struct {
@@ -274,6 +280,9 @@ func (ctx *compileCtx) compileAST(t ast.Expr) error {
 
 			case x.Name == "runtime" && node.Sel.Name == "rangeParentOffset":
 				ctx.pushOp(&PushRangeParentOffset{})
+
+			case x.Name == BreakpointHitCountVarNamePackage && node.Sel.Name == BreakpointHitCountVarName:
+				ctx.pushOp(&PushBreakpointHitCount{})
 
 			default:
 				ctx.pushOp(&PushPackageVarOrSelect{Name: x.Name, Sel: node.Sel.Name})

--- a/pkg/proc/evalop/ops.go
+++ b/pkg/proc/evalop/ops.go
@@ -324,3 +324,10 @@ type PushPinAddress struct {
 }
 
 func (*PushPinAddress) depthCheck() (npop, npush int) { return 0, 1 }
+
+// PushBreakpointHitCount pushes a special array containing the hit counts
+// of breakpoints.
+type PushBreakpointHitCount struct {
+}
+
+func (*PushBreakpointHitCount) depthCheck() (npop, npush int) { return 0, 1 }

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -71,6 +71,7 @@ func NewGroup(procgrp ProcessGroup, cfg NewTargetGroupConfig) (*TargetGroup, Add
 // Breakpoints that can not be set will be discarded, if discard is not nil
 // it will be called for each discarded breakpoint.
 func Restart(grp, oldgrp *TargetGroup, discard func(*LogicalBreakpoint, error)) {
+	toenable := []*LogicalBreakpoint{}
 	for _, bp := range oldgrp.LogicalBreakpoints {
 		if _, ok := grp.LogicalBreakpoints[bp.LogicalID]; ok {
 			continue
@@ -80,14 +81,17 @@ func Restart(grp, oldgrp *TargetGroup, discard func(*LogicalBreakpoint, error)) 
 		bp.HitCount = make(map[int64]uint64)
 		bp.Set.PidAddrs = nil // breakpoints set through a list of addresses can not be restored after a restart
 		if bp.enabled {
-			bp.condSatisfiable = breakpointConditionSatisfiable(bp)
-			err := grp.enableBreakpoint(bp)
-			if err != nil {
-				if discard != nil {
-					discard(bp, err)
-				}
-				delete(grp.LogicalBreakpoints, bp.LogicalID)
+			toenable = append(toenable, bp)
+		}
+	}
+	for _, bp := range toenable {
+		bp.condSatisfiable = breakpointConditionSatisfiable(grp.LogicalBreakpoints, bp)
+		err := grp.enableBreakpoint(bp)
+		if err != nil {
+			if discard != nil {
+				discard(bp, err)
 			}
+			delete(grp.LogicalBreakpoints, bp.LogicalID)
 		}
 	}
 	if oldgrp.followExecEnabled {
@@ -265,7 +269,7 @@ func (grp *TargetGroup) SetBreakpointEnabled(lbp *LogicalBreakpoint, enabled boo
 		err = grp.disableBreakpoint(lbp)
 	case !lbp.enabled && enabled:
 		lbp.enabled = true
-		lbp.condSatisfiable = breakpointConditionSatisfiable(lbp)
+		lbp.condSatisfiable = breakpointConditionSatisfiable(grp.LogicalBreakpoints, lbp)
 		err = grp.enableBreakpoint(lbp)
 	}
 	return
@@ -424,12 +428,14 @@ func (grp *TargetGroup) ChangeBreakpointCondition(lbp *LogicalBreakpoint, cond, 
 		lbp.HitCondPerG = hitCondPerG
 	}
 
+	lbp.condUsesHitCounts = breakpointConditionUsesHitCounts(lbp)
+
 	if lbp.enabled {
 		switch {
-		case lbp.condSatisfiable && !breakpointConditionSatisfiable(lbp):
+		case lbp.condSatisfiable && !breakpointConditionSatisfiable(grp.LogicalBreakpoints, lbp):
 			lbp.condSatisfiable = false
 			grp.disableBreakpoint(lbp)
-		case !lbp.condSatisfiable && breakpointConditionSatisfiable(lbp):
+		case !lbp.condSatisfiable && breakpointConditionSatisfiable(grp.LogicalBreakpoints, lbp):
 			lbp.condSatisfiable = true
 			grp.enableBreakpoint(lbp)
 		}
@@ -483,9 +489,15 @@ func parseHitCondition(hitCond string) (token.Token, int, error) {
 func (grp *TargetGroup) manageUnsatisfiableBreakpoints() error {
 	for _, lbp := range grp.LogicalBreakpoints {
 		if lbp.enabled {
-			if lbp.condSatisfiable && !breakpointConditionSatisfiable(lbp) {
+			if lbp.condSatisfiable && !breakpointConditionSatisfiable(grp.LogicalBreakpoints, lbp) {
 				lbp.condSatisfiable = false
 				err := grp.disableBreakpoint(lbp)
+				if err != nil {
+					return err
+				}
+			} else if lbp.condUsesHitCounts && !lbp.condSatisfiable && breakpointConditionSatisfiable(grp.LogicalBreakpoints, lbp) {
+				lbp.condSatisfiable = true
+				err := grp.enableBreakpoint(lbp)
 				if err != nil {
 					return err
 				}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1648,6 +1648,10 @@ func (v *Variable) loadSliceInfo(t *godwarf.SliceType) {
 		}
 	}
 
+	if v.Addr == fakeAddressUnresolv && v.fieldType == nil {
+		return
+	}
+
 	v.stride = v.fieldType.Size()
 	if t, ok := v.fieldType.(*godwarf.PtrType); ok {
 		v.stride = t.ByteSize

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -508,7 +508,7 @@ The command 'on x -edit' can be used to edit the list of commands executed when 
 
 Specifies that the breakpoint, tracepoint or watchpoint should break only if the boolean expression is true.
 
-See Documentation/cli/expr.md for a description of supported expressions.
+See Documentation/cli/expr.md for a description of supported expressions and Documentation/cli/cond.md for a description of how breakpoint conditions are evaluated.
 
 With the -hitcount option a condition on the breakpoint hit count can be set, the following operators are supported
 


### PR DESCRIPTION
Expose breakpoint hitcounts in the expression language through the
special variable runtime.bphitcount:
runtime.bphitcount[1]
runtime.bphitcount["bpname"]
will evaluate respectively to the hitcount of breakpoint with id == 1
and to the hitcount of the breakpoint named "bpname".

This is intended to be used in breakpoint conditions and allows
breakpoints to be chained such that one breakpoint is only hit after a
different is hit first.

A few optimizations are implemented so that chained breakpoints are
evaluated efficiently.
