### PR TITLE
proc: fix bug telemetry counter increment

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -2239,8 +2239,8 @@ func loadBinaryInfoGoRuntimeElf(bi *BinaryInfo, image *Image, path string, elfFi
 	// recover all panics.
 	defer func() {
 		ierr := recover()
-		logflags.Bug.Inc()
 		if ierr != nil {
+			logflags.Bug.Inc()
 			err = fmt.Errorf("error loading binary info from Go runtime: %v", ierr)
 		}
 	}()
@@ -2282,8 +2282,8 @@ func loadBinaryInfoGoRuntimeMacho(bi *BinaryInfo, image *Image, path string, exe
 	// recover all panics.
 	defer func() {
 		ierr := recover()
-		logflags.Bug.Inc()
 		if ierr != nil {
+			logflags.Bug.Inc()
 			err = fmt.Errorf("error loading binary info from Go runtime: %v", ierr)
 		}
 	}()

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1050,8 +1050,8 @@ func (stack *evalStack) executeOp() {
 	scope, ops, curthread := stack.scope, stack.ops, stack.curthread
 	defer func() {
 		err := recover()
-		logflags.Bug.Inc()
 		if err != nil {
+			logflags.Bug.Inc()
 			stack.err = fmt.Errorf("internal debugger error: %v (recovered)\n%s", err, string(debug.Stack()))
 		}
 	}()

--- a/pkg/terminal/starbind/starlark.go
+++ b/pkg/terminal/starbind/starlark.go
@@ -199,11 +199,11 @@ func (env *Env) printFunc() func(_ *starlark.Thread, msg string) {
 // After the file is executed if a function named mainFnName exists it will be called, passing args to it.
 func (env *Env) Execute(path string, source interface{}, mainFnName string, args []interface{}) (_ starlark.Value, _err error) {
 	defer func() {
-		logflags.Bug.Inc()
 		err := recover()
 		if err == nil {
 			return
 		}
+		logflags.Bug.Inc()
 		_err = fmt.Errorf("panic executing starlark script: %v", err)
 		fmt.Fprintf(env.out, "panic executing starlark script: %v\n", err)
 		for i := 0; ; i++ {


### PR DESCRIPTION
The stack counter for executeOp errors is accidentally incremented too early.
