### PR TITLE
proc/gdbserial: use rr version to determine style of qRRCmd

### DIFF
--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -47,7 +47,8 @@ type gdbConn struct {
 	goarch                string
 	goos                  string
 
-	useXcmd bool // forces writeMemory to use the 'X' command
+	useXcmd       bool // forces writeMemory to use the 'X' command
+	newRRCmdStyle bool // forces qRRCmd to use the post-5.8.0 style always
 
 	log logflags.Logger
 }
@@ -1194,7 +1195,7 @@ func (conn *gdbConn) qRRCmd(args ...string) (string, error) {
 	fmt.Fprint(&conn.outbuf, "$qRRCmd")
 	for i, arg := range args {
 		fmt.Fprint(&conn.outbuf, ":")
-		if i == 0 && conn.threadSuffixSupported {
+		if i == 0 && (conn.newRRCmdStyle || conn.threadSuffixSupported) {
 			// newer versions of RR require the command to be followed by a thread id
 			// and the command name to be unescaped.
 			fmt.Fprintf(&conn.outbuf, "%s:-1", arg)


### PR DESCRIPTION
Previously we relied on availability of the thread suffix protocol
extension to determine whether we should use the old or new encoding
for the qRRCmd extension of rr. Newly released version 5.9.0 of rr
removes this ability by not reporting the thread suffix extension as
available unless it gets to start lldb itself.

Use the value of rr's version instead.

Fixes #3920
