### PR TITLE
add support for reading runtime.sigtrampgo context on loong64

### DIFF
--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -533,8 +533,6 @@ func mustSupportCore(t *testing.T) {
 	switch runtime.GOARCH {
 	case "386", "ppc64le":
 		t.Skip("unsupported")
-	case "loong64":
-		t.Skip("could not read runtime.sigtrampgo context")
 	}
 
 	if os.Getenv("CI") == "true" && buildMode == "pie" {


### PR DESCRIPTION
This PR adds support for reading the runtime.sigtrampgo context on loong64.