### PR TITLE
gdbserial: do not set detached if we kill the process

### DIFF
--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -1095,13 +1095,13 @@ func (p *gdbProcess) Detach(_pid int, kill bool) error {
 		if err := p.conn.detach(); err != nil {
 			return err
 		}
+		p.detached = true
 	}
 	if p.process != nil {
 		p.process.Kill()
 		<-p.waitChan
 		p.process = nil
 	}
-	p.detached = true
 	return nil
 }
 


### PR DESCRIPTION
To mach the behaviour of the native backend, do not set detached to
true if when we kill the process. This fixes a test failure of
TestRestartRequestRebuildFail on macOS.
