### PR TITLE
proc/core: skip tests on ppc64le

### DIFF
--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -249,15 +249,8 @@ func logRegisters(t *testing.T, regs proc.Registers, arch *proc.Arch) {
 }
 
 func TestCore(t *testing.T) {
-	if runtime.GOOS != "linux" || runtime.GOARCH == "386" {
-		t.Skip("unsupported")
-	}
-	if runtime.GOOS != "linux" || runtime.GOARCH == "loong64" {
-		t.Skip("could not read runtime.sigtrampgo context")
-	}
-	if runtime.GOOS == "linux" && os.Getenv("CI") == "true" && buildMode == "pie" {
-		t.Skip("disabled on linux, Github Actions, with PIE buildmode")
-	}
+	mustSupportCore(t)
+
 	grp := withCoreFile(t, "panic", "")
 	p := grp.Selected
 
@@ -412,15 +405,8 @@ func TestCoreFpRegisters(t *testing.T) {
 }
 
 func TestCoreWithEmptyString(t *testing.T) {
-	if runtime.GOOS != "linux" || runtime.GOARCH == "386" {
-		t.Skip("unsupported")
-	}
-	if runtime.GOOS != "linux" || runtime.GOARCH == "loong64" {
-		t.Skip("could not read runtime.sigtrampgo context")
-	}
-	if runtime.GOOS == "linux" && os.Getenv("CI") == "true" && buildMode == "pie" {
-		t.Skip("disabled on linux, Github Actions, with PIE buildmode")
-	}
+	mustSupportCore(t)
+
 	grp := withCoreFile(t, "coreemptystring", "")
 	p := grp.Selected
 
@@ -535,4 +521,23 @@ func procdump(t *testing.T, exePath string) string {
 
 	t.Fatalf("could not find dump file")
 	return ""
+}
+
+func mustSupportCore(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("test must be run on linux")
+	}
+
+	switch runtime.GOARCH {
+	case "386", "ppc64le":
+		t.Skip("unsupported")
+	case "loong64":
+		t.Skip("could not read runtime.sigtrampgo context")
+	}
+
+	if os.Getenv("CI") == "true" && buildMode == "pie" {
+		t.Skip("disabled on linux, Github Actions, with PIE buildmode")
+	}
 }


### PR DESCRIPTION
These tests have been somewhat silently failing on our CI because the test ends up
 being skipped [due to the lack of coredumpctl](https://delve.teamcity.com/buildConfiguration/Delve_linux_ppc64le_1_24/66766?buildTab=tests&focusLine=NaN&name=testcore&suite=github.com%2Fgo-delve%2Fdelve%2Fpkg%2Fproc%2Fcore%3A+&expandedTest=build%3A%28id%3A66766%29%2Cid%3A2000000704&showLog=66766_20670_112.20612.20670&logFilter=debug&logView=flowAware).

When `coredumpctl` is present, the test [fails anyways](https://issues.redhat.com/browse/RHEL-83939), so let's just skip it on ppc64le for now.