### PR TITLE
*: fix tests on windows and arm64 for go1.26

### DIFF
--- a/_fixtures/goroutine_start_line.star
+++ b/_fixtures/goroutine_start_line.star
@@ -2,7 +2,10 @@ def command_goroutine_start_line(args):
 	"prints the line of source code that started each currently running goroutine"
 	gs = goroutines().Goroutines
 	for g in gs:
-		line = read_file(g.StartLoc.File).splitlines()[g.StartLoc.Line-1].strip()
+		if g.StartLoc.File != "":
+			line = read_file(g.StartLoc.File).splitlines()[g.StartLoc.Line-1].strip()
+		else:
+			line = "<nothing>"
 		print(g.ID, "\t", g.StartLoc.File + ":" + str(g.StartLoc.Line), "\t", line)
 
 def main():

--- a/pkg/proc/stepping_test.go
+++ b/pkg/proc/stepping_test.go
@@ -1122,39 +1122,74 @@ func TestRangeOverFuncNext(t *testing.T) {
 			})
 		})
 
-		t.Run("TestGotoA1", func(t *testing.T) {
-			testseq2intl(t, fixture, grp, p, nil, []seqTest{
-				funcBreak(t, "main.TestGotoA1"),
-				{contContinue, 192},
-				nx(193),
-				nx(194), // for _, x := range (x == -1)
-				nx(195), // result = append(result, x)
-				nx(196), // if x == -4
-				nx(199), // for _, y := range (y == 1)
-				nx(200), // if y == 3
-				nx(203), // result = append(result, y)
-				nx(204),
+		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 26) && runtime.GOARCH == "arm64" {
+			t.Run("TestGotoA1", func(t *testing.T) {
+				testseq2intl(t, fixture, grp, p, nil, []seqTest{
+					funcBreak(t, "main.TestGotoA1"),
+					{contContinue, 192},
+					nx(194), // for _, x := range (x == -1)
+					nx(195), // result = append(result, x)
+					nx(196), // if x == -4
+					nx(199), // for _, y := range (y == 1)
+					nx(200), // if y == 3
+					nx(203), // result = append(result, y)
+					nx(204),
 
-				nx(199), // for _, y := range (y == 2)
-				nx(200), // if y == 3
-				nx(203), // result = append(result, y)
-				nx(204),
+					nx(199), // for _, y := range (y == 2)
+					nx(200), // if y == 3
+					nx(203), // result = append(result, y)
+					nx(204),
 
-				nx(199), // for _, y := range (y == 3)
-				nx(200), // if y == 3
-				nx(201), // goto A
-				nx(204),
-				nx(206), // result = append(result, x)
-				nx(207),
+					nx(199), // for _, y := range (y == 3)
+					nx(200), // if y == 3
+					nx(201), // goto A
+					nx(204),
+					nx(206), // result = append(result, x)
+					nx(207),
 
-				nx(194), // for _, x := range (x == -4)
-				nx(195), // result = append(result, x)
-				nx(196), // if x == -4
-				nx(197), // break
-				nx(207),
-				nx(208), // fmt.Println
+					nx(194), // for _, x := range (x == -4)
+					nx(195), // result = append(result, x)
+					nx(196), // if x == -4
+					nx(197), // break
+					nx(207),
+					nx(208), // fmt.Println
+				})
 			})
-		})
+		} else {
+			t.Run("TestGotoA1", func(t *testing.T) {
+				testseq2intl(t, fixture, grp, p, nil, []seqTest{
+					funcBreak(t, "main.TestGotoA1"),
+					{contContinue, 192},
+					nx(193),
+					nx(194), // for _, x := range (x == -1)
+					nx(195), // result = append(result, x)
+					nx(196), // if x == -4
+					nx(199), // for _, y := range (y == 1)
+					nx(200), // if y == 3
+					nx(203), // result = append(result, y)
+					nx(204),
+
+					nx(199), // for _, y := range (y == 2)
+					nx(200), // if y == 3
+					nx(203), // result = append(result, y)
+					nx(204),
+
+					nx(199), // for _, y := range (y == 3)
+					nx(200), // if y == 3
+					nx(201), // goto A
+					nx(204),
+					nx(206), // result = append(result, x)
+					nx(207),
+
+					nx(194), // for _, x := range (x == -4)
+					nx(195), // result = append(result, x)
+					nx(196), // if x == -4
+					nx(197), // break
+					nx(207),
+					nx(208), // fmt.Println
+				})
+			})
+		}
 
 		t.Run("TestGotoB1", func(t *testing.T) {
 			testseq2intl(t, fixture, grp, p, nil, []seqTest{


### PR DESCRIPTION
Fix some failing tests for go1.26. The arm64 failures are due to
different optimizations. The test failures on windows are due to there
being an extra goroutine with a starting location for which we do not
have line number informations.
