### PR TITLE
pkg/proc,service,pkg/terminal: add stacktrace caching

### DIFF
--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -65,7 +65,7 @@ process_pid() | Equivalent to API call [ProcessPid](https://pkg.go.dev/github.co
 recorded() | Equivalent to API call [Recorded](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Recorded)
 restart(Position, ResetArgs, NewArgs, Rerecord, Rebuild, NewRedirects) | Equivalent to API call [Restart](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Restart)
 set_expr(Scope, Symbol, Value) | Equivalent to API call [Set](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Set)
-stacktrace(Id, Depth, Full, Defers, Opts, Cfg) | Equivalent to API call [Stacktrace](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Stacktrace)
+stacktrace(Id, Depth, Full, Defers, Opts, Cfg, Skip) | Equivalent to API call [Stacktrace](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Stacktrace)
 state(NonBlocking) | Equivalent to API call [State](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.State)
 toggle_breakpoint(Id, Name) | Equivalent to API call [ToggleBreakpoint](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.ToggleBreakpoint)
 dlv_command(command) | Executes the specified command as if typed at the dlv_prompt

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -111,6 +111,14 @@ func (frame *Stackframe) contains(off int64) bool {
 func ThreadStacktrace(tgt *Target, thread Thread, depth int) ([]Stackframe, error) {
 	g, _ := GetG(thread)
 	if g == nil {
+		if cachedStack := tgt.scache.get(0, thread.ThreadID()); cachedStack != nil {
+			frames, err := cachedStack.it.stacktrace(depth, cachedStack.frames)
+			if err != nil {
+				return nil, err
+			}
+			tgt.scache.put(0, thread.ThreadID(), cachedStack.it, frames)
+			return limitframes(frames, depth+1), nil
+		}
 		regs, err := thread.Registers()
 		if err != nil {
 			return nil, err
@@ -119,7 +127,13 @@ func ThreadStacktrace(tgt *Target, thread Thread, depth int) ([]Stackframe, erro
 		dwarfRegs := *(thread.BinInfo().Arch.RegistersToDwarfRegisters(so.StaticBase, regs))
 		dwarfRegs.ChangeFunc = thread.SetReg
 		it := newStackIterator(tgt, thread.BinInfo(), thread.ProcessMemory(), dwarfRegs, 0, nil, 0)
-		return it.stacktrace(depth)
+		frames, err := it.stacktrace(depth, nil)
+		if err != nil {
+			return nil, err
+		}
+		tgt.scache.put(0, thread.ThreadID(), it, frames)
+		return frames, nil
+
 	}
 	return GoroutineStacktrace(tgt, g, depth, 0)
 }
@@ -165,16 +179,33 @@ const (
 // GoroutineStacktrace returns the stack trace for a goroutine.
 // Note the locations in the array are return addresses not call addresses.
 func GoroutineStacktrace(tgt *Target, g *G, depth int, opts StacktraceOptions) ([]Stackframe, error) {
+	if opts == 0 {
+		var threadID int
+		if g.Thread != nil {
+			threadID = g.Thread.ThreadID()
+		}
+		if cachedStack := tgt.scache.get(g.ID, threadID); cachedStack != nil {
+			frames, err := cachedStack.it.stacktrace(depth, cachedStack.frames)
+			if err != nil {
+				return nil, err
+			}
+			tgt.scache.put(g.ID, threadID, cachedStack.it, frames)
+			return limitframes(frames, depth+1), nil
+		}
+	}
 	it, err := goroutineStackIterator(tgt, g, opts)
 	if err != nil {
 		return nil, err
 	}
-	frames, err := it.stacktrace(depth)
+	frames, err := it.stacktrace(depth, nil)
 	if err != nil {
 		return nil, err
 	}
 	if opts&StacktraceReadDefers != 0 {
 		g.readDefers(frames)
+	}
+	if opts == 0 {
+		tgt.scache.put(g.ID, 0, it, frames)
 	}
 	return frames, nil
 }
@@ -385,11 +416,19 @@ func (it *stackIterator) newStackframe(ret, retaddr uint64) Stackframe {
 	return r
 }
 
-func (it *stackIterator) stacktrace(depth int) ([]Stackframe, error) {
+func (it *stackIterator) stacktrace(depth int, initialFrames []Stackframe) ([]Stackframe, error) {
 	if depth < 0 {
 		return nil, errors.New("negative maximum stack depth")
 	}
-	frames := make([]Stackframe, 0, depth+1)
+	var frames []Stackframe
+	if len(initialFrames) > 0 {
+		frames = initialFrames
+		if len(frames) >= depth+1 {
+			return frames, nil
+		}
+	} else {
+		frames = make([]Stackframe, 0, depth+1)
+	}
 	f := func(frame Stackframe) bool {
 		frames = append(frames, frame)
 		return len(frames) < depth+1
@@ -414,7 +453,6 @@ func (it *stackIterator) stacktrace(depth int) ([]Stackframe, error) {
 		}
 
 		frames = append(frames, Stackframe{Err: err})
-
 	}
 	return frames, nil
 }
@@ -1102,4 +1140,37 @@ func rangeFuncStackTrace(tgt *Target, g *G) ([]Stackframe, error) {
 	}
 	g.readDefers(frames)
 	return frames, nil
+}
+
+type cachedStack struct {
+	it     *stackIterator
+	frames []Stackframe
+}
+
+type stackCacheKey struct {
+	goid     int64
+	threadID int
+}
+
+type stackCache struct {
+	m map[stackCacheKey]*cachedStack
+}
+
+func (cache *stackCache) init() {
+	cache.m = make(map[stackCacheKey]*cachedStack)
+}
+
+func (cache *stackCache) get(goid int64, threadID int) *cachedStack {
+	return cache.m[stackCacheKey{goid, threadID}]
+}
+
+func (cache *stackCache) put(goid int64, threadID int, it *stackIterator, frames []Stackframe) {
+	cache.m[stackCacheKey{goid, threadID}] = &cachedStack{it, frames}
+}
+
+func limitframes(frames []Stackframe, n int) []Stackframe {
+	if len(frames) < n {
+		return frames
+	}
+	return frames[:n]
 }

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -67,7 +67,10 @@ type Target struct {
 	// have read and parsed from the targets memory.
 	// This must be cleared whenever the target is resumed.
 	gcache goroutineCache
-	iscgo  *bool
+	// scache is a cache for stack traces.
+	scache stackCache
+
+	iscgo *bool
 
 	// exitStatus is the exit status of the process we are debugging.
 	// Saved here to relay to any future commands.
@@ -224,6 +227,7 @@ func (grp *TargetGroup) newTarget(p ProcessInternal, pid int, currentThread Thre
 	t.createPluginOpenBreakpoint()
 
 	t.gcache.init(p.BinInfo())
+	t.scache.init()
 	t.fakeMemoryRegistryMap = make(map[string]*compositeMemory)
 
 	if grp.cfg.DisableAsyncPreempt {
@@ -282,6 +286,7 @@ func (t *Target) SupportsFunctionCalls() bool {
 // This should be called anytime the target process executes instructions.
 func (t *Target) ClearCaches() {
 	t.clearFakeMemory()
+	clear(t.scache.m)
 	t.gcache.Clear()
 	t.BinInfo().moduleDataCache = nil
 	for _, thread := range t.ThreadList() {

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -889,7 +889,7 @@ func (c *Commands) printGoroutines(t *Term, ctx callContext, indent string, gs [
 			writeGoroutineLabels(t.stdout, g, indent+"\t")
 		}
 		if flags&api.PrintGoroutinesStack != 0 {
-			stack, err := t.client.Stacktrace(g.ID, depth, 0, nil)
+			stack, err := t.client.Stacktrace(g.ID, depth, 0, 0, nil)
 			if err != nil {
 				return err
 			}
@@ -1043,11 +1043,11 @@ func (c *Commands) frameCommand(t *Term, ctx callContext, argstr string, directi
 	if frame < 0 {
 		return fmt.Errorf("Invalid frame %d", frame)
 	}
-	stack, err := t.client.Stacktrace(ctx.Scope.GoroutineID, frame, 0, nil)
+	stack, err := t.client.Stacktrace(ctx.Scope.GoroutineID, frame, frame, 0, nil)
 	if err != nil {
 		return err
 	}
-	if frame >= len(stack) {
+	if len(stack) == 0 {
 		return fmt.Errorf("Invalid frame %d", frame)
 	}
 	c.frame = frame
@@ -1056,7 +1056,7 @@ func (c *Commands) frameCommand(t *Term, ctx callContext, argstr string, directi
 		return err
 	}
 	printcontext(t, state)
-	th := stack[frame]
+	th := stack[0]
 	fmt.Fprintf(t.stdout, "Frame %d: %s:%d (PC: %x)\n", frame, t.formatPath(th.File), th.Line, th.PC)
 	printfile(t, th.File, th.Line, true)
 	return nil
@@ -2484,7 +2484,7 @@ func stackCommand(t *Term, ctx callContext, args string) error {
 	if sa.full {
 		cfg = &ShortLoadConfig
 	}
-	stack, err := t.client.Stacktrace(ctx.Scope.GoroutineID, sa.depth, sa.opts, cfg)
+	stack, err := t.client.Stacktrace(ctx.Scope.GoroutineID, sa.depth, 0, sa.opts, cfg)
 	if err != nil {
 		return err
 	}
@@ -2605,14 +2605,14 @@ func getLocation(t *Term, ctx callContext, args string, showContext bool) (file 
 		return state.CurrentThread.File, state.CurrentThread.Line, true, nil
 
 	case len(args) == 0 && ctx.scoped():
-		locs, err := t.client.Stacktrace(ctx.Scope.GoroutineID, ctx.Scope.Frame, 0, nil)
+		locs, err := t.client.Stacktrace(ctx.Scope.GoroutineID, ctx.Scope.Frame, ctx.Scope.Frame, 0, nil)
 		if err != nil {
 			return "", 0, false, err
 		}
-		if ctx.Scope.Frame >= len(locs) {
+		if len(locs) == 0 {
 			return "", 0, false, fmt.Errorf("Frame %d does not exist in goroutine %d", ctx.Scope.Frame, ctx.Scope.GoroutineID)
 		}
-		loc := locs[ctx.Scope.Frame]
+		loc := locs[0]
 		gid := ctx.Scope.GoroutineID
 		if gid < 0 {
 			state, err := t.client.GetState()

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -1675,6 +1675,12 @@ func (env *Env) starlarkPredeclare() (starlark.StringDict, map[string]string) {
 				return starlark.None, decorateError(thread, err)
 			}
 		}
+		if len(args) > 6 && args[6] != starlark.None {
+			err := unmarshalStarlarkValue(args[6], &rpcArgs.Skip, "Skip")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
 		for _, kv := range kwargs {
 			var err error
 			switch kv[0].(starlark.String) {
@@ -1690,6 +1696,8 @@ func (env *Env) starlarkPredeclare() (starlark.StringDict, map[string]string) {
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Opts, "Opts")
 			case "Cfg":
 				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Cfg, "Cfg")
+			case "Skip":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Skip, "Skip")
 			default:
 				err = fmt.Errorf("unknown argument %q", kv[0])
 			}
@@ -1703,7 +1711,7 @@ func (env *Env) starlarkPredeclare() (starlark.StringDict, map[string]string) {
 		}
 		return env.interfaceToStarlarkValue(&rpcRet), nil
 	})
-	doc["stacktrace"] = "builtin stacktrace(Id, Depth, Full, Defers, Opts, Cfg)\n\nstacktrace returns stacktrace of goroutine Id up to the specified Depth.\n\nIf Full is set it will also the variable of all local variables\nand function arguments of all stack frames."
+	doc["stacktrace"] = "builtin stacktrace(Id, Depth, Full, Defers, Opts, Cfg, Skip)\n\nstacktrace returns stacktrace of goroutine Id up to the specified Depth.\n\nIf Full is set it will also the variable of all local variables\nand function arguments of all stack frames."
 	r["state"] = starlark.NewBuiltin("state", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		if err := isCancelled(thread); err != nil {
 			return starlark.None, decorateError(thread, err)

--- a/service/client.go
+++ b/service/client.go
@@ -128,7 +128,7 @@ type Client interface {
 	ListGoroutinesWithFilter(start, count int, filters []api.ListGoroutinesFilter, group *api.GoroutineGroupingOptions, scope *api.EvalScope) ([]*api.Goroutine, []api.GoroutineGroup, int, bool, error)
 
 	// Stacktrace returns stacktrace
-	Stacktrace(goroutineID int64, depth int, opts api.StacktraceOptions, cfg *api.LoadConfig) ([]api.Stackframe, error)
+	Stacktrace(goroutineID int64, depth, skip int, opts api.StacktraceOptions, cfg *api.LoadConfig) ([]api.Stackframe, error)
 
 	// Ancestors returns ancestor stacktraces
 	Ancestors(goroutineID int64, numAncestors int, depth int) ([]api.Ancestor, error)

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -447,9 +447,9 @@ func (c *RPCClient) ListGoroutinesWithFilter(start, count int, filters []api.Lis
 	return out.Goroutines, out.Groups, out.Nextg, out.TooManyGroups, err
 }
 
-func (c *RPCClient) Stacktrace(goroutineId int64, depth int, opts api.StacktraceOptions, cfg *api.LoadConfig) ([]api.Stackframe, error) {
+func (c *RPCClient) Stacktrace(goroutineId int64, depth, skip int, opts api.StacktraceOptions, cfg *api.LoadConfig) ([]api.Stackframe, error) {
 	var out StacktraceOut
-	err := c.call("Stacktrace", StacktraceIn{goroutineId, depth, false, false, opts, cfg}, &out)
+	err := c.call("Stacktrace", StacktraceIn{goroutineId, depth, false, false, opts, cfg, skip}, &out)
 	return out.Locations, err
 }
 

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -194,6 +194,7 @@ type StacktraceIn struct {
 	Defers bool // read deferred functions (equivalent to passing StacktraceReadDefers in Opts)
 	Opts   api.StacktraceOptions
 	Cfg    *api.LoadConfig
+	Skip   int // number of frames to skip
 }
 
 type StacktraceOut struct {
@@ -215,6 +216,13 @@ func (s *RPCServer) Stacktrace(arg StacktraceIn, out *StacktraceOut) error {
 	rawlocs, err := s.debugger.Stacktrace(arg.Id, arg.Depth, arg.Opts)
 	if err != nil {
 		return err
+	}
+	if arg.Skip > 0 {
+		if arg.Skip >= len(rawlocs) {
+			rawlocs = nil
+		} else {
+			rawlocs = rawlocs[arg.Skip:]
+		}
 	}
 	out.Locations, err = s.debugger.ConvertStacktrace(rawlocs, api.LoadConfigToProc(cfg))
 	return err

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -1300,7 +1300,7 @@ func TestClientServer_FullStacktrace(t *testing.T) {
 		assertNoError(err, t, "GoroutinesInfo()")
 		found := make([]bool, 10)
 		for _, g := range gs {
-			frames, err := c.Stacktrace(g.ID, 40, 0, &normalLoadConfig)
+			frames, err := c.Stacktrace(g.ID, 40, 0, 0, &normalLoadConfig)
 			assertNoError(err, t, fmt.Sprintf("Stacktrace(%d)", g.ID))
 			t.Logf("goroutine %d", g.ID)
 			for i, frame := range frames {
@@ -1341,7 +1341,7 @@ func TestClientServer_FullStacktrace(t *testing.T) {
 			t.Fatalf("Continue(): %v\n", state.Err)
 		}
 
-		frames, err := c.Stacktrace(-1, 10, 0, &normalLoadConfig)
+		frames, err := c.Stacktrace(-1, 10, 0, 0, &normalLoadConfig)
 		assertNoError(err, t, "Stacktrace")
 
 		cur := 3
@@ -1362,6 +1362,12 @@ func TestClientServer_FullStacktrace(t *testing.T) {
 			if cur < 0 {
 				break
 			}
+		}
+
+		framesWithSkip, err := c.Stacktrace(-1, 10, len(frames)-1, 0, nil)
+		assertNoError(err, t, "Stacktrace")
+		if len(framesWithSkip) != 1 {
+			t.Errorf("wrong number of frames returned with skip parameter: %d\n", len(framesWithSkip))
 		}
 	})
 }
@@ -1424,7 +1430,7 @@ func TestIssue355(t *testing.T) {
 		assertError(err, t, "ListScopeRegisters()")
 		_, _, err = c.ListGoroutines(0, 0)
 		assertError(err, t, "ListGoroutines()")
-		_, err = c.Stacktrace(gid, 10, 0, &normalLoadConfig)
+		_, err = c.Stacktrace(gid, 10, 0, 0, &normalLoadConfig)
 		assertError(err, t, "Stacktrace()")
 		_, _, err = c.FindLocation(api.EvalScope{GoroutineID: gid}, "+1", false, nil)
 		assertError(err, t, "FindLocation()")
@@ -1560,7 +1566,7 @@ func TestNegativeStackDepthBug(t *testing.T) {
 		ch := c.Continue()
 		state := <-ch
 		assertNoError(state.Err, t, "Continue()")
-		_, err = c.Stacktrace(-1, -2, 0, &normalLoadConfig)
+		_, err = c.Stacktrace(-1, -2, 0, 0, &normalLoadConfig)
 		assertError(err, t, "Stacktrace()")
 	})
 }
@@ -2741,7 +2747,7 @@ func TestGenericsBreakpoint(t *testing.T) {
 		}
 
 		frame1Line := func() int {
-			frames, err := c.Stacktrace(-1, 10, 0, nil)
+			frames, err := c.Stacktrace(-1, 10, 0, 0, nil)
 			assertNoError(err, t, "Stacktrace")
 			return frames[1].Line
 		}


### PR DESCRIPTION
Adds caching to stacktraces so that stacktrace requests are not
quadratic. Also add a Skip parameter to the Stacktrace RPC request so
that clients can only request the frames they need.

Fixes #3809
Fixes #989
