### PR TITLE
proc: allow access to thread registers after a function call

### DIFF
--- a/_fixtures/issue3310.go
+++ b/_fixtures/issue3310.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+var i = 2
+var val = reflect.ValueOf(i)
+
+func reflectFunc(value reflect.Value) {
+	fmt.Printf("%s\n", value.Type().Name())
+}
+
+func main() {
+	reflectFunc(val)
+	fmt.Println(&i)
+}

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1946,3 +1946,15 @@ func TestClassicMap(t *testing.T) {
 		}
 	})
 }
+
+func TestCallFunctionRegisterArg(t *testing.T) {
+	protest.MustSupportFunctionCalls(t, testBackend)
+	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
+		t.Skip("not supported")
+	}
+	withTestProcessArgs("issue3310", t, ".", []string{}, protest.AllNonOptimized, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+		setFileBreakpoint(p, t, fixture.Source, 12)
+		assertNoError(grp.Continue(), t, "Continue()")
+		assertNoError(proc.EvalExpressionWithCalls(grp, p.SelectedGoroutine(), "value.Type()", pnormalLoadConfig, true), t, "EvalExpressionWithCalls")
+	})
+}


### PR DESCRIPTION
After a call injection sequence terminates allow the evaluator to
access thread registers again so that variables stored in registers can
be used as arguments.

Fixes #3310
