### PR TITLE
Add log for build argument

### DIFF
--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-delve/delve/pkg/config"
+	"github.com/go-delve/delve/pkg/logflags"
 )
 
 // Remove the file at path and issue a warning to stderr if this fails.
@@ -128,5 +129,6 @@ func gocommandExecCmd(command string, args ...string) (string, *exec.Cmd) {
 	allargs := []string{command}
 	allargs = append(allargs, args...)
 	goBuild := exec.Command("go", allargs...)
+	logflags.DebuggerLogger().Debugf("gobuild args: %v", allargs)
 	return strings.Join(append([]string{"go"}, allargs...), " "), goBuild
 }


### PR DESCRIPTION
Sometime is useful to find out how delve build code for debug

This maybe useful

In VSCode settings.json
```json
"go.delveConfig": {
        "logOutput": "debugger",
        "showLog": true,
},
```

If too trivial I will close it.

Thanks