### PR TITLE
goversion: add check for DWARFv5 compatibility

### DIFF
--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -1,11 +1,14 @@
 package goversion
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 
 	"github.com/go-delve/delve/pkg/logflags"
 )
+
+//lint:file-ignore ST1005 errors here can be capitalized
 
 var (
 	MinSupportedVersionOfGoMajor = 1
@@ -20,7 +23,7 @@ var (
 
 // Compatible checks that the version specified in the producer string is compatible with
 // this version of delve.
-func Compatible(producer string, warnonly bool) error {
+func Compatible(dwarfVer uint8, producer string, warnonly bool) error {
 	ver := ParseProducer(producer)
 	if ver.IsOldDevel() {
 		return nil
@@ -45,6 +48,16 @@ func Compatible(producer string, warnonly bool) error {
 			return nil
 		}
 		return fmt.Errorf(dlvTooOldErr, ver.String())
+	}
+	if dwarfVer >= 5 {
+		if !VersionAfterOrEqual(runtime.Version(), 1, 25) {
+			const errstr = "To debug executables using DWARFv5 or later Delve must be built with Go version 1.25.0 or later"
+			if warnonly {
+				logflags.WriteError(errstr)
+				return nil
+			}
+			return errors.New(errstr)
+		}
 	}
 	return nil
 }

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1386,6 +1386,19 @@ func (bi *BinaryInfo) Producer() string {
 	return ""
 }
 
+// DwarfVersion returns the maximum DWARF version in the executable.
+func (bi *BinaryInfo) DwarfVersion() uint8 {
+	r := uint8(0)
+	for _, so := range bi.Images {
+		for _, cu := range so.compileUnits {
+			if cu.Version > r {
+				r = cu.Version
+			}
+		}
+	}
+	return r
+}
+
 // Type returns the Dwarf type entry at `offset`.
 func (image *Image) Type(offset dwarf.Offset) (godwarf.Type, error) {
 	return godwarf.ReadType(image.dwarf, image.index, offset, image.typeCache)

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -254,7 +254,8 @@ func (d *Debugger) checkGoVersion() error {
 	if producer == "" {
 		return nil
 	}
-	return goversion.Compatible(producer, !d.config.CheckGoVersion)
+	dwarfVer := d.target.Selected.BinInfo().DwarfVersion()
+	return goversion.Compatible(dwarfVer, producer, !d.config.CheckGoVersion)
 }
 
 func (d *Debugger) TargetGoVersion() string {


### PR DESCRIPTION
Due to #3861 which was fixed in:

https://go-review.googlesource.com/c/go/+/656675
https://go-review.googlesource.com/c/go/+/655976

debugging DWARFv5 executables only works if Delve itself is built with
1.25 or later. Add this check to the version compatibility checks.

Fixes #3861
