### PR TITLE
tests: removing of dlvbin is not needed

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -60,7 +60,6 @@ func TestBuild(t *testing.T) {
 	const listenAddr = "127.0.0.1:40573"
 
 	dlvbin := protest.GetDlvBinary(t)
-	defer os.Remove(dlvbin)
 
 	fixtures := protest.FindFixturesDir()
 
@@ -1421,7 +1420,6 @@ func TestUnixDomainSocket(t *testing.T) {
 	listenPath := filepath.Join(tmpdir, "delve_test")
 
 	dlvbin := protest.GetDlvBinary(t)
-	defer os.Remove(dlvbin)
 
 	fixtures := protest.FindFixturesDir()
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3169,7 +3169,6 @@ func TestGuessSubstitutePath(t *testing.T) {
 		defer os.Setenv("GOFLAGS", oldgoflags)
 
 		dlvbin := protest.GetDlvBinary(t)
-		defer os.Remove(dlvbin)
 
 		listener, clientConn := service.ListenerPipe()
 		defer listener.Close()


### PR DESCRIPTION
This PR removes useless `os.Remove(dlvbin)` in tests.

`protest.GetDlvBinary` calls `getDlvBinInternal` which creates `dlv.exe` inside the temporary directory from `t.TempDir()`. And [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir) function automatically removes the returned directory.