### PR TITLE
service/api: remove variable formatting helper methods

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -5756,7 +5756,7 @@ func TestReadClosure(t *testing.T) {
 		for i := range 4 {
 			assertNoError(grp.Continue(), t, "Continue()")
 			accV := evalVariable(p, t, "acc")
-			t.Log(api.ConvertVar(accV).MultilineString("", ""))
+			t.Log(multiLineVar(accV))
 			if len(accV.Children) != 2 {
 				t.Fatal("wrong number of children")
 			}

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -109,6 +109,10 @@ func setVariable(p *proc.Target, symbol, value string) error {
 	return scope.SetVariable(symbol, value)
 }
 
+func multiLineVar(v *proc.Variable) string {
+	return api.ConvertVar(v).StringWithOptions("", "", api.PrettyNewlines)
+}
+
 func TestVariableEvaluation(t *testing.T) {
 	protest.AllowRecording(t)
 	testcases := []struct {
@@ -443,7 +447,7 @@ func TestMultilineVariableEvaluation(t *testing.T) {
 		for _, tc := range testcases {
 			variable, err := evalVariableWithCfg(p, tc.name, pnormalLoadConfig)
 			assertNoError(err, t, "EvalVariable() returned an error")
-			if ms := api.ConvertVar(variable).MultilineString("", ""); !matchStringOrPrefix(ms, tc.value) {
+			if ms := multiLineVar(variable); !matchStringOrPrefix(ms, tc.value) {
 				t.Fatalf("Expected %s got %q (variable %s)\n", tc.value, ms, variable.Name)
 			}
 		}
@@ -1057,7 +1061,7 @@ func TestMapEvaluation(t *testing.T) {
 		m1v, err := evalVariableWithCfg(p, "m1", pnormalLoadConfig)
 		assertNoError(err, t, "EvalVariable()")
 		m1 := api.ConvertVar(m1v)
-		t.Logf("m1 = %v", m1.MultilineString("", ""))
+		t.Logf("m1 = %v", multiLineVar(m1v))
 
 		if m1.Type != "map[string]main.astruct" {
 			t.Fatalf("Wrong type: %s", m1.Type)
@@ -1248,7 +1252,7 @@ func TestConstants(t *testing.T) {
 			assertNoError(err, t, fmt.Sprintf("EvalVariable(%s)", testcase.name))
 			assertVariable(t, variable, testcase)
 			cv := api.ConvertVar(variable)
-			str := cv.SinglelineStringFormatted("%#x")
+			str := cv.StringWithOptions("", "%#x", 0)
 			if str != testcase.alternate {
 				t.Errorf("for %s expected %q got %q when formatting in hexadecimal", testcase.name, testcase.alternate, str)
 			}

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2269,7 +2269,7 @@ func (c *Commands) printVar(t *Term, ctx callContext, args string) error {
 
 	t.stdout.pw.PageMaybe(nil)
 
-	fmt.Fprintln(t.stdout, val.MultilineString("", fmtstr))
+	fmt.Fprintln(t.stdout, val.StringWithOptions("", fmtstr, api.PrettyNewlines))
 
 	if val.Kind == reflect.Chan {
 		fmt.Fprintln(t.stdout)
@@ -2350,7 +2350,7 @@ func (t *Term) printFilteredVariables(varType string, vars []api.Variable, filte
 			if cfg == ShortLoadConfig {
 				fmt.Fprintf(t.stdout, "%s = %s\n", name, v.SinglelineString())
 			} else {
-				fmt.Fprintf(t.stdout, "%s = %s\n", name, v.MultilineString("", ""))
+				fmt.Fprintf(t.stdout, "%s = %s\n", name, multiLineVar(&v, ""))
 			}
 		}
 	}
@@ -2863,7 +2863,7 @@ func printReturnValues(t *Term, th *api.Thread) {
 	}
 	fmt.Fprintln(t.stdout, "Values returned:")
 	for _, v := range th.ReturnValues {
-		fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, v.MultilineString("\t", ""))
+		fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, multiLineVar(&v, "\t"))
 	}
 	fmt.Fprintln(t.stdout)
 }
@@ -2994,13 +2994,13 @@ func printBreakpointInfo(t *Term, th *api.Thread, tracepointOnNewline bool) {
 
 	for _, v := range bpi.Variables {
 		tracepointnl()
-		fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, v.MultilineString("\t", ""))
+		fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, multiLineVar(&v, "\t"))
 	}
 
 	for _, v := range bpi.Locals {
 		tracepointnl()
 		if *bp.LoadLocals == longLoadConfig {
-			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, v.MultilineString("\t", ""))
+			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, multiLineVar(&v, "\t"))
 		} else {
 			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, v.SinglelineString())
 		}
@@ -3009,7 +3009,7 @@ func printBreakpointInfo(t *Term, th *api.Thread, tracepointOnNewline bool) {
 	if bp.LoadArgs != nil && *bp.LoadArgs == longLoadConfig {
 		for _, v := range bpi.Arguments {
 			tracepointnl()
-			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, v.MultilineString("\t", ""))
+			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, multiLineVar(&v, "\t"))
 		}
 	}
 	if bpi.Stacktrace != nil {
@@ -3657,4 +3657,8 @@ func (t *Term) formatBreakpointLocation(bp *api.Breakpoint) string {
 		fmt.Fprintf(&out, "%s:%d", p, bp.Line)
 	}
 	return out.String()
+}
+
+func multiLineVar(v *api.Variable, indent string) string {
+	return v.StringWithOptions(indent, "", api.PrettyNewlines)
 }

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -645,7 +645,7 @@ func (t *Term) printDisplay(i int) {
 		fmt.Fprintf(t.stdout, "%d: %s = error %v\n", i, expr, err)
 		return
 	}
-	fmt.Fprintf(t.stdout, "%d: %s = %s\n", i, val.Name, val.SinglelineStringFormatted(fmtstr))
+	fmt.Fprintf(t.stdout, "%d: %s = %s\n", i, val.Name, val.StringWithOptions("", fmtstr, 0))
 }
 
 func (t *Term) printDisplays() {

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -2908,7 +2908,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		}
 		return s.variableHandles.create(&fullyQualifiedVariable{v, qualifiedNameOrExpr, false /*not a scope*/, 0})
 	}
-	value = api.ConvertVar(v).SinglelineStringWithShortTypes()
+	value = formatVar(v)
 	if v.Unreadable != nil {
 		return value, 0
 	}
@@ -2922,7 +2922,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		// TODO(polina): Get *proc.Variable object from debugger instead. Export a function to set v.loaded to false
 		// and call v.loadValue gain with a different load config. It's more efficient, and it's guaranteed to keep
 		// working with generics.
-		value = api.ConvertVar(v).SinglelineStringWithShortTypes()
+		value = formatVar(v)
 		typeName := api.PrettyTypeName(v.DwarfType)
 		loadExpr := fmt.Sprintf("*(*%q)(%#x)", typeName, v.Addr)
 		s.config.log.Debugf("loading %s (type %s) with %s", qualifiedNameOrExpr, typeName, loadExpr)
@@ -2936,7 +2936,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		} else {
 			v.Children = vLoaded.Children
 			v.Value = vLoaded.Value
-			value = api.ConvertVar(v).SinglelineStringWithShortTypes()
+			value = formatVar(v)
 		}
 		return value
 	}
@@ -2968,7 +2968,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 					} else {
 						cLoaded.Name = v.Children[0].Name // otherwise, this will be the pointer expression
 						v.Children = []proc.Variable{*cLoaded}
-						value = api.ConvertVar(v).SinglelineStringWithShortTypes()
+						value = formatVar(v)
 					}
 				} else {
 					value = reloadVariable(v, qualifiedNameOrExpr)
@@ -4481,4 +4481,8 @@ func (s *syncflag) raise() {
 	s.flag = true
 	s.mu.Unlock()
 	s.cond.Broadcast()
+}
+
+func formatVar(v *proc.Variable) string {
+	return api.ConvertVar(v).StringWithOptions("", "", api.PrettyShortenType)
 }

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1707,7 +1707,7 @@ func TestIssue406(t *testing.T) {
 		assertNoError(state.Err, t, "Continue()")
 		v, err := c.EvalVariable(api.EvalScope{GoroutineID: -1}, "cfgtree", normalLoadConfig)
 		assertNoError(err, t, "EvalVariable()")
-		vs := v.MultilineString("", "")
+		vs := v.StringWithOptions("", "", api.PrettyNewlines)
 		t.Logf("cfgtree formats to: %s\n", vs)
 	})
 }
@@ -2838,7 +2838,7 @@ func TestClientServer_SinglelineStringFormattedWithBigInts(t *testing.T) {
 
 		constvar, err := c.EvalVariable(api.EvalScope{GoroutineID: -1}, "9331634762088972288", normalLoadConfig)
 		assertNoError(err, t, "ErrVariable(9331634762088972288)")
-		out := constvar.SinglelineStringFormatted("%X")
+		out := constvar.StringWithOptions("", "%X", 0)
 		t.Logf("constant: %q\n", out)
 		if out != "8180A06000000000" {
 			t.Errorf("expected \"8180A06000000000\" got %q when printing constant", out)
@@ -2862,7 +2862,7 @@ func TestClientServer_SinglelineStringFormattedWithBigInts(t *testing.T) {
 				t.Errorf("wrong kind for variable %s\n", child.Kind)
 			}
 			out1 := child.SinglelineString()
-			out2 := child.SinglelineStringFormatted("%X")
+			out2 := child.StringWithOptions("", "%X", 0)
 			t.Logf("%q %q\n", out1, out2)
 			if out1 != expected[i*2] {
 				t.Errorf("for child %d expected %s got %s (decimal)", i, expected[i*2], out1)
@@ -3441,7 +3441,7 @@ func TestEvalNonunicodeString(t *testing.T) {
 		assertNoError(state.Err, t, "Continue")
 		v, err := c.EvalVariable(api.EvalScope{GoroutineID: -1}, "string(issue4072)", normalLoadConfig)
 		assertNoError(err, t, "EvalVariable")
-		t.Logf("%s", v.MultilineString("", ""))
+		t.Logf("%s", v.StringWithOptions("", "", api.PrettyNewlines))
 		tgt := string([]byte{116, 121, 112, 101, 32, 84, 32, 115, 116, 114, 117, 99, 116, 32, 123, 12, 12, 9, 255, 102, 108, 100, 99, 111, 109, 255})
 		if v.Value != tgt {
 			t.Errorf("wrong value for string issue4072 expected %q, got %q", tgt, v.Value)


### PR DESCRIPTION
Replace SinglelineStringFormatted, SinglelineStringWithShortTypes and
MultilineString with a single configurable StringWithOptions.

The Variable type was starting to have too many formatting helper methods.

Keep SinglelineString since it's used everywhere.
