### PR TITLE
service/dap: fix restart handling when compilation fails

### DIFF
--- a/_fixtures/testRestartRequestRebuildFailFixture.go
+++ b/_fixtures/testRestartRequestRebuildFailFixture.go
@@ -1,0 +1,12 @@
+package main
+
+import "math"
+
+var f = 1.5
+
+func main() {
+	floatvar1 := math.Floor(f)
+	floatvar2 := float64(int(f))
+	_ = floatvar1
+	_ = floatvar2
+}


### PR DESCRIPTION
* always send the restart response message, it's just an acknowledgment
and if it isn't sent VSCode will wedge itself (even if an error is sent
instead).

* if Restart errors after detaching from the target process also send a
terminated event.

Fixes #4213
