### PR TITLE
lru: remove mutex from lru cache

### DIFF
--- a/pkg/internal/lru/lru.go
+++ b/pkg/internal/lru/lru.go
@@ -2,12 +2,10 @@ package lru
 
 import (
 	"container/list"
-	"sync"
 )
 
 // Cache is a simple LRU (Least Recently Used) cache implementation.
 type Cache[K comparable, V any] struct {
-	mu        sync.Mutex
 	capacity  int
 	items     map[K]*list.Element
 	evictList *list.List
@@ -31,9 +29,6 @@ func NewCache[K comparable, V any](capacity int) *Cache[K, V] {
 // the value and moves it to the front. If the cache is at capacity,
 // it evicts the least recently used item.
 func (c *Cache[K, V]) Add(key K, value V) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	// Check if the key already exists.
 	if elem, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(elem)
@@ -58,9 +53,6 @@ func (c *Cache[K, V]) Add(key K, value V) {
 // to the front (marking it as recently used) and returns (value, true).
 // If not found, returns (zero value, false).
 func (c *Cache[K, V]) Get(key K) (V, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if elem, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(elem)
 		return elem.Value.(*entry[K, V]).value, true

--- a/pkg/internal/lru/lru_test.go
+++ b/pkg/internal/lru/lru_test.go
@@ -1,7 +1,6 @@
 package lru_test
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/go-delve/delve/pkg/internal/lru"
@@ -98,35 +97,4 @@ func TestCacheOrder(t *testing.T) {
 	if val, ok := cache.Get(3); !ok || val != "three" {
 		t.Errorf("Get(3) = %v, %v; want 'three', true", val, ok)
 	}
-}
-
-func TestCacheConcurrent(t *testing.T) {
-	// Test passes if no race conditions occur.
-	cache := lru.NewCache[int, int](100)
-
-	var wg sync.WaitGroup
-
-	// Concurrent writes
-	for i := range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for j := range 100 {
-				cache.Add(i*100+j, i)
-			}
-		}()
-	}
-
-	// Concurrent reads
-	for i := range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for j := range 100 {
-				cache.Get(i*100 + j)
-			}
-		}()
-	}
-
-	wg.Wait()
 }


### PR DESCRIPTION
We only use the lru cache in contexts that are non-thread reentrant,
regardless. The mutex is superfluous (it was originally introduced by a
dependency update, originally the code used simplelru which did not
have a mutex).
