### PR TITLE
proc: simplify and rename structMember

### DIFF
--- a/_scripts/rtype.go
+++ b/_scripts/rtype.go
@@ -37,14 +37,14 @@
 // 	all calls to:
 //		v.loadFieldNamed
 //		v.fieldVariable
-//		v.structMember
+//		v.structField
 //	and check that type T has the specified fields.
 //
 // v.loadFieldNamed("F") // +rtype T
 // v.loadFieldNamed("F") // +rtype -opt T
 //
 // 	checks that field F of the struct type declared for v has type T. Can
-// 	also be used for fieldVariable, structMember and, inside parseG,
+// 	also be used for fieldVariable, structField and, inside parseG,
 // 	loadInt64Maybe.
 // 	The -opt flag specifies that the field can be missing (but if it exists
 // 	it must have type T).
@@ -439,7 +439,7 @@ func processProcVariableUses(decl ast.Node, tinfo *types.Info, procVarIdent *ast
 		}
 
 		switch methodName {
-		case "loadFieldNamed", "fieldVariable", "loadInt64Maybe", "structMember":
+		case "loadFieldNamed", "fieldVariable", "loadInt64Maybe", "structField":
 			rtcmntIdx := -1
 			if cmntgrps := cmntmap[lastStmt]; len(cmntgrps) > 0 && len(cmntgrps[0].List) > 0 {
 				rtcmntIdx = findComment(cmntgrps[0].List[0].Slash, rtcmnts)

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -341,9 +341,6 @@ func TestGeneratedDoc(t *testing.T) {
 		//TODO(alexsaezm): finish CI integration
 		t.Skip("skipping test on Linux/PPC64LE in CI")
 	}
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) {
-		t.Skip("disabled due to export format changes")
-	}
 	// Checks gen-cli-docs.go
 	var generatedBuf bytes.Buffer
 	commands := terminal.DebugCommands(nil)

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -253,7 +253,7 @@ func (scope *EvalScope) ChanGoroutines(expr string, start, count int) ([]int64, 
 	structMemberMulti := func(v *Variable, names ...string) *Variable {
 		for _, name := range names {
 			var err error
-			v, err = v.structMember(name)
+			v, err = v.structField(name)
 			if err != nil {
 				return nil
 			}
@@ -297,7 +297,7 @@ func (scope *EvalScope) ChanGoroutines(expr string, start, count int) ([]int64, 
 				goids = append(goids, goid)
 			}
 
-			nextVar, err := qvar.structMember("next")
+			nextVar, err := qvar.structField("next")
 			if err != nil {
 				return err
 			}

--- a/pkg/proc/moduledata.go
+++ b/pkg/proc/moduledata.go
@@ -34,7 +34,7 @@ func LoadModuleData(bi *BinaryInfo, mem MemoryReadWriter) ([]ModuleData, error) 
 
 		for _, fieldName := range []string{typesField, etypesField, textField, etextField, nextField, typemapField} {
 			var err error
-			vars[fieldName], err = md.structMember(fieldName)
+			vars[fieldName], err = md.structField(fieldName)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -669,9 +669,9 @@ func (it *stackIterator) loadG0SchedSP() {
 	}
 	it.g0_sched_sp_loaded = true
 	if it.g != nil {
-		mvar, _ := it.g.variable.structMember("m")
+		mvar, _ := it.g.variable.structField("m")
 		if mvar != nil {
-			g0var, _ := mvar.structMember("g0")
+			g0var, _ := mvar.structField("g0")
 			if g0var != nil {
 				g0, _ := g0var.parseG()
 				if g0 != nil {

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -343,7 +343,7 @@ func setAsyncPreemptOff(p *Target, v int64) {
 		logger.Warnf("runtime/debug variable unreadable: %v", err, debugv.Unreadable)
 		return
 	}
-	asyncpreemptoffv, err := debugv.structMember("asyncpreemptoff") // +rtype int32
+	asyncpreemptoffv, err := debugv.structField("asyncpreemptoff") // +rtype int32
 	if err != nil {
 		logger.Warnf("could not find asyncpreemptoff field: %v", err)
 		return

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -1766,7 +1766,7 @@ func stepIntoCoroutineMaybe(curthread Thread, p *Target, text []AsmInstruction) 
 	// runtime.coro (it is normally iter.coro, which is an internal
 	// placeholder).
 
-	cvar, err := clos.structMember("c")
+	cvar, err := clos.structField("c")
 	if err != nil {
 		logflags.DebuggerLogger().Errorf("iter.Pull problems accessing captured 'c' variable in closure: %v", err)
 		return false, nil


### PR DESCRIPTION
With the recent changes in 1e3ccee (#4118) structMember became largely
reduntant with the new findStructMemberOrMethod. This commit simplifies
the code of structMember so that it does not handle embedded structs
and interfaces and changes its name to structField so that it can be
kept as an internal lightweight version of findStructMemberOrMethod.
