### PR TITLE
*: update riscv64 capslock file

### DIFF
--- a/_scripts/capslock_linux_riscv64-output.txt
+++ b/_scripts/capslock_linux_riscv64-output.txt
@@ -9,7 +9,6 @@ Analyzed packages:
   github.com/derekparker/trie/v3 v3.2.0
   github.com/go-delve/liner v1.2.3-0.20231231155935-4726ab1d7f62
   github.com/google/go-dap v0.12.0
-  github.com/hashicorp/golang-lru/v2 v2.0.7
   github.com/mattn/go-isatty v0.0.20
   github.com/mattn/go-runewidth v0.0.13
   github.com/rivo/uniseg v0.2.0

--- a/_scripts/gen-capslock-all.go
+++ b/_scripts/gen-capslock-all.go
@@ -22,6 +22,7 @@ var platforms = []Platform{
 	{GOOS: "linux", GOARCH: "amd64"},
 	{GOOS: "linux", GOARCH: "386"},
 	{GOOS: "linux", GOARCH: "arm64"},
+	{GOOS: "linux", GOARCH: "riscv64"},
 	{GOOS: "linux", GOARCH: "ppc64le", BuildTags: "exp.linuxppc64le"},
 	{GOOS: "darwin", GOARCH: "amd64"},
 	{GOOS: "darwin", GOARCH: "arm64"},

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -1304,8 +1304,7 @@ func TestCapsLock(t *testing.T) {
 	cmd.Env = append(os.Environ(), fmt.Sprintf("GOOS=%s", goos), fmt.Sprintf("GOARCH=%s", goarch))
 	out, _ := cmd.CombinedOutput()
 
-	genCommand := fmt.Sprintf("capslock -goos %s -goarch %s %s > %s",
-		goos, goarch, strings.Join(args, " "), expectedFile)
+	genCommand := "go run _scripts/gen-capslock-all.go"
 	checkAutogenDoc(t, expectedFile, genCommand, out)
 }
 


### PR DESCRIPTION
This also updates the test to output the correct command to regenerate these files, and fixes the generation script to generate the riscv64 output file.