### PR TITLE
service/dap: avoid Session.conn race in breakpoint-after-disconnect test

### DIFF
--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -8292,7 +8292,15 @@ func TestBreakpointAfterDisconnect(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 
-	server.impl.session.conn = &connection{ReadWriteCloser: discard{}} // fake a race condition between onDisconnectRequest and the runUntilStopAndNotify goroutine
+	sess := server.impl.session
+	conn := sess.conn
+	sess.sendingMu.Lock()
+	conn.mu.Lock()
+	conn.ReadWriteCloser = discard{}
+	conn.closed = false
+	conn.closedChan = nil
+	conn.mu.Unlock()
+	sess.sendingMu.Unlock()
 
 	// Wait for port to be available
 	select {


### PR DESCRIPTION
Fixes #4117 