### PR TITLE
service: remember that we attached in WaitFor attach mode

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -192,6 +192,7 @@ func New(config *Config, processArgs []string) (*Debugger, error) {
 			err = noDebugErrorWarning(err)
 			return nil, attachErrorMessage(d.config.AttachPid, err)
 		}
+		d.config.AttachPid = d.target.Selected.Pid()
 
 	case d.config.CoreFile != "":
 		var err error

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -731,9 +731,7 @@ type AttachedToExistingProcessOut struct {
 
 // AttachedToExistingProcess returns whether we attached to a running process or not
 func (s *RPCServer) AttachedToExistingProcess(arg AttachedToExistingProcessIn, out *AttachedToExistingProcessOut) error {
-	if s.config.Debugger.AttachPid != 0 {
-		out.Answer = true
-	}
+	out.Answer = s.debugger.AttachPid() != 0
 	return nil
 }
 


### PR DESCRIPTION
Save the attached to PID to the configuration when WaitFor is used so
that we later know that we attached and behave identically to when the
normal attach command is used, particularly with respect to killing the
process on exit.

Fixes #4119
