### PR TITLE
proc: remove irrelevant TODO comment

### DIFF
--- a/pkg/proc/arm64_disasm.go
+++ b/pkg/proc/arm64_disasm.go
@@ -1,7 +1,3 @@
-// TODO: disassembler support should be compiled in unconditionally,
-// instead of being decided by the build-target architecture, and be
-// part of the Arch object instead.
-
 package proc
 
 import (


### PR DESCRIPTION
The arm64 disassembler is in fact already compiled in unconditionally.
