### PR TITLE
Propagate short type option when printing structs.

### DIFF
--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -313,7 +313,7 @@ func (v *Variable) writeStructTo(buf io.Writer, flags prettyFlags, indent, fmtst
 			fmt.Fprintf(buf, "\n%s%s", indent, indentString)
 		}
 		fmt.Fprintf(buf, "%s: ", v.Children[i].Name)
-		v.Children[i].writeTo(buf, flags.set(prettyNewlines, nl), indent+indentString, fmtstr)
+		v.Children[i].writeTo(buf, prettyIncludeType.set(prettyShortenType, flags.shortenType()).set(prettyNewlines, nl), indent+indentString, fmtstr)
 		if i != len(v.Children)-1 || nl {
 			fmt.Fprint(buf, ",")
 			if !nl {
@@ -357,7 +357,7 @@ func (v *Variable) writeMapTo(buf io.Writer, flags prettyFlags, indent, fmtstr s
 
 		key.writeTo(buf, 0, indent+indentString, fmtstr)
 		fmt.Fprint(buf, ": ")
-		value.writeTo(buf, flags.set(prettyNewlines, nl), indent+indentString, fmtstr)
+		value.writeTo(buf, prettyFlags(0).set(prettyShortenType, flags.shortenType()).set(prettyNewlines, nl), indent+indentString, fmtstr)
 		if i != len(v.Children)-1 || nl {
 			fmt.Fprint(buf, ", ")
 		}
@@ -457,7 +457,7 @@ func (v *Variable) writeSliceOrArrayTo(buf io.Writer, flags prettyFlags, indent,
 		if nl {
 			fmt.Fprintf(buf, "\n%s%s", indent, indentString)
 		}
-		v.Children[i].writeTo(buf, flags.set(prettyNewlines, nl), indent+indentString, fmtstr)
+		v.Children[i].writeTo(buf, prettyFlags(0).set(prettyShortenType, flags.shortenType()).set(prettyNewlines, nl), indent+indentString, fmtstr)
 		if i != len(v.Children)-1 || nl {
 			fmt.Fprint(buf, ",")
 		}


### PR DESCRIPTION
Fix for issue https://github.com/go-delve/delve/issues/3910
It will propagate same prettyFlags keeping shortTypes passed to writeToStruct