### PR TITLE
fix: go mod vendor

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -97,4 +97,3 @@ golang.org/x/telemetry/internal/upload
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# github.com/go-delve/build-tools@latest => ../build-tools-for-delve/


### PR DESCRIPTION
6018abbe2fe81920d5be17aeebdfb4860e16a5ce removed the replace line in go.mod but did not update vendor/modules.txt.

This caused build issues:

```
❮ git switch --detach 6018abbe2fe81920d5be17aeebdfb4860e16a5ce && go build -o dlv
# ...
go: inconsistent vendoring in /Users/hjdivad/src/github/go-delve/delve:
        github.com/go-delve/build-tools@latest: is marked as replaced in vendor/modules.txt, but not replaced in go.mod

        To ignore the vendor directory, use -mod=readonly or -mod=mod.
        To sync the vendor directory, run:
                go mod vendor
```

see #4206.

Fix by re-running `go mod vendor`
