### PR TITLE
proc: relax DWARFv5 check

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1391,7 +1391,7 @@ func (bi *BinaryInfo) DwarfVersion() uint8 {
 	r := uint8(0)
 	for _, so := range bi.Images {
 		for _, cu := range so.compileUnits {
-			if cu.Version > r {
+			if cu.isgo && cu.Version > r {
 				r = cu.Version
 			}
 		}


### PR DESCRIPTION
When using cgo some of the compilation units are produced by the C
compiler and could be in DWARFv5 even if most of the executable is
DWARFv4. In those cases debugging will still work fine outside of C
areas of the executable, it's probably better to proceed.
