### PR TITLE
gdbserial: do not abort register reload on the first failed register

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1738,7 +1738,10 @@ func (t *gdbThread) reloadRegisters(regs map[uint64]uint64) error {
 				}
 			} else {
 				if err := t.p.conn.readRegister(t.strID, r.Regnum, t.regs.regs[r.Name].value); err != nil {
-					return err
+					logflags.DebuggerLogger().Errorf("Could not read register %s: %v\n", r.Name, err)
+					for i := range t.regs.regs[r.Name].value {
+						t.regs.regs[r.Name].value[i] = 0
+					}
 				}
 			}
 		}


### PR DESCRIPTION
While loading thread registers always complete the process, even if the
stub can not return the value of some of the registers that it claims
exist.

Fixes #3964
Fixes #3965
