### PR TITLE
proc: clear stepping breakpoints on every target in TargetGroup

### DIFF
--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -279,7 +279,9 @@ func (grp *TargetGroup) HasSteppingBreakpoints() bool {
 func (grp *TargetGroup) ClearSteppingBreakpoints() error {
 	for _, t := range grp.targets {
 		if t.Breakpoints().HasSteppingBreakpoints() {
-			return t.ClearSteppingBreakpoints()
+			if err := t.ClearSteppingBreakpoints(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

`TargetGroup.ClearSteppingBreakpoints` used `return t.ClearSteppingBreakpoints()` inside the loop, so it exited after clearing the **first** target that had stepping breakpoints. Any other targets in the group still had stepping breakpoints.

## Change

Only return early on error; otherwise continue and clear stepping breakpoints for every target that needs it.