### PR TITLE
pkg/proc: guard register logging from nil pointer dereferences

### DIFF
--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -168,7 +168,11 @@ func (grp *TargetGroup) Continue() error {
 				log.Debugf("callInjection protocol on:")
 				for _, th := range threads {
 					regs, _ := th.Registers()
-					log.Debugf("\t%d PC=%#x", th.ThreadID(), regs.PC())
+					if regs != nil {
+						log.Debugf("\t%d PC=%#x", th.ThreadID(), regs.PC())
+					} else {
+						log.Debugf("\t%d (no registers)", th.ThreadID())
+					}
 				}
 			}
 			callInjectionDoneThis, callErrThis := callInjectionProtocol(dbp, trapthread, threads)


### PR DESCRIPTION
If we can't read a thread's registers don't try to print them.

Fixes #4187
