### PR TITLE
service/dap: provide process events after launch

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1154,6 +1154,18 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 		s.mu.Lock()
 		defer s.mu.Unlock() // Make sure to unlock in case of panic that will become internal error
 		s.debugger, err = debugger.New(&s.config.Debugger, s.config.ProcessArgs)
+
+		if s.debugger != nil {
+			s.send(&dap.ProcessEvent{
+				Event: *newEvent("process"),
+				Body: dap.ProcessEventBody{
+					Name:            s.debugger.Target().CmdLine,
+					SystemProcessId: s.debugger.ProcessPid(),
+					IsLocalProcess:  true,
+					StartMethod:     "launch",
+				},
+			})
+		}
 	}()
 	if err != nil {
 		if s.binaryToRemove != "" {


### PR DESCRIPTION
This change adds support to emit the process DAP event after handling launch requests.

Note: I found myself in a situation where I needed this exact event get process information from delve. I discovered this event was not implemented, so I have added it in the place that seems to be the most logical place (just based on my limited exposure to the codebase). Please let me know if this change is unwarranted or if useful, if it needs any additional work.

Thanks!