### PR TITLE
Revert "winarm64: remove experimental build tags (#4176)"

### DIFF
--- a/Documentation/faq.md
+++ b/Documentation/faq.md
@@ -17,7 +17,6 @@ Currently Delve supports (GOOS / GOARCH):
 * linux / arm64 (AARCH64)
 * linux / 386
 * windows / amd64
-* windows / arm64
 * darwin (macOS) / amd64
 
 There is no planned ETA for support of other architectures or operating systems. Bugs tracking requested support are:

--- a/_scripts/gen-capslock-all.go
+++ b/_scripts/gen-capslock-all.go
@@ -27,7 +27,7 @@ var platforms = []Platform{
 	{GOOS: "darwin", GOARCH: "amd64"},
 	{GOOS: "darwin", GOARCH: "arm64"},
 	{GOOS: "windows", GOARCH: "amd64"},
-	{GOOS: "windows", GOARCH: "arm64"},
+	{GOOS: "windows", GOARCH: "arm64", BuildTags: "exp.winarm64"},
 }
 
 const (

--- a/_scripts/make.go
+++ b/_scripts/make.go
@@ -305,6 +305,9 @@ func tagFlags(isTest bool) string {
 		tags = append(tags, mactags)
 	}
 	if isTest {
+		if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" {
+			tags = append(tags, "exp.winarm64")
+		}
 		if runtime.GOOS == "linux" && runtime.GOARCH == "ppc64le" {
 			tags = append(tags, "exp.linuxppc64le")
 		}

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -825,6 +825,9 @@ func TestTraceDirRecursion(t *testing.T) {
 }
 
 func TestTraceMultipleGoroutines(t *testing.T) {
+	if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" {
+		t.Skip("broken")
+	}
 	t.Parallel()
 	dlvbin := protest.GetDlvBinary(t)
 
@@ -1391,6 +1394,9 @@ func TestCapsLock(t *testing.T) {
 	args := []string{"-packages", "./cmd/dlv"}
 	if goos == "linux" && goarch == "ppc64le" {
 		args = append([]string{"-buildtags", "exp.linuxppc64le"}, args...)
+	}
+	if goos == "windows" && goarch == "arm64" {
+		args = append([]string{"-buildtags", "exp.winarm64"}, args...)
 	}
 
 	if goos == "linux" && goarch == "riscv64" {

--- a/pkg/proc/native/support_sentinel_windows.go
+++ b/pkg/proc/native/support_sentinel_windows.go
@@ -1,4 +1,4 @@
-//go:build windows && !amd64 && !arm64
+//go:build windows && !amd64 && !(arm64 && exp.winarm64)
 
 // This file is used to detect build on unsupported GOOS/GOARCH combinations.
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2135,6 +2135,7 @@ func TestStepOut(t *testing.T) {
 
 func TestStepConcurrentDirect(t *testing.T) {
 	protest.AllowRecording(t)
+	skipOn(t, "broken - step concurrent", "windows", "arm64")
 	withTestProcess("teststepconcurrent", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		bp := setFileBreakpoint(p, t, fixture.Source, 37)
 

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -454,6 +454,9 @@ func GetDlvBinary(t *testing.T) string {
 	t.Helper()
 
 	var tags []string
+	if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" {
+		tags = []string{"-tags=exp.winarm64"}
+	}
 	if runtime.GOOS == "linux" && runtime.GOARCH == "ppc64le" {
 		tags = []string{"-tags=exp.linuxppc64le"}
 	}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -5063,6 +5063,9 @@ func getPC(t *testing.T, client *daptest.Client, threadId int) (uint64, error) {
 // TestNextParked tests that we can switched selected goroutine to a parked one
 // and perform next operation on it.
 func TestNextParked(t *testing.T) {
+	if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" {
+		t.Skip("broken")
+	}
 	runTest(t, "parallel_next", func(client *daptest.Client, fixture protest.Fixture) {
 		runDebugSessionWithBPs(t, client, "launch",
 			// Launch

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3253,6 +3253,10 @@ func TestGuessSubstitutePath(t *testing.T) {
 			t.Setenv("GOFLAGS", "-tags=exp.linuxriscv64")
 		case "loong64":
 			t.Setenv("GOFLAGS", "-tags=exp.linuxloong64")
+		case "arm64":
+			if runtime.GOOS == "windows" {
+				t.Setenv("GOFLAGS", "-tags=exp.winarm64")
+			}
 		}
 
 		gsp, err := client.GuessSubstitutePath()


### PR DESCRIPTION
This reverts commit cd7257f5181eb61fb4f926a805fba7e3b15270d3.

Disable falky TestStepConcurrentDirect.
