### PR TITLE
dwarf/godwarf: fix regression debugging DWARFv5 on macOS

### DIFF
--- a/pkg/dwarf/godwarf/sections.go
+++ b/pkg/dwarf/godwarf/sections.go
@@ -92,6 +92,10 @@ func GetDebugSectionMacho(f *macho.File, name string) ([]byte, error) {
 // Because of what the valid names of DWARFv5 sections are (appendix B)
 // there are no risks of collision.
 func getDebugSectionMachoHelper(f *macho.File, name string) *macho.Section {
+	sec := f.Section(name)
+	if sec != nil {
+		return sec
+	}
 	if len(name) > 16 {
 		name = name[:16]
 	}

--- a/pkg/dwarf/line/line_parser.go
+++ b/pkg/dwarf/line/line_parser.go
@@ -312,8 +312,12 @@ func parseFileEntries5(info *DebugLineInfo, buf *bytes.Buffer) bool {
 				case _DW_FORM_string:
 					p = fileEntryFormReader.str
 				case _DW_FORM_line_strp:
-					buf := bytes.NewBuffer(info.debugLineStr[fileEntryFormReader.u64:])
-					p, _ = dwarf.ReadString(buf)
+					if info.debugLineStr == nil {
+						p = "<DW_FORM_line_strp without debug_line_str section>"
+					} else {
+						buf := bytes.NewBuffer(info.debugLineStr[fileEntryFormReader.u64:])
+						p, _ = dwarf.ReadString(buf)
+					}
 				default:
 					info.Logf("unsupported string form %#x", fileEntryFormReader.formCode)
 				}


### PR DESCRIPTION
The change introduced to fix #4302 happens to conflict with a similar
workaround in debug/macho I forgot exists.

The telemetry report was probably from a binary that legitimately did
not have a debug_line_str section (but referenced it) and we just
misidentified the cause, the fix however is still worth keeping since
there are versions of Go without the workaround that could be affected.

Fixes #4311
