### PR TITLE
proc: do not always allocate struct literals

### DIFF
--- a/pkg/proc/evalop/ops.go
+++ b/pkg/proc/evalop/ops.go
@@ -347,3 +347,11 @@ type PushRuntimeType struct {
 }
 
 func (*PushRuntimeType) depthCheck() (npop, npush int) { return 0, 1 }
+
+// PushNewFakeVariable pushes a new debugger-allocated variable on to the
+// stack with the given type.
+type PushNewFakeVariable struct {
+	Type godwarf.Type
+}
+
+func (*PushNewFakeVariable) depthCheck() (npop, npush int) { return 0, 1 }

--- a/pkg/proc/mem.go
+++ b/pkg/proc/mem.go
@@ -190,7 +190,11 @@ func (mem *compositeMemory) WriteMemory(addr uint64, data []byte) (int, error) {
 		return 0, errors.New("write out of bounds")
 	}
 	if mem.regs.ChangeFunc == nil {
-		return 0, errors.New("can not write registers")
+		for _, piece := range mem.pieces {
+			if piece.Kind == op.RegPiece {
+				return 0, errors.New("can not write registers")
+			}
+		}
 	}
 
 	copy(mem.data[addr:], data)
@@ -216,7 +220,6 @@ func (mem *compositeMemory) WriteMemory(addr uint64, data []byte) (int, error) {
 					return donesz + n, err
 				}
 			case op.ImmPiece:
-				//TODO(aarzilli): maybe return an error if the user tried to change the value?
 				// nothing to do
 			default:
 				panic("unsupported piece kind")


### PR DESCRIPTION
Do not always allocate new struct literals to the target's memroy. Wait
until they actually need to have an address.

Fixes #1465
