### PR TITLE
telemetry: add stack counter for internal errors

### DIFF
--- a/pkg/logflags/logflags.go
+++ b/pkg/logflags/logflags.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/telemetry/counter"
 )
 
 var any = false
@@ -28,6 +30,8 @@ var minidump = false
 var stack = false
 
 var logOut io.WriteCloser
+
+var Bug = counter.NewStack("delve/bug", 16)
 
 func makeLogger(flag bool, attrs ...interface{}) Logger {
 	if lf := loggerFactory; lf != nil {

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -2215,6 +2215,7 @@ func loadBinaryInfoGoRuntimeElf(bi *BinaryInfo, image *Image, path string, elfFi
 	// recover all panics.
 	defer func() {
 		ierr := recover()
+		logflags.Bug.Inc()
 		if ierr != nil {
 			err = fmt.Errorf("error loading binary info from Go runtime: %v", ierr)
 		}
@@ -2257,6 +2258,7 @@ func loadBinaryInfoGoRuntimeMacho(bi *BinaryInfo, image *Image, path string, exe
 	// recover all panics.
 	defer func() {
 		ierr := recover()
+		logflags.Bug.Inc()
 		if ierr != nil {
 			err = fmt.Errorf("error loading binary info from Go runtime: %v", ierr)
 		}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1046,6 +1046,7 @@ func (stack *evalStack) executeOp() {
 	scope, ops, curthread := stack.scope, stack.ops, stack.curthread
 	defer func() {
 		err := recover()
+		logflags.Bug.Inc()
 		if err != nil {
 			stack.err = fmt.Errorf("internal debugger error: %v (recovered)\n%s", err, string(debug.Stack()))
 		}

--- a/pkg/terminal/starbind/starlark.go
+++ b/pkg/terminal/starbind/starlark.go
@@ -15,6 +15,7 @@ import (
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 
+	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/api"
 )
@@ -198,6 +199,7 @@ func (env *Env) printFunc() func(_ *starlark.Thread, msg string) {
 // After the file is executed if a function named mainFnName exists it will be called, passing args to it.
 func (env *Env) Execute(path string, source interface{}, mainFnName string, args []interface{}) (_ starlark.Value, _err error) {
 	defer func() {
+		logflags.Bug.Inc()
 		err := recover()
 		if err == nil {
 			return

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -576,6 +576,7 @@ func (s *Session) ServeDAPCodec() {
 // in case it's a dup and ignored by the client, we also log the error.
 func (s *Session) recoverPanic(request dap.Message) {
 	if ierr := recover(); ierr != nil {
+		logflags.Bug.Inc()
 		s.config.log.Errorf("recovered panic: %s\n%s\n", ierr, debug.Stack())
 		s.sendInternalErrorResponse(request.GetSeq(), fmt.Sprintf("%v", ierr))
 	}

--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -390,6 +390,7 @@ type internalErrorFrame struct {
 }
 
 func newInternalError(ierr interface{}, skip int) *internalError {
+	logflags.Bug.Inc()
 	r := &internalError{ierr, nil}
 	for i := skip; ; i++ {
 		pc, file, line, ok := runtime.Caller(i)


### PR DESCRIPTION
Add stack counter for the various places where we catch internal
errors.
