### PR TITLE
goversion: Fix ProducerAfterOrEqual comparison for devel builds

### DIFF
--- a/pkg/proc/stepping_test.go
+++ b/pkg/proc/stepping_test.go
@@ -1122,7 +1122,7 @@ func TestRangeOverFuncNext(t *testing.T) {
 			})
 		})
 
-		if goversion.ProducerAfterOrEqual(p.BinInfo().Producer(), 1, 26) && runtime.GOARCH == "arm64" {
+		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 26) && runtime.GOARCH == "arm64" {
 			t.Run("TestGotoA1", func(t *testing.T) {
 				testseq2intl(t, fixture, grp, p, nil, []seqTest{
 					funcBreak(t, "main.TestGotoA1"),


### PR DESCRIPTION
The VersionAfterOrEqual function uses the versionedDevel constant
whereas ProducerAfterOrEqual used 0. This can cause inconsistency
when comparing the "same" version string in different situations.

One of the tests: TestRangeOverFuncNext/TestGotoA1 passes for
gotip due to two wrongs making a right. In particular,
- The version string for checking the stepping sequence is
  derived from `runtime.Version()` instead of
  `p.BinInfo().Producer()`. However, the debuginfo
  depends on the toolchain used to compile the binary,
  not the toolchain used to compile Delve itself.
- When `p.BinInfo().Producer()` is used, the comparison
  function used for it should be `ProducerAfterOrEqual()`
  and not `VersionAfterOrEqual()`.

So we also fix the check in TestGotoA1 to use p.BinInfo().Producer()
and ProducerAfterOrEqual().
