### PR TITLE
service/debugger: fix FindLocation with child processes

### DIFF
--- a/_fixtures/spawn.go
+++ b/_fixtures/spawn.go
@@ -44,5 +44,11 @@ func main() {
 	case "child":
 		traceme2(os.Args[2])
 
+	case "spawn2":
+		cmd := exec.Command(os.Args[2])
+		cmd.Stdout = os.Stdout
+		cmd.Start()
+		cmd.Wait()
+
 	}
 }

--- a/_fixtures/spawnchild.go
+++ b/_fixtures/spawnchild.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func traceme5() {
+	fmt.Println("hello world")
+}
+
+func main() {
+	traceme5()
+}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1943,7 +1943,7 @@ func (d *Debugger) findLocation(goid int64, frame, deferredCall int, locStr stri
 		if s1 != "" {
 			subst = s1
 		}
-		if err != nil {
+		if err != nil && !errors.As(err, new(*locspec.ErrLocationNotFound)) {
 			return nil, "", err
 		}
 		for i := range locs {
@@ -1960,6 +1960,9 @@ func (d *Debugger) findLocation(goid int64, frame, deferredCall int, locStr stri
 			}
 		}
 		locations = append(locations, locs...)
+	}
+	if len(locations) == 0 {
+		return locations, subst, &locspec.ErrLocationNotFound{Spec: locStr}
 	}
 	return locations, subst, nil
 }


### PR DESCRIPTION
FindLocation should only return a "location not found" error if none of
the attached target processes can find the location.

Fixes #3933
