### PR TITLE
proc: propogate errors from switchToGoroutineStack 

### DIFF
--- a/pkg/proc/amd64_arch.go
+++ b/pkg/proc/amd64_arch.go
@@ -136,7 +136,10 @@ const amd64cgocallSPOffsetSaveSlot = 0x28
 func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 	if it.frame.Current.Fn == nil {
 		if it.systemstack && it.g != nil && it.top {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 		return false
@@ -208,7 +211,10 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 
 	case "runtime.mcall":
 		if it.systemstack && it.g != nil {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 		it.atend = true
@@ -231,12 +237,18 @@ func amd64SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 			return false
 		}
 
-		it.switchToGoroutineStack()
+		if err := it.switchToGoroutineStack(); err != nil {
+			it.err = err
+			return false
+		}
 		return true
 
 	case "runtime.newstack", "runtime.systemstack":
 		if it.systemstack && it.g != nil {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 

--- a/pkg/proc/arm64_arch.go
+++ b/pkg/proc/arm64_arch.go
@@ -147,7 +147,10 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 	linux := runtime.GOOS == "linux"
 	if it.frame.Current.Fn == nil {
 		if it.systemstack && it.g != nil && it.top {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 		return false
@@ -225,7 +228,10 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 
 	case "runtime.mcall":
 		if it.systemstack && it.g != nil {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 		it.atend = true
@@ -275,13 +281,19 @@ func arm64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool 
 				return false
 			}
 
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 
 	case "runtime.newstack", "runtime.systemstack":
 		if it.systemstack && it.g != nil {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 	}

--- a/pkg/proc/i386_arch.go
+++ b/pkg/proc/i386_arch.go
@@ -119,7 +119,10 @@ func i386FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *BinaryI
 func i386SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 	if it.frame.Current.Fn == nil {
 		if it.systemstack && it.g != nil && it.top {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 		return false
@@ -134,7 +137,10 @@ func i386SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 
 	case "runtime.mcall":
 		if it.systemstack && it.g != nil {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 		it.atend = true
@@ -157,12 +163,18 @@ func i386SwitchStack(it *stackIterator, _ *op.DwarfRegisters) bool {
 			return false
 		}
 
-		it.switchToGoroutineStack()
+		if err := it.switchToGoroutineStack(); err != nil {
+			it.err = err
+			return false
+		}
 		return true
 
 	case "runtime.newstack", "runtime.systemstack":
 		if it.systemstack && it.g != nil {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 

--- a/pkg/proc/loong64_arch.go
+++ b/pkg/proc/loong64_arch.go
@@ -91,7 +91,10 @@ func loong64FixFrameUnwindContext(fctxt *frame.FrameContext, pc uint64, bi *Bina
 func loong64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
 	if it.frame.Current.Fn == nil {
 		if it.systemstack && it.g != nil && it.top {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 		return false
@@ -111,7 +114,10 @@ func loong64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) boo
 			// Since we are only interested in printing the system stack for cgo
 			// calls we switch directly to the goroutine stack if we detect that the
 			// function at the top of the stack is a runtime function.
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 	}

--- a/pkg/proc/ppc64le_arch.go
+++ b/pkg/proc/ppc64le_arch.go
@@ -104,7 +104,10 @@ const ppc64prevG0schedSPOffsetSaveSlot = 40
 
 func ppc64leSwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
 	if it.frame.Current.Fn == nil && it.systemstack && it.g != nil && it.top {
-		it.switchToGoroutineStack()
+		if err := it.switchToGoroutineStack(); err != nil {
+			it.err = err
+			return false
+		}
 		return true
 	}
 	if it.frame.Current.Fn != nil {
@@ -117,7 +120,10 @@ func ppc64leSwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) boo
 			return true
 		case "runtime.mcall":
 			if it.systemstack && it.g != nil {
-				it.switchToGoroutineStack()
+				if err := it.switchToGoroutineStack(); err != nil {
+					it.err = err
+					return false
+				}
 				return true
 			}
 			it.atend = true
@@ -146,7 +152,10 @@ func ppc64leSwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) boo
 				// Since we are only interested in printing the system stack for cgo
 				// calls we switch directly to the goroutine stack if we detect that the
 				// function at the top of the stack is a runtime function.
-				it.switchToGoroutineStack()
+				if err := it.switchToGoroutineStack(); err != nil {
+					it.err = err
+					return false
+				}
 				return true
 			}
 		}

--- a/pkg/proc/riscv64_arch.go
+++ b/pkg/proc/riscv64_arch.go
@@ -141,7 +141,10 @@ const riscv64prevG0schedSPOffsetSaveSlot = 0x10
 func riscv64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) bool {
 	if it.frame.Current.Fn == nil {
 		if it.systemstack && it.g != nil && it.top {
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 		return false
@@ -172,7 +175,10 @@ func riscv64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) boo
 			return false
 		}
 
-		it.switchToGoroutineStack()
+		if err := it.switchToGoroutineStack(); err != nil {
+			it.err = err
+			return false
+		}
 		return true
 	default:
 		if it.systemstack && it.top && it.g != nil && strings.HasPrefix(it.frame.Current.Fn.Name, "runtime.") && it.frame.Current.Fn.Name != "runtime.throw" && it.frame.Current.Fn.Name != "runtime.fatalthrow" {
@@ -183,7 +189,10 @@ func riscv64SwitchStack(it *stackIterator, callFrameRegs *op.DwarfRegisters) boo
 			// Since we are only interested in printing the system stack for cgo
 			// calls we switch directly to the goroutine stack if we detect that the
 			// function at the top of the stack is a runtime function.
-			it.switchToGoroutineStack()
+			if err := it.switchToGoroutineStack(); err != nil {
+				it.err = err
+				return false
+			}
 			return true
 		}
 	}

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -299,7 +299,7 @@ func (it *stackIterator) switchToGoroutineStack() {
 	it.pc = it.g.PC
 	it.regs.Reg(it.regs.SPRegNum).Uint64Val = it.g.SP
 	it.regs.AddReg(it.regs.BPRegNum, op.DwarfRegisterFromUint64(it.g.BP))
-	if it.bi.Arch.Name == "arm64" || it.bi.Arch.Name == "ppc64le" || it.bi.Arch.Name == "riscv64" || it.bi.Arch.Name == "loong64" {
+	if it.bi.Arch.usesLR {
 		it.regs.Reg(it.regs.LRRegNum).Uint64Val = it.g.LR
 	}
 }
@@ -580,7 +580,7 @@ func (it *stackIterator) advanceRegs() (callFrameRegs op.DwarfRegisters, ret uin
 		}
 	}
 
-	if it.bi.Arch.Name == "arm64" || it.bi.Arch.Name == "ppc64le" || it.bi.Arch.Name == "riscv64" || it.bi.Arch.Name == "loong64" {
+	if it.bi.Arch.usesLR {
 		if ret == 0 && it.regs.Reg(it.regs.LRRegNum) != nil {
 			ret = it.regs.Reg(it.regs.LRRegNum).Uint64Val
 		}


### PR DESCRIPTION
As seen via https://github.com/go-delve/delve/pull/4017 it's possible
that lldb debugserver, in certain versions and circumstances (the
combination is currently not known) can return incorrect or incomplete
information on CPU registers. Be defensive on this by checking if the
result of `it.regs.Reg(it.regs.LRRegNum)` is nil.

Fixes https://github.com/go-delve/delve/issues/4030