### PR TITLE
service/test: reduce TestGoroutinesGrouping runtime

### DIFF
--- a/_fixtures/goroutinegroup.go
+++ b/_fixtures/goroutinegroup.go
@@ -59,7 +59,7 @@ func main() {
 
 	for _, lbl := range []string{"one", "two", "three", "four", "five"} {
 		for _, f := range []func(*sync.WaitGroup, string){startpoint1, startpoint2, startpoint3, startpoint4, startpoint5} {
-			for i := 0; i < 1000; i++ {
+			for i := 0; i < 10; i++ {
 				wg.Add(5)
 				gopoint1(&wg, lbl, f)
 				gopoint2(&wg, lbl, f)
@@ -69,7 +69,7 @@ func main() {
 			}
 		}
 	}
-	time.Sleep(2 * time.Second)
+	time.Sleep(10 * time.Millisecond)
 	runtime.Breakpoint()
 	wg.Wait()
 }

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -2594,7 +2594,12 @@ func TestGoroutinesGrouping(t *testing.T) {
 	withTestClient2("goroutinegroup", t, func(c service.Client) {
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue")
-		_, ggrp, _, _, err := c.ListGoroutinesWithFilter(0, 0, nil, &api.GoroutineGroupingOptions{GroupBy: api.GoroutineLabel, GroupByKey: "name", MaxGroupMembers: 5, MaxGroups: 10}, nil)
+		_, ggrp, _, _, err := c.ListGoroutinesWithFilter(0, 0, nil, &api.GoroutineGroupingOptions{
+			GroupBy:         api.GoroutineLabel,
+			GroupByKey:      "name",
+			MaxGroupMembers: 5,
+			MaxGroups:       10,
+		}, nil)
 		assertNoError(err, t, "ListGoroutinesWithFilter (group by label)")
 		t.Logf("%#v\n", ggrp)
 		if len(ggrp) < 5 {


### PR DESCRIPTION
The test was spinning up more goroutines than necessary and was sleeping longer than necessary, casuing the test to run for a really long time and often timeout. Reduce both goroutine count and sleep time. Test still passes, as the test is based on goroutine groups not total count of goroutines.