### PR TITLE
fix: wrong returned errors

### DIFF
--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -1058,7 +1058,7 @@ func rangeFuncStackTrace(tgt *Target, g *G) ([]Stackframe, error) {
 		return true
 	})
 	if it.Err() != nil {
-		return nil, err
+		return nil, it.Err()
 	}
 	if nonMonotonicSP {
 		return nil, errors.New("corrupted stack (SP not monotonically decreasing)")

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1035,7 +1035,7 @@ func Ancestors(p *Target, g *G, n int) ([]Ancestor, error) {
 	av = av.maybeDereference()
 	av.loadValue(LoadConfig{MaxArrayValues: n, MaxVariableRecurse: 1, MaxStructFields: -1})
 	if av.Unreadable != nil {
-		return nil, err
+		return nil, av.Unreadable
 	}
 	if av.Addr == 0 {
 		// no ancestors


### PR DESCRIPTION
There are 2 cases where the returned error is not the right one.