### PR TITLE
proc: add support for struct literals

### DIFF
--- a/_fixtures/fncall.go
+++ b/_fixtures/fncall.go
@@ -57,6 +57,14 @@ func stringsJoin(v []string, sep string) string {
 	return strings.Join(v, sep)
 }
 
+func mul2(x a2struct) int {
+	return x.Y * 2
+}
+
+func mul2ptr(x *a2struct) int {
+	return x.Y * 2
+}
+
 type astruct struct {
 	X int
 }
@@ -208,6 +216,16 @@ func (i Issue3364) String() string {
 	return fmt.Sprintf("%d %d", i.a, i.b)
 }
 
+type intpair struct {
+	X, Y int
+}
+
+var m = map[intpair]string{
+	{1, 1}: "one,one",
+	{1, 2}: "one,two",
+	{3, 1}: "three,one",
+}
+
 func main() {
 	one, two := 1, 2
 	intslice := []int{1, 2, 3}
@@ -254,5 +272,5 @@ func main() {
 	d.Method()
 	d.Base.Method()
 	x.CallMe()
-	fmt.Println(one, two, zero, call, call0, call2, callexit, callpanic, callbreak, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga, escapeArg, a2, square, intcallpanic, onetwothree, curriedAdd, getAStruct, getAStructPtr, getVRcvrableFromAStruct, getPRcvrableFromAStructPtr, getVRcvrableFromAStructPtr, pa2, noreturncall, str, d, x, x2.CallMe(5), longstrs, regabistacktest, regabistacktest2, issue2698.String(), issue3364.String(), regabistacktest3, rast3, floatsum, ref)
+	fmt.Println(one, two, zero, call, call0, call2, callexit, callpanic, callbreak, callstacktrace, stringsJoin, intslice, stringslice, comma, a.VRcvr, a.PRcvr, pa, vable_a, vable_pa, pable_pa, fn2clos, fn2glob, fn2valmeth, fn2ptrmeth, fn2nil, ga, escapeArg, a2, square, intcallpanic, onetwothree, curriedAdd, getAStruct, getAStructPtr, getVRcvrableFromAStruct, getPRcvrableFromAStructPtr, getVRcvrableFromAStructPtr, pa2, noreturncall, str, d, x, x2.CallMe(5), longstrs, regabistacktest, regabistacktest2, issue2698.String(), issue3364.String(), regabistacktest3, rast3, floatsum, ref, mul2, mul2ptr, m)
 }

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1445,6 +1445,17 @@ func (bi *BinaryInfo) parseDebugFrameGeneral(image *Image, debugFrameBytes []byt
 	}
 }
 
+func (bi *BinaryInfo) getModuleData(mem MemoryReadWriter) ([]ModuleData, error) {
+	if bi.moduleDataCache == nil {
+		var err error
+		bi.moduleDataCache, err = LoadModuleData(bi, mem)
+		if err != nil {
+			return nil, fmt.Errorf("error loading module data: %v", err)
+		}
+	}
+	return bi.moduleDataCache, nil
+}
+
 // ELF ///////////////////////////////////////////////////////////////
 
 // openSeparateDebugInfo searches for a file containing the separate

--- a/pkg/proc/evalop/ops.go
+++ b/pkg/proc/evalop/ops.go
@@ -214,6 +214,12 @@ type Roll struct {
 
 func (*Roll) depthCheck() (npop, npush int) { return 1, 1 }
 
+// Dup duplicates the topmost stack entry
+type Dup struct {
+}
+
+func (*Dup) depthCheck() (npop, npush int) { return 1, 2 }
+
 // BuiltinCall pops len(Args) argument from the stack, calls the specified
 // builtin on them and pushes the result back on the stack.
 type BuiltinCall struct {
@@ -333,3 +339,11 @@ type PushBreakpointHitCount struct {
 }
 
 func (*PushBreakpointHitCount) depthCheck() (npop, npush int) { return 0, 1 }
+
+// PushRuntimeType pushes the *runtime._type corresponding to the
+// godwarf.Type.
+type PushRuntimeType struct {
+	Type godwarf.Type
+}
+
+func (*PushRuntimeType) depthCheck() (npop, npush int) { return 0, 1 }

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -69,11 +69,23 @@ func LoadModuleData(bi *BinaryInfo, mem MemoryReadWriter) ([]ModuleData, error) 
 	return r, nil
 }
 
-func findModuleDataForType(bi *BinaryInfo, mds []ModuleData, typeAddr uint64, mem MemoryReadWriter) *ModuleData {
+func findModuleDataForType(mds []ModuleData, typeAddr uint64) *ModuleData {
 	for i := range mds {
 		if typeAddr >= mds[i].types && typeAddr < mds[i].etypes {
 			return &mds[i]
 		}
 	}
 	return nil
+}
+
+func findModuleDataForImage(mds []ModuleData, so *Image) *ModuleData {
+	var md *ModuleData
+	for i := range mds {
+		if so == nil || mds[i].text > so.StaticBase {
+			if md == nil || mds[i].text < md.text {
+				md = &mds[i]
+			}
+		}
+	}
+	return md
 }

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1098,6 +1098,9 @@ func (v *Variable) structMember(memberName string) (*Variable, error) {
 		return v.clone(), nil
 	}
 	vname := v.Name
+	if v.Name == "" {
+		vname = v.DwarfType.String()
+	}
 	if v.loaded && (v.Flags&VariableFakeAddress) != 0 {
 		for i := range v.Children {
 			if v.Children[i].Name == memberName {

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1402,6 +1402,14 @@ func TestCallFunction(t *testing.T) {
 		{`floatsum(1, 2)`, []string{":float64:3"}, nil, 0},
 	}
 
+	var testcases123 = []testCaseCallFunction{
+		{`mul2(main.a2struct{Y: 3})`, []string{":int:6"}, nil, 1},
+		{`mul2(main.a2struct{4})`, []string{":int:8"}, nil, 1},
+		{`mul2ptr(&main.a2struct{Y: 3})`, []string{":int:6"}, nil, 1},
+		{`mul2ptr(&main.a2struct{1})`, []string{":int:2"}, nil, 1},
+		{`m[main.intpair{3, 1}]`, []string{`:string:"three,one"`}, nil, 1},
+	}
+
 	withTestProcessArgs("fncall", t, ".", nil, protest.AllNonOptimized, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		testCallFunctionSetBreakpoint(t, p, grp, fixture)
 
@@ -1436,6 +1444,12 @@ func TestCallFunction(t *testing.T) {
 
 		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 17) {
 			for _, tc := range testcases117 {
+				testCallFunction(t, grp, p, tc)
+			}
+		}
+
+		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
+			for _, tc := range testcases123 {
 				testCallFunction(t, grp, p, tc)
 			}
 		}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -6150,7 +6150,6 @@ func TestSetVariable(t *testing.T) {
 
 					// Args of foobar(baz string, bar FooBar)
 					checkVarExact(t, locals, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)
-					tester.failSetVariable(localsScope, "bar", `main.FooBar {Baz: 42, Bur: "ipsum"}`, "*ast.CompositeLit not implemented")
 
 					// Nested field.
 					barRef := checkVarExact(t, locals, 1, "bar", "bar", `main.FooBar {Baz: 10, Bur: "lorem"}`, "main.FooBar", hasChildren)

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3308,7 +3308,7 @@ func TestFollowExecFindLocation(t *testing.T) {
 	if buildMode == "pie" {
 		buildFlags |= protest.BuildModePIE
 	}
-	childFixture := protest.BuildFixture("spawnchild", buildFlags)
+	childFixture := protest.BuildFixture(t, "spawnchild", buildFlags)
 
 	withTestClient2Extended("spawn", t, 0, [3]string{}, []string{"spawn2", childFixture.Path}, func(c service.Client, fixture protest.Fixture) {
 		assertNoError(c.FollowExec(true, ""), t, "FollowExec")


### PR DESCRIPTION
Adds support for evaluating struct literals, and allocating them into
the target's memory.

Updates #1465
