### PR TITLE
proc/internal/ebpf: improve shutdown for polling & ebpf objects

### DIFF
--- a/Documentation/usage/dlv_log.md
+++ b/Documentation/usage/dlv_log.md
@@ -22,7 +22,7 @@ names selected from this list:
 	stack           Log stacktracer
 
 Additionally --log-dest can be used to specify where the logs should be
-written. 
+written.
 If the argument is a number it will be interpreted as a file descriptor,
 otherwise as a file path.
 This option will also redirect the "server listening at" message in headless

--- a/Documentation/usage/dlv_redirect.md
+++ b/Documentation/usage/dlv_redirect.md
@@ -4,7 +4,7 @@ Help about file redirection.
 
 ### Synopsis
 
-The standard file descriptors of the target process can be controlled using the '-r' and '--tty' arguments. 
+The standard file descriptors of the target process can be controlled using the '-r' and '--tty' arguments.
 
 The --tty argument allows redirecting all standard descriptors to a terminal, specified as an argument to --tty.
 

--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -492,7 +492,7 @@ names selected from this list:
 	stack           Log stacktracer
 
 Additionally --log-dest can be used to specify where the logs should be
-written. 
+written.
 If the argument is a number it will be interpreted as a file descriptor,
 otherwise as a file path.
 This option will also redirect the "server listening at" message in headless
@@ -504,7 +504,7 @@ and dap modes.
 	rootCommand.AddCommand(&cobra.Command{
 		Use:   "redirect",
 		Short: "Help about file redirection.",
-		Long: `The standard file descriptors of the target process can be controlled using the '-r' and '--tty' arguments. 
+		Long: `The standard file descriptors of the target process can be controlled using the '-r' and '--tty' arguments.
 
 The --tty argument allows redirecting all standard descriptors to a terminal, specified as an argument to --tty.
 
@@ -851,7 +851,8 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 					default:
 						tracepoints, err := client.GetBufferedTracepoints()
 						if err != nil {
-							panic(err)
+							fmt.Fprintf(os.Stderr, "Error retrieving buffered tracepoints: %v\n", err)
+							return
 						}
 						for _, t := range tracepoints {
 							var params strings.Builder


### PR DESCRIPTION
Improves cleanup on exit to properly close out more ebpf links and wait for goroutines to exit.