### PR TITLE
TeamCity: remove riscv64 from configuration

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -53,8 +53,6 @@ val targets = arrayOf(
 
         "linux/ppc64le/1.24",
 
-        "linux/riscv64/tip",
-
         "windows/amd64/1.24",
         "windows/amd64/tip",
 
@@ -270,7 +268,7 @@ class TestBuild(val os: String, val arch: String, val version: String, buildId: 
             "386", "amd64" -> equals("teamcity.agent.jvm.os.arch", if (os == "mac") "x86_64" else "amd64")
             "arm64" -> equals("teamcity.agent.jvm.os.arch", "aarch64")
             "ppc64le" -> equals("teamcity.agent.jvm.os.arch", "ppc64le")
-            "riscv64" -> equals("teamcity.agent.jvm.os.arch", "riscv64")
+            // "riscv64" -> equals("teamcity.agent.jvm.os.arch", "riscv64") // The riscv64 needs a builder
         }
         when (os) {
             "linux" -> {


### PR DESCRIPTION
We haven't had a builder for 2 months, remove the configuration.
