### PR TITLE
cmd/dlv: use goversion.ParseProducer for DW_AT_producer

### DIFF
--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -699,7 +699,7 @@ func (t *Term) goVersion() *goversion.GoVersion {
 		return t.goVersionCache
 	}
 	vers := t.client.GetVersion()
-	v, _ := goversion.Parse(vers.TargetGoVersion)
+	v := goversion.ParseProducer(vers.TargetGoVersion)
 	t.goVersionCache = &v
 	return t.goVersionCache
 }


### PR DESCRIPTION
~~For some reason, a prefix is added to the raw go version.  It may be caused by how I built go.  This simply removes the prefix.~~

Actually uses goversion.ParseProducer