### PR TITLE
proc: fix sigpanic in openOnRead

### DIFF
--- a/pkg/proc/redirector_other.go
+++ b/pkg/proc/redirector_other.go
@@ -33,6 +33,10 @@ func (oor *openOnRead) Read(p []byte) (n int, err error) {
 func (oor *openOnRead) Close() error {
 	defer os.Remove(oor.path)
 
+	if oor.rd == nil {
+		return nil
+	}
+
 	fh, _ := os.OpenFile(oor.path, os.O_WRONLY|syscall.O_NONBLOCK, 0)
 	if fh != nil {
 		fh.Close()


### PR DESCRIPTION
If the openOnRead io.Reader is never read from the file descriptor is
never opened and it therefore we shouldn't try to close it.

Fixes #4009
