### PR TITLE
pkg/proc: update riscv64 support and fix several tests

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -53,7 +53,7 @@ val targets = arrayOf(
 
         "linux/ppc64le/1.25",
 
-        // "linux/riscv64/1.25", // needs agent
+        "linux/riscv64/1.25",
 
         "windows/amd64/1.25",
         "windows/amd64/tip",
@@ -224,11 +224,15 @@ class TestBuild(val os: String, val arch: String, val version: String, buildId: 
                         dockerArch
                     }
                 }
+                val ubuntuVersion = when (arch) {
+                    "riscv64" -> "24.04"
+                    else -> "20.04"
+                }
                 dockerCommand {
                     name = "Pull Ubuntu"
                     commandType = other {
                         subCommand = "pull"
-                        commandArgs = "$dockerArch/ubuntu:20.04"
+                        commandArgs = "$dockerArch/ubuntu:$ubuntuVersion"
                     }
                 }
                 dockerCommand {
@@ -241,7 +245,7 @@ class TestBuild(val os: String, val arch: String, val version: String, buildId: 
                         --env CI=true
                         --privileged
                         --platform linux/$dockerPlatformArch
-                        $dockerArch/ubuntu:20.04
+                        $dockerArch/ubuntu:$ubuntuVersion
                         /delve/_scripts/test_linux.sh ${"go$version"} $arch
                     """.trimIndent()
                     }

--- a/Documentation/backend_test_health.md
+++ b/Documentation/backend_test_health.md
@@ -32,8 +32,7 @@ Tests skipped by each supported backend:
 	* 1 broken in linux ppc64le
 * linux/ppc64le/native/pie skipped = 3
 	* 3 broken - pie mode
-* linux/riscv64 skipped = 2
-	* 1 broken - cgo stacktraces
+* linux/riscv64 skipped = 1
 	* 1 not working on linux/riscv64
 * loong64 skipped = 7
 	* 1 broken - global variable symbolication
@@ -44,8 +43,7 @@ Tests skipped by each supported backend:
 	* 6 broken
 	* 1 broken - global variable symbolication
 	* 7 not implemented
-* riscv64 skipped = 8
-	* 2 broken
+* riscv64 skipped = 6
 	* 1 broken - global variable symbolication
 	* 5 not implemented
 * windows skipped = 9

--- a/_scripts/capslock.sh
+++ b/_scripts/capslock.sh
@@ -9,5 +9,6 @@ cl linux 386
 cl linux amd64
 cl linux arm64
 cl linux ppc64le
+cl linux riscv64
 cl windows amd64
 cl windows arm64

--- a/_scripts/capslock_linux_riscv64-output.txt
+++ b/_scripts/capslock_linux_riscv64-output.txt
@@ -1,0 +1,41 @@
+Capslock is an experimental tool for static analysis of Go packages.
+Share feedback and file bugs at https://github.com/google/capslock.
+For additional debugging signals, use verbose mode with -output=verbose
+To get machine-readable full analysis output, use -output=json
+
+Analyzed packages:
+  github.com/cosiner/argv v0.1.0
+  github.com/cpuguy83/go-md2man/v2 v2.0.6
+  github.com/derekparker/trie/v3 v3.2.0
+  github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62
+  github.com/google/go-dap v0.12.0
+  github.com/hashicorp/golang-lru/v2 v2.0.7
+  github.com/mattn/go-isatty v0.0.20
+  github.com/mattn/go-runewidth v0.0.13
+  github.com/rivo/uniseg v0.2.0
+  github.com/russross/blackfriday/v2 v2.1.0
+  github.com/spf13/cobra v1.9.1
+  github.com/spf13/pflag v1.0.6
+  go.starlark.net v0.0.0-20231101134539-556fd59b42f6
+  golang.org/x/arch v0.11.0
+  golang.org/x/sync v0.8.0
+  golang.org/x/sys v0.26.0
+  golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
+  gopkg.in/yaml.v3 v3.0.1
+
+ARBITRARY_EXECUTION: 1 references
+EXEC: 2 references
+FILES: 2 references
+MODIFY_SYSTEM_STATE/CHDIR: 1 references
+MODIFY_SYSTEM_STATE/ENV: 1 references
+MODIFY_SYSTEM_STATE/LOGGING: 1 references
+MODIFY_SYSTEM_STATE/SIGNALS: 1 references
+NETWORK: 1 references
+OPERATING_SYSTEM: 1 references
+READ_SYSTEM_STATE: 2 references
+REFLECT: 2 references
+RUNTIME: 1 references
+SYSTEM_CALLS: 1 references
+UNANALYZED: 1 references
+UNSAFE_POINTER: 1 references
+

--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -18,6 +18,11 @@ if [ "$arch" != "ppc64le" ]; then
 	dwz --version
 fi
 
+if [ "$arch" == "riscv64" ]; then
+	apt-get install -y git
+	git --version
+fi
+
 function getgo {
 	export GOROOT=/usr/local/go/$1
 	if [ ! -d "$GOROOT" ]; then

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1295,6 +1295,10 @@ func TestCapsLock(t *testing.T) {
 		args = append([]string{"-buildtags", "exp.linuxppc64le"}, args...)
 	}
 
+	if goos == "linux" && goarch == "riscv64" {
+		args = append([]string{"-buildtags", "exp.linuxriscv64"}, args...)
+	}
+
 	cmd := exec.Command("capslock", args...)
 	cmd.Dir = protest.ProjectRoot()
 	cmd.Env = append(os.Environ(), fmt.Sprintf("GOOS=%s", goos), fmt.Sprintf("GOARCH=%s", goarch))

--- a/pkg/proc/native/support_sentinel_linux.go
+++ b/pkg/proc/native/support_sentinel_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !amd64 && !arm64 && !386 && !(riscv64 && exp.linuxriscv64) && !(loong64 && exp.linuxloong64) && !ppc64le
+//go:build linux && !amd64 && !arm64 && !386 && !riscv64 && !(loong64 && exp.linuxloong64) && !ppc64le
 
 // This file is used to detect build on unsupported GOOS/GOARCH combinations.
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -3073,7 +3073,6 @@ func TestCgoStacktrace(t *testing.T) {
 	skipOn(t, "broken - cgo stacktraces", "386")
 	skipOn(t, "broken - cgo stacktraces", "windows", "arm64")
 	skipOn(t, "broken - cgo stacktraces", "linux", "ppc64le")
-	skipOn(t, "broken - cgo stacktraces", "linux", "riscv64")
 	protest.MustHaveCgo(t)
 
 	// Tests that:
@@ -3753,7 +3752,6 @@ func TestIssue951(t *testing.T) {
 
 func TestDWZCompression(t *testing.T) {
 	skipOn(t, "broken", "ppc64le")
-	skipOn(t, "broken", "riscv64")
 	// If dwz is not available in the system, skip this test
 	if _, err := exec.LookPath("dwz"); err != nil {
 		t.Skip("dwz not installed")
@@ -4351,7 +4349,6 @@ func TestCgoStacktrace2(t *testing.T) {
 	skipOn(t, "broken - cgo stacktraces", "darwin", "arm64")
 	skipOn(t, "broken - cgo stacktraces", "windows", "arm64")
 	skipOn(t, "broken", "ppc64le")
-	skipOn(t, "broken", "riscv64")
 	protest.MustHaveCgo(t)
 	// If a panic happens during cgo execution the stacktrace should show the C
 	// function that caused the problem.


### PR DESCRIPTION
This pull request adds support for stack-switching functions, contextregnum and sigtramp on riscv64, which fix `TestCgoStacktrace`, `TestCgoStacktrace2`, `TestStepIntoCoroutine`, `TestCapturedVarVisibleOnFirstLine` and `TestDWZCompression`.