### PR TITLE
service/dap: add build message

### DIFF
--- a/service/dap/daptest/resp.go
+++ b/service/dap/daptest/resp.go
@@ -4,6 +4,7 @@ package daptest
 // The code generator program is in ./gen directory.
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-dap"
@@ -403,6 +404,10 @@ func (c *Client) CheckInvalidatedEvent(t *testing.T, m dap.Message) *dap.Invalid
 func (c *Client) ExpectLaunchResponse(t *testing.T) *dap.LaunchResponse {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	if oev, isoutput := m.(*dap.OutputEvent); isoutput && strings.HasPrefix(oev.Body.Output, "Building") {
+		// skip this one, it's a the build message
+		m = c.ExpectMessage(t)
+	}
 	return c.CheckLaunchResponse(t, m)
 }
 
@@ -570,6 +575,10 @@ func (c *Client) CheckPauseResponse(t *testing.T, m dap.Message) *dap.PauseRespo
 func (c *Client) ExpectProcessEvent(t *testing.T) *dap.ProcessEvent {
 	t.Helper()
 	m := c.ExpectMessage(t)
+	if oev, isoutput := m.(*dap.OutputEvent); isoutput && strings.HasPrefix(oev.Body.Output, "Building") {
+		// skip this one, it's a the build message
+		m = c.ExpectMessage(t)
+	}
 	return c.CheckProcessEvent(t, m)
 }
 

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1096,12 +1096,24 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 			s.config.Debugger.Packages = []string{args.Program}
 			whatWeAreLaunching = " " + args.Program
 			s.config.Debugger.BuildFlags = args.BuildFlags.value
+			s.send(&dap.OutputEvent{
+				Event: *s.newEvent("output"),
+				Body: dap.OutputEventBody{
+					Output:   fmt.Sprintf("Building %s", args.Program),
+					Category: "stdout",
+				}})
 			cmd, out, err = gobuild.GoBuildCombinedOutput(args.Output, []string{args.Program}, args.BuildFlags.value)
 		case "test":
 			s.config.Debugger.ExecuteKind = debugger.ExecutingGeneratedTest
 			s.config.Debugger.Packages = []string{args.Program}
 			whatWeAreLaunching = " tests of " + args.Program
 			s.config.Debugger.BuildFlags = args.BuildFlags.value
+			s.send(&dap.OutputEvent{
+				Event: *s.newEvent("output"),
+				Body: dap.OutputEventBody{
+					Output:   fmt.Sprintf("Building tests of %s", args.Program),
+					Category: "stdout",
+				}})
 			cmd, out, err = gobuild.GoTestBuildCombinedOutput(args.Output, []string{args.Program}, args.BuildFlags.value)
 		}
 		args.DlvCwd, _ = filepath.Abs(args.DlvCwd)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -6919,6 +6919,7 @@ func TestBadLaunchRequests(t *testing.T) {
 			"Failed to launch: invalid debug configuration - cannot unmarshal number …")
 
 		client.LaunchRequestWithArgs(map[string]any{"mode": "debug", "program": fixture.Source, "backend": "foo"})
+		client.ExpectOutputEvent(t) // build message
 		checkFailedToLaunchWithMessageRe(client.ExpectVisibleErrorResponse(t),
 			"Failed to launch .*: could not launch process: unknown backend \"foo\"")
 
@@ -6948,6 +6949,7 @@ func TestBadLaunchRequests(t *testing.T) {
 		checkFailedToLaunch(client.ExpectVisibleErrorResponse(t)) // No such file or directory
 
 		client.LaunchRequest("debug", fixture.Path+"_does_not_exist", stopOnEntry)
+		client.ExpectOutputEvent(t) // build message
 		oe := client.ExpectOutputEvent(t)
 		if !strings.HasPrefix(oe.Body.Output, "Build Error: ") || oe.Body.Category != "stderr" {
 			t.Errorf("got %#v, want Category=\"stderr\" Output=\"Build Error: ...\"", oe)
@@ -6960,6 +6962,7 @@ func TestBadLaunchRequests(t *testing.T) {
 			"program":     fixture.Path + "_does_not_exist",
 			"stopOnEntry": stopOnEntry,
 		})
+		client.ExpectOutputEvent(t) // build message
 		oe = client.ExpectOutputEvent(t)
 		if !strings.HasPrefix(oe.Body.Output, "Build Error: ") || oe.Body.Category != "stderr" {
 			t.Errorf("got %#v, want Category=\"stderr\" Output=\"Build Error: ...\"", oe)
@@ -6970,12 +6973,14 @@ func TestBadLaunchRequests(t *testing.T) {
 		checkFailedToLaunch(client.ExpectVisibleErrorResponse(t)) // Not an executable
 
 		client.LaunchRequestWithArgs(map[string]any{"mode": "debug", "program": fixture.Source, "buildFlags": "-bad -flags"})
+		client.ExpectOutputEvent(t) // build message
 		oe = client.ExpectOutputEvent(t)
 		if !strings.HasPrefix(oe.Body.Output, "Build Error: ") || oe.Body.Category != "stderr" {
 			t.Errorf("got %#v, want Category=\"stderr\" Output=\"Build Error: ...\"", oe)
 		}
 		checkFailedToLaunchWithMessage(client.ExpectInvisibleErrorResponse(t), "Failed to launch: Build error: Check the debug console for details.")
 		client.LaunchRequestWithArgs(map[string]any{"mode": "debug", "program": fixture.Source, "noDebug": true, "buildFlags": "-bad -flags"})
+		client.ExpectOutputEvent(t) // build message
 		oe = client.ExpectOutputEvent(t)
 		if !strings.HasPrefix(oe.Body.Output, "Build Error: ") || oe.Body.Category != "stderr" {
 			t.Errorf("got %#v, want Category=\"stderr\" Output=\"Build Error: ...\"", oe)
@@ -6984,8 +6989,10 @@ func TestBadLaunchRequests(t *testing.T) {
 
 		// Bad "cwd"
 		client.LaunchRequestWithArgs(map[string]any{"mode": "debug", "program": fixture.Source, "noDebug": false, "cwd": "dir/invalid"})
+		client.ExpectOutputEvent(t)                               // build message
 		checkFailedToLaunch(client.ExpectVisibleErrorResponse(t)) // invalid directory, the error message is system-dependent.
 		client.LaunchRequestWithArgs(map[string]any{"mode": "debug", "program": fixture.Source, "noDebug": true, "cwd": "dir/invalid"})
+		client.ExpectOutputEvent(t)                               // build message
 		checkFailedToLaunch(client.ExpectVisibleErrorResponse(t)) // invalid directory, the error message is system-dependent.
 
 		// Bad "noDebug"


### PR DESCRIPTION
This is a second attempt at #3207, which was abandoned.

Prints a build message before starting the build so that the user knows
why the debug session is taking time to start.

The whole command line is not printed, it can be seen by adding the
appropriate logging options already.

Fixes #3173
