### PR TITLE
teamcity: add linux/loong64 to configuration

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -53,6 +53,9 @@ val targets = arrayOf(
 
         "linux/ppc64le/1.25",
 
+        "linux/loong64/1.25",
+        "linux/loong64/tip",
+
         "windows/amd64/1.25",
         "windows/amd64/tip",
 
@@ -270,6 +273,7 @@ class TestBuild(val os: String, val arch: String, val version: String, buildId: 
             "arm64" -> equals("teamcity.agent.jvm.os.arch", "aarch64")
             "ppc64le" -> equals("teamcity.agent.jvm.os.arch", "ppc64le")
             // "riscv64" -> equals("teamcity.agent.jvm.os.arch", "riscv64") // The riscv64 needs a builder
+            "loong64" -> equals("teamcity.agent.jvm.os.arch", "loongarch64")
         }
         when (os) {
             "linux" -> {


### PR DESCRIPTION
Hi, the CI machine for loong64 is now ready, and the TeamCity agent is already running on it.

Here is the agent configuration (conf/buildAgent.properties):
```
serverUrl=https://delve.teamcity.com
name=Linux-loong64-1
```