### PR TITLE
native: propagate PtraceSetRegs error on linux/ppc64le

### DIFF
--- a/pkg/proc/native/registers_linux_ppc64le.go
+++ b/pkg/proc/native/registers_linux_ppc64le.go
@@ -25,7 +25,7 @@ func ptraceGetGRegs(pid int, regs *linutil.PPC64LEPtraceRegs) (err error) {
 }
 
 func ptraceSetGRegs(pid int, regs *linutil.PPC64LEPtraceRegs) (err error) {
-	sys.PtraceSetRegs(pid, (*sys.PtraceRegs)(regs))
+	err = sys.PtraceSetRegs(pid, (*sys.PtraceRegs)(regs))
 	if err == syscall.Errno(0) {
 		err = nil
 	}


### PR DESCRIPTION
ptraceSetGRegs discarded the return value from `sys.PtraceSetRegs`, so `setPC` / `SetReg` on linux ppc64le never surfaced syscall failures when writing GPRs.

Capture the errno and normalize `syscall.Errno(0)` to nil, consistent with neighbouring ptrace helpers.