### PR TITLE
native: propagate PtraceGetRegs error on linux/ppc64le

### DIFF
--- a/pkg/proc/native/registers_linux_ppc64le.go
+++ b/pkg/proc/native/registers_linux_ppc64le.go
@@ -17,7 +17,7 @@ const (
 )
 
 func ptraceGetGRegs(pid int, regs *linutil.PPC64LEPtraceRegs) (err error) {
-	sys.PtraceGetRegs(pid, (*sys.PtraceRegs)(regs))
+	err = sys.PtraceGetRegs(pid, (*sys.PtraceRegs)(regs))
 	if err == syscall.Errno(0) {
 		err = nil
 	}


### PR DESCRIPTION
`ptraceGetGRegs` ignored the return value from `sys.PtraceGetRegs`, so `registers()` on linux ppc64le never surfaced syscall failures when reading GPRs.

Capture the errno and normalize `syscall.Errno(0)` to nil, consistent with neighbouring ptrace helpers.