### PR TITLE
Add savestate command

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -152,9 +152,9 @@ A tracepoint is a breakpoint that does not stop the execution of the program, in
 
 See also: "help on", "help cond" and "help clear"`},
 		{aliases: []string{"watch"}, group: breakCmds, cmdFn: watchpoint, helpMsg: `Set watchpoint.
-	
+
 	watch [-r|-w|-rw] <expr>
-	
+
 	-r	stops when the memory location is read
 	-w	stops when the memory location is written
 	-rw	stops when the memory location is read or written
@@ -176,7 +176,7 @@ For recorded targets the command takes the following forms:
 	restart					resets to the start of the recording
 	restart [checkpoint]			resets the recording to the given checkpoint
 	restart -r [newargv...]	[redirects...]	re-records the target process
-	
+
 For live targets the command takes the following forms:
 
 	restart [newargv...] [redirects...]	restarts the process
@@ -213,9 +213,9 @@ Optional [count] argument allows you to skip multiple lines.
 `},
 		{aliases: []string{"stepout", "so"}, group: runCmds, allowedPrefixes: revPrefix, cmdFn: c.stepout, helpMsg: "Step out of the current function."},
 		{aliases: []string{"call"}, group: runCmds, cmdFn: c.call, helpMsg: `Resumes process, injecting a function call (EXPERIMENTAL!!!)
-	
+
 	call [-unsafe] <function call expression>
-	
+
 Current limitations:
 - only pointers to stack-allocated objects can be passed as argument.
 - only some automatic type conversions are supported.
@@ -274,34 +274,34 @@ To only display goroutines where the specified location contains (or does not co
 	curloc: filter by the location of the topmost stackframe (including frames inside private runtime functions)
 	goloc: filter by the location of the go instruction that created the goroutine
 	startloc: filter by the location of the start function
-	
+
 To only display goroutines that have (or do not have) the specified label key and value, use:
 
 	goroutines -with label key=value
 	goroutines -without label key=value
-	
+
 To only display goroutines that have (or do not have) the specified label key, use:
 
 	goroutines -with label key
 	goroutines -without label key
-	
+
 To only display goroutines that are running (or are not running) on a OS thread, use:
 
 
 	goroutines -with running
 	goroutines -without running
-	
+
 To only display user (or runtime) goroutines, use:
 
 	goroutines -with user
 	goroutines -without user
 
 CHANNELS
-	
+
 To only show goroutines waiting to send to or receive from a specific channel use:
 
 	goroutines -chan expr
-	
+
 Note that 'expr' must not contain spaces.
 
 GROUPING
@@ -339,7 +339,7 @@ Called without arguments it will show information about the current goroutine.
 Called with a single argument it will switch to the specified goroutine.
 Called with more arguments it will execute a command on the specified goroutine.`},
 		{aliases: []string{"breakpoints", "bp"}, group: breakCmds, cmdFn: breakpoints, helpMsg: `Print out info for active breakpoints.
-	
+
 	breakpoints [-a]
 
 Specifying -a prints all physical breakpoint, including internal breakpoints.`},
@@ -401,9 +401,9 @@ If regex is specified only package variables with a name matching it will be ret
 
 Argument -a shows more registers. Individual registers can also be displayed by 'print' and 'display'. See Documentation/cli/expr.md.`},
 		{aliases: []string{"exit", "quit", "q"}, cmdFn: exitCommand, helpMsg: `Exit the debugger.
-		
+
 	exit [-c]
-	
+
 When connected to a headless instance started with the --accept-multiclient, pass -c to resume the execution of the target process before disconnecting.`},
 		{aliases: []string{"list", "ls", "l"}, cmdFn: listCommand, helpMsg: `Show source code.
 
@@ -473,10 +473,15 @@ Executes the specified command (print, args, locals) in the context of the n-th 
 		{aliases: []string{"source"}, cmdFn: c.sourceCommand, helpMsg: `Executes a file containing a list of delve commands
 
 	source <path>
-	
+
 If path ends with the .star extension it will be interpreted as a starlark script. See Documentation/cli/starlark.md for the syntax.
 
 If path is a single '-' character an interactive starlark interpreter will start instead. Type 'exit' to exit.`},
+		{aliases: []string{"savestate"}, cmdFn: c.saveStateCommand, helpMsg: `Saves all current breakpoints to a file
+
+			savestate <path>
+
+This command writes the current state of all active breakpoints to the specified file. The file will contain a sequence of Delve 'break' commands that can be loaded later using the 'source' command to re-establish the breakpoints.`},
 		{aliases: []string{"disassemble", "disass"}, cmdFn: disassCommand, helpMsg: `Disassembler.
 
 	[goroutine <n>] [frame <m>] disassemble [-a <start> <end>] [-l <locspec>]
@@ -489,11 +494,11 @@ If no argument is specified the function being executed in the selected stack fr
 
 	on <breakpoint name or id> <command>
 	on <breakpoint name or id> -edit
-	
 
-Supported commands: print, stack, goroutine, trace and cond. 
+
+Supported commands: print, stack, goroutine, trace and cond.
 To convert a breakpoint into a tracepoint use:
-	
+
 	on <breakpoint name or id> trace
 
 The command 'on <bp> cond <cond-arguments>' is equivalent to 'cond <bp> <cond-arguments>'.
@@ -523,7 +528,7 @@ With the -hitcount option a condition on the breakpoint hit count can be set, th
 The -per-g-hitcount option works like -hitcount, but use per goroutine hitcount to compare with n.
 
 With the -clear option a condition on the breakpoint can removed.
-	
+
 The '% n' form means we should stop at the breakpoint when the hitcount is a multiple of n.
 
 Examples:
@@ -572,7 +577,7 @@ Adds, removes or clears debug-info-directories.`},
 		{aliases: []string{"edit", "ed"}, cmdFn: edit, helpMsg: `Open where you are in $DELVE_EDITOR or $EDITOR
 
 	edit [locspec]
-	
+
 If locspec is omitted edit will open the current source file in the editor, otherwise it will open the specified location.`},
 		{aliases: []string{"libraries"}, cmdFn: libraries, helpMsg: `List loaded dynamic libraries`},
 
@@ -2631,6 +2636,48 @@ func (c *Commands) sourceCommand(t *Term, ctx callContext, args string) error {
 	}
 
 	return c.executeFile(t, args)
+}
+
+func (c *Commands) saveStateCommand(t *Term, ctx callContext, args string) error {
+	if len(args) == 0 {
+		return errors.New("wrong number of arguments: source <filename>")
+	}
+	breakPoints, err := t.client.ListBreakpoints(args == "-a")
+	if err != nil {
+		return err
+	}
+	var fileContent string
+	for _, bp := range breakPoints {
+		// We don't need to store these breakpoints
+		if bp.ID < 0 {
+			continue
+		}
+		fileContent += fmt.Sprintf("break %s:%d\n", bp.File, bp.Line)
+		if len(bp.Cond) > 0 {
+			fileContent += fmt.Sprintf("condition %d %s\n", bp.ID, bp.Cond)
+		}
+		if bp.Disabled {
+			fileContent += fmt.Sprintf("toggle %d\n", bp.ID)
+		}
+	}
+	filePath := args
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("file '%s' already exists and cannot be overwritten", filePath)
+		}
+		return fmt.Errorf("failed to open file '%s': %w", filePath, err)
+	}
+	defer file.Close() // Ensure the file is closed.
+
+	// Write the collected content to the file.
+	_, err = file.WriteString(fileContent)
+	if err != nil {
+		return fmt.Errorf("failed to write to file '%s': %w", filePath, err)
+	}
+
+	fmt.Printf("Breakpoints successfully saved to '%s'\n", filePath)
+	return nil
 }
 
 var errDisasmUsage = errors.New("wrong number of arguments: disassemble [-a <start> <end>] [-l <locspec>]")


### PR DESCRIPTION
This is a very simplistic approach to fixing #4033. Basically, it creates a file with the breakpoint commands. Kind of like the counterpart of the source command.

It's incomplete because it doesn't take in consideration all the possible stuff a breakpoint might have, but I open the PR to see if this approach is something desirable, or it needs a more robust approach.