### PR TITLE
pkg/proc: add way to disable stop-on-error for breakpoint conditions

### DIFF
--- a/_fixtures/delvecatch.go
+++ b/_fixtures/delvecatch.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	for i, iface := range []any{12, "test", nil, 2.2, "hello", 7} {
+		fmt.Println(i, iface)
+	}
+}

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -881,6 +881,7 @@ type evalStack struct {
 	curthread           Thread
 	lastRetiredFncall   *functionCallState
 	debugPinner         *Variable
+	disabledErrors      bool
 }
 
 func (s *evalStack) push(v *Variable) {
@@ -1327,6 +1328,9 @@ func (stack *evalStack) executeOp() {
 
 	case *evalop.PushNewFakeVariable:
 		stack.pushNewFakeVariable(scope, op.Type)
+
+	case *evalop.DisableErrors:
+		stack.disabledErrors = true
 
 	default:
 		stack.err = fmt.Errorf("internal debugger error: unknown eval opcode: %#v", op)

--- a/pkg/proc/evalop/ops.go
+++ b/pkg/proc/evalop/ops.go
@@ -355,3 +355,9 @@ type PushNewFakeVariable struct {
 }
 
 func (*PushNewFakeVariable) depthCheck() (npop, npush int) { return 0, 1 }
+
+// DisableErrors disables error reporing for the rest of the execution
+type DisableErrors struct {
+}
+
+func (*DisableErrors) depthCheck() (npop, npush int) { return 0, 0 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -5897,3 +5897,13 @@ func TestChainedBreakpoint(t *testing.T) {
 		}
 	})
 }
+
+func TestDelveCatch(t *testing.T) {
+	withTestProcess("delvecatch", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+		bp := setFileBreakpoint(p, t, fixture.Source, 7)
+		bp.UserBreaklet().Cond, _ = parser.ParseExpr(`delve.catch(iface.(data) == "hello")`)
+		assertNoError(grp.Continue(), t, "Continue")
+		assertLineNumber(p, t, 7, "continue")
+		assertVariable(t, evalVariable(p, t, "i"), varTest{name: "i", preserveName: true, value: "4", varType: "int"})
+	})
+}


### PR DESCRIPTION
Add a fake delve.catch function that can be used to wrap the expression
of breakpoint conditions so that they do not stop if the expression can
not be evaluated correctly.

The main use case for this is that it's hard to set breakpoint
conditions on interface variables that assume different types but it
can also be useful in other cases (for example checking the value of a
pointer-to-struct that sometimes is nil).
