### PR TITLE
pkg/proc: add support for additional stack-switching functions on loong64

### DIFF
--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -23,8 +23,7 @@ Tests skipped by each supported backend:
 	* 2 not working on linux/386
 * linux/386/pie skipped = 1
 	* 1 broken
-* linux/loong64 skipped = 2
-	* 1 broken - cgo stacktraces
+* linux/loong64 skipped = 1
 	* 1 not working on linux/loong64
 * linux/ppc64le skipped = 3
 	* 1 broken - cgo stacktraces
@@ -36,8 +35,8 @@ Tests skipped by each supported backend:
 * linux/riscv64 skipped = 2
 	* 1 broken - cgo stacktraces
 	* 1 not working on linux/riscv64
-* loong64 skipped = 9
-	* 2 broken
+* loong64 skipped = 8
+	* 1 broken
 	* 1 broken - global variable symbolication
 	* 6 not implemented
 * pie skipped = 2

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2961,7 +2961,6 @@ func TestCgoStacktrace(t *testing.T) {
 	skipOn(t, "broken - cgo stacktraces", "windows", "arm64")
 	skipOn(t, "broken - cgo stacktraces", "linux", "ppc64le")
 	skipOn(t, "broken - cgo stacktraces", "linux", "riscv64")
-	skipOn(t, "broken - cgo stacktraces", "linux", "loong64")
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 21) {
 		skipOn(t, "broken - cgo stacktraces", "windows", "arm64")
 	}
@@ -4200,7 +4199,6 @@ func TestCgoStacktrace2(t *testing.T) {
 	skipOn(t, "broken - cgo stacktraces", "darwin", "arm64")
 	skipOn(t, "broken", "ppc64le")
 	skipOn(t, "broken", "riscv64")
-	skipOn(t, "broken", "loong64")
 	protest.MustHaveCgo(t)
 	// If a panic happens during cgo execution the stacktrace should show the C
 	// function that caused the problem.


### PR DESCRIPTION
These functions involve stack switching on loong64 and must be recognized for Delve to correctly unwind and produce accurate stack traces.

With Go 1.19 and later, cgo is fully supported on linux/loong64, so supporting these functions is required for proper debugging on this platform.

Fixes #4099