### PR TITLE
gobuild: propagate goBuildArgs2 errors from GoBuild

### DIFF
--- a/pkg/gobuild/gobuild.go
+++ b/pkg/gobuild/gobuild.go
@@ -36,7 +36,10 @@ func Remove(path string) {
 // GoBuild builds non-test files in 'pkgs' with the specified 'buildflags'
 // and writes the output at 'debugname'.
 func GoBuild(debugname string, pkgs []string, buildflags any) error {
-	args, _ := goBuildArgs2(debugname, pkgs, buildflags, false)
+	args, err := goBuildArgs2(debugname, pkgs, buildflags, false)
+	if err != nil {
+		return err
+	}
 	return gocommandRun("build", args...)
 }
 


### PR DESCRIPTION
`GoBuild` called `goBuildArgs2` but discarded its error, unlike `GoBuildCombinedOutput` / `GoTestBuildCombinedOutput`.

When argument construction fails (e.g. bad `buildflags` shape for the `any` path), return that error instead of running `go build` with missing or partial args.
