### PR TITLE
*: downgrade riscv64

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -53,7 +53,7 @@ val targets = arrayOf(
 
         "linux/ppc64le/1.26",
 
-        "linux/riscv64/1.26",
+        // "linux/riscv64/1.26", // needs exp.linuxriscv64 build tag, disabled due to CI issues
 
         "windows/amd64/1.26",
         "windows/amd64/tip",

--- a/pkg/proc/native/support_sentinel_linux.go
+++ b/pkg/proc/native/support_sentinel_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !amd64 && !arm64 && !386 && !riscv64 && !(loong64 && exp.linuxloong64) && !ppc64le
+//go:build linux && !amd64 && !arm64 && !386 && !(riscv64 && exp.linuxriscv64) && !(loong64 && exp.linuxloong64) && !ppc64le
 
 // This file is used to detect build on unsupported GOOS/GOARCH combinations.
 


### PR DESCRIPTION
The riscv64 builder has been broken since it was enabled. While we wait for a stable builder and assurances that riscv64 is passing, disable the CI target and require the `exp.linuxriscv64` tag.