### PR TITLE
proc: fix SP calculation for sigpanic frames on arm64

### DIFF
--- a/_fixtures/issue3591.go
+++ b/_fixtures/issue3591.go
@@ -1,0 +1,18 @@
+// Fixture for issue #3591: nil pointer crash to test SP calculation in core dumps.
+package main
+
+func main() {
+	map_value := make(map[string]*int)
+
+	var value_1 int = 1
+	var value_2 int = 2
+	map_value["a"] = &value_1
+	map_value["b"] = &value_2
+
+	mod_map(map_value)
+}
+
+func mod_map(map_value map[string]*int) {
+	p_value := map_value["c"]
+	*p_value = 3
+}

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -10,7 +10,9 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -543,5 +545,115 @@ func mustSupportCore(t *testing.T) {
 
 	if os.Getenv("CI") == "true" && buildMode == "pie" {
 		t.Skip("disabled on linux, Github Actions, with PIE buildmode")
+	}
+}
+
+// parseIssue3591RuntimeModMapSP parses runtime's SP for main.mod_map from panic output.
+func parseIssue3591RuntimeModMapSP(stderr []byte) (uint64, error) {
+	i := bytes.Index(stderr, []byte("main.mod_map("))
+	if i < 0 {
+		return 0, fmt.Errorf("main.mod_map not found in panic output:\n%s", stderr)
+	}
+	window := stderr[i:]
+	if len(window) > 2048 {
+		window = window[:2048]
+	}
+	m := regexp.MustCompile(`sp=(0x[0-9a-f]+)`).FindSubmatch(window)
+	if len(m) < 2 {
+		return 0, fmt.Errorf("sp= not found after main.mod_map in panic output:\n%s", window)
+	}
+	return strconv.ParseUint(string(m[1])[2:], 16, 64)
+}
+
+// TestIssue3591_CoreModMapFrameSP verifies Delve reports the same SP as the
+// Go runtime for sigpanic frames in linux/arm64 core dumps.
+func TestIssue3591_CoreModMapFrameSP(t *testing.T) {
+	if runtime.GOOS != "linux" || runtime.GOARCH != "arm64" {
+		t.Skip("issue #3591 reproduces on linux/arm64 ELF cores only")
+	}
+	mustSupportCore(t)
+
+	tempDir := t.TempDir()
+	var buildFlags test.BuildFlags
+	if buildMode == "pie" {
+		buildFlags = test.BuildModePIE
+	}
+	fix := test.BuildFixture(t, "issue3591", buildFlags)
+
+	panicPath := filepath.Join(tempDir, "panic.txt")
+	bashCmd := fmt.Sprintf("cd %q && ulimit -c unlimited && GOTRACEBACK=crash %q 2>%q",
+		tempDir, fix.Path, panicPath)
+	if out, err := exec.Command("bash", "-c", bashCmd).CombinedOutput(); len(out) > 0 {
+		t.Logf("crash run output: %s", out)
+		_ = err // process exits non-zero on crash
+	}
+
+	stderr, err := os.ReadFile(panicPath)
+	if err != nil || len(stderr) == 0 {
+		t.Fatalf("reading panic output: err=%v len=%d", err, len(stderr))
+	}
+	wantSP, err := parseIssue3591RuntimeModMapSP(stderr)
+	if err != nil {
+		t.Fatalf("%v\n--- panic.txt ---\n%s", err, stderr)
+	}
+
+	cores, err := filepath.Glob(path.Join(tempDir, "core*"))
+	switch {
+	case err != nil || len(cores) > 1:
+		t.Fatalf("core glob: err=%v cores=%v", err, cores)
+	case len(cores) == 0:
+		// Write outside t.TempDir(): global fixture cleanup runs after the temp
+		// directory is removed (see withCoreFile in this package).
+		cores = []string{fix.Path + ".issue3591.coredump"}
+		err := exec.Command("coredumpctl", "--output="+cores[0], "dump", fix.Path).Run()
+		if err != nil {
+			t.Skipf("no core in cwd and coredumpctl failed: %v", err)
+		}
+		test.AddPathToRemove(cores[0])
+	}
+	corePath := cores[0]
+
+	grp, err := OpenCore(corePath, fix.Path, []string{})
+	if err != nil {
+		t.Fatalf("OpenCore(%q): %v", corePath, err)
+	}
+	t.Cleanup(func() { grp.Detach(true) })
+	p := grp.Selected
+
+	gs, _, err := proc.GoroutinesInfo(p, 0, 0)
+	if err != nil || len(gs) == 0 {
+		t.Fatalf("GoroutinesInfo: err=%v n=%d", err, len(gs))
+	}
+	var g *proc.G
+	for _, gi := range gs {
+		if gi.ID == 1 {
+			g = gi
+			break
+		}
+	}
+	if g == nil {
+		t.Fatalf("goroutine 1 not found among %d goroutines", len(gs))
+	}
+
+	stack, err := proc.GoroutineStacktrace(p, g, 80, 0)
+	if err != nil {
+		t.Fatalf("GoroutineStacktrace: %v", err)
+	}
+	var modMap *proc.Stackframe
+	for i := range stack {
+		fn := stack[i].Current.Fn
+		if fn != nil && fn.Name == "main.mod_map" {
+			modMap = &stack[i]
+			break
+		}
+	}
+	if modMap == nil {
+		t.Fatalf("main.mod_map not in stack (%d frames)", len(stack))
+	}
+
+	gotSP := uint64(modMap.Regs.SP())
+	if gotSP != wantSP {
+		t.Fatalf("issue #3591: main.mod_map frame SP mismatch: delve=%#x runtime=%#x (see panic.txt in test temp dir pattern)",
+			gotSP, wantSP)
 	}
 }

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -200,7 +200,7 @@ func TestSplicedReader(t *testing.T) {
 	}
 }
 
-func withCoreFile(t *testing.T, name, args string) *proc.TargetGroup {
+func withCoreFile(t *testing.T, name, args string) (*proc.TargetGroup, []byte) {
 	// This is all very fragile and won't work on hosts with non-default core patterns.
 	// Might be better to check in the binary and core?
 	tempDir := t.TempDir()
@@ -210,7 +210,7 @@ func withCoreFile(t *testing.T, name, args string) *proc.TargetGroup {
 	}
 	fix := test.BuildFixture(t, name, buildFlags)
 	bashCmd := fmt.Sprintf("cd %v && ulimit -c unlimited && GOTRACEBACK=crash %v %s", tempDir, fix.Path, args)
-	exec.Command("bash", "-c", bashCmd).Run()
+	output, _ := exec.Command("bash", "-c", bashCmd).CombinedOutput()
 	cores, err := filepath.Glob(path.Join(tempDir, "core*"))
 	switch {
 	case err != nil || len(cores) > 1:
@@ -220,7 +220,7 @@ func withCoreFile(t *testing.T, name, args string) *proc.TargetGroup {
 		err := exec.Command("coredumpctl", "--output="+cores[0], "dump", fix.Path).Run()
 		if err != nil {
 			t.Skipf("core file was not produced, could not run test, coredumpctl error: %v", err)
-			return nil
+			return nil, nil
 		}
 		test.AddPathToRemove(cores[0])
 	}
@@ -235,7 +235,7 @@ func withCoreFile(t *testing.T, name, args string) *proc.TargetGroup {
 		t.Errorf("read apport log: %q, %v", apport, err)
 		t.Fatalf("previous errors")
 	}
-	return p
+	return p, output
 }
 
 func logRegisters(t *testing.T, regs proc.Registers, arch *proc.Arch) {
@@ -256,7 +256,7 @@ func TestCore(t *testing.T) {
 
 	mustSupportCore(t)
 
-	grp := withCoreFile(t, "panic", "")
+	grp, _ := withCoreFile(t, "panic", "")
 	p := grp.Selected
 
 	recorded, _ := grp.Recorded()
@@ -333,7 +333,7 @@ func TestCoreFpRegisters(t *testing.T) {
 		t.Skip("not supported in go1.10 and later")
 	}
 
-	grp := withCoreFile(t, "fputest/", "panic")
+	grp, _ := withCoreFile(t, "fputest/", "panic")
 	p := grp.Selected
 
 	gs, _, err := proc.GoroutinesInfo(p, 0, 0)
@@ -414,7 +414,7 @@ func TestCoreWithEmptyString(t *testing.T) {
 	t.Parallel()
 	mustSupportCore(t)
 
-	grp := withCoreFile(t, "coreemptystring", "")
+	grp, _ := withCoreFile(t, "coreemptystring", "")
 	p := grp.Selected
 
 	gs, _, err := proc.GoroutinesInfo(p, 0, 0)
@@ -573,52 +573,13 @@ func TestIssue3591_CoreModMapFrameSP(t *testing.T) {
 	}
 	mustSupportCore(t)
 
-	tempDir := t.TempDir()
-	var buildFlags test.BuildFlags
-	if buildMode == "pie" {
-		buildFlags = test.BuildModePIE
-	}
-	fix := test.BuildFixture(t, "issue3591", buildFlags)
+	grp, stderr := withCoreFile(t, "issue3591", "")
+	p := grp.Selected
 
-	panicPath := filepath.Join(tempDir, "panic.txt")
-	bashCmd := fmt.Sprintf("cd %q && ulimit -c unlimited && GOTRACEBACK=crash %q 2>%q",
-		tempDir, fix.Path, panicPath)
-	if out, err := exec.Command("bash", "-c", bashCmd).CombinedOutput(); len(out) > 0 {
-		t.Logf("crash run output: %s", out)
-		_ = err // process exits non-zero on crash
-	}
-
-	stderr, err := os.ReadFile(panicPath)
-	if err != nil || len(stderr) == 0 {
-		t.Fatalf("reading panic output: err=%v len=%d", err, len(stderr))
-	}
 	wantSP, err := parseIssue3591RuntimeModMapSP(stderr)
 	if err != nil {
-		t.Fatalf("%v\n--- panic.txt ---\n%s", err, stderr)
+		t.Fatalf("%v\n--- crash output ---\n%s", err, stderr)
 	}
-
-	cores, err := filepath.Glob(path.Join(tempDir, "core*"))
-	switch {
-	case err != nil || len(cores) > 1:
-		t.Fatalf("core glob: err=%v cores=%v", err, cores)
-	case len(cores) == 0:
-		// Write outside t.TempDir(): global fixture cleanup runs after the temp
-		// directory is removed (see withCoreFile in this package).
-		cores = []string{fix.Path + ".issue3591.coredump"}
-		err := exec.Command("coredumpctl", "--output="+cores[0], "dump", fix.Path).Run()
-		if err != nil {
-			t.Skipf("no core in cwd and coredumpctl failed: %v", err)
-		}
-		test.AddPathToRemove(cores[0])
-	}
-	corePath := cores[0]
-
-	grp, err := OpenCore(corePath, fix.Path, []string{})
-	if err != nil {
-		t.Fatalf("OpenCore(%q): %v", corePath, err)
-	}
-	t.Cleanup(func() { grp.Detach(true) })
-	p := grp.Selected
 
 	gs, _, err := proc.GoroutinesInfo(p, 0, 0)
 	if err != nil || len(gs) == 0 {

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -778,6 +778,14 @@ func (it *stackIterator) advanceRegsDWARF() (callFrameRegs op.DwarfRegisters, re
 		}
 	}
 
+	// Issue #3591: On LR architectures, runtime.sigpanic's DWARF CFA points to the
+	// signaled frame's SP, not the caller's SP. Add 2 words (saved FP + saved LR)
+	// to compute the correct caller SP.
+	if fn := it.bi.PCToFunc(it.pc); fn != nil && fn.Name == "runtime.sigpanic" && it.bi.Arch.usesLR {
+		callerSP := uint64(it.regs.CFA) + uint64(2*it.bi.Arch.PtrSize())
+		callFrameRegs.AddReg(callFrameRegs.SPRegNum, op.DwarfRegisterFromUint64(callerSP))
+	}
+
 	if it.bi.Arch.usesLR {
 		if ret == 0 && it.regs.Reg(it.regs.LRRegNum) != nil {
 			ret = it.regs.Reg(it.regs.LRRegNum).Uint64Val


### PR DESCRIPTION
Stack traces from linux/arm64 core dumps showed SP values that differed from the runtime's panic output.

This patch adds a reproducer based on the original snippet from the issue and a test that tries to verify if the SP is the same.

Fixes #3591