### PR TITLE
proc: produce materialized breakpoint event for follow-exec mode

### DIFF
--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -579,7 +579,7 @@ func (t *Target) pluginOpenCallback(Thread, *Target) (bool, error) {
 	logger := logflags.DebuggerLogger()
 	for _, lbp := range t.Breakpoints().Logical {
 		// If the breakpoint is suspended, materialize it.
-		if !isSuspended(t, lbp) {
+		if !lbp.isSuspendedOnTarget(t) {
 			continue
 		}
 
@@ -604,9 +604,19 @@ func (t *Target) pluginOpenCallback(Thread, *Target) (bool, error) {
 	return false, nil
 }
 
-func isSuspended(t *Target, lbp *LogicalBreakpoint) bool {
+func (lbp *LogicalBreakpoint) isSuspendedOnTarget(t *Target) bool {
 	for _, bp := range t.Breakpoints().M {
 		if bp.LogicalID() == lbp.LogicalID {
+			return false
+		}
+	}
+	return true
+}
+
+func (lbp *LogicalBreakpoint) isSuspendedOnGroup(grp *TargetGroup) bool {
+	it := ValidTargets{Group: grp}
+	for it.Next() {
+		if !lbp.isSuspendedOnTarget(it.Target) {
 			return false
 		}
 	}

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3325,8 +3325,20 @@ func TestFollowExecFindLocation(t *testing.T) {
 		_, err := c.CreateBreakpointWithExpr(&api.Breakpoint{File: childFixture.Source, Line: 9}, fmt.Sprintf("%s:%d", childFixture.Source, 9), nil, true)
 		assertNoError(err, t, "CreateBreakpoint(spawnchild.go:9)")
 
+		gotBreakpointMaterialized := false
+		c.SetEventsFn(func(ev *api.Event) {
+			t.Logf("event = %#v", ev)
+			if ev.Kind == api.EventBreakpointMaterialized {
+				gotBreakpointMaterialized = true
+			}
+		})
+
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue()")
+
+		if !gotBreakpointMaterialized {
+			t.Error("did not get a breakpoint materialized event")
+		}
 
 		tgts, err := c.ListTargets()
 		assertNoError(err, t, "ListTargets")


### PR DESCRIPTION
When a previously suspended breakpoint is un-suspended we should
generate a BreakpointMaterialized event, we already did this when
breakpoints were materialized by opening plugins but we forgot to do it
when targets are added by follow-exec mode.
