### PR TITLE
chore: fix function name in comment to match actual function

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -1334,7 +1334,7 @@ func checkVarExact(t *testing.T, got *dap.VariablesResponse, i int, name, evalNa
 	return checkVarExactIndexed(t, got, i, name, evalName, value, typ, hasRef, -1, -1)
 }
 
-// checkVarExact is a helper like checkVar that matches value exactly.
+// checkVarExactIndexed is a helper like checkVar that matches value exactly.
 func checkVarExactIndexed(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, value, typ string, hasRef bool, indexed, named int) (ref int) {
 	t.Helper()
 	return checkVar(t, got, i, name, evalName, value, typ, true, hasRef, indexed, named)
@@ -1346,7 +1346,7 @@ func checkVarRegex(t *testing.T, got *dap.VariablesResponse, i int, name, evalNa
 	return checkVarRegexIndexed(t, got, i, name, evalName, value, typ, hasRef, -1, -1)
 }
 
-// checkVarRegex is a helper like checkVar that treats value, evalName or name as a regex.
+// checkVarRegexIndexed is a helper like checkVar that treats value, evalName or name as a regex.
 func checkVarRegexIndexed(t *testing.T, got *dap.VariablesResponse, i int, name, evalName, value, typ string, hasRef bool, indexed, named int) (ref int) {
 	t.Helper()
 	return checkVar(t, got, i, name, evalName, value, typ, false, hasRef, indexed, named)


### PR DESCRIPTION
fix function name in comment to match actual function