### PR TITLE
cmd/dlv: fix typo

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -719,7 +719,7 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 			processArgs = append([]string{debugname}, targetArgs...)
 		}
 		if dlvArgsLen >= 3 && traceFollowCalls <= 0 {
-			fmt.Fprintln(os.Stderr, "Need to specify a trace depth of atleast 1")
+			fmt.Fprintln(os.Stderr, "Need to specify a trace depth of at least 1")
 			return 1
 		}
 


### PR DESCRIPTION
The PR fixes a typo in trace cmd.