### PR TITLE
proc/debuginfod: add timeouts to debuginfod-find

### DIFF
--- a/pkg/proc/debuginfod/debuginfod.go
+++ b/pkg/proc/debuginfod/debuginfod.go
@@ -1,17 +1,26 @@
 package debuginfod
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 )
 
-const debuginfodFind = "debuginfod-find"
+const (
+	debuginfodFind       = "debuginfod-find"
+	debuginfodMaxtimeEnv = "DEBUGINFOD_MAXTIME"
+	debuginfodTimeoutEnv = "DEBUGINFOD_TIMEOUT"
+)
 
 func execFind(args ...string) (string, error) {
 	if _, err := exec.LookPath(debuginfodFind); err != nil {
 		return "", err
 	}
 	cmd := exec.Command(debuginfodFind, args...)
+	if os.Getenv(debuginfodMaxtimeEnv) == "" || os.Getenv(debuginfodTimeoutEnv) == "" {
+		cmd.Env = append(os.Environ(), debuginfodMaxtimeEnv+"=1", debuginfodTimeoutEnv+"=1")
+	}
+	cmd.Stderr = os.Stderr
 	out, err := cmd.Output() // ignore stderr
 	if err != nil {
 		return "", err

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3308,7 +3308,7 @@ func TestFollowExecFindLocation(t *testing.T) {
 	if buildMode == "pie" {
 		buildFlags |= protest.BuildModePIE
 	}
-	childFixture := protest.BuildFixture("spawnchild", buildFlags)
+	childFixture := protest.BuildFixture(t, "spawnchild", buildFlags)
 
 	withTestClient2Extended("spawn", t, 0, [3]string{}, []string{"spawn2", childFixture.Path}, func(c service.Client, fixture protest.Fixture) {
 		assertNoError(c.FollowExec(true, ""), t, "FollowExec")


### PR DESCRIPTION
Calls to debuginfod-find can take an arbitrarily long time to complete.

Set timeouts for them unless they were explicitly set by user, also
redirect its stderr to our stderr so that, if they produce progress
output, it is seen.

Updates #3906
