### PR TITLE
Private/issue 3786 vars expression spec

### DIFF
--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2344,6 +2344,9 @@ func (t *Term) printFilteredVariables(varType string, vars []api.Variable, filte
 		if reg == nil || reg.Match([]byte(v.Name)) {
 			match = true
 			name := v.Name
+			if varType == "vars" {
+				name = quotePackagePath(name)
+			}
 			if v.Flags&api.VariableShadowed != 0 {
 				name = "(" + name + ")"
 			}
@@ -2358,6 +2361,29 @@ func (t *Term) printFilteredVariables(varType string, vars []api.Variable, filte
 		fmt.Fprintf(t.stdout, "(no %s)\n", varType)
 	}
 	return nil
+}
+
+// quotePackagePath quotes the package path portion of a fully qualified
+// variable name (e.g. "internal/bytealg.MaxLen") so that the output
+// matches the expression spec accepted by the 'print' command.
+// If the package path contains a '/', it is wrapped in double quotes:
+//
+//	internal/bytealg.MaxLen  →  "internal/bytealg".MaxLen
+//	main.x                  →  main.x  (unchanged)
+func quotePackagePath(name string) string {
+	// Find the last '.' that separates package path from symbol name.
+	// For receiver methods the name may look like "pkg/path.(*Type).Method",
+	// we want to quote only the package portion before the first '.'.
+	dot := strings.Index(name, ".")
+	if dot < 0 {
+		return name
+	}
+	pkg := name[:dot]
+	rest := name[dot:] // includes the leading '.'
+	if strings.Contains(pkg, "/") {
+		return `"` + pkg + `"` + rest
+	}
+	return name
 }
 
 func (t *Term) printSortedStrings(v []string, err error) error {

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -570,6 +570,44 @@ func TestNoVars(t *testing.T) {
 	})
 }
 
+func TestQuotePackagePath(t *testing.T) {
+	testcases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{
+			name: "quoted when package path contains slash",
+			in:   "internal/bytealg.MaxLen",
+			out:  `"internal/bytealg".MaxLen`,
+		},
+		{
+			name: "unchanged when package has no slash",
+			in:   "main.x",
+			out:  "main.x",
+		},
+		{
+			name: "unchanged when no selector",
+			in:   "MaxLen",
+			out:  "MaxLen",
+		},
+		{
+			name: "quotes package for method expression",
+			in:   "internal/abi.(*Type).Method",
+			out:  `"internal/abi".(*Type).Method`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := quotePackagePath(tc.in)
+			if got != tc.out {
+				t.Fatalf("quotePackagePath(%q) = %q, want %q", tc.in, got, tc.out)
+			}
+		})
+	}
+}
+
 func TestOnPrefixLocals(t *testing.T) {
 	const prefix = "\ti: "
 	test.AllowRecording(t)


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #3786

`vars` output is not always aligned with Delve expression syntax for package-qualified names, making copy/paste workflows unreliable.

Example:
- `vars` can show `internal/bytealg.MaxLen`
- but expression syntax for full package paths requires quoted package paths (for example `"internal/bytealg".MaxLen`)

As a result, users cannot always copy an entry from `vars` and use it directly with `print`, even though this should be a natural workflow during debugging.

### What changed and how does it work?
This PR makes `vars` emit package-qualified identifiers in expression-compatible form, consistent with `Documentation/cli/expr.md` (`Specifying package paths`).

Key changes:
1. Update variable-name formatting in the `vars` output path so package paths containing `/` are quoted.
2. Preserve existing output for names that are already expression-compatible.
3. Ensure entries shown by `vars` can be reused directly in `print` without manual rewriting.
4. Add/adjust tests around CLI variable listing behavior to verify expression compatibility.

### Why this approach?
- Matches Delve’s documented expression rules.
- Improves CLI usability by making `vars` output directly actionable.
- Keeps the change narrowly scoped to output formatting, without changing symbol-resolution semantics.

### Check List
Tests
- [ ] Unit test
- [ ] CLI/integration test (where applicable)
- [ ] Manual test
  - Build a sample program with debug symbols.
  - Run `dlv exec ./hello`.
  - Break, run `vars`, then copy one package-qualified variable and run `print <copied_expr>`.
  - Verify copied expression works without manual rewrites.
- [ ] No need to test

Documentation
- [x] Affects user-facing CLI behavior
- [ ] Additional docs required

### Release note
Align `vars` output with Delve expression syntax so package-qualified entries can be copied directly into `print` without manual edits.