### PR TITLE
proc: propagate AddrPiece ReadMemory errors in composite memory

### DIFF
--- a/pkg/proc/mem.go
+++ b/pkg/proc/mem.go
@@ -147,7 +147,9 @@ func newCompositeMemory(mem MemoryReadWriter, arch *Arch, regs op.DwarfRegisters
 			cmem.data = append(cmem.data, reg[:piece.Size]...)
 		case op.AddrPiece:
 			buf := make([]byte, piece.Size)
-			mem.ReadMemory(buf, piece.Val)
+			if _, err := mem.ReadMemory(buf, piece.Val); err != nil {
+				return nil, fmt.Errorf("could not read %d bytes from address %#x: %v", piece.Size, piece.Val, err)
+			}
 			cmem.data = append(cmem.data, buf...)
 		case op.ImmPiece:
 			buf := piece.Bytes


### PR DESCRIPTION
`newCompositeMemory` ignored errors from `MemoryReadWriter.ReadMemory` for `op.AddrPiece` fragments, so failed memory reads silently produced zeros in the synthesized buffer.

Check the error and return a wrapped message with piece size and address, aligned with existing `RegPiece` error handling in the same function.