### PR TITLE
Reforeground debugger process after debugge exits

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -977,6 +977,8 @@ func waitForDisconnectSignal(disconnectChan chan struct{}) {
 		// On windows Ctrl-C sent to inferior process is delivered
 		// as SIGINT to delve. Ignore it instead of stopping the server
 		// in order to be able to debug signal handlers.
+
+		//TODO: One should be notified by the debugger here if the debuggee process exited and if it did, this should start capturing signals
 		go func() {
 			for range ch {
 			}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/snabb/tcxpgrp v1.0.4 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/mod v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/snabb/tcxpgrp v1.0.4 h1:Ym+Rfw48kfq8xf2f9ot5mXgfUOJXVqSxwLK09D4+zAg=
+github.com/snabb/tcxpgrp v1.0.4/go.mod h1:NnpVAYwbrQrZZCumQiJyDIyfqdyy6d2gQ5gAVLBhrws=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/vendor/github.com/snabb/tcxpgrp/LICENSE
+++ b/vendor/github.com/snabb/tcxpgrp/LICENSE
@@ -1,0 +1,20 @@
+Copyright © 2019-2023 Janne Snabb snabb AT epipe.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/snabb/tcxpgrp/README.md
+++ b/vendor/github.com/snabb/tcxpgrp/README.md
@@ -1,0 +1,45 @@
+tcxpgrp
+=======
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/snabb/tcxpgrp.svg)](https://pkg.go.dev/github.com/snabb/tcxpgrp)
+[![Go Report Card](https://goreportcard.com/badge/github.com/snabb/tcxpgrp)](https://goreportcard.com/report/github.com/snabb/tcxpgrp)
+
+The Go package tcxpgrp implements POSIX.1 (IEEE Std 1003.1) tcgetpgrp
+and tcsetpgrp functions.
+
+There is also a function for determining if the calling process is a
+foreground process.
+
+This package is Linux/UNIX specific.
+
+
+Documentation
+-------------
+
+https://pkg.go.dev/github.com/snabb/tcxpgrp
+
+
+Example
+-------
+
+Determine if a process is foreground or background process:
+
+```Go
+	fg := tcxpgrp.IsForeground()
+	fmt.Println("foreground:", fg)
+	// Output: foreground: true
+	//   or
+	// Output: foreground: false
+```
+
+
+Repository
+----------
+
+https://github.com/snabb/tcxpgrp
+
+
+License
+-------
+
+MIT

--- a/vendor/github.com/snabb/tcxpgrp/tcxpgrp.go
+++ b/vendor/github.com/snabb/tcxpgrp/tcxpgrp.go
@@ -1,0 +1,51 @@
+// Package tcxpgrp implements POSIX.1 (IEEE Std 1003.1) tcgetpgrp and
+// tcsetpgrp functions for Go programming language.
+//
+// There is also a function for determining if the calling process is a
+// foreground process.
+//
+// This package is Linux/UNIX specific.
+package tcxpgrp
+
+import "golang.org/x/sys/unix"
+
+// TcGetpgrp gets the process group ID of the foreground process
+// group associated with the terminal referred to by fd.
+//
+// See POSIX.1 documentation for more details:
+// http://pubs.opengroup.org/onlinepubs/009695399/functions/tcgetpgrp.html
+func TcGetpgrp(fd int) (pgrp int, err error) {
+	return unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+}
+
+// TcSetpgrp sets the foreground process group ID associated with the
+// terminal referred to by fd to pgrp.
+//
+// See POSIX.1 documentation for more details:
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsetpgrp.html
+func TcSetpgrp(fd int, pgrp int) (err error) {
+	return unix.IoctlSetPointerInt(fd, unix.TIOCSPGRP, pgrp)
+}
+
+// IsForeground returns true if the calling process is a foreground process.
+//
+// Note that the foreground/background status of a process can change
+// at any moment if the user utilizes the shell job control commands (fg/bg).
+//
+// Example use for command line tools: suppress extra output if a
+// process is running in background, provide verbose output when
+// running on foreground.
+func IsForeground() bool {
+	fd, err := unix.Open("/dev/tty", 0666, unix.O_RDONLY)
+	if err != nil {
+		return false
+	}
+	defer unix.Close(fd)
+
+	pgrp1, err := TcGetpgrp(fd)
+	if err != nil {
+		return false
+	}
+	pgrp2 := unix.Getpgrp()
+	return pgrp1 == pgrp2
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,6 +54,9 @@ github.com/russross/blackfriday/v2
 # github.com/sirupsen/logrus v1.9.3
 ## explicit; go 1.13
 github.com/sirupsen/logrus
+# github.com/snabb/tcxpgrp v1.0.4
+## explicit; go 1.17
+github.com/snabb/tcxpgrp
 # github.com/spf13/cobra v1.7.0
 ## explicit; go 1.15
 github.com/spf13/cobra


### PR DESCRIPTION
I am debugging a bubbletea application and a lot of times I would love to mash CTRL-C to exit the application and the server. This very crude commit allows that. I also added a TODO for the windows side, because there the debugger needs to notify (via a channel) the `debug` command to start capturing signals.
One other thing that should probably be implemented is that client should exit on a headless server's exit.