### PR TITLE
Exclude internal breakpoints from response

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -3768,7 +3768,12 @@ func (s *Session) runUntilStopAndNotify(command string, allowNextStateChange *sy
 				if strings.HasPrefix(bp.Name, instructionBpPrefix) {
 					stopped.Body.Reason = "instruction breakpoint"
 				}
-				stopped.Body.HitBreakpointIds = []int{bp.ID}
+				// Filter out internal delve breakpoints (panic, fatal, hardcoded, etc.)
+				if bp.ID > 0 {
+					stopped.Body.HitBreakpointIds = []int{bp.ID}
+				} else {
+					stopped.Body.HitBreakpointIds = []int{}
+				}
 			}
 		}
 


### PR DESCRIPTION
While working on debugger support for [Zed](https://zed.dev), I noticed that
delve returns internal breakpoints in the "hit breakpoints" array when handling
a panic.

Although there's nothing really wrong with doing this, it caused an edge-case
in our parsing code (as in practice everyone uses unsigned integers for
breakpoint ids), and there's no particular value in doing so (because the
client has no record of the internal breakpoints).

