### PR TITLE
service/rpccommon: print error when we can't decode request body

### DIFF
--- a/service/rpccommon/server.go
+++ b/service/rpccommon/server.go
@@ -238,7 +238,9 @@ func (s *ServerImpl) serveJSONCodec(conn io.ReadWriteCloser) {
 		}
 		// argv guaranteed to be a pointer now.
 		if err = codec.ReadRequestBody(argv.Interface()); err != nil {
-			return
+			s.log.Errorf("can't read request body: %v", err)
+			s.sendResponse(sending, &req, &rpc.Response{}, nil, codec, fmt.Sprintf("malformed request body: %v", err))
+			continue
 		}
 		if argIsValue {
 			argv = argv.Elem()


### PR DESCRIPTION
Instead of shutting down the connection without doing saying anything
we should print an error, send an error response and try to continue
serving the connection.
