### PR TITLE
proc: in-progress calls must be properly terminated

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -982,6 +982,11 @@ func (stack *evalStack) resume(g *G) {
 	if finished {
 		funcCallFinish(scope, stack)
 	}
+	if stack.err == nil && len(stack.fncalls) > 0 {
+		if fncall := stack.fncallPeek(); fncall.err != nil {
+			stack.err = fncall.err
+		}
+	}
 
 	if stack.callInjectionContinue {
 		// not done with call injection, stay in this mode

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -809,7 +809,7 @@ func funcCallStep(callScope *EvalScope, stack *evalStack, thread Thread) bool {
 	regs, err := thread.Registers()
 	if err != nil {
 		fncall.err = err
-		return true
+		return false
 	}
 
 	regval := bi.Arch.RegistersToDwarfRegisters(0, regs).Uint64Val(fncall.protocolReg)


### PR DESCRIPTION
If we have an error in funcCallStep we must not mark the function call
as finished, otherwise the error will be discarded and execution will
continue under the assumption that there was no error.

Fixes #4085
