### PR TITLE
pkg/proc: add support for function calls on loong64

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1057,7 +1057,7 @@ func (stack *evalStack) run() {
 					regs, _ := curthread.Registers()
 					setSP(curthread, regs.SP()+uint64(scope.BinInfo.Arch.PtrSize()))
 					setPC(curthread, fncall.undoInjection.oldpc)
-				case "arm64", "ppc64le":
+				case "arm64", "ppc64le", "loong64":
 					setLR(curthread, fncall.undoInjection.oldlr)
 					setPC(curthread, fncall.undoInjection.oldpc)
 				default:

--- a/pkg/proc/loong64_arch.go
+++ b/pkg/proc/loong64_arch.go
@@ -35,11 +35,13 @@ func LOONG64Arch(goos string) *Arch {
 		PCRegNum:                         regnum.LOONG64_PC,
 		SPRegNum:                         regnum.LOONG64_SP,
 		ContextRegNum:                    regnum.LOONG64_R0 + 29,
+		LRRegNum:                         regnum.LOONG64_LR,
 		asmRegisters:                     loong64AsmRegisters,
 		RegisterNameToDwarf:              nameToDwarfFunc(regnum.LOONG64NameToDwarf),
 		RegnumToString:                   regnum.LOONG64ToName,
 		debugCallMinStackSize:            280,
 		maxRegArgBytes:                   16*8 + 16*8, // 16 int argument registers plus 16 float argument registers
+		argumentRegs:                     []int{regnum.LOONG64_R0 + 4, regnum.LOONG64_R0 + 5, regnum.LOONG64_R0 + 6},
 	}
 }
 

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -252,7 +252,7 @@ func (t *Target) Valid() (bool, error) {
 // Currently only non-recorded processes running on AMD64 support
 // function calls.
 func (t *Target) SupportsFunctionCalls() bool {
-	return t.Process.BinInfo().Arch.Name == "amd64" || (t.Process.BinInfo().Arch.Name == "arm64" && t.Process.BinInfo().GOOS != "windows") || t.Process.BinInfo().Arch.Name == "ppc64le"
+	return t.Process.BinInfo().Arch.Name == "amd64" || (t.Process.BinInfo().Arch.Name == "arm64" && t.Process.BinInfo().GOOS != "windows") || t.Process.BinInfo().Arch.Name == "ppc64le" || t.Process.BinInfo().Arch.Name == "loong64"
 }
 
 // ClearCaches clears internal caches that should not survive a restart.

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -322,7 +322,9 @@ func MustSupportFunctionCalls(t *testing.T, testBackend string) {
 		t.Skip(fmt.Errorf("%s does not support FunctionCall for now", runtime.GOARCH))
 	}
 	if runtime.GOARCH == "loong64" {
-		t.Skip(fmt.Errorf("%s does not support FunctionCall for now", runtime.GOARCH))
+		if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) {
+			t.Skip("function calls not supported on loong64 with Go < 1.24")
+		}
 	}
 	if runtime.GOARCH == "arm64" {
 		if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 19) || runtime.GOOS == "windows" {


### PR DESCRIPTION
This change enables function call support on loong64, which was previously unsupported for Go versions before 1.24. With this patch, users can now evaluate expressions and perform function calls when debugging on loong64.