### PR TITLE
proc,service,terminal: allow cancelling of debuginfod downloads

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -88,7 +88,7 @@ Command | Description
 [exit](#exit) | Exit the debugger.
 [funcs](#funcs) | Print list of functions.
 [help](#help) | Prints the help message.
-[libraries](#libraries) | List loaded dynamic libraries
+[libraries](#libraries) | List loaded dynamic libraries.
 [list](#list) | Show source code.
 [packages](#packages) | Print list of packages.
 [source](#source) | Executes a file containing a list of delve commands
@@ -511,7 +511,11 @@ Type "help" followed by the name of a command for more information about it.
 Aliases: h
 
 ## libraries
-List loaded dynamic libraries
+List loaded dynamic libraries.
+	
+	libraries [-d N]
+
+If used with the -d option it will re-attempt to download the debug symbols for library N, using debuginfod-find.
 
 
 ## list

--- a/_fixtures/fake-debuginfod-find/debuginfod-find
+++ b/_fixtures/fake-debuginfod-find/debuginfod-find
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for i in $(seq 1 100000 1000000); do
+	echo "Downloading $i..." >&2
+	sleep 1
+done
+
+echo "i-dont-actually-have-a-path-im-a-fake-stub-sorry"

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -131,6 +131,11 @@ func (grp *TargetGroup) Continue() error {
 			if err != nil {
 				logflags.DebuggerLogger().Errorf("could not clear inactivated stepping breakpoints: %v", err)
 			}
+			bi := it.BinInfo()
+			bi.cancelDownloadsMu.Lock()
+			bi.downloadsCtx = nil
+			bi.cancelDownloads = nil
+			bi.cancelDownloadsMu.Unlock()
 		}
 
 		if contOnceErr != nil {

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -543,6 +543,21 @@ func (grp *TargetGroup) SetEventsFn(eventsFn func(*Event)) {
 	grp.Selected.BinInfo().eventsFn = eventsFn
 }
 
+// CancelDownloads cancels ongoing downloads, if any.
+func (grp *TargetGroup) CancelDownloads() bool {
+	r := false
+	it := ValidTargets{Group: grp}
+	for it.Next() {
+		it.BinInfo().cancelDownloadsMu.Lock()
+		if it.BinInfo().cancelDownloads != nil {
+			it.BinInfo().cancelDownloads()
+			r = true
+		}
+		it.BinInfo().cancelDownloadsMu.Unlock()
+	}
+	return r
+}
+
 // ValidTargets iterates through all valid targets in Group.
 type ValidTargets struct {
 	*Target

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -569,7 +569,11 @@ Adds, removes or clears debug-info-directories.`},
 	edit [locspec]
 	
 If locspec is omitted edit will open the current source file in the editor, otherwise it will open the specified location.`},
-		{aliases: []string{"libraries"}, cmdFn: libraries, helpMsg: `List loaded dynamic libraries`},
+		{aliases: []string{"libraries"}, cmdFn: libraries, helpMsg: `List loaded dynamic libraries.
+	
+	libraries [-d N]
+
+If used with the -d option it will re-attempt to download the debug symbols for library N, using debuginfod-find.`},
 
 		{aliases: []string{"examinemem", "x"}, group: dataCmds, cmdFn: examineMemoryCmd, helpMsg: `Examine raw memory at the given address.
 
@@ -2685,6 +2689,21 @@ func disassCommand(t *Term, ctx callContext, args string) error {
 }
 
 func libraries(t *Term, ctx callContext, args string) error {
+	argv := config.Split2PartsBySpace(args)
+	if len(argv) == 2 {
+		switch argv[0] {
+		case "-d":
+			n, err := strconv.Atoi(argv[1])
+			if err != nil {
+				return err
+			}
+			t.client.DownloadLibraryDebugInfo(n)
+		default:
+			return errors.New("wrong arguments")
+		}
+		return nil
+	}
+
 	libs, err := t.client.ListDynamicLibraries()
 	if err != nil {
 		return err

--- a/service/client.go
+++ b/service/client.go
@@ -211,6 +211,11 @@ type Client interface {
 	// GuessSubstitutePath tries to guess a substitute-path configuration for the client
 	GuessSubstitutePath() ([][2]string, error)
 
+	// CancelDownloads cancels binary info downloads, if any.
+	CancelDownloads() error
+	// DownloadLibraryDebugInfo attempts to download the specified library's debug info.
+	DownloadLibraryDebugInfo(n int) error
+
 	// CallAPI allows calling an arbitrary rpc method (used by starlark bindings)
 	CallAPI(method string, args, reply any) error
 }

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2140,6 +2140,9 @@ func (s *Session) stepUntilStopAndNotify(command string, threadId int, granulari
 // onPauseRequest handles 'pause' request.
 // This is a mandatory request to support.
 func (s *Session) onPauseRequest(request *dap.PauseRequest) {
+	if s.debugger.CancelDownloads() {
+		return
+	}
 	s.changeStateMu.Lock()
 	defer s.changeStateMu.Unlock()
 	s.setHaltRequested(true)
@@ -4059,7 +4062,7 @@ func (s *Session) convertDebuggerEvent(event *proc.Event) {
 		s.send(&dap.OutputEvent{
 			Event: *newEvent("output"),
 			Body: dap.OutputEventBody{
-				Output:   fmt.Sprintf("Download debug info for %s: %s\n", event.BinaryInfoDownloadEventDetails.ImagePath, event.BinaryInfoDownloadEventDetails.Progress),
+				Output:   fmt.Sprintf("Download debug info for %s: %s (pause again to cancel)\n", event.BinaryInfoDownloadEventDetails.ImagePath, event.BinaryInfoDownloadEventDetails.Progress),
 				Category: "console",
 			},
 		})

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2462,6 +2462,21 @@ func (d *Debugger) GuessSubstitutePath(args *api.GuessSubstitutePathIn) map[stri
 	})
 }
 
+// CancelDownloads cancels ongoing downloads, if any.
+func (d *Debugger) CancelDownloads() bool {
+	if d.isRecording() {
+		return false
+	}
+	return d.target.CancelDownloads()
+}
+
+// DownloadLibraryDebugInfo attempts to download the specified library's debug info.
+func (d *Debugger) DownloadLibraryDebugInfo(n int) error {
+	d.targetMutex.Lock()
+	defer d.targetMutex.Unlock()
+	return d.target.Selected.BinInfo().LoadImageBinaryInfoAgain(n)
+}
+
 func guessSubstitutePath(args *api.GuessSubstitutePathIn, bins [][]proc.Function, fileForFunc func(int, *proc.Function) string) map[string]string {
 	serverMod2Dir := map[string]string{}
 	serverMod2DirCandidate := map[string]map[string]int{}

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -693,7 +693,17 @@ func (c *RPCClient) GuessSubstitutePath() ([][2]string, error) {
 	return out.List, err
 }
 
-func (c *RPCClient) call(method string, args, reply any) error {
+func (c *RPCClient) CancelDownloads() error {
+	out := &CancelDownloadsOut{}
+	return c.call("CancelDownloads", CancelDownloadsIn{}, out)
+}
+
+func (c *RPCClient) DownloadLibraryDebugInfo(n int) error {
+	out := DownloadLibraryDebugInfoOut{}
+	return c.call("DownloadLibraryDebugInfo", DownloadLibraryDebugInfoIn{n}, out)
+}
+
+func (c *RPCClient) call(method string, args, reply interface{}) error {
 	return c.client.Call("RPCServer."+method, args, reply)
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -1192,3 +1192,26 @@ func (s *RPCServer) GetEvents(arg GetEventsIn, cb service.RPCCallback) {
 	}
 	cb.Return(out, nil)
 }
+
+type CancelDownloadsIn struct {
+}
+
+type CancelDownloadsOut struct {
+}
+
+func (s *RPCServer) CancelDownloads(arg CancelDownloadsIn, cb service.RPCCallback) {
+	close(cb.SetupDoneChan())
+	s.debugger.CancelDownloads()
+	cb.Return(new(CancelDownloadsOut), nil)
+}
+
+type DownloadLibraryDebugInfoIn struct {
+	N int
+}
+
+type DownloadLibraryDebugInfoOut struct {
+}
+
+func (s *RPCServer) DownloadLibraryDebugInfo(arg DownloadLibraryDebugInfoIn, out DownloadLibraryDebugInfoOut) error {
+	return s.debugger.DownloadLibraryDebugInfo(arg.N)
+}

--- a/service/rpccommon/suitablemethods.go
+++ b/service/rpccommon/suitablemethods.go
@@ -12,6 +12,7 @@ func suitableMethods2(s *rpc2.RPCServer, methods map[string]*methodType) {
 	methods["RPCServer.Ancestors"] = &methodType{method: reflect.ValueOf(s.Ancestors)}
 	methods["RPCServer.AttachedToExistingProcess"] = &methodType{method: reflect.ValueOf(s.AttachedToExistingProcess)}
 	methods["RPCServer.BuildID"] = &methodType{method: reflect.ValueOf(s.BuildID)}
+	methods["RPCServer.CancelDownloads"] = &methodType{method: reflect.ValueOf(s.CancelDownloads)}
 	methods["RPCServer.CancelNext"] = &methodType{method: reflect.ValueOf(s.CancelNext)}
 	methods["RPCServer.Checkpoint"] = &methodType{method: reflect.ValueOf(s.Checkpoint)}
 	methods["RPCServer.ClearBreakpoint"] = &methodType{method: reflect.ValueOf(s.ClearBreakpoint)}
@@ -23,6 +24,7 @@ func suitableMethods2(s *rpc2.RPCServer, methods map[string]*methodType) {
 	methods["RPCServer.DebugInfoDirectories"] = &methodType{method: reflect.ValueOf(s.DebugInfoDirectories)}
 	methods["RPCServer.Detach"] = &methodType{method: reflect.ValueOf(s.Detach)}
 	methods["RPCServer.Disassemble"] = &methodType{method: reflect.ValueOf(s.Disassemble)}
+	methods["RPCServer.DownloadLibraryDebugInfo"] = &methodType{method: reflect.ValueOf(s.DownloadLibraryDebugInfo)}
 	methods["RPCServer.DumpCancel"] = &methodType{method: reflect.ValueOf(s.DumpCancel)}
 	methods["RPCServer.DumpStart"] = &methodType{method: reflect.ValueOf(s.DumpStart)}
 	methods["RPCServer.DumpWait"] = &methodType{method: reflect.ValueOf(s.DumpWait)}

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3344,3 +3344,33 @@ func TestFollowExecFindLocation(t *testing.T) {
 		assertNoError(err, t, "FindLocation(spawn.go:19)")
 	})
 }
+
+func TestCancelDownload(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	fakedebuginfodDir, _ := filepath.Abs(filepath.Join(protest.FindFixturesDir(), "fake-debuginfod-find"))
+	t.Setenv("PATH", os.ExpandEnv(fakedebuginfodDir+":$PATH"))
+	withTestClient2("cgotest", t, func(c service.Client) {
+		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main"})
+		assertNoError(err, t, "CreateBreakpoint")
+		eventReceived := false
+		c.SetEventsFn(func(ev *api.Event) {
+			switch ev.Kind {
+			case api.EventBinaryInfoDownload:
+				eventReceived = true
+				t.Logf("download event: %q %q", ev.BinaryInfoDownloadEventDetails.ImagePath, ev.BinaryInfoDownloadEventDetails.Progress)
+				assertNoError(c.CancelDownloads(), t, "CancelDownloads")
+			}
+		})
+		t0 := time.Now()
+		state := <-c.Continue()
+		assertNoError(state.Err, t, "Continue")
+		if !eventReceived {
+			t.Errorf("Download event was not received")
+		}
+		if time.Since(t0) > 3*time.Second {
+			t.Errorf("Continue took to long, we probably couldn't cancel the download")
+		}
+	})
+}


### PR DESCRIPTION
Adds an RPC call to cancel in-progress debuginfod-find downloads. Wires
this call to ^C in the terminal interface and to receiving a Pause
request while already pausing in DAP.

Adds a new terminal command to download the debug info for libraries
for which it hasn't been downloaded already.

Fixes #3906
