### PR TITLE
proc: fix nil pointer dereference in swiss table iterator

### DIFF
--- a/pkg/proc/mapiter.go
+++ b/pkg/proc/mapiter.go
@@ -349,6 +349,7 @@ var errSwissTableCouldNotLoad = errors.New("could not load one of the tables")
 var errSwissMapBadType = errors.New("swiss table type does not have some required fields")
 var errSwissMapBadTableField = errors.New("swiss table bad table field")
 var errSwissMapBadGroupTypeErr = errors.New("bad swiss map type, group type lacks some required fields")
+var errSwissTableNilGroups = errors.New("bad swiss map, groups pointer is nil")
 
 // loadTypes determines the correct type for it.dirPtr:  the linker records
 // this type as **table but in reality it is either *[dirLen]*table for
@@ -565,6 +566,11 @@ func (it *mapIteratorSwiss) loadCurrentTable() {
 	r.groups.DwarfType = pointerTo(fakeArrayType(groupsLengthMask+1, it.groupType), it.v.bi.Arch)
 	r.groups.RealType = r.groups.DwarfType
 	r.groups = r.groups.maybeDereference()
+
+	if r.groups.Addr == 0 {
+		it.v.Unreadable = errSwissTableNilGroups
+		return
+	}
 
 	it.tab = r
 }


### PR DESCRIPTION
This is probably the reason for the panics reported by telemetry, the
circumstances that cause this are unclear but we should be defensive
about this anyway.

Fixes #4005
