### PR TITLE
pkg/proc: fix nil pointer dereference when calling extra on a nil func

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -721,6 +721,9 @@ func (fn *Function) rangeParentName() string {
 // extra loads information about fn that is expensive to compute and we
 // only need for a minority of the functions.
 func (fn *Function) extra(bi *BinaryInfo) *functionExtra {
+	if fn == nil {
+		return &functionExtra{}
+	}
 	if fn.extraCache != nil {
 		return fn.extraCache
 	}


### PR DESCRIPTION
Fixes #4172
