### PR TITLE
config,terminal: better documentation for configuration file

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -2,7 +2,7 @@
 
 If `$XDG_CONFIG_HOME` is set, then configuration and command history files are located in `$XDG_CONFIG_HOME/dlv`. Otherwise, they are located in `$HOME/.config/dlv` on Linux and `$HOME/.dlv` on other systems.
 
-The configuration file `config.yml` contains all the configurable options and their default values. The command history is stored in `.dbg_history`.
+The configuration file `config.yml` contains all the configurable options and their default values ([config.yml documentation](./config.md)). The command history is stored in `.dbg_history`.
 
 # Commands
 
@@ -252,30 +252,10 @@ Saves the configuration file to disk, overwriting the current configuration file
 
 	config <parameter> <value>
 
-Changes the value of a configuration parameter.
+Changes the value of simple configuration parameters.
 
-	config substitute-path <from> <to>
-	config substitute-path <from>
-	config substitute-path -clear
-	config substitute-path -guess
+Use 'help config &lt;parameter>' for more informations on specific configuration options.
 
-Adds or removes a path substitution rule, if -clear is used all
-substitute-path rules are removed. Without arguments shows the current list
-of substitute-path rules.
-The -guess option causes Delve to try to guess your substitute-path
-configuration automatically.
-See also [Documentation/cli/substitutepath.md](//github.com/go-delve/delve/tree/master/Documentation/cli/substitutepath.md) for how the rules are applied.
-
-	config alias <command> <alias>
-	config alias <alias>
-
-Defines &lt;alias> as an alias to &lt;command> or removes an alias.
-
-	config debug-info-directories -add <path>
-	config debug-info-directories -rm <path>
-	config debug-info-directories -clear
-
-Adds, removes or clears debug-info-directories.
 
 
 ## continue

--- a/Documentation/cli/config.md
+++ b/Documentation/cli/config.md
@@ -1,0 +1,31 @@
+# Configuration
+
+The configuration file `config.yml` is found in `$XDG_CONFIG_HOME/dlv` if `$XDG_CONFIG_HOME` is set, if it isn't set it will be in `$HOME/.config/dlv` on Linux and `$HOME/.dlv` in other operating systems.
+
+The following options are available:
+
+Option | Description
+-------|------------
+aliases | Map fo command aliases `command: [ "alias1", "alias2" ]`.
+debug-info-directories | List of directories to use when searching for separate debug info files.
+disassemble-flavor | Disassembler syntax. Can be 'intel', 'gun' or 'go'.
+max-array-values | Maximum number of array values when printing variables.
+max-string-len | Maximum string length used when printing variables.
+max-variable-recurse | Maximum number of nested struct members when printing variables.
+position | Controls how the current position in the program is displayed (source | disassembly | default).
+prompt-color | Prompt color, as a terminal escape sequence.
+show-location-expr | If true the 'whatis' command will print the DWARF location expression of its argument.
+source-list-arrow-color | Source list arrow color, as a terminal escape sequence.
+source-list-comment-color | Source list comment color, as a terminal escape sequence.
+source-list-keyword-color | Source list keyword color, as a terminal escape sequence.
+source-list-line-color | Source list line-number color, as a terminal escape sequence.
+source-list-line-count | Number of lines to list above and below the cursor when printing source code.
+source-list-number-color | Source list number color, as a terminal escape sequence.
+source-list-string-color | Source list string color, as a terminal escape sequence.
+source-list-tab-color | Source list tab color, as a terminal escape sequence.
+stacktrace-basename-color | Color for the base name in paths in the stack trace, as a terminal escape sequence.
+stacktrace-function-color | Color for function names in the stack trace, as a terminal escape sequence.
+substitute-path | Path substitution rules, a list of `{ from: path, to: path }` pairs.
+tab | Changes what is printed when a tab character is encountered in source code.
+trace-show-timestamp | If true timestamps are shown in the trace output.
+

--- a/_scripts/gen-cli-docs.go
+++ b/_scripts/gen-cli-docs.go
@@ -7,19 +7,34 @@ import (
 	"log"
 	"os"
 
+	"github.com/go-delve/delve/pkg/config"
 	"github.com/go-delve/delve/pkg/terminal"
 )
 
 func main() {
-	fh, err := os.Create("./Documentation/cli/README.md")
-	if err != nil {
-		log.Fatalf("could not create README.md: %v", err)
+	{
+		fh, err := os.Create("./Documentation/cli/README.md")
+		if err != nil {
+			log.Fatalf("could not create README.md: %v", err)
+		}
+		defer fh.Close()
+
+		w := bufio.NewWriter(fh)
+		defer w.Flush()
+
+		commands := terminal.DebugCommands(nil)
+		commands.WriteMarkdown(w)
 	}
-	defer fh.Close()
+	{
+		fh, err := os.Create("./Documentation/cli/config.md")
+		if err != nil {
+			log.Fatalf("could not create config.md: %v", err)
+		}
+		defer fh.Close()
 
-	w := bufio.NewWriter(fh)
-	defer w.Flush()
+		w := bufio.NewWriter(fh)
+		defer w.Flush()
+		config.WriteConfigDocumentation(w)
+	}
 
-	commands := terminal.DebugCommands(nil)
-	commands.WriteMarkdown(w)
 }

--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-delve/delve/pkg/config"
 	"github.com/go-delve/delve/pkg/goversion"
 	protest "github.com/go-delve/delve/pkg/proc/test"
 	"github.com/go-delve/delve/pkg/terminal"
@@ -338,6 +339,10 @@ func TestGeneratedDoc(t *testing.T) {
 	commands := terminal.DebugCommands(nil)
 	commands.WriteMarkdown(&generatedBuf)
 	checkAutogenDoc(t, "Documentation/cli/README.md", "_scripts/gen-cli-docs.go", generatedBuf.Bytes())
+
+	generatedBuf.Reset()
+	config.WriteConfigDocumentation(&generatedBuf)
+	checkAutogenDoc(t, "Documentation/cli/config.md", "_scripts/gen-cli-docs.go", generatedBuf.Bytes())
 
 	// Checks gen-usage-docs.go
 	if runtime.GOARCH != "ppc64le" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,10 +3,12 @@ package config
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/user"
 	"path"
 	"runtime"
+	"slices"
 
 	"github.com/go-delve/delve/service/api"
 	"go.yaml.in/yaml/v3"
@@ -114,6 +116,61 @@ type Config struct {
 	// TraceShowTimestamp controls whether to show timestamp in the trace
 	// output.
 	TraceShowTimestamp bool `yaml:"trace-show-timestamp"`
+}
+
+var Documentation = map[string]string{
+	"aliases": `Configures command aliases.
+	
+	config alias <command> <alias>
+	config alias <alias>
+
+Defines <alias> as an alias to <command> or removes an alias.
+`,
+
+	"substitute-path": `	config substitute-path <from> <to>
+	config substitute-path <from>
+	config substitute-path -clear
+	config substitute-path -guess
+
+Adds or removes a path substitution rule, if -clear is used all
+substitute-path rules are removed. Without arguments shows the current list
+of substitute-path rules.
+The -guess option causes Delve to try to guess your substitute-path
+configuration automatically.
+See also Documentation/cli/substitutepath.md for how the rules are applied.
+`,
+
+	"max-string-len":            "Maximum string length used when printing variables.\n",
+	"max-array-values":          "Maximum number of array values when printing variables.\n",
+	"max-variable-recurse":      "Maximum number of nested struct members when printing variables.\n",
+	"disassemble-flavor":        "Disassembler syntax. Can be 'intel', 'gun' or 'go'.\n",
+	"show-location-expr":        "If true the 'whatis' command will print the DWARF location expression of its argument.\n",
+	"source-list-line-color":    "Source list line-number color, as a terminal escape sequence.\n",
+	"source-list-arrow-color":   "Source list arrow color, as a terminal escape sequence.\n",
+	"source-list-keyword-color": "Source list keyword color, as a terminal escape sequence.\n",
+	"source-list-string-color":  "Source list string color, as a terminal escape sequence.\n",
+	"source-list-number-color":  "Source list number color, as a terminal escape sequence.\n",
+	"source-list-comment-color": "Source list comment color, as a terminal escape sequence.\n",
+	"prompt-color":              "Prompt color, as a terminal escape sequence.\n",
+	"source-list-tab-color":     "Source list tab color, as a terminal escape sequence.\n",
+	"stacktrace-function-color": "Color for function names in the stack trace, as a terminal escape sequence.\n",
+	"stacktrace-basename-color": "Color for the base name in paths in the stack trace, as a terminal escape sequence.\n",
+	"source-list-line-count":    "Number of lines to list above and below the cursor when printing source code.\n",
+	"tab":                       "Changes what is printed when a tab character is encountered in source code.\n",
+	"trace-show-timestamp":      "If true timestamps are shown in the trace output.\n",
+
+	"debug-info-directories": `	config debug-info-directories -add <path>
+	config debug-info-directories -rm <path>
+	config debug-info-directories -clear
+
+Adds, removes or clears debug-info-directories.
+`,
+
+	"position": `Controls how the current position in the program is displayed. The possible values are:
+ - 'source': always show the current position in the source code.
+ - 'disassembly': always show the current position in the program disassembly.
+ - 'default': show the current position in the disassembly after 'step-instruction', otherwise in source code.
+`,
 }
 
 func (c *Config) GetSourceListLineCount() int {
@@ -311,6 +368,13 @@ substitute-path:
 
 # List of directories to use when searching for separate debug info files.
 debug-info-directories: ["/usr/lib/debug/.build-id"]
+
+# Uncomment to change how the current program position is displayed.
+# Possible options
+#  - 'source' always shows source code 
+#  - 'disassembly' always show disassembly
+#  - 'default' show disassembly after step-instruction, source otherwise
+# position default
 `)
 	return err
 }
@@ -365,4 +429,31 @@ func getUserHomeDir() string {
 		userHomeDir = usr.HomeDir
 	}
 	return userHomeDir
+}
+
+func WriteConfigDocumentation(w io.Writer) {
+	fmt.Fprint(w, "# Configuration\n\n")
+	fmt.Fprint(w, "The configuration file `config.yml` is found in `$XDG_CONFIG_HOME/dlv` if `$XDG_CONFIG_HOME` is set, if it isn't set it will be in `$HOME/.config/dlv` on Linux and `$HOME/.dlv` in other operating systems.\n\n")
+	fmt.Fprint(w, "The following options are available:\n\n")
+	fmt.Fprint(w, "Option | Description\n")
+	fmt.Fprint(w, "-------|------------\n")
+	for _, name := range slices.Sorted(maps.Keys(Documentation)) {
+		switch name {
+		case "substitute-path":
+			fmt.Fprint(w, "substitute-path | Path substitution rules, a list of `{ from: path, to: path }` pairs.\n")
+		case "aliases":
+			fmt.Fprint(w, "aliases | Map fo command aliases `command: [ \"alias1\", \"alias2\" ]`.\n")
+		case "debug-info-directories":
+			fmt.Fprint(w, "debug-info-directories | List of directories to use when searching for separate debug info files.\n")
+		case "position":
+			fmt.Fprint(w, "position | Controls how the current position in the program is displayed (source | disassembly | default).\n")
+		default:
+			doc := Documentation[name]
+			if doc[len(doc)-1] == '\n' {
+				doc = doc[:len(doc)-1]
+			}
+			fmt.Fprintf(w, "%s | %s\n", name, doc)
+		}
+	}
+	fmt.Fprint(w, "\n")
 }

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -543,30 +543,10 @@ Saves the configuration file to disk, overwriting the current configuration file
 
 	config <parameter> <value>
 
-Changes the value of a configuration parameter.
+Changes the value of simple configuration parameters.
 
-	config substitute-path <from> <to>
-	config substitute-path <from>
-	config substitute-path -clear
-	config substitute-path -guess
-
-Adds or removes a path substitution rule, if -clear is used all
-substitute-path rules are removed. Without arguments shows the current list
-of substitute-path rules.
-The -guess option causes Delve to try to guess your substitute-path
-configuration automatically.
-See also Documentation/cli/substitutepath.md for how the rules are applied.
-
-	config alias <command> <alias>
-	config alias <alias>
-
-Defines <alias> as an alias to <command> or removes an alias.
-
-	config debug-info-directories -add <path>
-	config debug-info-directories -rm <path>
-	config debug-info-directories -clear
-
-Adds, removes or clears debug-info-directories.`},
+Use 'help config <parameter>' for more informations on specific configuration options.
+`},
 
 		{aliases: []string{"edit", "ed"}, cmdFn: edit, helpMsg: `Open where you are in $DELVE_EDITOR or $EDITOR
 
@@ -776,6 +756,17 @@ func nullCommand(t *Term, ctx callContext, args string) error {
 
 func (c *Commands) help(t *Term, ctx callContext, args string) error {
 	if args != "" {
+		if p1, p2, ok := strings.Cut(args, " "); ok && p1 == "config" {
+			if !configureValidParameter(t, p2) {
+				return errors.New("unknown config parameter")
+			}
+			if doc := config.Documentation[p2]; doc != "" {
+				fmt.Fprintln(t.stdout, doc)
+				return nil
+			}
+			return errors.New("not documented")
+		}
+
 		for _, cmd := range c.cmds {
 			if slices.Contains(cmd.aliases, args) {
 				fmt.Fprintln(t.stdout, cmd.helpMsg)

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -57,7 +57,9 @@ const logCommandOutput = false
 func (ft *FakeTerminal) Exec(cmdstr string) (outstr string, err error) {
 	var buf bytes.Buffer
 	ft.Term.stdout.pw.w = &buf
-	ft.Term.starlarkEnv.Redirect(ft.Term.stdout)
+	if ft.Term.starlarkEnv != nil {
+		ft.Term.starlarkEnv.Redirect(ft.Term.stdout)
+	}
 	err = ft.cmds.Call(cmdstr, ft.Term)
 	outstr = buf.String()
 	if logCommandOutput {
@@ -908,6 +910,13 @@ func TestConfig(t *testing.T) {
 	assertDebugInfoDirs(t, term.conf.DebugInfoDirectories, "a", "c")
 	assertNoErrorConfigureCmd(t, &term, "debug-info-directories -clear")
 	assertDebugInfoDirs(t, term.conf.DebugInfoDirectories)
+
+	ft := &FakeTerminal{&term, t}
+	_, err = ft.Exec("help config blah")
+	if err == nil {
+		t.Errorf("expected error executing help config for an unknown parameter")
+	}
+	ft.MustExec("help config substitute-path")
 }
 
 func TestIssue1090(t *testing.T) {

--- a/pkg/terminal/config.go
+++ b/pkg/terminal/config.go
@@ -40,6 +40,10 @@ func configureList(t *Term) error {
 	return w.Flush()
 }
 
+func configureValidParameter(t *Term, cfgname string) bool {
+	return config.ConfigureFindFieldByName(t.conf, cfgname, "yaml") != (reflect.Value{})
+}
+
 func configureSet(t *Term, args string) error {
 	v := config.Split2PartsBySpace(args)
 

--- a/pkg/terminal/docgen.go
+++ b/pkg/terminal/docgen.go
@@ -52,7 +52,7 @@ func (c *Commands) WriteMarkdown(w io.Writer) {
 	fmt.Fprint(w, "# Configuration and Command History\n\n")
 	fmt.Fprint(w, "If `$XDG_CONFIG_HOME` is set, then configuration and command history files are located in `$XDG_CONFIG_HOME/dlv`. ")
 	fmt.Fprint(w, "Otherwise, they are located in `$HOME/.config/dlv` on Linux and `$HOME/.dlv` on other systems.\n\n")
-	fmt.Fprint(w, "The configuration file `config.yml` contains all the configurable options and their default values. ")
+	fmt.Fprint(w, "The configuration file `config.yml` contains all the configurable options and their default values ([config.yml documentation](./config.md)). ")
 	fmt.Fprint(w, "The command history is stored in `.dbg_history`.\n\n")
 
 	fmt.Fprint(w, "# Commands\n")


### PR DESCRIPTION
Provide an online documentation for the configuration file parameters
and the 'config' command.

Until now the configuration parameters were only documented in the
default configuration file and in the source code, neither of which is
very discoverable.
