### PR TITLE
service/debugger: use address in ClearBreakpoint only when ID is 0

### DIFF
--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -911,7 +911,7 @@ func (d *Debugger) copyLogicalBreakpointInfo(lbp *proc.LogicalBreakpoint, reques
 func (d *Debugger) ClearBreakpoint(requestedBp *api.Breakpoint) (*api.Breakpoint, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
-	if requestedBp.ID <= 0 {
+	if requestedBp.ID == 0 {
 		if len(d.target.Targets()) != 1 {
 			return nil, ErrNotImplementedWithMultitarget
 		}


### PR DESCRIPTION
We've always said that predefined breakpoints (like the
unrecovered-panic breakpoint) are just like any other breakpoint and
clients can remove them by using the ClearBreakpoint API.

However commit 78471b3a in 2022 made this not true by treating negative
IDs (which is what we assign to predefined breakpoints) specially.

That change was made as part of a series of changes to support
debugging child processes: prior to that change breakpoints were
cleared by address only (which worked fine for predefined breakpoints)
but this was not tenable for multiprocess debugging.

So ClearBreakpoint was changed to clear breakpoints by breakpoint ID
and only use address in a backward compatibility mode when no ID was
specified.

The current implementation of ClearBreakpoint works fine for user
breakpoints in all cases and for predefined breakpoints as long as
there is only one target process (clearing a predefined breakpoint will
be processed in backwards compatibility mode using its address).

However it should be possible to clear predefined breakpoints even when
Delve is attached to multiple processes. For this reason limit the
backwards compatibility mode of ClearBreakpoint to only ID == 0,
sparing negative IDs as valid.
