### PR TITLE
proc: handle moving of direct interface flag in Go 1.26

### DIFF
--- a/_scripts/rtype-out.txt
+++ b/_scripts/rtype-out.txt
@@ -67,10 +67,8 @@ const internal/runtime/maps.ctrlEmpty = 128
 
 const kindDirectIface|internal/abi.KindDirectIface = 32
 
-const kindGCProg|internal/abi.KindGCProg = 64
-
-const kindMask|internal/abi.KindMask = 31
-
 const minTopHash = 4
 or const minTopHash = 5
+
+const tflagDirectIface|internal/abi.TFlagDirectIface = 32
 

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1026,7 +1026,7 @@ type Image struct {
 func (image *Image) registerRuntimeTypeToDIE(entry *dwarf.Entry, ardr *reader.Reader) {
 	if off, ok := entry.Val(godwarf.AttrGoRuntimeType).(uint64); ok {
 		if _, ok := image.runtimeTypeToDIE[off]; !ok {
-			image.runtimeTypeToDIE[off] = runtimeTypeDIE{entry.Offset, -1}
+			image.runtimeTypeToDIE[off] = runtimeTypeDIE{entry.Offset}
 		}
 	}
 }

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -2135,14 +2135,14 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool, cfg LoadConfig
 		return
 	}
 
-	typ, kind, err := RuntimeTypeToDIE(_type, data.Addr, mds)
+	typ, directIface, err := RuntimeTypeToDIE(_type, data.Addr, mds)
 	if err != nil {
 		v.Unreadable = err
 		return
 	}
 
 	deref := false
-	if kind&kindDirectIface == 0 {
+	if !directIface {
 		realtyp := godwarf.ResolveTypedef(typ)
 		if _, isptr := realtyp.(*godwarf.PtrType); !isptr {
 			typ = pointerTo(typ, v.bi.Arch)


### PR DESCRIPTION
The "direct interface" flag in internal/abi.Type is moving from the Kind_ field to the TFlag field. See https://go-review.googlesource.com/c/go/+/681936

A few of the other Kind fields dlv doesn't use (and don't exist in Go anymore), so this code can be simplified somewhat.
