### PR TITLE
pkg/proc: support ContextRegNum on loong64

### DIFF
--- a/pkg/proc/loong64_arch.go
+++ b/pkg/proc/loong64_arch.go
@@ -34,6 +34,7 @@ func LOONG64Arch(goos string) *Arch {
 		usesLR:                           true,
 		PCRegNum:                         regnum.LOONG64_PC,
 		SPRegNum:                         regnum.LOONG64_SP,
+		ContextRegNum:                    regnum.LOONG64_R0 + 29,
 		asmRegisters:                     loong64AsmRegisters,
 		RegisterNameToDwarf:              nameToDwarfFunc(regnum.LOONG64NameToDwarf),
 		RegnumToString:                   regnum.LOONG64ToName,


### PR DESCRIPTION
Fix failing test cases TestStepIntoCoroutine and TestCapturedVarVisibleOnFirstLine on linuxloong64.

Fixes [#4094 ](https://github.com/go-delve/delve/issues/4094)