### PR TITLE
pkg/proc/debuginfod: fix debuginfod download progress

### DIFF
--- a/_fixtures/fake-debuginfod-find/debuginfod-find
+++ b/_fixtures/fake-debuginfod-find/debuginfod-find
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ "$1" == "--help" ]; then
+	exit 0
+fi
+
 for i in $(seq 1 100000 1000000); do
 	echo "Downloading $i..." >&2
 	sleep 1

--- a/pkg/proc/debuginfod/debuginfod.go
+++ b/pkg/proc/debuginfod/debuginfod.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 )
@@ -22,7 +22,7 @@ func execFind(ctx context.Context, notify func(string), args ...string) (string,
 	}
 	cmd := exec.CommandContext(ctx, debuginfodFind, args...)
 	if notify != nil {
-		cmd.Env = append(os.Environ(), "DEBUGINFOD_PROGRESS=yes")
+		cmd.Args = slices.Insert(cmd.Args, 1, "--verbose")
 		stderr, err := cmd.StderrPipe()
 		if err != nil {
 			return "", err

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -141,6 +141,9 @@ func New(client service.Client, conf *config.Config) *Term {
 				t.downloadsMu.Unlock()
 				if !firstEventBinaryInfoDownload {
 					fmt.Fprintf(t.stdout, "\r")
+					if strings.ToLower(os.Getenv("TERM")) != "dumb" {
+						fmt.Fprintf(t.stdout, "\x1b[J") // clear to the end of the line
+					}
 				}
 				fmt.Fprintf(t.stdout, "Downloading debug info for %s: %s (press ^C to cancel)", event.BinaryInfoDownloadEventDetails.ImagePath, event.BinaryInfoDownloadEventDetails.Progress)
 				firstEventBinaryInfoDownload = false


### PR DESCRIPTION
debuginfod-find added a --verbose flag and in the process broke the old
way to get download progress information:

https://sourceware.org/bugzilla/show_bug.cgi?id=33937

Restore this functionality.
