### PR TITLE
service/debugger,rpc2,dap: target locking review

### DIFF
--- a/pkg/proc/arch.go
+++ b/pkg/proc/arch.go
@@ -45,7 +45,7 @@ type Arch struct {
 	// DwarfRegisterToString returns the name and value representation of the
 	// given register, the register value can be nil in which case only the
 	// register name will be returned.
-	DwarfRegisterToString func(int, *op.DwarfRegister) (string, bool, string)
+	DwarfRegisterToString DwarfRegisterToStringFunc
 	// inhibitStepInto returns whether StepBreakpoint can be set at pc.
 	inhibitStepInto     func(bi *BinaryInfo, pc uint64) bool
 	RegisterNameToDwarf func(s string) (int, bool)
@@ -84,6 +84,8 @@ const (
 	mask16 = 0x0000ffff
 	mask32 = 0xffffffff
 )
+
+type DwarfRegisterToStringFunc func(int, *op.DwarfRegister) (string, bool, string)
 
 // PtrSize returns the size of a pointer for the architecture.
 func (a *Arch) PtrSize() int {


### PR DESCRIPTION
We had a few problems with missing targetMutex acquisitions in
service/debugger, this commit takes care of a few other methods (although I
don't think any of these are problems in practice).

* DwarfRegisterToString is removed, there is no need to call this method
outside of the context of ScopeRegisters/ThreadRegisters which can
directly return the function that DwarfRegisterToString would call
* add lock acquisition to BuildID
* remove Target, TargetGroup, TargetLock and TargetUnlock. Replace them with
a single LockTargetGroup method that acquires the lock and returns the
target group and the unlock function. Callers can still misuse
LockTargetGroup by calling unlock immediately and continuing to use the
target group but this is harder to do accidentally compared to the others.
