### PR TITLE
service/test: disable TestGuessSubstitutePath on TeamCity/linux/tip

### DIFF
--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -600,7 +600,7 @@ func MakeGuessSusbtitutePathIn() (*api.GuessSubstitutePathIn, error) {
 	cmd := exec.Command("go", "list", "--json", "all")
 	buf, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error running go list %v: output %q", err, string(buf))
 	}
 	importPathOfMainPackage := ""
 	importPathOfMainPackageOk := true

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3156,6 +3156,14 @@ func TestBreakpointVariablesWithoutG(t *testing.T) {
 
 func TestGuessSubstitutePath(t *testing.T) {
 	t.Setenv("NOCERT", "1")
+	ver, _ := goversion.Parse(runtime.Version())
+	if ver.IsDevelBuild() && os.Getenv("CI") != "" && runtime.GOOS == "linux" {
+		// The TeamCity builders for linux/amd64/tip and linux/arm64/tip end up
+		// with a broken .git directory which makes the 'go list' command used for
+		// GuessSubstitutePath fail.
+		t.Skip("does not work in TeamCity + tip + linux")
+	}
+
 	slashnorm := func(s string) string {
 		if runtime.GOOS != "windows" {
 			return s


### PR DESCRIPTION
It does not work because of how TeamCity creates the build directory.
