### PR TITLE
native: return ptrace error from riscv64 setSP

### DIFF
--- a/pkg/proc/native/registers_linux_riscv64.go
+++ b/pkg/proc/native/registers_linux_riscv64.go
@@ -87,7 +87,7 @@ func (thread *nativeThread) setSP(sp uint64) (err error) {
 	r.Regs.Sp = sp
 	thread.dbp.execPtraceFunc(func() { err = ptraceSetGRegs(thread.ID, r.Regs) })
 
-	return nil
+	return err
 }
 
 func (thread *nativeThread) SetReg(regNum uint64, reg *op.DwarfRegister) error {


### PR DESCRIPTION
## Summary

`setSP` on linux/riscv64 ignored the error from `ptraceSetGRegs` and always returned `nil`, so callers could not detect failures when updating the stack pointer.

## Change

Return `err` after the ptrace call, consistent with other register helpers.

## Notes

This follows the same error-handling pattern as the rest of the native backend.