### PR TITLE
proc: fix defer loading in go 1.26

### DIFF
--- a/_scripts/rtype-out.txt
+++ b/_scripts/rtype-out.txt
@@ -4,7 +4,6 @@ var debug anytype
 
 type _defer struct {
 	fn anytype
-	pc uintptr
 	sp uintptr
 	siz int32 (optional)
 	link *_defer

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -107,7 +107,7 @@ type BinaryInfo struct {
 	inlinedCallLines map[fileLine][]uint64
 
 	// dwrapUnwrapCache caches unwrapping of defer wrapper functions (dwrap)
-	dwrapUnwrapCache map[uint64]*Function
+	dwrapUnwrapCache map[uint64]unwrapCacheEntry
 
 	moduleDataCache []ModuleData
 
@@ -2534,7 +2534,7 @@ func (bi *BinaryInfo) loadDebugInfoMaps(image *Image, debugInfoBytes, debugLineB
 		bi.inlinedCallLines = make(map[fileLine][]uint64)
 	}
 	if bi.dwrapUnwrapCache == nil {
-		bi.dwrapUnwrapCache = make(map[uint64]*Function)
+		bi.dwrapUnwrapCache = make(map[uint64]unwrapCacheEntry)
 	}
 
 	image.runtimeTypeToDIE = make(map[uint64]runtimeTypeDIE)

--- a/pkg/proc/dwarf_export_test.go
+++ b/pkg/proc/dwarf_export_test.go
@@ -41,3 +41,8 @@ func (bi *BinaryInfo) HasDebugPinner() bool {
 func DebugPinCount() int {
 	return debugPinCount
 }
+
+// DebugDeferPC returns deferPC for testing purposes.
+func (d *Defer) DebugDeferPC() uint64 {
+	return d.deferPC
+}

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2990,7 +2990,17 @@ func logStacktrace(t *testing.T, p *proc.Target, frames []proc.Stackframe) {
 			if fn != nil {
 				fnname = fn.Name
 			}
-			defers += fmt.Sprintf("%d %#x %s |", deferIdx, _defer.DwrapPC, fnname)
+			defers += fmt.Sprintf("%d %#x %s", deferIdx, _defer.DwrapPC, fnname)
+
+			drf, drl, drfn := _defer.DeferredFrom(p)
+			drfnname := ""
+			if drfn != nil {
+				drfnname = drfn.Name
+			}
+			defers += fmt.Sprintf(" from:%s %s:%d", drfnname, filepath.Base(drf), drl)
+
+			defers += " | "
+
 		}
 
 		frame := frames[j]
@@ -3889,13 +3899,17 @@ func TestReadDefer(t *testing.T) {
 			defers       []string
 		}{
 			// main.call3 (defers nothing, topmost defer main.f2)
-			{0, "main.f2", []string{}},
+			{0, "main.f2 from: deferstack.go:22", []string{}},
 
 			// main.call2 (defers main.f2, main.f3, topmost defer main.f2)
-			{1, "main.f2", []string{"main.f2", "main.f3"}},
+			{1, "main.f2 from: deferstack.go:22", []string{
+				"main.f2 from: deferstack.go:22",
+				"main.f3 ..."}},
 
 			// main.call1 (defers main.f1, main.f2, topmost defer main.f1)
-			{2, "main.f1", []string{"main.f1", "main.f2"}},
+			{2, "main.f1 ...", []string{
+				"main.f1 ...",
+				"main.f2 from: deferstack.go:15"}},
 
 			// main.main (defers nothing)
 			{3, "", []string{}}}
@@ -3911,9 +3925,23 @@ func TestReadDefer(t *testing.T) {
 			if dfn == nil {
 				t.Fatalf("expected %q as %s of frame %d, got %#x", tgt, deferName, frameIdx, d.DwrapPC)
 			}
-			if dfn.Name != tgt {
-				t.Fatalf("expected %q as %s of frame %d, got %q", tgt, deferName, frameIdx, dfn.Name)
+
+			got := dfn.Name
+
+			const originUndetermined = " ..."
+
+			if strings.HasSuffix(tgt, originUndetermined) {
+				got += originUndetermined
+			} else {
+				drf, drl, _ := d.DeferredFrom(p)
+
+				got += fmt.Sprintf(" from: %s:%d", filepath.Base(drf), drl)
 			}
+
+			if got != tgt {
+				t.Fatalf("expected %q as %s of frame %d, got %q", tgt, deferName, frameIdx, got)
+			}
+
 		}
 
 		for _, example := range examples {

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -541,7 +541,7 @@ func (g *G) Go() Location {
 // StartLoc returns the starting location of the goroutine.
 func (g *G) StartLoc(tgt *Target) Location {
 	fn := g.variable.bi.PCToFunc(g.StartPC)
-	fn = tgt.dwrapUnwrap(fn)
+	fn, _ = tgt.dwrapUnwrap(fn)
 	if fn == nil {
 		return Location{PC: g.StartPC}
 	}

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2015,12 +2015,12 @@ func (d *Debugger) convertDefers(defers []*proc.Defer) []api.Defer {
 	r := make([]api.Defer, len(defers))
 	for i := range defers {
 		ddf, ddl, ddfn := defers[i].DeferredFunc(d.target.Selected)
-		drf, drl, drfn := d.target.Selected.BinInfo().PCToLine(defers[i].DeferPC)
+		drf, drl, drfn := defers[i].DeferredFrom(d.target.Selected)
 
 		if defers[i].Unreadable != nil {
 			r[i].Unreadable = defers[i].Unreadable.Error()
 		} else {
-			var entry = defers[i].DeferPC
+			var entry uint64
 			if ddfn != nil {
 				entry = ddfn.Entry
 			}
@@ -2032,7 +2032,6 @@ func (d *Debugger) convertDefers(defers []*proc.Defer) []api.Defer {
 					Fn:   ddfn,
 				}),
 				DeferLoc: api.ConvertLocation(proc.Location{
-					PC:   defers[i].DeferPC,
 					File: drf,
 					Line: drl,
 					Fn:   drfn,


### PR DESCRIPTION
Go 1.26 removed the 'pc' field from the _defer struct. Use the defer
wrapper function, when available to discover the line where the defer
was created. For every other case leave the field empty without
crashing.

Also disables capslock check on everything except the latest minor
version of Go (because the output can change)
