### PR TITLE
pkg: refactor sort.Sort to slices.SortFunc

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -2,6 +2,7 @@ package proc
 
 import (
 	"bytes"
+	"cmp"
 	"debug/dwarf"
 	"debug/elf"
 	"debug/macho"
@@ -2305,7 +2306,7 @@ func loadBinaryInfoGoRuntimeCommon(bi *BinaryInfo, image *Image, cu *compileUnit
 	for i := range inlFuncs {
 		bi.Functions = append(bi.Functions, *inlFuncs[i])
 	}
-	sort.Sort(functionsDebugInfoByEntry(bi.Functions))
+	slices.SortFunc(bi.Functions, func(a, b Function) int { return cmp.Compare(a.Entry, b.Entry) })
 	for f := range image.symTable.Files {
 		bi.Sources = append(bi.Sources, f)
 	}
@@ -2534,9 +2535,9 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugInfoBytes, debugLineB
 		}
 	}
 
-	sort.Sort(compileUnitsByOffset(image.compileUnits))
-	sort.Sort(functionsDebugInfoByEntry(bi.Functions))
-	sort.Sort(packageVarsByAddr(bi.packageVars))
+	slices.SortFunc(image.compileUnits, func(a, b *compileUnit) int { return cmp.Compare(a.offset, b.offset) })
+	slices.SortFunc(bi.Functions, func(a, b Function) int { return cmp.Compare(a.Entry, b.Entry) })
+	slices.SortFunc(bi.packageVars, func(a, b packageVar) int { return cmp.Compare(a.addr, b.addr) })
 
 	bi.lookupFunc = nil
 	bi.lookupGenericFunc = nil

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -38,24 +38,6 @@ func pointerTo(typ godwarf.Type, arch *Arch) godwarf.Type {
 	}
 }
 
-type functionsDebugInfoByEntry []Function
-
-func (v functionsDebugInfoByEntry) Len() int           { return len(v) }
-func (v functionsDebugInfoByEntry) Less(i, j int) bool { return v[i].Entry < v[j].Entry }
-func (v functionsDebugInfoByEntry) Swap(i, j int)      { v[i], v[j] = v[j], v[i] }
-
-type compileUnitsByOffset []*compileUnit
-
-func (v compileUnitsByOffset) Len() int               { return len(v) }
-func (v compileUnitsByOffset) Less(i int, j int) bool { return v[i].offset < v[j].offset }
-func (v compileUnitsByOffset) Swap(i int, j int)      { v[i], v[j] = v[j], v[i] }
-
-type packageVarsByAddr []packageVar
-
-func (v packageVarsByAddr) Len() int               { return len(v) }
-func (v packageVarsByAddr) Less(i int, j int) bool { return v[i].addr < v[j].addr }
-func (v packageVarsByAddr) Swap(i int, j int)      { v[i], v[j] = v[j], v[i] }
-
 type loadDebugInfoMapsContext struct {
 	ardr                *reader.Reader
 	abstractOriginTable map[dwarf.Offset]int

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -2,6 +2,7 @@ package proc
 
 import (
 	"bytes"
+	"cmp"
 	"debug/dwarf"
 	"encoding/binary"
 	"errors"
@@ -11,7 +12,7 @@ import (
 	"math"
 	"math/bits"
 	"reflect"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -2278,7 +2279,9 @@ func (cm constantsMap) Get(typ godwarf.Type) *constantType {
 	typepkg := packageName(typ.String()) + "."
 	if !ctyp.initialized {
 		ctyp.initialized = true
-		sort.Sort(constantValuesByValue(ctyp.values))
+		slices.SortFunc(ctyp.values, func(a, b constantValue) int {
+			return cmp.Compare(a.value, b.value)
+		})
 		for i := range ctyp.values {
 			ctyp.values[i].name = strings.TrimPrefix(ctyp.values[i].name, typepkg)
 			if bits.OnesCount64(uint64(ctyp.values[i].value)) == 1 {
@@ -2337,12 +2340,6 @@ func (v *variablesByDepthAndDeclLine) Swap(i int, j int) {
 	v.depths[i], v.depths[j] = v.depths[j], v.depths[i]
 	v.vars[i], v.vars[j] = v.vars[j], v.vars[i]
 }
-
-type constantValuesByValue []constantValue
-
-func (v constantValuesByValue) Len() int               { return len(v) }
-func (v constantValuesByValue) Less(i int, j int) bool { return v[i].value < v[j].value }
-func (v constantValuesByValue) Swap(i int, j int)      { v[i], v[j] = v[j], v[i] }
 
 const (
 	timeTimeWallHasMonotonicBit uint64 = (1 << 63) // hasMonotonic bit of time.Time.wall

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -450,23 +450,6 @@ func TestMultilineVariableEvaluation(t *testing.T) {
 	})
 }
 
-type varArray []*proc.Variable
-
-// Len is part of sort.Interface.
-func (s varArray) Len() int {
-	return len(s)
-}
-
-// Swap is part of sort.Interface.
-func (s varArray) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-// Less is part of sort.Interface. It is implemented by calling the "by" closure in the sorter.
-func (s varArray) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
-}
-
 func TestLocalVariables(t *testing.T) {
 	testcases := []struct {
 		fn     func(*proc.EvalScope, proc.LoadConfig) ([]*proc.Variable, error)
@@ -534,7 +517,9 @@ func TestLocalVariables(t *testing.T) {
 			vars, err := tc.fn(scope, pnormalLoadConfig)
 			assertNoError(err, t, "LocalVariables() returned an error")
 
-			sort.Sort(varArray(vars))
+			slices.SortFunc(vars, func(a, b *proc.Variable) int {
+				return strings.Compare(a.Name, b.Name)
+			})
 
 			if len(tc.output) != len(vars) {
 				t.Fatalf("Invalid variable count. Expected %d got %d.", len(tc.output), len(vars))


### PR DESCRIPTION
The PR replaces `sort.Sort` with `slices.SortFunc` across the `pkg/proc` and `pkg/terminal` packages.

This change is made because the slices functions are slightly faster and easier to use.

See https://go-review.googlesource.com/c/go/+/626038.