### PR TITLE
pkg/proc: optimize range body lookup cost by trie searching and use moduledata cache to reduce LoadModuleData cost

### DIFF
--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -149,7 +149,7 @@ func dwarfToRuntimeType(bi *BinaryInfo, mem MemoryReadWriter, typ godwarf.Type) 
 		return 0, false, false, nil
 	}
 
-	mds, err := LoadModuleData(bi, mem)
+	mds, err := bi.getModuleData(mem)
 	if err != nil {
 		return 0, false, false, err
 	}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -2132,7 +2132,7 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool, cfg LoadConfig
 		return
 	}
 
-	mds, err := LoadModuleData(_type.bi, _type.mem)
+	mds, err := _type.bi.getModuleData(_type.mem)
 	if err != nil {
 		v.Unreadable = fmt.Errorf("error loading module data: %v", err)
 		return


### PR DESCRIPTION
Fixes #4112 