### PR TITLE
pkg/goversion: update MinSupportedVersionOfGoMinor

### DIFF
--- a/pkg/goversion/compat.go
+++ b/pkg/goversion/compat.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	MinSupportedVersionOfGoMajor = 1
-	MinSupportedVersionOfGoMinor = 22
+	MinSupportedVersionOfGoMinor = 23
 	MaxSupportedVersionOfGoMajor = 1
 	MaxSupportedVersionOfGoMinor = 25
 	goTooOldErr                  = fmt.Sprintf("Go version %%s is too old for this version of Delve (minimum supported version %d.%d, suppress this error with --check-go-version=false)", MinSupportedVersionOfGoMajor, MinSupportedVersionOfGoMinor)


### PR DESCRIPTION
The oldest version of Go we run in CI is 1.23,
MinSupportedVersionOfGoMinor should reflect that.