### PR TITLE
build: add goreleaser release automation with cosign signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run only (snapshot build, not published to GitHub Releases)'
+        type: boolean
+        default: true
+
+# Cancel in-progress runs for the same ref.
+concurrency:
+  group: "${{ github.ref }}-release"
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # create GitHub Release and upload assets
+  id-token: write   # cosign OIDC for keyless signing
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history required for goreleaser release notes
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Run goreleaser (release)
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: ~> v2
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run goreleaser (snapshot)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: ~> v2
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload snapshot artifacts
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-dist
+          path: dist/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ localtests
 .teamcity/target
 .vscode
 .claude
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,76 @@
+version: 2
+
+project_name: dlv
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - main: ./cmd/dlv
+    binary: dlv
+    # CGO is left at its default: enabled for native builds, automatically
+    # disabled by the Go toolchain when cross-compiling. This means linux/amd64
+    # release binaries are built with CGO on a linux/amd64 CI runner, while all
+    # cross-compiled targets (darwin, windows, linux/arm64, etc.) use pure Go.
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - "386"
+      - ppc64le
+    ignore:
+      # darwin and windows only support amd64 and arm64 in this release config.
+      # riscv64 and loong64 are supported by Delve but excluded here because
+      # goreleaser cross-compilation toolchains for those targets are not yet
+      # available in standard CI environments.
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: ppc64le
+      - goos: windows
+        goarch: "386"
+      - goos: windows
+        goarch: ppc64le
+    ldflags:
+      - -X main.Build={{.FullCommit}}
+
+archives:
+  - formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "dlv_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+# Cosign keyless signing via Sigstore. Signing runs automatically in GitHub
+# Actions with `id-token: write` permission — cosign v2 auto-detects the
+# GitHub Actions OIDC identity. No private key or secret is required.
+# To verify: cosign verify-blob --certificate <file>.cert --signature <file>.sig <file>
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.cert"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - --yes
+    artifacts: checksum
+    output: true
+
+release:
+  github:
+    owner: go-delve
+    name: delve
+
+snapshot:
+  version_template: "{{ .Tag }}-next"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,12 @@ When filing an issue, make sure to answer these six questions:
 
 Fork this repo and create your own feature branch. Install all dependencies as documented in the README.
 
+### Build prerequisites
+
+- Go (see `go.mod` for minimum version)
+- [goreleaser v2](https://goreleaser.com/install/) — required for `make build`
+  Install: `go install github.com/goreleaser/goreleaser/v2@latest`
+
 ### Guidelines
 
 Consider the following guidelines when preparing to submit a patch:

--- a/Documentation/installation/README.md
+++ b/Documentation/installation/README.md
@@ -17,6 +17,30 @@ $ go install github.com/go-delve/delve/cmd/dlv@v1.7.4-0.20211208103735-2f1367276
 
 See [Versions](https://go.dev/ref/mod#versions) and [Pseudo-versions](https://go.dev/ref/mod#pseudo-versions) for how to format the version suffixes.
 
+## Download a binary release
+
+Pre-built binaries for Linux, macOS, and Windows are available on the
+[GitHub Releases page](https://github.com/go-delve/delve/releases).
+
+Download the archive for your platform, extract it, and place `dlv` in
+your `$PATH`.
+
+To verify a release with cosign, verify the signed checksum file and then
+check your archive against it:
+
+```sh
+# Verify the signed checksum file (validates both signature and signer identity)
+cosign verify-blob \
+  --certificate checksums.txt.cert \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp "https://github.com/go-delve/delve/.github/workflows/release.yml@refs/tags/.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
+
+# Verify your archive matches the checksum
+sha256sum -c --ignore-missing checksums.txt
+```
+
 Alternatively, clone the git repository and build:
 
 ```

--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -43,17 +43,19 @@ func NewMakeCommands() *cobra.Command {
 		Use:   "build",
 		Short: "Build delve",
 		Run: func(cmd *cobra.Command, args []string) {
-			envflags := []string{}
-			if len(Architecture) > 0 {
-				envflags = append(envflags, "GOARCH="+Architecture)
-			}
-			if len(OS) > 0 {
-				envflags = append(envflags, "GOOS="+OS)
-			}
-			if len(envflags) > 0 {
+			if len(Architecture) > 0 || len(OS) > 0 {
+				// Explicit cross-compile target: fall back to direct go build.
+				envflags := []string{}
+				if len(Architecture) > 0 {
+					envflags = append(envflags, "GOARCH="+Architecture)
+				}
+				if len(OS) > 0 {
+					envflags = append(envflags, "GOOS="+OS)
+				}
 				executeEnv(envflags, "go", "build", "-ldflags", "-extldflags -static", tagFlags(false), buildFlags(), DelveMainPackagePath)
 			} else {
-				execute("go", "build", "-ldflags", "-extldflags -static", tagFlags(false), buildFlags(), DelveMainPackagePath)
+				// Default: goreleaser for consistent local/release builds.
+				execute("goreleaser", "build", "--single-target", "--snapshot", "--clean", "--output", "./dlv")
 			}
 			if runtime.GOOS == "darwin" && os.Getenv("CERT") != "" && canMacnative() && !isCodesigned("./dlv") {
 				codesign("./dlv")
@@ -528,12 +530,10 @@ func allPackages() []string {
 }
 
 // getBuildSHA will invoke git to return the current SHA of the commit at HEAD.
-// If invoking git has been disabled, it will return an empty string instead.
 func getBuildSHA() (string, error) {
 	if DisableGit {
 		return "", nil
 	}
-
 	buildSHA, err := exec.Command("git", "rev-parse", "HEAD").CombinedOutput()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Adds goreleaser-based release automation integrated with GitHub Releases.

On pushing a v* tag, the release workflow cross-compiles dlv for 8 platforms (linux/darwin/windows × amd64/arm64/386/ppc64le where supported), packages them as .tar.gz/.zip archives, generates a SHA256 checksums file, signs checksums.txt with cosign keyless signing via GitHub Actions OIDC, and publishes everything to GitHub Releases.

A workflow_dispatch trigger supports dry-run testing without publishing.

Changes:
- .goreleaser.yaml: goreleaser v2 config for builds, archives, checksums, cosign signing, and GitHub Release publishing
- .github/workflows/release.yml: release workflow with tag push and manual dispatch triggers
- _scripts/make.go: make build now delegates to goreleaser --single-target so local and release builds share identical config
- Documentation/installation/README.md: document binary release download and cosign verification
- CONTRIBUTING.md: document goreleaser v2 as a build prerequisite

Fixes #2241