### PR TITLE
proc/gdbserial: fix out of bounds access reading registers

### DIFF
--- a/pkg/proc/gdbserial/gdbserver_conn.go
+++ b/pkg/proc/gdbserial/gdbserver_conn.go
@@ -534,6 +534,10 @@ func (conn *gdbConn) readRegister(threadID string, regnum int, data []byte) erro
 		return err
 	}
 
+	if len(resp) > len(data)*2 {
+		return fmt.Errorf("wrong response length, expected %d got %d", len(data)*2, len(resp))
+	}
+
 	for i := 0; i < len(resp); i += 2 {
 		n, _ := strconv.ParseUint(string(resp[i:i+2]), 16, 8)
 		data[i/2] = uint8(n)


### PR DESCRIPTION
It looks like some versions of debugserver in some circumstances will
return the wrong number of bytes when reading some registers.

Check for this condition and return an error instead of panic'ing.

Fixes #4008
