### PR TITLE
proc: add test for interfaces with otherwise unreachable runtime types

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -169,6 +169,10 @@ type ThreeInts struct {
 	a, b, c int
 }
 
+type OnlyUsedInInterface struct {
+	s string
+}
+
 type Message []byte
 
 var _ I = (*W2)(nil)
@@ -427,6 +431,8 @@ func main() {
 
 	var messageVar Message = Message{1, 2, 3, 4, 5}
 
+	var iface7 interface{} = OnlyUsedInInterface{"test"}
+
 	var amb1 = 1
 	runtime.Breakpoint()
 	for amb1 := 0; amb1 < 10; amb1++ {
@@ -437,5 +443,5 @@ func main() {
 	longslice := make([]int, 100, 100)
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice, enum1, enum2, enum3, enum4, enum5, enum6, zeropoint4, mlarge, messageVar)
+	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice, enum1, enum2, enum3, enum4, enum5, enum6, zeropoint4, mlarge, messageVar, iface7)
 }

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -958,6 +958,11 @@ func getEvalExpressionTestCases() []varTest {
 		testcases = append(testcases, varTest{`**(**runtime.hmap)(uintptr(&m1))`, false, `…`, `…`, "runtime.hmap", nil})
 	}
 
+	if goversion.VersionAfterOrEqualRev(runtime.Version(), 1, 25, 2) {
+		testcases = append(testcases, varTest{"iface7", true, "interface {}(main.OnlyUsedInInterface) {s: \"test\"}", "interface {}(main.OnlyUsedInInterface) {s: \"test\"}", "interface {}", nil})
+
+	}
+
 	return testcases
 }
 


### PR DESCRIPTION
### proc: add test for interfaces with otherwise unreachable runtime types

Add a test to read the runtime type of an interface variable that is
not used in any other ways except through interfaces.

This is a regression check for issue #4080 which is a compiler problem.

### proc: early fixes for Go 1.26

Change 091ff506 fixed loading the direct flag for Go 1.26 when we go
from a runtime type to a dwarf type, we also did the same check from
the dwarf type to a runtime type when converting variables into
'interface {}'.

This commit deletes unifies the two code paths deleting the one that
wasn't updated.

Fixes the tests on tip.

### *: fix some failing tests on go1.25

* Skip TestIssue256 on linux/386, it fails because the line it relies
on
(a return) does not have code generated for it.

* Skip running gen-usage-docs in TestGeneratedDocs on linux/ppc64le, I
don't know why this fails, likely just a problem with the build
agent,
but it doesn't matter: the test doesn't need to run on every
architecture.

* Change TestRestartRequestWithNewArgs so that it doesn't depend on the
cap value of a slice (it changed in go1.25/windows/amd64)
