### PR TITLE
proc: add RegnumToString to PPC64LE architecture

### DIFF
--- a/pkg/proc/ppc64le_arch.go
+++ b/pkg/proc/ppc64le_arch.go
@@ -39,6 +39,7 @@ func PPC64LEArch(goos string) *Arch {
 		LRRegNum:                         regnum.PPC64LE_LR,
 		asmRegisters:                     ppc64leAsmRegisters,
 		RegisterNameToDwarf:              nameToDwarfFunc(regnum.PPC64LENameToDwarf),
+		RegnumToString:                   regnum.PPC64LEToName,
 		debugCallMinStackSize:            320,
 		maxRegArgBytes:                   13*8 + 13*8,
 		argumentRegs:                     []int{regnum.PPC64LE_R0 + 3, regnum.PPC64LE_R0 + 4, regnum.PPC64LE_R0 + 5},


### PR DESCRIPTION
This field was not initialized.
