### PR TITLE
service/api: Update waitReason switch for Go 1.27

### DIFF
--- a/service/api/waitreason.go
+++ b/service/api/waitreason.go
@@ -271,7 +271,7 @@ func WaitReasonString(goVersion *goversion.GoVersion, waitReason int64) string {
 		waitReasonStrings = waitReasonStrings1dot24
 	case 25:
 		waitReasonStrings = waitReasonStrings1dot25
-	case 26:
+	case 26, 27:
 		waitReasonStrings = waitReasonStrings1dot26
 	}
 


### PR DESCRIPTION
There are no new waitReason values in Go 1.27,
so we can reuse the existing slice.

This fixes the test failure for
`TestClientServer_chanGoroutines` when running
against gotip.