### PR TITLE
goversion,proc_test: add go1.24 compatiblity, disable broken test

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -41,27 +41,27 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2023.05"
 
 val targets = arrayOf(
-        "linux/amd64/1.21",
         "linux/amd64/1.22",
         "linux/amd64/1.23",
+        "linux/amd64/1.24",
         "linux/amd64/tip",
 
-        "linux/386/1.23",
+        "linux/386/1.24",
 
-        "linux/arm64/1.23",
+        "linux/arm64/1.24",
         "linux/arm64/tip",
 
-        "linux/ppc64le/1.23",
+        "linux/ppc64le/1.24",
 
         "linux/riscv64/tip",
 
-        "windows/amd64/1.23",
+        "windows/amd64/1.24",
         "windows/amd64/tip",
 
-        "mac/amd64/1.23",
+        "mac/amd64/1.24",
         "mac/amd64/tip",
 
-        "mac/arm64/1.23",
+        "mac/arm64/1.24",
         "mac/arm64/tip"
 )
 

--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -11,7 +11,7 @@ var (
 	MinSupportedVersionOfGoMajor = 1
 	MinSupportedVersionOfGoMinor = 21
 	MaxSupportedVersionOfGoMajor = 1
-	MaxSupportedVersionOfGoMinor = 23
+	MaxSupportedVersionOfGoMinor = 24
 	goTooOldErr                  = fmt.Sprintf("Go version %%s is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	goTooOldWarn                 = fmt.Sprintf("WARNING: undefined behavior - Go version %%s is too old for this version of Delve (minimum supported version %d.%d)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)
 	dlvTooOldErr                 = fmt.Sprintf("Version of Delve is too old for Go version %%s (maximum supported version %d.%d, suppress this error with --check-go-version=false)", MaxSupportedVersionOfGoMajor, MaxSupportedVersionOfGoMinor)

--- a/pkg/proc/stepping_test.go
+++ b/pkg/proc/stepping_test.go
@@ -1218,6 +1218,9 @@ func TestRangeOverFuncNextInlined(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
 		t.Skip("N/A")
 	}
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) && !goversion.VersionAfterOrEqual(runtime.Version(), 1, 25) {
+		t.Skip("broken due to inlined symbol names")
+	}
 
 	var bp *proc.Breakpoint
 


### PR DESCRIPTION
Add go1.24 to compatibility set and test matrix.

Remove go1.21 from test matrix.

TestRangeOverFuncNextInlined is disabled because the improved inlining
of go1.24 produces symbol names that are too complicated for us to
correlate, a fix for this will require a change to the compiler that
will probably be too complex to make it into 1.24.
