### PR TITLE
pkg/proc: split off rangeParent from function extras

### DIFF
--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -855,7 +855,7 @@ func next(dbp *Target, stepInto, inlinedStepOut bool) error {
 			rpoff = rangeFrames[len(rangeFrames)-2].FrameOffset()
 		}
 		rpc := astutil.And(sameGCond, astutil.Eql(astutil.PkgVar("runtime", "rangeParentOffset"), astutil.Int(rpoff)))
-		for _, fn := range rangeParent.extra(bi).rangeBodies {
+		for _, fn := range rangeParent.rangeBodies(bi) {
 			if fn.Entry != 0 {
 				pc, err := FirstPCAfterPrologue(dbp, fn, false)
 				if err != nil {

--- a/pkg/proc/types.go
+++ b/pkg/proc/types.go
@@ -149,7 +149,7 @@ func dwarfToRuntimeType(bi *BinaryInfo, mem MemoryReadWriter, typ godwarf.Type) 
 		return 0, false, false, nil
 	}
 
-	mds, err := bi.getModuleData(mem)
+	mds, err := LoadModuleData(bi, mem)
 	if err != nil {
 		return 0, false, false, err
 	}

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -2141,7 +2141,7 @@ func (v *Variable) loadInterface(recurseLevel int, loadData bool, cfg LoadConfig
 		return
 	}
 
-	mds, err := _type.bi.getModuleData(_type.mem)
+	mds, err := LoadModuleData(_type.bi, _type.mem)
 	if err != nil {
 		v.Unreadable = fmt.Errorf("error loading module data: %v", err)
 		return


### PR DESCRIPTION
The rangeParent calculation was changed 0b74953f0 to address slowness
(due to repeated calculations) when calling PackageVariables. That
changed caused to program to use a lot of memory due to having to
calculate the range bodies of every function. This change reverts
0b74953f0 and splits off rangeBodies calculation from the extras method
of Function, so that it isn't called from PackageVariables.

Fixes #4146
