### PR TITLE
proc: accept uintptr sources in EvalScope pointer casts

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1542,7 +1542,7 @@ func (scope *EvalScope) evalTypeCast(op *evalop.TypeCast, stack *evalStack) {
 		switch argv.Kind {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			// ok
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			// ok
 		default:
 			stack.err = converr


### PR DESCRIPTION
In `evalTypeCast`, the `*godwarf.PtrType` branch only whitelisted signed int kinds and fixed-size unsigned kinds when turning a loaded constant into a pointer variable.

`reflect.Uintptr` behaves like an unsigned, pointer-sized integer in the Go type system, but it was not in the switch, so expressions such as casting a `uintptr` holding an address to `*T` errored even when the operand was otherwise valid.

Add `reflect.Uintptr` beside the existing uint branches.
