### PR TITLE
proc: some refactorings for supporting struct literals

### DIFF
--- a/pkg/astutil/astutil.go
+++ b/pkg/astutil/astutil.go
@@ -3,7 +3,9 @@
 package astutil
 
 import (
+	"bytes"
 	"go/ast"
+	"go/printer"
 	"go/token"
 	"strconv"
 )
@@ -42,4 +44,11 @@ func Or(x, y ast.Expr) ast.Expr {
 		return nil
 	}
 	return &ast.BinaryExpr{Op: token.LOR, X: x, Y: y}
+}
+
+// ExprToString uses go/printer to format an ast.Expr into a string.
+func ExprToString(t ast.Expr) string {
+	var buf bytes.Buffer
+	printer.Fprint(&buf, token.NewFileSet(), t)
+	return buf.String()
 }

--- a/pkg/dwarf/godwarf/fakes.go
+++ b/pkg/dwarf/godwarf/fakes.go
@@ -53,3 +53,9 @@ func FakeBasicType(name string, bitSize int) Type {
 		panic("unsupported")
 	}
 }
+
+// FakePointerType synthesizes a pointer type
+func FakePointerType(typ Type, ptrSize int64) *PtrType {
+	typename := "*" + typ.Common().Name
+	return &PtrType{CommonType: CommonType{ByteSize: ptrSize, Name: typename}, Type: typ}
+}

--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -1101,3 +1101,17 @@ func zeroArray(t Type) {
 		t = at.Type
 	}
 }
+
+// ResolveTypedef returns the underlying type of a typedef or qualified type.
+func ResolveTypedef(typ Type) Type {
+	for {
+		switch tt := typ.(type) {
+		case *TypedefType:
+			typ = tt.Type
+		case *QualType:
+			typ = tt.Type
+		default:
+			return typ
+		}
+	}
+}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-delve/delve/pkg/astutil"
 	pdwarf "github.com/go-delve/delve/pkg/dwarf"
 	"github.com/go-delve/delve/pkg/dwarf/frame"
 	"github.com/go-delve/delve/pkg/dwarf/godwarf"
@@ -2374,10 +2375,10 @@ func (bi *BinaryInfo) findTypeExpr(expr ast.Expr) (godwarf.Type, error) {
 		alen, litlen := anode.Len.(*ast.BasicLit)
 		if litlen && alen.Kind == token.INT {
 			n, _ := strconv.Atoi(alen.Value)
-			return bi.findArrayType(n, exprToString(anode.Elt))
+			return bi.findArrayType(n, astutil.ExprToString(anode.Elt))
 		}
 	}
-	return bi.findType(exprToString(expr))
+	return bi.findType(astutil.ExprToString(expr))
 }
 
 func (bi *BinaryInfo) findArrayType(n int, etyp string) (godwarf.Type, error) {

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -12,6 +12,7 @@ import (
 	"go/token"
 	"reflect"
 
+	"github.com/go-delve/delve/pkg/astutil"
 	"github.com/go-delve/delve/pkg/dwarf/godwarf"
 	"github.com/go-delve/delve/pkg/dwarf/op"
 	"github.com/go-delve/delve/pkg/dwarf/reader"
@@ -213,17 +214,17 @@ func (bp *Breakpoint) VerboseDescr() []string {
 	for _, breaklet := range bp.Breaklets {
 		switch breaklet.Kind {
 		case UserBreakpoint:
-			r = append(r, fmt.Sprintf("User Cond=%q HitCond=%v", exprToString(breaklet.Cond), lbp.hitCond))
+			r = append(r, fmt.Sprintf("User Cond=%q HitCond=%v", astutil.ExprToString(breaklet.Cond), lbp.HitCond()))
 		case NextBreakpoint:
-			r = append(r, fmt.Sprintf("Next Cond=%q", exprToString(breaklet.Cond)))
+			r = append(r, fmt.Sprintf("Next Cond=%q", astutil.ExprToString(breaklet.Cond)))
 		case NextDeferBreakpoint:
-			r = append(r, fmt.Sprintf("NextDefer Cond=%q DeferReturns=%#x", exprToString(breaklet.Cond), breaklet.DeferReturns))
+			r = append(r, fmt.Sprintf("NextDefer Cond=%q DeferReturns=%#x", astutil.ExprToString(breaklet.Cond), breaklet.DeferReturns))
 		case StepBreakpoint:
-			r = append(r, fmt.Sprintf("Step Cond=%q", exprToString(breaklet.Cond)))
+			r = append(r, fmt.Sprintf("Step Cond=%q", astutil.ExprToString(breaklet.Cond)))
 		case WatchOutOfScopeBreakpoint:
-			r = append(r, fmt.Sprintf("WatchOutOfScope Cond=%q checkPanicCall=%v", exprToString(breaklet.Cond), breaklet.checkPanicCall))
+			r = append(r, fmt.Sprintf("WatchOutOfScope Cond=%q checkPanicCall=%v", astutil.ExprToString(breaklet.Cond), breaklet.checkPanicCall))
 		case StackResizeBreakpoint:
-			r = append(r, fmt.Sprintf("StackResizeBreakpoint Cond=%q", exprToString(breaklet.Cond)))
+			r = append(r, fmt.Sprintf("StackResizeBreakpoint Cond=%q", astutil.ExprToString(breaklet.Cond)))
 		case PluginOpenBreakpoint:
 			r = append(r, "PluginOpenBreakpoint")
 		case StepIntoNewProcBreakpoint:
@@ -231,7 +232,7 @@ func (bp *Breakpoint) VerboseDescr() []string {
 		case NextInactivatedBreakpoint:
 			r = append(r, "NextInactivatedBreakpoint")
 		case StepIntoRangeOverFuncBodyBreakpoint:
-			r = append(r, "StepIntoRangeOverFuncBodyBreakpoint Cond=%q", exprToString(breaklet.Cond))
+			r = append(r, "StepIntoRangeOverFuncBodyBreakpoint Cond=%q", astutil.ExprToString(breaklet.Cond))
 		default:
 			r = append(r, fmt.Sprintf("Unknown %d", breaklet.Kind))
 		}

--- a/pkg/proc/mapiter.go
+++ b/pkg/proc/mapiter.go
@@ -18,7 +18,7 @@ type mapIterator interface {
 func (v *Variable) mapIterator(maxNumBuckets uint64) mapIterator {
 	mt := v.RealType.(*godwarf.MapType)
 	sv := v.clone()
-	sv.RealType = resolveTypedef(&(sv.RealType.(*godwarf.MapType).TypedefType))
+	sv.RealType = godwarf.ResolveTypedef(&(sv.RealType.(*godwarf.MapType).TypedefType))
 	sv = sv.maybeDereference()
 	v.Base = sv.Addr
 
@@ -383,7 +383,7 @@ func (it *mapIteratorSwiss) loadTypes() {
 						it.groupsFieldData = field
 						typ, ok := field.Type.(*godwarf.PtrType)
 						if ok {
-							it.groupType, _ = resolveTypedef(typ.Type).(*godwarf.StructType)
+							it.groupType, _ = godwarf.ResolveTypedef(typ.Type).(*godwarf.StructType)
 						}
 					case "lengthMask":
 						it.groupsFieldLengthMask = field
@@ -409,7 +409,7 @@ func (it *mapIteratorSwiss) loadTypes() {
 		return
 	}
 
-	slotsType, ok := resolveTypedef(it.groupFieldSlots.Type).(*godwarf.ArrayType)
+	slotsType, ok := godwarf.ResolveTypedef(it.groupFieldSlots.Type).(*godwarf.ArrayType)
 	if !ok {
 		it.v.Unreadable = errSwissMapBadGroupTypeErr
 		return

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -1590,7 +1590,7 @@ type onNextGoroutineWalker struct {
 
 func (w *onNextGoroutineWalker) Visit(n ast.Node) ast.Visitor {
 	if binx, isbin := n.(*ast.BinaryExpr); isbin && binx.Op == token.EQL {
-		x := exprToString(binx.X)
+		x := astutil.ExprToString(binx.X)
 		if x == "runtime.curg.goid" || x == "runtime.threadid" {
 			w.ret, w.err = evalBreakpointCondition(w.tgt, w.thread, n.(ast.Expr))
 			return nil


### PR DESCRIPTION
* deduplicates exprToString, defined in multiple packages, and moves it
to astutil
* moves resolveTypedef into pkg/dwarf/godwarf, this is currently only
used by pkg/proc but we will need to call it from pkg/proc/evalop
* creates a new FakePointerType function in pkg/dwarf/godwarf, this is
also a function that is only used by pkg/proc but pkg/proc/evalop will
also need.

Updates #1465
