### PR TITLE
pkg/proc/internal/ebpf: Fix uprobe address

### DIFF
--- a/pkg/proc/internal/ebpf/helpers.go
+++ b/pkg/proc/internal/ebpf/helpers.go
@@ -79,7 +79,7 @@ func (ctx *EBPFContext) AttachUprobe(pid int, name string, offset uint64) error 
 	if ctx.executable == nil {
 		return errors.New("no eBPF program loaded")
 	}
-	l, err := ctx.executable.Uprobe(name, ctx.objs.tracePrograms.UprobeDlvTrace, &link.UprobeOptions{PID: pid, Offset: offset})
+	l, err := ctx.executable.Uprobe(name, ctx.objs.tracePrograms.UprobeDlvTrace, &link.UprobeOptions{PID: pid, Address: offset})
 	ctx.links = append(ctx.links, l)
 	return err
 }


### PR DESCRIPTION
The update of gilium/ebpf introduced a beaking change in it's API: The `offset` in the UprobeOptions is now relative to the added option `address`. Since `address` was only default initalized, the library did not use `address` and `offset` as address for the uprobe, but tried to calculate the offset itself based on the given symbol. Since we set the path of the executable as symbol, the library errored when trying to resolve it.

Fixes https://github.com/go-delve/delve/pull/3491

How to test this PR: Run `sudo -E go run _scripts/make.go test -v --test-set cmd/dlv --test-run='^.*EBPF.*$' ` on the main branch, notice how it fails and re-run on this branch.