### PR TITLE
fix map nil point

### DIFF
--- a/pkg/proc/mapiter.go
+++ b/pkg/proc/mapiter.go
@@ -234,6 +234,9 @@ func (it *mapIteratorClassic) nextBucket() bool {
 		return false
 	}
 
+	if it.overflow == nil {
+		return false
+	}
 	if it.overflow.Kind != reflect.Struct {
 		it.v.Unreadable = errMapBucketsNotStruct
 		return false


### PR DESCRIPTION
goversion: 1.22
dlv version: 1.24.0

runtime.panicmem (0x4516f7)
/opt/tiger/go/go/src/runtime/panic.go:261
runtime.sigpanic (0x4516c5)
/opt/tiger/go/go/src/runtime/signal_unix.go:861
github.com/go-delve/delve/pkg/proc.*maplteratorClassic).nextBucket (0x7d073b)
/home/xxx/workspace/go/src/code.byted.org/inf/delve/pkg/proc/mapiter.go:237
github.com/go-delve/delve/pkg/proc.(*maplteratorClassic).next
/home/xxx/workspace/go/src/code.byted.org/inf/delve/pkg/proc/mapiter.go:248
github.com/go-delve/delve/pkg/proc.(*Variable).loadMap (0x8038f1)
/home/xxx/workspace/go/src/code.byted.org/inf/delve/pkg/proc/variables.go:2030
github.com/go-delve/delve/pkg/proc.*Variable).loadValuelnternal (0x7ff6fe)
/home/xxx/workspace/go/src/code.byted.org/inf/delve/pkg/proc/variables.go:1382
github.com/go-delve/delve/pkg/proc.(*Variable).loadValuelnternal (0x7fff2d)
/home/xxx/workspace/go/src/code.byted.org/inf/delve/pkg/proc/variables.go:1441


