### PR TITLE
Suspend breakpoint if file is not found

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -930,6 +930,10 @@ func (err *ErrCouldNotFindLine) Error() string {
 	return fmt.Sprintf("could not find file %s", err.filename)
 }
 
+func (err *ErrCouldNotFindLine) IsFileFound() bool {
+	return err.fileFound
+}
+
 // AllPCsForFileLines returns a map providing all PC addresses for filename and each line in linenos
 func (bi *BinaryInfo) AllPCsForFileLines(filename string, linenos []int) map[int][]uint64 {
 	r := make(map[int][]uint64)

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1511,7 +1511,8 @@ func (s *Session) setBreakpoints(prefix string, totalBps int, metadataFunc func(
 					// Create new breakpoints.
 					got, err = s.debugger.CreateBreakpoint(bp, "", nil, false)
 					if createBpError, isCouldNotFindLine := err.(*proc.ErrCouldNotFindLine); isCouldNotFindLine && !createBpError.IsFileFound() {
-						got, err = s.debugger.CreateBreakpoint(bp, "", nil, true)
+						// try to create a suspended breakpoint instead
+						got, _ = s.debugger.CreateBreakpoint(bp, "", nil, true)
 					}
 				}
 			}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1510,6 +1510,9 @@ func (s *Session) setBreakpoints(prefix string, totalBps int, metadataFunc func(
 				if err == nil {
 					// Create new breakpoints.
 					got, err = s.debugger.CreateBreakpoint(bp, "", nil, false)
+					if createBpError, isCouldNotFindLine := err.(*proc.ErrCouldNotFindLine); isCouldNotFindLine && !createBpError.IsFileFound() {
+						got, err = s.debugger.CreateBreakpoint(bp, "", nil, true)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This is a follow-up from #3390

Any breakpoints for which the file is not found will be suspended by default. These should usually be any breakpoints that are defined in the plugin code. that are not verified will now get suspended by default. This seems to resolve the issue in VSCode: https://github.com/golang/vscode-go/issues/2775

TODO:
  - [ ] add a test