### PR TITLE
For DAP try using debug filename pattern for debug binary path before using random string. fix for #3494 (new Windows Firewall detections)

### DIFF
--- a/pkg/gobuild/defaultexe.go
+++ b/pkg/gobuild/defaultexe.go
@@ -11,9 +11,21 @@ import (
 // directory named 'name' followed by a random string
 func DefaultDebugBinaryPath(name string) string {
 	pattern := name
+
 	if runtime.GOOS == "windows" {
-		pattern += "*.exe"
+		pattern += ".exe"
+		// Try to create the file atomically with O_EXCL to avoid race conditions
+		f, err := os.OpenFile(pattern, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+		if err == nil {
+			// Successfully created the file
+			r := f.Name()
+			f.Close()
+			return r
+		}
+		// If file already exists or other error, fall back to CreateTemp
+		// (we don't need to specifically check os.IsExist because CreateTemp will handle any case)
 	}
+
 	f, err := os.CreateTemp(".", pattern)
 	if err != nil {
 		logflags.DebuggerLogger().Errorf("could not create temporary file for build output: %v", err)


### PR DESCRIPTION
Instead of using the pattern that is always randomized, check if it doesn't exist otherwise use a random filename including the pattern. 

Removes annoying windows firewall issue #3494