### PR TITLE
terminal: add shortcut syntax to starlark to access target vars

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -102,6 +102,8 @@ If the command function has a doc string it will be used as a help message.
 
 Variables of the target program can be accessed using `local_vars`, `function_args` or the `eval` functions. Each variable will be returned as a [Variable](https://pkg.go.dev/github.com/go-delve/delve/service/api#Variable) struct, with one special field: `Value`.
 
+As a convenience a special global object exists, called `tgt`: evaluating `tgt.varname` is equivalent to evaluating `eval(None, "varname").Variable.Value`.
+
 ## Variable.Value
 
 The `Value` field will return the value of the target variable converted to a starlark value:

--- a/pkg/terminal/starbind/conv.go
+++ b/pkg/terminal/starbind/conv.go
@@ -749,3 +749,41 @@ func unmarshalStarlarkValueIntl(val starlark.Value, dst reflect.Value, path stri
 	}
 	return nil
 }
+
+var _ starlark.HasAttrs = starlarkTargetObject{}
+
+type starlarkTargetObject struct {
+	env *Env
+}
+
+func (starlarkTargetObject) Freeze() {
+}
+
+func (starlarkTargetObject) Hash() (uint32, error) {
+	return 0, errors.New("not hashable")
+}
+
+func (starlarkTargetObject) String() string {
+	return "<target variables>"
+}
+
+func (starlarkTargetObject) Truth() starlark.Bool {
+	return true
+}
+
+func (starlarkTargetObject) Type() string {
+	return "<target variables>"
+}
+
+func (tgt starlarkTargetObject) AttrNames() []string {
+	return nil
+}
+
+func (tgt starlarkTargetObject) Attr(name string) (starlark.Value, error) {
+	env := tgt.env
+	v, err := env.ctx.Client().EvalVariable(env.ctx.Scope(), name, env.ctx.LoadConfig())
+	if err != nil {
+		return starlark.None, fmt.Errorf("could not find variable %q: %v", name, err)
+	}
+	return env.variableValueToStarlarkValue(v, true)
+}

--- a/pkg/terminal/starbind/starlark.go
+++ b/pkg/terminal/starbind/starlark.go
@@ -31,6 +31,7 @@ const (
 	dlvContextName               = "dlv_context"
 	curScopeBuiltinName          = "cur_scope"
 	defaultLoadConfigBuiltinName = "default_load_config"
+	targetObjectName             = "tgt"
 	helpBuiltinName              = "help"
 )
 
@@ -139,6 +140,8 @@ func New(ctx Context, out EchoWriter) *Env {
 	})
 	builtindoc(defaultLoadConfigBuiltinName, "()", "returns the default load configuration.")
 
+	env.env[targetObjectName] = starlarkTargetObject{env}
+
 	env.env[helpBuiltinName] = starlark.NewBuiltin(helpBuiltinName, func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		switch len(args) {
 		case 0:
@@ -154,6 +157,7 @@ func New(ctx Context, out EchoWriter) *Env {
 			for _, bin := range bins {
 				fmt.Fprintf(env.out, "\t%s\n", bin)
 			}
+			fmt.Fprintf(env.out, "\n\nUse tgt.varname to access the varname variable in the target process (it is equivalent to 'eval(None, \"varname\").Variable.Value').\n")
 		case 1:
 			switch x := args[0].(type) {
 			case *starlark.Builtin:

--- a/pkg/terminal/starlark_test.go
+++ b/pkg/terminal/starlark_test.go
@@ -182,6 +182,12 @@ func TestStarlarkVariable(t *testing.T) {
 			{`v = eval(None, "s2").Variable; print(v.Value[1].A)`, "3"},
 			{`v = eval(None, "s2").Variable; print(v.Value[1].A + 10)`, "13"},
 			{`v = eval(None, "s2").Variable; print(v.Value[1]["B"])`, "4"},
+
+			// Using target object
+			{`print(tgt.i1)`, "1"},
+			{`print(tgt.m1["Malone"])`, "main.astruct {A: 2, B: 3}"},
+			{`print(tgt.c1.pb)`, "*main.bstruct {a: main.astruct {A: 1, B: 2}}"},
+			{`print(tgt.c1.pb.a.B)`, "2"},
 		} {
 			out := strings.TrimSpace(term.MustExecStarlark(tc.expr))
 			if out != tc.tgt {


### PR DESCRIPTION
Adds a special global variable to the starlark environment to simplify
access to the target process variables.

The expression `tgt.varname` is equivalent to

    eval(None, "varname").Variable.Value
