### PR TITLE
proc: Remove special-casing for 1.23 in tests

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -5748,9 +5748,6 @@ func TestPanicLine(t *testing.T) {
 }
 
 func TestReadClosure(t *testing.T) {
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("not implemented")
-	}
 	withTestProcess("closurecontents", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		avalues := []int64{0, 3, 9, 27}
 		for i := range 4 {

--- a/pkg/proc/stepping_test.go
+++ b/pkg/proc/stepping_test.go
@@ -659,10 +659,6 @@ func TestNextGenericMethodThroughInterface(t *testing.T) {
 }
 
 func TestRangeOverFuncNext(t *testing.T) {
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("N/A")
-	}
-
 	var bp *proc.Breakpoint
 
 	funcBreak := func(t *testing.T, fnname string) seqTest {
@@ -1213,10 +1209,6 @@ func TestRangeOverFuncNext(t *testing.T) {
 }
 
 func TestRangeOverFuncStepOut(t *testing.T) {
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("N/A")
-	}
-
 	testseq2(t, "rangeoverfunc", "", []seqTest{
 		{contContinue, 97},
 		{contStepout, 251},
@@ -1224,9 +1216,6 @@ func TestRangeOverFuncStepOut(t *testing.T) {
 }
 
 func TestRangeOverFuncNextInlined(t *testing.T) {
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("N/A")
-	}
 	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) && !goversion.VersionAfterOrEqual(runtime.Version(), 1, 27) {
 		t.Skip("broken due to inlined symbol names")
 	}
@@ -1776,9 +1765,6 @@ func TestRangeOverFuncNextInlined(t *testing.T) {
 }
 
 func TestStepIntoCoroutine(t *testing.T) {
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("N/A")
-	}
 	skipOn(t, "not working due to optimizations", "386")
 	withTestProcessArgs("backwardsiter", t, ".", []string{}, 0, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		testseq2intl(t, fixture, grp, p, nil, []seqTest{

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -996,8 +996,8 @@ func TestEvalExpression(t *testing.T) {
 					return
 				}
 				if err != nil && err.Error() == "expression *ast.CompositeLit not implemented" {
-					if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) || runtime.GOARCH == "386" {
-						// composite literals not supported before 1.22
+					if runtime.GOARCH == "386" {
+						// composite literals are currently unsupported on 386
 						return
 					}
 				}
@@ -1463,10 +1463,8 @@ func TestCallFunction(t *testing.T) {
 			}
 		}
 
-		if goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-			for _, tc := range testcases123 {
-				testCallFunction(t, grp, p, tc)
-			}
+		for _, tc := range testcases123 {
+			testCallFunction(t, grp, p, tc)
 		}
 
 		// LEAVE THIS AS THE LAST ITEM, IT BREAKS THE TARGET PROCESS!!!
@@ -1941,10 +1939,6 @@ func TestCapturedVariable(t *testing.T) {
 
 func TestSetupRangeFramesCrash(t *testing.T) {
 	// See issue #3806
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("N/A")
-	}
-
 	for _, options := range []protest.BuildFlags{0, protest.EnableInlining | protest.EnableOptimization} {
 		withTestProcessArgs("setiterator", t, ".", []string{}, options, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 			setFileBreakpoint(p, t, fixture.Source, 48)
@@ -2027,9 +2021,6 @@ func TestClassicMap(t *testing.T) {
 
 func TestCallFunctionRegisterArg(t *testing.T) {
 	protest.MustSupportFunctionCalls(t, testBackend)
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("not supported")
-	}
 	withTestProcessArgs("issue3310", t, ".", []string{}, protest.AllNonOptimized, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		setFileBreakpoint(p, t, fixture.Source, 12)
 		assertNoError(grp.Continue(), t, "Continue()")
@@ -2041,9 +2032,6 @@ func TestCapturedVarVisibleOnFirstLine(t *testing.T) {
 	// Checks that a variable captured by a closure is visible on the first
 	// line of the closure function.
 	// See issue #4000
-	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 23) {
-		t.Skip("not implemented")
-	}
 	skipOn(t, "broken", "linux", "386")
 	withTestProcess("issue4000", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		addrs, err := proc.FindFileLocation(p, fixture.Source, 7)


### PR DESCRIPTION
go.mod specifies 1.24, so it's not possible to compile the
tests with Go toolchains <= 1.23 anyway. It doesn't make
sense to skip certain tests for older toolchains, because
attempting to use old toolchains will fail at build time.
