### PR TITLE
service/dap: Add hit conditional breakpoint capability

### DIFF
--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -930,6 +930,7 @@ func (s *Session) onInitializeRequest(request *dap.InitializeRequest) {
 	response := &dap.InitializeResponse{Response: *newResponse(request.Request)}
 	response.Body.SupportsConfigurationDoneRequest = true
 	response.Body.SupportsConditionalBreakpoints = true
+	response.Body.SupportsHitConditionalBreakpoints = true
 	response.Body.SupportsDelayedStackTraceLoading = true
 	response.Body.SupportsFunctionBreakpoints = true
 	response.Body.SupportsInstructionBreakpoints = true


### PR DESCRIPTION
We already have support for this kind of breakpoints but corresponding capability was missed.

You can find existed tests [here](https://github.com/go-delve/delve/blob/master/service/dap/server_test.go#L3999).