### PR TITLE
panic fix

### DIFF
--- a/pkg/proc/mapiter.go
+++ b/pkg/proc/mapiter.go
@@ -234,7 +234,7 @@ func (it *mapIteratorClassic) nextBucket() bool {
 		return false
 	}
 
-	if it.overflow.Kind != reflect.Struct {
+	if it.overflow != nil && it.overflow.Kind != reflect.Struct {
 		it.v.Unreadable = errMapBucketsNotStruct
 		return false
 	}


### PR DESCRIPTION
Internal debugger error: runtime error: invalid memory address or nil pointer dereference
runtime.gopanic (0x4396d1)
	/opt/go/src/runtime/panic.go:770
runtime.panicmem (0x4524d7)
	/opt/go/src/runtime/panic.go:261
runtime.sigpanic (0x4524a5)
	/opt/go/src/runtime/signal_unix.go:881
github.com/go-delve/delve/pkg/proc.(*mapIteratorClassic).nextBucket (0x79111b)
	/root/data/go/src/github.com/delve/pkg/proc/mapiter.go:237
github.com/go-delve/delve/pkg/proc.(*mapIteratorClassic).next (0x79125d)
	/root/data/go/src/github.com/delve/pkg/proc/mapiter.go:248
github.com/go-delve/delve/pkg/proc.(*Variable).loadMap (0x7c4091)
	/root/data/go/src/github.com/delve/pkg/proc/variables.go:2041
github.com/go-delve/delve/pkg/proc.(*Variable).loadValueInternal (0x7bfd7e)
	/root/data/go/src/github.com/delve/pkg/proc/variables.go:1389
github.com/go-delve/delve/pkg/proc.(*Variable).loadValueInternal (0x7c05ed)
	/root/data/go/src/github.com/delve/pkg/proc/variables.go:1448
github.com/go-delve/delve/pkg/proc.(*Variable).loadValueInternal (0x7c04c7)
	/root/data/go/src/github.com/delve/pkg/proc/variables.go:1372
github.com/go-delve/delve/pkg/proc.(*Variable).loadInterface (0x7c4cfa)
	/root/data/go/src/github.com/delve/pkg/proc/variables.go:2161
github.com/go-delve/delve/pkg/proc.(*Variable).loadValueInternal (0x7bfd38)
	/root/data/go/src/github.com/delve/pkg/proc/variables.go:1456
github.com/go-delve/delve/pkg/proc.loadValues (0x771fb9)
	/root/data/go/src/github.com/delve/pkg/proc/variables.go:1337
github.com/go-delve/delve/pkg/proc.(*EvalScope).FunctionArguments (0x771f4b)
	/root/data/go/src/github.com/delve/pkg/proc/eval.go:691
github.com/go-delve/delve/service/debugger.(*Debugger).FunctionArguments (0x8726eb)
	/root/data/go/src/github.com/delve/service/debugger/debugger.go:1544
github.com/go-delve/delve/service/rpc2.(*RPCServer).ListFunctionArgs (0x99278f)
	/root/data/go/src/github.com/delve/service/rpc2/server.go:511
reflect.Value.call (0x4cae45)
	/opt/go/src/reflect/value.go:596
reflect.Value.Call (0x4ca0d8)
	/opt/go/src/reflect/value.go:380
github.com/go-delve/delve/service/rpccommon.(*ServerImpl).serveJSONCodec.func2 (0xa7807c)
	/root/data/go/src/github.com/delve/service/rpccommon/server.go:262
github.com/go-delve/delve/service/rpccommon.(*ServerImpl).serveJSONCodec (0xa77487)
	/root/data/go/src/github.com/delve/service/rpccommon/server.go:264
runtime.goexit (0x46fde0)
	/opt/go/src/runtime/asm_amd64.s:1695