### PR TITLE
terminal: trace /regexp/ should set ret breakpoints correctly

### DIFF
--- a/_fixtures/traceret.go
+++ b/_fixtures/traceret.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+func fncall1() int {
+	return 1
+}
+
+func fncall2() int {
+	return 2
+}
+
+func main() {
+	fmt.Println(fncall1())
+	fmt.Println(fncall2())
+}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -1915,12 +1915,12 @@ func setBreakpoint(t *Term, ctx callContext, tracepoint bool, argstr string) ([]
 	case *locspec.RegexLocationSpec:
 		shouldSetReturnBreakpoints = true
 	}
-	if tracepoint && shouldSetReturnBreakpoints && locs[0].Function != nil {
+	if tracepoint && shouldSetReturnBreakpoints {
 		for i := range locs {
 			if locs[i].Function == nil {
 				continue
 			}
-			addrs, err := t.client.(*rpc2.RPCClient).FunctionReturnLocations(locs[0].Function.Name())
+			addrs, err := t.client.(*rpc2.RPCClient).FunctionReturnLocations(locs[i].Function.Name())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1601,3 +1601,17 @@ func TestBreakPointFailWithCond(t *testing.T) {
 		}
 	})
 }
+
+func TestTraceRegexpReturn(t *testing.T) {
+	withTestTerminal("traceret", t, func(term *FakeTerminal) {
+		out, err := term.Exec(`trace /main\.fncall./`)
+		if err != nil {
+			t.Errorf("error executing trace command: %v", err)
+		}
+		out, _ = term.Exec("continue")
+		t.Logf("continue: %q", out)
+		if out != "> goroutine(1): main.fncall1()\n>> goroutine(1): main.fncall1 => (1)\n> goroutine(1): main.fncall2()\n>> goroutine(1): main.fncall2 => (2)\n" {
+			t.Errorf("wrong output for continue")
+		}
+	})
+}


### PR DESCRIPTION
Fix the way the trace command sets return breakpoints when a regexp is passed.

Fixes #4036
