### PR TITLE
proc: early fixes for Go 1.26

### DIFF
--- a/pkg/proc/stepping_test.go
+++ b/pkg/proc/stepping_test.go
@@ -1227,7 +1227,7 @@ func TestRangeOverFuncNextInlined(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
 		t.Skip("N/A")
 	}
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) && !goversion.VersionAfterOrEqual(runtime.Version(), 1, 26) {
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) && !goversion.VersionAfterOrEqual(runtime.Version(), 1, 27) {
 		t.Skip("broken due to inlined symbol names")
 	}
 

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1514,11 +1514,11 @@ func convertToEface(srcv, dstv *Variable) error {
 		dstv.writeEmptyInterface(_type.Addr, data)
 		return nil
 	}
-	typeAddr, typeKind, runtimeTypeFound, err := dwarfToRuntimeType(srcv.bi, srcv.mem, srcv.RealType)
+	typeAddr, direct, runtimeTypeFound, err := dwarfToRuntimeType(srcv.bi, srcv.mem, srcv.RealType)
 	if err != nil {
 		return fmt.Errorf("can not convert value of type %s to %s: %v", srcv.DwarfType.String(), dstv.DwarfType.String(), err)
 	}
-	if !runtimeTypeFound || typeKind&kindDirectIface == 0 {
+	if !runtimeTypeFound || !direct {
 		return &typeConvErr{srcv.DwarfType, dstv.RealType}
 	}
 	return dstv.writeEmptyInterface(typeAddr, srcv)


### PR DESCRIPTION
Change 091ff506 fixed loading the direct flag for Go 1.26 when we go
from a runtime type to a dwarf type, we also did the same check from
the dwarf type to a runtime type when converting variables into
'interface {}'.

This commit deletes unifies the two code paths deleting the one that
wasn't updated.

Fixes the tests on tip.
