### PR TITLE
service/dap: allow clients to specify rebuild on restart

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -5383,7 +5383,7 @@ func TestLaunchDebugRequest(t *testing.T) {
 		// We reuse the harness that builds, but ignore the built binary,
 		// only relying on the source to be built in response to LaunchRequest.
 		runDebugSession(t, client, "launch", func() {
-			client.LaunchRequestWithArgs(map[string]interface{}{
+			client.LaunchRequestWithArgs(map[string]any{
 				"mode": "debug", "program": fixture.Source, "output": tmpBin,
 			})
 		})
@@ -6015,6 +6015,47 @@ func TestRestartRequest(t *testing.T) {
 					checkStop(t, client, 1, "main.main", 16)
 
 					client.RestartRequest(nil)
+					client.ExpectRestartResponse(t)
+
+					client.ExpectInitializedEvent(t)
+
+					client.ConfigurationDoneRequest()
+					client.ExpectConfigurationDoneResponse(t)
+
+					// Ensure breakpoints are preserved
+					// Now we should hit the breakpoint again at main.main
+					client.ExpectStoppedEvent(t)
+					checkStop(t, client, 1, "main.main", 16)
+				},
+				disconnect: true,
+			}})
+	})
+}
+
+func TestRestartRequestRebuild(t *testing.T) {
+	runTest(t, "loopprog", func(client *daptest.Client, fixture protest.Fixture) {
+		runDebugSessionWithBPs(t, client, "launch",
+			// Launch
+			func() {
+				client.LaunchRequestWithArgs(map[string]any{
+					"mode": "debug", "program": fixture.Source,
+				})
+			},
+			// Set breakpoints
+			fixture.Source, []int{16}, // Set breakpoint at main.main
+			[]onBreakpoint{{
+				execute: func() {
+					checkStop(t, client, 1, "main.main", 16)
+
+					client.RestartRequest(map[string]any{
+						"arguments": map[string]any{
+							"request":     "launch",
+							"mode":        "debug",
+							"program":     fixture.Source,
+							"stopOnEntry": false,
+							"rebuild":     true,
+						},
+					})
 					client.ExpectRestartResponse(t)
 
 					client.ExpectInitializedEvent(t)


### PR DESCRIPTION
Adds a new param to the restart request which if set will cause the debugger to recompile the program before restarting it.

Note the existing behavior is unchanged, clients *must* specify this new flag to trigger a recompile.

Fixes https://github.com/golang/vscode-go/issues/3835#issuecomment-3204417618