### PR TITLE
debugger: check that breakpoint exists in ClearBreakpoint

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -915,10 +915,16 @@ func (d *Debugger) ClearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint
 			return nil, ErrNotImplementedWithMultitarget
 		}
 		bp := d.target.Selected.Breakpoints().M[requestedBp.Addr]
+		if bp == nil {
+			return nil, fmt.Errorf("no breakpoint at address %#x", requestedBp.Addr)
+		}
 		requestedBp.ID = bp.LogicalID()
 	}
 
 	lbp := d.target.LogicalBreakpoints[requestedBp.ID]
+	if lbp == nil {
+		return nil, fmt.Errorf("no breakpoint with ID %d", requestedBp.ID)
+	}
 	clearedBp := d.convertBreakpoint(lbp)
 
 	err := d.target.SetBreakpointEnabled(lbp, false)

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -495,6 +495,14 @@ func TestClientServer_clearBreakpoint(t *testing.T) {
 			t.Fatalf("Expected breakpoint count %d, got %d", e, a)
 		}
 
+		const nonExistentBreakpointId = 9999
+		if bp.ID != nonExistentBreakpointId {
+			_, err := c.ClearBreakpoint(nonExistentBreakpointId)
+			if err == nil {
+				t.Fatalf("Expected error, got none deleting non-existent breakpoint")
+			}
+		}
+
 		deleted, err := c.ClearBreakpoint(bp.ID)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
ClearBreakpoint should check that the breakpoint exists before trying
to manipulate it.

Fixes #4137
