### PR TITLE
proc: remove dieToRuntimeType

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1266,7 +1266,7 @@ func (stack *evalStack) executeOp() {
 		stack.push(newVariable(evalop.BreakpointHitCountVarNameQualified, fakeAddressUnresolv, godwarf.FakeSliceType(godwarf.FakeBasicType("uint", 64)), scope.BinInfo, scope.Mem))
 
 	case *evalop.PushRuntimeType:
-		typeAddr, err := dieToRuntimeType(scope.BinInfo, scope.Mem, op.Type)
+		typeAddr, _, _, err := dwarfToRuntimeType(scope.BinInfo, scope.Mem, op.Type)
 		if err != nil {
 			stack.err = err
 			break

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -77,15 +77,3 @@ func findModuleDataForType(mds []ModuleData, typeAddr uint64) *ModuleData {
 	}
 	return nil
 }
-
-func findModuleDataForImage(mds []ModuleData, so *Image) *ModuleData {
-	var md *ModuleData
-	for i := range mds {
-		if so == nil || mds[i].text > so.StaticBase {
-			if md == nil || mds[i].text < md.text {
-				md = &mds[i]
-			}
-		}
-	}
-	return md
-}

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -191,22 +191,3 @@ func dwarfToRuntimeType(bi *BinaryInfo, mem MemoryReadWriter, typ godwarf.Type) 
 	typeKind, _ = constant.Uint64Val(kindv.Value)
 	return typeAddr, typeKind, true, nil
 }
-
-func dieToRuntimeType(bi *BinaryInfo, mem MemoryReadWriter, typ godwarf.Type) (uint64, error) {
-	typc := typ.Common()
-	so := bi.Images[typc.Index]
-	mds, err := bi.getModuleData(mem)
-	if err != nil {
-		return 0, err
-	}
-	md := findModuleDataForImage(mds, so)
-	if md == nil {
-		return 0, fmt.Errorf("could not allocate type %s", typ.String())
-	}
-	for off, rtdie := range so.runtimeTypeToDIE {
-		if rtdie.offset == typc.Offset {
-			return md.types + off, nil
-		}
-	}
-	return 0, fmt.Errorf("could not allocate type %s", typ.String())
-}


### PR DESCRIPTION
The dwarfToRuntimeType does basically the same thing in another way and
doesn't have a bug with making unsigned comparisons that should be
signed. It also does more things compared to dieToRuntimeType but it
shouldn't matter since function call injection is very slow anyway.

Fixes an intermittent bug on windows:
https://delve.teamcity.com/buildConfiguration/Delve_windows_amd64_1_24/67152
