### PR TITLE
pkg/dwarf: do not insist stmt is same line as entry

### DIFF
--- a/_fixtures/multinamedreturns.go
+++ b/_fixtures/multinamedreturns.go
@@ -1,0 +1,30 @@
+package main
+
+import "fmt"
+
+//go:noinline
+func ManyArgsWithNamedReturns(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p int) (sum int, product int) {
+	sum = a + b + c + d + e + f + g + h
+	product = 1
+
+	temp1 := i * j
+	temp2 := k * l
+	temp3 := m * n
+	temp4 := o * p
+
+	sum += temp1 + temp2 + temp3 + temp4
+
+	product = (a + 1) * (b + 1) * (c + 1) * (d + 1)
+	product += (e + f) * (g + h) * (i + j) * (k + l)
+	product += (m + n) * (o + p)
+
+	sum = sum * 2
+	product = product / 2
+
+	return sum, product
+}
+
+func main() {
+	sum, product := ManyArgsWithNamedReturns(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+	fmt.Println(sum, product)
+}

--- a/pkg/dwarf/line/state_machine.go
+++ b/pkg/dwarf/line/state_machine.go
@@ -351,21 +351,16 @@ func (lineInfo *DebugLineInfo) PrologueEndPC(start, end uint64) (pc uint64, file
 	}
 }
 
-// FirstStmtForLine looks in the half open interval [start, end) for the
-// first PC address marked as stmt for the line at address 'start'.
-func (lineInfo *DebugLineInfo) FirstStmtForLine(start, end uint64) (pc uint64, file string, line int, ok bool) {
-	first := true
+// FirstStmt looks in the half open interval [start, end) for the
+// first PC address marked as stmt.
+func (lineInfo *DebugLineInfo) FirstStmt(start, end uint64) (pc uint64, file string, line int, ok bool) {
 	sm := lineInfo.stateMachineForEntry(start)
 	for {
 		if sm.valid {
 			if sm.address >= end {
 				return 0, "", 0, false
 			}
-			if first {
-				first = false
-				file, line = sm.file, sm.line
-			}
-			if sm.isStmt && sm.file == file && sm.line == line {
+			if sm.isStmt {
 				return sm.address, sm.file, sm.line, true
 			}
 		}

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -38,7 +38,7 @@ import (
 	"github.com/go-delve/delve/pkg/logflags"
 	"github.com/go-delve/delve/pkg/proc/debuginfod"
 	"github.com/go-delve/delve/pkg/proc/evalop"
-	"github.com/hashicorp/golang-lru/v2"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 const (
@@ -405,7 +405,7 @@ func FirstPCAfterPrologue(p Process, fn *Function, sameline bool) (uint64, error
 		// Look for the first instruction with the stmt flag set, so that setting a
 		// breakpoint with file:line and with the function name always result on
 		// the same instruction being selected.
-		if pc2, _, _, ok := fn.cu.lineInfo.FirstStmtForLine(fn.Entry, fn.End); ok {
+		if pc2, _, _, ok := fn.cu.lineInfo.FirstStmt(fn.Entry, fn.End); ok {
 			return pc2, nil
 		}
 	}


### PR DESCRIPTION
This invariant does not hold for optimized binaries. For the example program included in this patch, the disassembly of the function for an optimized build looks like the following:

```
TEXT main.ManyArgsWithNamedReturns(SB) /home/deparker/Code/delve/_fixtures/multinamedreturns.go
multinamedreturns.go:24 0x4a9f40 4c894c2470 mov qword ptr [rsp+0x70], r9
multinamedreturns.go:24 0x4a9f45 4c899c2480000000 mov qword ptr
[rsp+0x80], r11 => multinamedreturns.go:7 0x4a9f4d 488d1403 lea rdx, ptr
[rbx+rax*1] multinamedreturns.go:7 0x4a9f51 4801ca add rdx, rcx
multinamedreturns.go:7 0x4a9f54 4801fa add rdx, rdi
multinamedreturns.go:7 0x4a9f57 4801f2 add rdx, rsi
multinamedreturns.go:7 0x4a9f5a 4c01c2 add rdx, r8
multinamedreturns.go:7 0x4a9f5d 4c01ca add rdx, r9
multinamedreturns.go:7 0x4a9f60 4c01d2 add rdx, r10
... 
```

As you can see the entry is marked as line 24, whereas the first line we
really want to stop at is line 7 in this build. Enforcing that we want
to find a statement with the same line as the entry, this makes Delve
stop at the end at the `ret` instruction:

```
multinamedreturns.go:22 0x4aa01b 488d1c11 lea rbx, ptr [rcx+rdx*1]
multinamedreturns.go:22 0x4aa01f 48d1fb sar rbx, 0x1
multinamedreturns.go:24 0x4aa022 c3 ret
```