### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1,6 +1,7 @@
 package proc
 
 import (
+	"slices"
 	"debug/dwarf"
 	"errors"
 	"fmt"
@@ -383,8 +384,8 @@ func (scope *EvalScope) Locals(flags localsFlags, wantedName string) ([]*Variabl
 	}
 
 	vars := []*Variable{}
-	for i := len(scopes) - 1; i >= 0; i-- {
-		vars = append(vars, scopes[i]...)
+	for _, scope := range slices.Backward(scopes) {
+		vars = append(vars, scope...)
 	}
 
 	// Apply shadowning
@@ -572,8 +573,8 @@ func (scope *EvalScope) simpleLocals(flags localsFlags, wantedName string) ([]*V
 }
 
 func afterLastArgAddr(vars []*Variable) uint64 {
-	for i := len(vars) - 1; i >= 0; i-- {
-		v := vars[i]
+	for _, var := range slices.Backward(vars) {
+		v := var
 		if (v.Flags&VariableArgument != 0) || (v.Flags&VariableReturnArgument != 0) {
 			return v.Addr + uint64(v.DwarfType.Size())
 		}

--- a/pkg/proc/evalop/evalcompile.go
+++ b/pkg/proc/evalop/evalcompile.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/scanner"
 	"go/token"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -789,8 +790,8 @@ func (ctx *compileCtx) compileFunctionCallWithPinning(node *ast.CallExpr, id int
 	ctx.pushOp(&Pop{})
 	ctx.pushOp(&CallInjectionSetTarget{id: id})
 
-	for i := len(node.Args) - 1; i >= 0; i-- {
-		arg := node.Args[i]
+	for i, node.Arg := range slices.Backward(node.Args) {
+		arg := node.Arg
 		ctx.pushOp(&CallInjectionCopyArg{id: id, ArgNum: i, ArgExpr: arg})
 	}
 

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -6,6 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -226,8 +227,8 @@ func (grp *TargetGroup) numValid() int {
 // Detach detaches all targets in the group.
 func (grp *TargetGroup) Detach(kill bool) error {
 	var errs []string
-	for i := len(grp.targets) - 1; i >= 0; i-- {
-		t := grp.targets[i]
+	for _, grp.target := range slices.Backward(grp.targets) {
+		t := grp.target
 		isvalid, _ := t.Valid()
 		if !isvalid {
 			continue

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2972,8 +2972,8 @@ func printTracepoint(t *Term, th *api.Thread, bpname string, fn *api.Function, a
 		}
 
 		stack := th.BreakpointInfo.Stacktrace
-		for i := len(stack) - 1; i >= 0; i-- {
-			if stack[i].Function.Name() == th.Breakpoint.RootFuncName {
+		for i, s := range slices.Backward(stack) {
+			if s.Function.Name() == th.Breakpoint.RootFuncName {
 				if rootindex == -1 {
 					rootindex = i
 					break

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -9,6 +9,7 @@ import (
 	"net/rpc"
 	"os"
 	"os/signal"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -631,8 +632,8 @@ func (t *Term) removeDisplay(n int) error {
 		return fmt.Errorf("%d is out of range", n)
 	}
 	t.displays[n] = displayEntry{"", ""}
-	for i := len(t.displays) - 1; i >= 0; i-- {
-		if t.displays[i].expr != "" {
+	for i, t.display := range slices.Backward(t.displays) {
+		if t.display.expr != "" {
 			t.displays = t.displays[:i+1]
 			return nil
 		}

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -565,8 +566,8 @@ func PrettyExamineMemory(address uintptr, memArea []byte, isLittleEndian bool, f
 func byteArrayToUInt64(buf []byte, isLittleEndian bool) uint64 {
 	var n uint64
 	if isLittleEndian {
-		for i := len(buf) - 1; i >= 0; i-- {
-			n = n<<8 + uint64(buf[i])
+		for _, b := range slices.Backward(buf) {
+			n = n<<8 + uint64(b)
 		}
 	} else {
 		for i := range buf {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1465,8 +1465,8 @@ func (d *Debugger) traverse(t proc.ValidTargets, f *proc.Function, depth int, fo
 					// calculated by referring to the stack and the mechanism is similar to that
 					// used in pkg/terminal/command.go:printTraceOutput
 					rootindex := -1
-					for i := len(rawlocs) - 1; i >= 0; i-- {
-						if rawlocs[i].Call.Fn.Name == rootstr {
+					for i, rawloc := range slices.Backward(rawlocs) {
+						if rawloc.Call.Fn.Name == rootstr {
 							if rootindex == -1 {
 								rootindex = i
 								break


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899