### PR TITLE
cmd/dlv: prevent trace killing attached process

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -704,6 +704,8 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 		}
 
 		var debugname string
+
+		shouldKill := true
 		if traceAttachPid == 0 {
 			if dlvArgsLen >= 2 && traceExecFile != "" {
 				fmt.Fprintln(os.Stderr, "Cannot specify package when using --exec.")
@@ -721,6 +723,8 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 			}
 
 			processArgs = append([]string{debugname}, targetArgs...)
+		} else {
+			shouldKill = false
 		}
 		if dlvArgsLen >= 3 && traceFollowCalls <= 0 {
 			fmt.Fprintln(os.Stderr, "Need to specify a trace depth of at least 1")
@@ -753,7 +757,7 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 			return 1
 		}
 		client := rpc2.NewClientFromConn(clientConn)
-		defer client.Detach(true)
+		defer client.Detach(shouldKill)
 
 		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, syscall.SIGINT)

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1070,6 +1071,11 @@ func TestTracePid(t *testing.T) {
 
 	if !bytes.Contains(output, expected) {
 		t.Fatalf("expected:\n%s\ngot:\n%s", string(expected), string(output))
+	}
+
+	err = targetCmd.Process.Signal(syscall.Signal(0))
+	if err != nil {
+		t.Fatalf("expected target process running after trace detached: %v", err)
 	}
 }
 


### PR DESCRIPTION
When using `dlv trace --pid`, the process should continue running after detach.

This change only kills the process when dlv started it, not when attaching to an existing process.