### PR TITLE
goversion: parse rc version with trailing suffix

### DIFF
--- a/pkg/goversion/go_version.go
+++ b/pkg/goversion/go_version.go
@@ -119,9 +119,15 @@ func Parse(ver string) (GoVersion, bool) {
 				// old boringcrypto version goX.YbZ
 				_, err3 = strconv.Atoi(rest)
 			case hasPrefix("rc"):
-				// old rc release goX.YrcZ
+				i := 0
+				for i < len(rest) && rest[i] >= '0' && rest[i] <= '9' {
+					i++
+				}
 				var rc int
-				rc, err3 = strconv.Atoi(rest)
+				rc, err3 = strconv.Atoi(rest[:i])
+				if err3 != nil || i == 0 {
+					return GoVersion{}, false
+				}
 				r.Rev = rcRev(rc)
 			default:
 				// what is this?

--- a/pkg/goversion/version_test.go
+++ b/pkg/goversion/version_test.go
@@ -64,6 +64,7 @@ func TestParseVersionStringAfterOrEqual(t *testing.T) {
 	versionAfterOrEqual2(t, "go1.16rc1", "go1.16beta1")
 	versionAfterOrEqual2(t, "go1.16beta2", "go1.16beta1")
 	versionAfterOrEqual2(t, "go1.16rc10", "go1.16rc8")
+	versionAfterOrEqual(t, "go1.26rc1-X:nodwarf5 linux/amd64", GoVersion{1, 26, rcRev(1), "", ""})
 }
 
 func TestParseVersionStringEqual(t *testing.T) {
@@ -81,6 +82,7 @@ func TestParseVersionStringEqual(t *testing.T) {
 	versionEqual(t, "devel +17efbfc Tue Jul 28 17:39:19 2015 +0000 linux/amd64", GoVersion{Major: -1})
 	versionEqual(t, "devel go1.24-1bb6f19a25 Mon Oct 14 15:17:20 2024 -0400 linux/amd64", GoVersion{1, 24, versionedDevel, "", ""})
 	versionEqual(t, "go1.25-devel_6953ef86cd Mon May 5 04:05:18 2025 -0700 linux/amd64", GoVersion{1, 25, versionedDevel, "", ""})
+	versionEqual(t, "go1.26rc1-X:nodwarf5 linux/amd64", GoVersion{1, 26, rcRev(1), "", ""})
 }
 
 func TestRoundtrip(t *testing.T) {


### PR DESCRIPTION
While updating Delve in Fedora 44, I found out that it is failing due to our currently uncommon Go version output: `go version go1.26rc2-X:nodwarf5 linux/amd64`.

The problem as I see it is that it fails to identify long release candidate versions with flags.

```log
+ echo '=== Start tests ==='
++ go list ./...
++ grep -v cmd
++ grep -v scripts
+ for d in $(go list ./... | grep -v cmd | grep -v scripts)
+ go test github.com/go-delve/delve/pkg/dwarf -skip TestGuessSubstitutePath
ok  	github.com/go-delve/delve/pkg/dwarf	0.003s
+ for d in $(go list ./... | grep -v cmd | grep -v scripts)
+ go test github.com/go-delve/delve/pkg/dwarf/dwarfbuilder -skip TestGuessSubstitutePath
?   	github.com/go-delve/delve/pkg/dwarf/dwarfbuilder	[no test files]
+ for d in $(go list ./... | grep -v cmd | grep -v scripts)
+ go test github.com/go-delve/delve/pkg/dwarf/frame -skip TestGuessSubstitutePath
ok  	github.com/go-delve/delve/pkg/dwarf/frame	0.003s
+ for d in $(go list ./... | grep -v cmd | grep -v scripts)
+ go test github.com/go-delve/delve/pkg/dwarf/godwarf -skip TestGuessSubstitutePath
ok  	github.com/go-delve/delve/pkg/dwarf/godwarf	0.003s
+ for d in $(go list ./... | grep -v cmd | grep -v scripts)
+ go test github.com/go-delve/delve/pkg/dwarf/leb128 -skip TestGuessSubstitutePath
ok  	github.com/go-delve/delve/pkg/dwarf/leb128	0.003s
+ for d in $(go list ./... | grep -v cmd | grep -v scripts)
+ go test github.com/go-delve/delve/pkg/dwarf/line -skip TestGuessSubstitutePath
--- FAIL: TestDebugLinePrologueParser (0.19s)
    line_parser_test.go:121: Include dirs not parsed correctly
FAIL
FAIL	github.com/go-delve/delve/pkg/dwarf/line	0.421s
FAIL
RPM build errors:
```
