### PR TITLE
support_sentinel_linux.go: Fixed the ppc64le clause in the file to  prevent build failures

### DIFF
--- a/pkg/proc/native/support_sentinel_linux.go
+++ b/pkg/proc/native/support_sentinel_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !amd64 && !arm64 && !386 && !(ppc64le && exp.linuxppc64le) && !(riscv64 && exp.linuxriscv64) && !(loong64 && exp.linuxloong64)
+//go:build linux && !amd64 && !arm64 && !386 && !(riscv64 && exp.linuxriscv64) && !(loong64 && exp.linuxloong64) && !ppc64le
 
 // This file is used to detect build on unsupported GOOS/GOARCH combinations.
 


### PR DESCRIPTION
-Delve is now being built for ppc64le, so support_sentinel_linux.go should not be compiled for that architecture.

-This prevents build errors due to conflicting packages when compiling on ppc64le.