### PR TITLE
proc/internal/ebpf: fix AddressToOffset off-by-one at section load

### DIFF
--- a/pkg/proc/internal/ebpf/helpers.go
+++ b/pkg/proc/internal/ebpf/helpers.go
@@ -369,7 +369,7 @@ func AddressToOffset(f *elf.File, addr uint64) (uint64, error) {
 	// Find what section the symbol is in by checking the executable section's
 	// addr space.
 	for m := range sectionsToSearchForSymbol {
-		if addr > sectionsToSearchForSymbol[m].Addr &&
+		if addr >= sectionsToSearchForSymbol[m].Addr &&
 			addr < sectionsToSearchForSymbol[m].Addr+sectionsToSearchForSymbol[m].Size {
 			executableSection = sectionsToSearchForSymbol[m]
 		}


### PR DESCRIPTION
`AddressToOffset` matched executable ELF sections using `addr > Section.Addr`, so PCs exactly equal to the section load address (`Section.Addr`) never landed in the VMA range `[Section.Addr, Section.Addr + Section.Size)` and lookups failed incorrectly.

Compare with `addr >= Section.Addr` so boundary addresses resolve consistently with the half-open VMA interval.