### PR TITLE
dap/command: port examinemem from dlv/terminal

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2088,101 +2088,15 @@ func watchpoint(t *Term, ctx callContext, args string) error {
 }
 
 func examineMemoryCmd(t *Term, ctx callContext, argstr string) error {
-	var (
-		address uint64
-		err     error
-		ok      bool
-		args    = strings.Split(argstr, " ")
-	)
-
-	// Default value
-	priFmt := byte('x')
-	count := int64(1)
-	size := int64(1)
-	isExpr := false
-	rawout := false
-
-	// nextArg returns the next argument that is not an empty string, if any, and
-	// advances the args slice to the position after that.
-	nextArg := func() string {
-		for len(args) > 0 {
-			arg := args[0]
-			args = args[1:]
-			if arg != "" {
-				return arg
-			}
-		}
-		return ""
+	args, err := api.ParseExamineMemoryArg(argstr)
+	if err != nil {
+		return err
 	}
 
-loop:
-	for {
-		switch cmd := nextArg(); cmd {
-		case "":
-			// no more arguments
-			break loop
-		case "-fmt":
-			arg := nextArg()
-			if arg == "" {
-				return errors.New("expected argument after -fmt")
-			}
-			if arg == "raw" {
-				rawout = true
-			} else {
-				fmtMapToPriFmt := map[string]byte{
-					"oct":         'o',
-					"octal":       'o',
-					"hex":         'x',
-					"hexadecimal": 'x',
-					"dec":         'd',
-					"decimal":     'd',
-					"bin":         'b',
-					"binary":      'b',
-				}
-				priFmt, ok = fmtMapToPriFmt[arg]
-				if !ok {
-					return fmt.Errorf("%q is not a valid format", arg)
-				}
-			}
-		case "-count", "-len":
-			arg := nextArg()
-			if arg == "" {
-				return errors.New("expected argument after -count/-len")
-			}
-			var err error
-			count, err = strconv.ParseInt(arg, 0, 64)
-			if err != nil || count <= 0 {
-				return errors.New("count/len must be a positive integer")
-			}
-		case "-size":
-			arg := nextArg()
-			if arg == "" {
-				return errors.New("expected argument after -size")
-			}
-			var err error
-			size, err = strconv.ParseInt(arg, 0, 64)
-			if err != nil || size <= 0 || size > 8 {
-				return errors.New("size must be a positive integer (<=8)")
-			}
-		case "-x":
-			isExpr = true
-			break loop // remaining args are going to be interpreted as expression
-		default:
-			if len(args) > 0 {
-				return fmt.Errorf("unknown option %q", args[0])
-			}
-			args = []string{cmd}
-			break loop // only one arg left to be evaluated as a uint
-		}
-	}
+	var address uint64
 
-	if len(args) == 0 {
-		return errors.New("no address specified")
-	}
-
-	if isExpr {
-		expr := strings.Join(args, " ")
-		val, err := t.client.EvalVariable(ctx.Scope, expr, t.loadConfig())
+	if args.IsExpr {
+		val, err := t.client.EvalVariable(ctx.Scope, args.Operand, t.loadConfig())
 		if err != nil {
 			return err
 		}
@@ -2203,7 +2117,7 @@ loop:
 			return fmt.Errorf("unsupported expression type: %s", val.Kind)
 		}
 	} else {
-		address, err = strconv.ParseUint(args[0], 0, 64)
+		address, err = strconv.ParseUint(args.Operand, 0, 64)
 		if err != nil {
 			return fmt.Errorf("convert address into uintptr type failed, %s", err)
 		}
@@ -2212,7 +2126,7 @@ loop:
 	t.stdout.pw.PageMaybe(nil)
 
 	start := address
-	remsz := int(count * size)
+	remsz := int(args.Count * args.Size)
 
 	for remsz > 0 {
 		reqsz := min(rpc2.ExamineMemoryLengthLimit, remsz)
@@ -2220,10 +2134,10 @@ loop:
 		if err != nil {
 			return err
 		}
-		if rawout {
+		if args.RawOut {
 			t.stdout.Write(memArea)
 		} else {
-			fmt.Fprint(t.stdout, api.PrettyExamineMemory(uintptr(start), memArea, isLittleEndian, priFmt, int(size)))
+			fmt.Fprint(t.stdout, api.PrettyExamineMemory(uintptr(start), memArea, isLittleEndian, args.Format, int(args.Size)))
 		}
 		start += uint64(reqsz)
 		remsz -= reqsz

--- a/service/api/command.go
+++ b/service/api/command.go
@@ -166,3 +166,110 @@ func readGoroutinesFilter(args []string, pi *int) (*ListGoroutinesFilter, error)
 
 	return r, nil
 }
+
+type ExamineMemoryArgs struct {
+	Operand string
+	Count   int64
+	Size    int64
+	IsExpr  bool
+	Format  byte
+	RawOut  bool
+}
+
+func ParseExamineMemoryArg(argstr string) (*ExamineMemoryArgs, error) {
+	// default args
+	out := ExamineMemoryArgs{
+		Format: byte('x'),
+		Count:  int64(1),
+		Size:   int64(1),
+		IsExpr: false,
+		RawOut: false,
+	}
+
+	var (
+		ok   bool
+		args = strings.Split(argstr, " ")
+	)
+
+	// nextArg returns the next argument that is not an empty string, if any, and
+	// advances the args slice to the position after that.
+	nextArg := func() string {
+		for len(args) > 0 {
+			arg := args[0]
+			args = args[1:]
+			if arg != "" {
+				return arg
+			}
+		}
+		return ""
+	}
+
+loop:
+	for {
+		switch cmd := nextArg(); cmd {
+		case "":
+			// no more arguments
+			break loop
+		case "-fmt":
+			arg := nextArg()
+			if arg == "" {
+				return nil, errors.New("expected argument after -fmt")
+			}
+			if arg == "raw" {
+				out.RawOut = true
+			} else {
+				fmtMapToPriFmt := map[string]byte{
+					"oct":         'o',
+					"octal":       'o',
+					"hex":         'x',
+					"hexadecimal": 'x',
+					"dec":         'd',
+					"decimal":     'd',
+					"bin":         'b',
+					"binary":      'b',
+				}
+				out.Format, ok = fmtMapToPriFmt[arg]
+				if !ok {
+					return nil, fmt.Errorf("%q is not a valid format", arg)
+				}
+			}
+		case "-count", "-len":
+			arg := nextArg()
+			if arg == "" {
+				return nil, errors.New("expected argument after -count/-len")
+			}
+			var err error
+			out.Count, err = strconv.ParseInt(arg, 0, 64)
+			if err != nil || out.Count <= 0 {
+				return nil, errors.New("count/len must be a positive integer")
+			}
+		case "-size":
+			arg := nextArg()
+			if arg == "" {
+				return nil, errors.New("expected argument after -size")
+			}
+			var err error
+			out.Size, err = strconv.ParseInt(arg, 0, 64)
+			if err != nil || out.Size <= 0 || out.Size > 8 {
+				return nil, errors.New("size must be a positive integer (<=8)")
+			}
+		case "-x":
+			out.IsExpr = true
+			// remaining args are going to be interpreted as expression
+			out.Operand = strings.Join(args, " ")
+			break loop
+		default:
+			if len(args) > 0 {
+				return nil, fmt.Errorf("unknown option %q", args[0])
+			}
+			out.Operand = cmd
+			break loop // only one arg left to be evaluated as a uint
+		}
+	}
+
+	if len(out.Operand) == 0 {
+		return nil, errors.New("no address specified")
+	}
+
+	return &out, nil
+}

--- a/service/dap/command.go
+++ b/service/dap/command.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/go-delve/delve/pkg/config"
+	"github.com/go-delve/delve/service/api"
+	"github.com/go-delve/delve/service/rpc2"
 	"github.com/google/go-dap"
 )
 
@@ -89,6 +92,25 @@ List currently attached processes.
         target switch [pid]
 
 Switches to the specified process.`
+
+	msgExamineMemory = `Examine raw memory at the given address.
+
+Examine memory:
+
+	examinemem [-fmt <format>] [-count|-len <count>] [-size <size>] <address>
+	examinemem [-fmt <format>] [-count|-len <count>] [-size <size>] -x <expression>
+
+Format represents the data format and the value is one of this list (default hex): bin(binary), oct(octal), dec(decimal), hex(hexadecimal) and raw.
+Length is the number of bytes (default 1) and must be less than or equal to 1000.
+Address is the memory location of the target to examine. Please note '-len' is deprecated by '-count and -size'.
+Expression can be an integer expression or pointer value of the memory location to examine.
+
+For example:
+
+    x -fmt hex -count 20 -size 1 0xc00008af38
+    x -fmt hex -count 20 -size 1 -x 0xc00008af38 + 8
+    x -fmt hex -count 20 -size 1 -x &myVar
+    x -fmt hex -count 20 -size 1 -x myPtrVar`
 )
 
 // debugCommands returns a list of commands with default commands defined.
@@ -98,6 +120,7 @@ func debugCommands(s *Session) []command {
 		{aliases: []string{"config"}, cmdFn: s.evaluateConfig, helpMsg: msgConfig},
 		{aliases: []string{"sources", "s"}, cmdFn: s.sources, helpMsg: msgSources},
 		{aliases: []string{"target"}, cmdFn: s.targetCmd, helpMsg: msgTarget},
+		{aliases: []string{"examinemem", "x"}, cmdFn: s.examineMemory, helpMsg: msgExamineMemory},
 	}
 }
 
@@ -131,6 +154,54 @@ func (s *Session) helpMessage(_, _ int, args string) (string, error) {
 	fmt.Fprintln(&buf)
 	fmt.Fprintln(&buf, "Type 'dlv help' followed by a command for full documentation.")
 	return buf.String(), nil
+}
+
+func (s *Session) examineMemory(goid, frame int, argstr string) (string, error) {
+	args, err := api.ParseExamineMemoryArg(argstr)
+	if err != nil {
+		return fmt.Errorf("bad arguments: %w", err).Error(), nil
+	}
+
+	var address uint64
+
+	if args.IsExpr {
+		pvar, err := s.debugger.EvalVariableInScope(int64(goid), frame, 0, args.Operand, DefaultLoadConfig)
+		if err != nil {
+			return "", err
+		}
+		val := api.ConvertVar(pvar)
+
+		// "-x &myVar" or "-x myPtrVar"
+		if val.Kind == reflect.Ptr {
+			if len(val.Children) < 1 {
+				return fmt.Errorf("bug? invalid pointer: %#v", val).Error(), nil
+			}
+			address = val.Children[0].Addr
+			// "-x 0xc000079f20 + 8" or -x 824634220320 + 8
+		} else if val.Kind == reflect.Int && val.Value != "" {
+			address, err = strconv.ParseUint(val.Value, 0, 64)
+			if err != nil {
+				return fmt.Errorf("bad expression result: %q: %s", val.Value, err).Error(), nil
+			}
+		} else {
+			return fmt.Errorf("unsupported expression type: %s", val.Kind).Error(), nil
+		}
+	} else {
+		address, err = strconv.ParseUint(args.Operand, 0, 64)
+		if err != nil {
+			return fmt.Errorf("convert address into uintptr type failed, %s", err).Error(), nil
+		}
+	}
+
+	memory, err := s.debugger.ExamineMemory(
+		address,
+		min(int(args.Count*args.Size), rpc2.ExamineMemoryLengthLimit),
+	)
+	if err != nil {
+		return fmt.Errorf("examine memory error: %w", err).Error(), nil
+	}
+
+	return api.PrettyExamineMemory(uintptr(address), memory, true, args.Format, int(args.Size)), nil
 }
 
 func (s *Session) evaluateConfig(_, _ int, expr string) (string, error) {

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/go-delve/delve/pkg/logflags"
@@ -4527,6 +4528,63 @@ func TestEvaluateCommandRequest(t *testing.T) {
 				disconnect: true,
 			}})
 	})
+}
+
+func TestEvaluateExaminememCommand(t *testing.T) {
+	runTest(t, "testvariables", func(client *daptest.Client, fixture protest.Fixture) {
+		runDebugSessionWithBPs(t, client, "launch",
+			// Launch
+			func() {
+				client.LaunchRequest("exec", fixture.Path, !stopOnEntry)
+			},
+			fixture.Source, []int{}, // Breakpoint set in the program
+			[]onBreakpoint{{ // Stop at first breakpoint
+				execute: func() {
+					checkStop(t, client, 1, "main.foobar", []int{65, 66})
+
+					client.EvaluateRequest("dlv x -fmt binary -x &b1", localsScope, "repl")
+					got := client.ExpectEvaluateResponse(t)
+					checkExaminememCommand(t, got, "00000001")
+
+					client.EvaluateRequest("dlv x -fmt oct -x &u8", localsScope, "repl")
+					got = client.ExpectEvaluateResponse(t)
+					checkExaminememCommand(t, got, "0377")
+
+					client.EvaluateRequest("dlv x -fmt hex -x &u8", localsScope, "repl")
+					got = client.ExpectEvaluateResponse(t)
+					checkExaminememCommand(t, got, "0xff")
+
+					var (
+						sizeOfInt = unsafe.Sizeof(int(0))
+						intArray  = "0x0000000000000001   0x0000000000000002"
+					)
+					if sizeOfInt == 4 {
+						// on GOARCH=386 int is 4 bytes
+						intArray = "0x00000001   0x00000002"
+					}
+					client.EvaluateRequest(fmt.Sprintf("dlv x -count 2 -size %d -fmt hex -x &a4", sizeOfInt), localsScope, "repl")
+					got = client.ExpectEvaluateResponse(t)
+					checkExaminememCommand(t, got, intArray)
+
+				},
+				disconnect: true,
+			}},
+		)
+	})
+}
+
+func checkExaminememCommand(t *testing.T, got *dap.EvaluateResponse, value string) {
+	t.Helper()
+
+	if got.Body.Result == "" {
+		t.Fatalf("result must not be empty")
+	}
+
+	want := fmt.Sprintf(":   %s   \n", value)
+
+	if !strings.HasSuffix(got.Body.Result, want) {
+		t.Errorf("\ngot:  %#q\nwant: %q\n", got.Body.Result, want)
+	}
 }
 
 // From testvariables2 fixture


### PR DESCRIPTION
I find `examinemem` command  sometimes quite useful. As i mostly use delve through dap, i wanted to port it from dlv/terminal package.

My current implementation in this PR is as follows:

1. Extract the argument parsing from [pkg/terminal/command examineMemoryCmd()](https://github.com/go-delve/delve/blob/master/pkg/terminal/command.go#L2090) into a separate `func ParseExamineMemoryArg(out *ExamineMemoryArgs, argstr string) error`
2. Import `pkg/terminal` in `service/dap/command` and reuse `func ParseExamineMemoryArg`
3. Use `debug.ExamineMemory` and `api.PrettyExamineMemory` to achieve the same examine memory functionality in dap

But as soon as i got it working, i tried to write test, and got an import cycle error:

```
$ make test
package github.com/go-delve/delve/pkg/terminal
        imports github.com/go-delve/delve/service/rpccommon from command_test.go
        imports github.com/go-delve/delve/service/dap from server.go
        imports github.com/go-delve/delve/pkg/terminal from command.go: import cycle not allowed in test
make: *** [vet] Error 1
```

Basically the step 2, where i imported `pkg/terminal` in `service/dap/command` is the root cause of an import cycle.

I can see a few solutions:

1. Just copy the argument parsing implementation
2. Extract argument parsing out of `pkg/terminal` somewhere else, maybe `service/api`?

The first one would require of you guys to keep both functions in sync, which seems bad, so im more in favor of a second one, but im not yet accustomed to delve code base to make a judgement call of where to extract it to.

I'd like to go through with the porting of this command to dap, so im looking forward for your feedback.