### PR TITLE
proc: fix OR handling in breakpointConditionSatisfiable

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -1258,13 +1258,7 @@ func breakpointConditionSatisfiable(lbpmap map[int]*LogicalBreakpoint, lbp *Logi
 		case token.AND:
 			return satisf(binexpr.X) && satisf(binexpr.Y)
 		case token.OR:
-			if !satisf(binexpr.X) {
-				return false
-			}
-			if !satisf(binexpr.Y) {
-				return false
-			}
-			return true
+			return satisf(binexpr.X) || satisf(binexpr.Y)
 		case token.EQL, token.LEQ, token.LSS, token.NEQ, token.GTR, token.GEQ:
 		default:
 			return true


### PR DESCRIPTION
When shortcut-checking breakpoint conditions that reference Delve breakpoint hit-counts, breakpointConditionSatisfiable mistakenly applied AND semantics inside token.OR branches: it returned false whenever either subtree was not satisfiable, instead of only when neither side could succeed.

Evaluate disjunction as satisf(X) || satisf(Y), matching token.AND and ordinary boolean logic.
