### PR TITLE
proc: skip invalid labels when debugging via Go 1.24

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -591,6 +591,12 @@ func (g *G) Labels() map[string]string {
 							}
 							v.loadValue(loadFullValue)
 							if len(v.Children) == 2 {
+								// Skip invalid key-value pairs caused by corrupted or incompatible label structures
+								// (e.g., labels set by some libraries: https://github.com/timandy/routine/blob/v1.1.4/goid.go#L50).
+								// This prevents panics when converting nil values via constant.StringVal().
+								if v.Children[0].Value == nil || v.Children[1].Value == nil {
+									continue
+								}
 								labels[constant.StringVal(v.Children[0].Value)] = constant.StringVal(v.Children[1].Value)
 							}
 						}


### PR DESCRIPTION
## Problem

When debugging Go 1.24 programs using some 3rd lib such as https://github.com/timandy/routine/tree/v1.1.4, Delve panics due to corrupted `labelMap` structures caused by unsafe pointer operations in older implementations. Specifically:

- These libraries would inject non-`labelMap` pointers (e.g., `*thread` structs) into `runtime.g.labels`.
- Delve's `Goroutine.Labels()` method assumes valid `runtime/pprof.labelMap` structures, leading to `panic: <nil> not a String` when encountering nil values during `constant.StringVal()` conversion.

This issue blocks debugging sessions for applications that still rely on older dependency versions while using the latest local Go version.

## Solution

Add defensive checks to handle corrupted label structures safely and skip invalid key-value pairs 