### PR TITLE
proc,service: detect and warn about trimpath

### DIFF
--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -91,6 +91,7 @@ const (
 	AllNonOptimized
 	// LinkDisableDWARF enables '-ldflags="-w"'.
 	LinkDisableDWARF
+	Trimpath
 )
 
 // TempFile makes a (good enough) random temporary file name
@@ -181,6 +182,9 @@ func BuildFixture(t testing.TB, name string, flags BuildFlags) Fixture {
 		if flags&EnableDWZCompression != 0 {
 			buildFlags = append(buildFlags, "-ldflags=-compressdwarf=false")
 		}
+	}
+	if flags&Trimpath != 0 {
+		buildFlags = append(buildFlags, "-trimpath")
 	}
 	if path != "" {
 		buildFlags = append(buildFlags, name+".go")

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2760,7 +2760,7 @@ func libraries(t *Term, ctx callContext, args string) error {
 		return nil
 	}
 
-	libs, err := t.client.ListDynamicLibraries()
+	libs, _, err := t.client.ListDynamicLibraries()
 	if err != nil {
 		return err
 	}

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -631,6 +631,7 @@ type Image struct {
 	Path      string
 	Address   uint64
 	LoadError string
+	Trimpath  bool
 }
 
 // Ancestor represents a goroutine ancestor

--- a/service/client.go
+++ b/service/client.go
@@ -176,7 +176,7 @@ type Client interface {
 	IsMulticlient() bool
 
 	// ListDynamicLibraries returns a list of loaded dynamic libraries.
-	ListDynamicLibraries() ([]api.Image, error)
+	ListDynamicLibraries() ([]api.Image, bool, error)
 
 	// ExamineMemory returns the raw memory stored at the given address.
 	// The amount of data to be read is specified by length which must be less than or equal to 1000.

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1308,6 +1308,7 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 	// will end the configuration sequence with 'configurationDone'.
 	s.send(&dap.InitializedEvent{Event: *newEvent("initialized")})
 	s.send(&dap.LaunchResponse{Response: *newResponse(request.Request)})
+	s.warnAboutTrimpathMaybe()
 }
 
 func (s *Session) getPackageDir(pkg string) string {
@@ -2216,6 +2217,20 @@ func (s *Session) onAttachRequest(request *dap.AttachRequest) {
 	// will end the configuration sequence with 'configurationDone'.
 	s.send(&dap.InitializedEvent{Event: *newEvent("initialized")})
 	s.send(&dap.AttachResponse{Response: *newResponse(request.Request)})
+	s.warnAboutTrimpathMaybe()
+}
+
+func (s *Session) warnAboutTrimpathMaybe() {
+	imgs := s.debugger.ListDynamicLibraries()
+	if imgs[0].Trimpath {
+		s.send(&dap.OutputEvent{
+			Event: *newEvent("output"),
+			Body: dap.OutputEventBody{
+				Category: "important",
+				Output:   "Warning: debugging executable built with trimpath",
+			},
+		})
+	}
 }
 
 // onNextRequest handles 'next' request.

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2223,7 +2223,7 @@ func (d *Debugger) ClearCheckpoint(id int) error {
 func (d *Debugger) ListDynamicLibraries() []*proc.Image {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
-	return d.target.Selected.BinInfo().Images[1:] // skips the first image because it's the executable file
+	return d.target.Selected.BinInfo().Images
 }
 
 // ExamineMemory returns the raw memory stored at the given address.

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -548,10 +548,10 @@ func (c *RPCClient) Disconnect(cont bool) error {
 	return c.client.Close()
 }
 
-func (c *RPCClient) ListDynamicLibraries() ([]api.Image, error) {
+func (c *RPCClient) ListDynamicLibraries() ([]api.Image, bool, error) {
 	var out ListDynamicLibrariesOut
 	c.call("ListDynamicLibraries", ListDynamicLibrariesIn{}, &out)
-	return out.List, nil
+	return out.List, out.ExecutableTrimpath, nil
 }
 
 func (c *RPCClient) ExamineMemory(address uint64, count int) ([]byte, bool, error) {


### PR DESCRIPTION
Detect if the binary we are debugging was built using trimpath,
propagate it through the API and warn about it in DAP.
