### PR TITLE
proc: wire LRRegNum into riscv64 Arch

### DIFF
--- a/pkg/proc/riscv64_arch.go
+++ b/pkg/proc/riscv64_arch.go
@@ -39,6 +39,7 @@ func RISCV64Arch(goos string) *Arch {
 		PCRegNum:                         regnum.RISCV64_PC,
 		SPRegNum:                         regnum.RISCV64_SP,
 		ContextRegNum:                    regnum.RISCV64_S10,
+		LRRegNum:                         regnum.RISCV64_LR,
 		asmRegisters:                     riscv64AsmRegisters,
 		RegisterNameToDwarf:              nameToDwarfFunc(regnum.RISCV64NameToDwarf),
 		RegnumToString:                   regnum.RISCV64ToName,


### PR DESCRIPTION
`Arch.LRRegNum` is used across `pkg/proc` for call-frame bookkeeping (e.g. `stack.go`, `threads.go` LR updates). ARM64, ppc64le, and loong64 all set it in their `*Arch` constructor; riscv64 did not, leaving the field at the zero default.

Set `LRRegNum` to `regnum.RISCV64_LR` (`x1`), consistent with existing riscv64 unwind / `NewDwarfRegisters` plumbing in the same package.
