### PR TITLE
proc: bail out of loadArrayValues after stride overflow

### DIFF
--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -1735,6 +1735,7 @@ func (v *Variable) loadArrayValues(recurseLevel int, cfg LoadConfig) {
 	}
 	if v.Base+uint64(v.stride*count) < v.Base {
 		v.Unreadable = fmt.Errorf("bad array base address %#x", v.Base)
+		return
 	}
 
 	if v.stride < maxArrayStridePrefetch {


### PR DESCRIPTION
`loadArrayValues` sets `v.Unreadable` when `v.Base + uint64(v.stride*count)` wraps (overflow check), mirroring defensive handling elsewhere.

Without an immediate return, the function still ran `cacheMemory` / the element loop afterward, contradicting `v.Unreadable` and risking confusing partially-filled `Children`. Add `return` after that assignment, consistent with the other early exits in the same function.
