### PR TITLE
service/dap: add missing response body close

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -7739,10 +7739,11 @@ func TestBreakpointAfterDisconnect(t *testing.T) {
 
 	httpClient := &http.Client{Timeout: time.Second}
 
-	_, err = httpClient.Get("http://127.0.0.1:9191/nobp")
+	resp, err := httpClient.Get("http://127.0.0.1:9191/nobp")
 	if err != nil {
 		t.Fatalf("Page request after disconnect failed: %v", err)
 	}
+	defer resp.Body.Close()
 
 	time.Sleep(200 * time.Millisecond)
 


### PR DESCRIPTION
This PR adds `resp.Body.Close()` in `TestBreakpointAfterDisconnect`.

From https://pkg.go.dev/net/http#Get:

> When err is nil, resp always contains a non-nil resp.Body. Caller should close resp.Body when done reading from it.