### PR TITLE
proc: accept uintptr sources when casting to dwarf IntType

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1608,7 +1608,7 @@ func (scope *EvalScope) evalTypeCast(op *evalop.TypeCast, stack *evalStack) {
 			v.Value = constant.MakeInt64(int64(convertInt(uint64(n), true, ttyp.Size())))
 			stack.push(v)
 			return
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			n, _ := constant.Uint64Val(argv.Value)
 			v.Value = constant.MakeInt64(int64(convertInt(n, true, ttyp.Size())))
 			stack.push(v)


### PR DESCRIPTION
In `evalTypeCast`'s `@godwarf.IntType` handling, operands from unsigned reflective kinds reuse `constant.Uint64Val`, then truncate to `ttyp.Size()` via `convertInt`, matching Go two's-complement integer casts.

`reflect.Uintptr` was omitted from that case list despite matching the stored unsigned width semantics, causing explicit casts from Go `uintptr` into dwarf-signed integer descriptors to fail. Add `uintptr` alongside other unsigned kinds.
