### PR TITLE
gobuild: fix gocommandRun stdout and stderr streams

### DIFF
--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -114,8 +114,8 @@ func goBuildArgs2(debugname string, pkgs []string, buildflags any, isTest bool) 
 
 func gocommandRun(command string, args ...string) error {
 	_, goBuild := gocommandExecCmd(command, args...)
-	goBuild.Stderr = os.Stdout
-	goBuild.Stdout = os.Stderr
+	goBuild.Stdout = os.Stdout
+	goBuild.Stderr = os.Stderr
 	return goBuild.Run()
 }
 


### PR DESCRIPTION
The go subprocess had Stdout and Stderr assigned to the wrong OS streams, so normal build output went to stderr and errors to stdout.