### PR TITLE
proc: fix nil pointer dereference loading malformed classic maps

### DIFF
--- a/pkg/proc/mapiter.go
+++ b/pkg/proc/mapiter.go
@@ -212,7 +212,7 @@ func (it *mapIteratorClassic) nextBucket() bool {
 	}
 
 	// sanity checks
-	if it.tophashes == nil || it.keys == nil || it.values == nil {
+	if it.tophashes == nil || it.keys == nil || it.values == nil || it.overflow == nil {
 		it.v.Unreadable = errors.New("malformed map type")
 		return false
 	}


### PR DESCRIPTION
This bug was reported previously as PRs to fix it but the reporters
always declined to provide more informations as to how it happens,
which remains a mystery.

Fixes #4063
