### PR TITLE
service/test: handle wider registers in test

### DIFF
--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2782,6 +2782,8 @@ func TestClientServer_SinglelineStringFormattedWithBigInts(t *testing.T) {
 			"9331634762088972288", "8180A06000000000",
 			"9259436018245828608", "8080200000000000",
 			"9259436018245828608", "8080200000000000",
+			"0", "0", "0", "0",
+			"0", "0", "0", "0",
 		}
 
 		for i := range xmm0var.Children {


### PR DESCRIPTION
When this test is run on machines with support for AVX-512, the length of xmm0var.Children will be greater, causing an out of bounds error when iterating through the `expected` slice.