### PR TITLE
pkg/proc: Fix flaky test on Windows

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -5621,7 +5621,10 @@ func testWaitForSetup(t *testing.T, mu *sync.Mutex, started *bool) (*exec.Cmd, *
 	}
 	fixture := protest.BuildFixture(t, "loopprog", buildFlags)
 
-	cmd := exec.Command(fixture.Path)
+	// Workaround to prevent WaitFor from trying to attach to old,
+	// already terminated, executions of loopprog on Windows, see #4292.
+	uniqueArg := fmt.Sprintf("%s-%d", t.Name(), time.Now().Unix())
+	cmd := exec.Command(fixture.Path, uniqueArg)
 
 	go func() {
 		time.Sleep(2 * time.Second)
@@ -5633,7 +5636,12 @@ func testWaitForSetup(t *testing.T, mu *sync.Mutex, started *bool) (*exec.Cmd, *
 		mu.Unlock()
 	}()
 
-	waitFor := &proc.WaitFor{Name: fixture.Path, Interval: 100 * time.Millisecond, Duration: 10 * time.Second}
+	waitFor := &proc.WaitFor{Name: fixture.Path + " " + uniqueArg, Interval: 100 * time.Millisecond, Duration: 10 * time.Second}
+	if runtime.GOOS == "darwin" && testBackend == "lldb" {
+		// LLDB/debugserver wait-for attach is by process name (or pid), not argv.
+		// See: https://lldb.llvm.org/man/lldb.html#cmdoption-lldb-wait-for
+		waitFor.Name = fixture.Path
+	}
 
 	return cmd, waitFor
 }


### PR DESCRIPTION
TestWaitFor was flaky on Windows. This seems to be linked to
prefix-based matching, where the fixture process spawned by
one test could be waited upon by another test. Adding a
unique no-op argument to different invocations of the
same fixture binary appears to fix the flakiness issue.

As I understand it, this happens because of the following:

- Per the docs of [`WaitForSingleObject`](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject),

  > Waits until the specified object is in the signaled state or the time-out interval elapses.

  Delve (via stdlib) calls `WaitForSingleObject`.

- After the process reaches a signaled state, the test
  which was waiting is unblocked and it proceeds.
  The test executor can switch to the next test
  after the test completes.

- Concurrent with subsequent test execution, the OS takes
  its own sweet time cleaning the process up from various places.
  (This might be delayed if someone else is holding a handle
  to the process. The Go stdlib closes it's own, I'm not 100%
  sure if it's the only one owning the handle, or whether
  the spawned debugger could still be holding it.)

- Delve calls `CreateToolhelp32Snapshot`. This can sometimes
  end up seeing the "not yet fully cleaned up" process.

Claude found this old mailing list thread with a similar issue.
https://microsoft.public.win32.programmer.kernel.narkive.com/k4zy5KXb/waitforsingleobject-and-process-termination

> i faced a interesting situation:
> I am waiting inside a thread for
> a process to exit on WaitForSingleObject().
> The process exits, the handle gets signaled
> and then i immediatelly call to a
> CreateToolhelp32Snapshot(...)
> with TH32CS_SNAPPROCESS
> and the process is is still listed
> in the snapshot. How come?

I'm 80% confident in the above explanation, but it's possible
that I missed something.

---

I've tested the fix by running the test with `-count=100`
on Windows.