### PR TITLE
service/dap: Implement suspended breakpoints

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -1104,7 +1104,8 @@ type LogicalBreakpoint struct {
 	// condUsesHitCounts is true when 'cond' uses breakpoint hitcounts
 	condUsesHitCounts bool
 
-	UserData interface{} // Any additional information about the breakpoint
+	DidUnsuspend func(*LogicalBreakpoint) // A function that is called if the breakpoint is unsuspended
+	UserData     interface{}              // Any additional information about the breakpoint
 	// Name of root function from where tracing needs to be done
 	RootFuncName string
 	// depth of tracing

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -585,6 +585,9 @@ func (t *Target) pluginOpenCallback(Thread, *Target) (bool, error) {
 			} else {
 				logger.Debugf("suspended breakpoint %d enabled", lbp.LogicalID)
 			}
+			if lbp.DidUnsuspend != nil {
+				lbp.DidUnsuspend(lbp)
+			}
 		}
 	}
 	return false, nil

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -132,7 +132,8 @@ type Breakpoint struct {
 	// Disabled flag, signifying the state of the breakpoint
 	Disabled bool `json:"disabled"`
 
-	UserData interface{} `json:"-"`
+	UserData     interface{}       `json:"-"`
+	DidUnsuspend func(*Breakpoint) `json:"-"`
 
 	// RootFuncName is the Root function from where tracing needs to be done
 	RootFuncName string

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1522,20 +1522,26 @@ func (s *Session) setBreakpoints(prefix string, totalBps int, metadataFunc func(
 				err = errors.New("breakpoint already exists")
 			} else {
 				bp := &api.Breakpoint{
-					Name:    want.name,
-					File:    wantLoc.file,
-					Line:    wantLoc.line,
-					Addr:    wantLoc.addr,
-					Addrs:   wantLoc.addrs,
-					Cond:    want.condition,
-					HitCond: want.hitCondition,
+					Name:         want.name,
+					File:         wantLoc.file,
+					Line:         wantLoc.line,
+					Addr:         wantLoc.addr,
+					Addrs:        wantLoc.addrs,
+					Cond:         want.condition,
+					HitCond:      want.hitCondition,
+					DidUnsuspend: s.didUnsuspendBreakpoint,
 				}
 				err = setLogMessage(bp, want.logMessage)
 				if err == nil {
 					// Create new breakpoints.
-					got, err = s.debugger.CreateBreakpoint(bp, "", nil, false)
+					got, err = s.debugger.CreateBreakpoint(bp, "", nil, true)
 				}
 			}
+		}
+		if len(got.Addrs) == 0 {
+			// Handle suspended breakpoints.
+			got.File = wantLoc.file
+			got.Line = wantLoc.line
 		}
 		createdBps[want.name] = struct{}{}
 		s.updateBreakpointsResponse(breakpoints, i, err, got)
@@ -1556,7 +1562,11 @@ func setLogMessage(bp *api.Breakpoint, msg string) error {
 }
 
 func (s *Session) updateBreakpointsResponse(breakpoints []dap.Breakpoint, i int, err error, got *api.Breakpoint) {
-	breakpoints[i].Verified = err == nil
+	if len(got.Addrs) > 0 {
+		breakpoints[i].Verified = true
+	} else {
+		breakpoints[i].Message = "Unable to set breakpoint"
+	}
 	if err != nil {
 		breakpoints[i].Message = err.Error()
 	} else {
@@ -1565,6 +1575,22 @@ func (s *Session) updateBreakpointsResponse(breakpoints []dap.Breakpoint, i int,
 		breakpoints[i].Line = got.Line
 		breakpoints[i].Source = &dap.Source{Name: filepath.Base(path), Path: path}
 	}
+}
+
+func (s *Session) didUnsuspendBreakpoint(bp *api.Breakpoint) {
+	path := s.toClientPath(bp.File)
+	s.send(&dap.BreakpointEvent{
+		Event: *newEvent("breakpoint"),
+		Body: dap.BreakpointEventBody{
+			Reason: "changed",
+			Breakpoint: dap.Breakpoint{
+				Verified: true,
+				Id:       bp.ID,
+				Line:     bp.Line,
+				Source:   &dap.Source{Name: filepath.Base(path), Path: path},
+			},
+		},
+	})
 }
 
 // functionBpPrefix is the prefix of bp.Name for every breakpoint bp set

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -800,6 +800,13 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string,
 
 	createdBp := d.convertBreakpoint(lbp)
 	d.log.Infof("created breakpoint: %#v", createdBp)
+
+	if requestedBp.DidUnsuspend != nil {
+		lbp.DidUnsuspend = func(*proc.LogicalBreakpoint) {
+			requestedBp.DidUnsuspend(createdBp)
+		}
+	}
+
 	return createdBp, nil
 }
 


### PR DESCRIPTION
This enables support for 'suspended' breakpoints, for example for a plugin that hasn't been loaded yet.

Fixes #4074