### PR TITLE
version: use git hash instead of file blob hash for Version.Build

### DIFF
--- a/pkg/version/fixbuild.go
+++ b/pkg/version/fixbuild.go
@@ -2,21 +2,38 @@
 
 package version
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+	"strings"
+)
 
 func init() {
 	fixBuild = buildInfoFixBuild
 }
 
 func buildInfoFixBuild(v *Version) {
+	// Return if v.Build already set, but not if it is Git ident expand file blob hash
+	if !strings.HasPrefix(v.Build, "$Id: ") && !strings.HasSuffix(v.Build, " $") {
+		return
+	}
+
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		return
 	}
-	for i := range info.Settings {
-		if info.Settings[i].Key == "gitrevision" {
-			v.Build = info.Settings[i].Value
-			break
+
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			v.Build = setting.Value
+			return
+		}
+	}
+
+	// If we didn't find vcs.revision, try the old key for backward compatibility
+	for _, setting := range info.Settings {
+		if setting.Key == "gitrevision" {
+			v.Build = setting.Value
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Description
Fixes #3986

### Problem
Prior to this change, the Delve debugger's version information (via `dlv version` command) displays the blob hash of `pkg/version/version.go` as the a Git ident identifier $Id$. Upon reviewing the code a handful of times I wonder if this is intended, given we search for gitrevision key and try to write its value to Version.Build. From this logic in `buildInfoFixBuild` I would assume we would want the latest commit hash dlv is built with and not the file blob hash of `pkg/version/version.go`. That, and many users (myself included) originally though Build should/would represent the commit hash delve was installed/built with (thus the reason for my going down this rabbit hole surmising why its done this way)

If this should in fact be the built git hash then `buildInfoFixBuild` func in `fixbuild.go` needs to be updated to search for the git hash in `vcs.revision` key's value rather than the current implementation searching for `gitrevision`.

### Solution
Add settings search for `vcs.revision` and if it doesn't find it, we fall back to searching for `gitrevision` to maintain backwards compatibility (I couldn't determine where that was used previously, but maybe a linker flag from awhile ago?)

### Note
If we do want to instead keep the Build Id as the blob hash of `pkg/verison/version.go` then I'm happy to close this PR, but the semantics of Build generally mean the commit hash the binary was installed/built with. 