### PR TITLE
native: stop ptraceGetRegset after failed GETFPREGS on linux amd64/386

### DIFF
--- a/pkg/proc/native/ptrace_linux_386.go
+++ b/pkg/proc/native/ptrace_linux_386.go
@@ -22,6 +22,9 @@ func ptraceGetRegset(tid int) (regset amd64util.AMD64Xstate, err error) {
 		// ignore ENODEV, it just means this CPU doesn't have X87 registers (??)
 		err = nil
 	}
+	if err != nil {
+		return
+	}
 
 	xstateargs := make([]byte, cpuid.AMD64XstateMaxSize())
 	iov := sys.Iovec{Base: &xstateargs[0], Len: uint32(len(xstateargs))}

--- a/pkg/proc/native/ptrace_linux_amd64.go
+++ b/pkg/proc/native/ptrace_linux_amd64.go
@@ -21,6 +21,9 @@ func ptraceGetRegset(tid int) (regset amd64util.AMD64Xstate, err error) {
 		// ignore ENODEV, it just means this CPU doesn't have X87 registers (??)
 		err = nil
 	}
+	if err != nil {
+		return
+	}
 
 	xstateargs := make([]byte, cpuid.AMD64XstateMaxSize())
 	iov := sys.Iovec{Base: &xstateargs[0], Len: uint64(len(xstateargs))}


### PR DESCRIPTION
ptraceGetRegset on linux amd64/386 clears errno after PTRACE_GETFPREGS only for success or ENODEV (per existing comments).

Any other failure was left in err yet execution continued into the NT_X86_XSTATE PTRACE_GETREGSET path and eventually returned mixed state. Short-circuit on err != nil after the FPREGS syscall so callers see the failing errno without follow-up ptrace unrelated to the root cause.

Files: pkg/proc/native/ptrace_linux_amd64.go, pkg/proc/native/ptrace_linux_386.go.
