### PR TITLE
proc,dwarf: support string constant parse

### DIFF
--- a/pkg/dwarf/godwarf/type.go
+++ b/pkg/dwarf/godwarf/type.go
@@ -151,6 +151,12 @@ type BoolType struct {
 	BasicType
 }
 
+// A ConstStringType represents a const string type.
+type ConstStringType struct {
+	BasicType
+	Value string
+}
+
 // An AddrType represents a machine address type.
 type AddrType struct {
 	BasicType
@@ -1041,6 +1047,18 @@ func readType(d *dwarf.Data, name string, r *dwarf.Reader, off dwarf.Offset, typ
 		typ = t
 		typeCache[off] = t
 		t.Name, _ = e.Val(dwarf.AttrName).(string)
+
+	case dwarf.TagStringType:
+		// String type (DWARF v3 §5.10)
+		// Attributes:
+		//      AttrName: name
+		//      AttrType: type of string [used by gdb to determine the size]
+		//      AttrConstValue: value of string
+		t := new(ConstStringType)
+		typ = t
+		typeCache[off] = t
+		t.Name, _ = e.Val(dwarf.AttrName).(string)
+		t.Value, _ = e.Val(dwarf.AttrConstValue).(string)
 
 	default:
 		// This is some other type DIE that we're currently not

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"go/ast"
+	"go/constant"
 	"go/token"
 	"hash/crc32"
 	"io"
@@ -792,7 +793,7 @@ type constantType struct {
 type constantValue struct {
 	name      string
 	fullName  string
-	value     int64
+	value     constant.Value
 	singleBit bool
 }
 
@@ -2708,17 +2709,25 @@ func (bi *BinaryInfo) loadDebugInfoMapsCompileUnit(ctxt *loadDebugInfoMapsContex
 		case dwarf.TagConstant:
 			name, okName := entry.Val(dwarf.AttrName).(string)
 			typ, okType := entry.Val(dwarf.AttrType).(dwarf.Offset)
-			val, okVal := entry.Val(dwarf.AttrConstValue).(int64)
-			if okName && okType && okVal {
-				if !cu.isgo {
-					name = "C." + name
+			if okName && okType {
+				var cval constant.Value
+				switch v := entry.Val(dwarf.AttrConstValue).(type) {
+				case int64:
+					cval = constant.MakeInt64(v)
+				case []byte:
+					cval = constant.MakeString(string(v))
 				}
-				ct := bi.consts[dwarfRef{image.index, typ}]
-				if ct == nil {
-					ct = &constantType{}
-					bi.consts[dwarfRef{image.index, typ}] = ct
+				if cval != nil {
+					if !cu.isgo {
+						name = "C." + name
+					}
+					ct := bi.consts[dwarfRef{image.index, typ}]
+					if ct == nil {
+						ct = &constantType{}
+						bi.consts[dwarfRef{image.index, typ}] = ct
+					}
+					ct.values = append(ct.values, constantValue{name: name, fullName: name, value: cval})
 				}
-				ct.values = append(ct.values, constantValue{name: name, fullName: name, value: val})
 			}
 			reader.SkipChildren()
 

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -803,9 +803,20 @@ func (scope *EvalScope) findGlobalInternal(name string) (*Variable, error) {
 				v := newVariable(name, 0x0, t, scope.BinInfo, scope.Mem)
 				switch v.Kind {
 				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-					v.Value = constant.MakeInt64(cval.value)
+					if n, ok := constant.Int64Val(cval.value); ok {
+						v.Value = constant.MakeInt64(n)
+					} else {
+						return nil, fmt.Errorf("invalid integer constant %s", name)
+					}
 				case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-					v.Value = constant.MakeUint64(uint64(cval.value))
+					if n, ok := constant.Uint64Val(cval.value); ok {
+						v.Value = constant.MakeUint64(n)
+					} else {
+						return nil, fmt.Errorf("invalid unsigned constant %s", name)
+					}
+				case reflect.String:
+					v.Value = cval.value
+					v.Len = int64(len(constant.StringVal(cval.value)))
 				default:
 					return nil, fmt.Errorf("unsupported constant kind %v", v.Kind)
 				}


### PR DESCRIPTION
This patch provides corresponding parsing support for CL https://go.dev/cl/677915, which is currently under review.