### PR TITLE
proc: uintptr eval casts and Variable Kind (combined)

### DIFF
--- a/_fixtures/testvariables2.go
+++ b/_fixtures/testvariables2.go
@@ -185,6 +185,8 @@ func main() {
 	f1 := 3.0
 	i3 := 3
 	p1 := &i1
+	upConst := uintptr(123)
+	upPtr := uintptr(unsafe.Pointer(p1))
 	pp1 := &p1
 	s1 := []string{"one", "two", "three", "four", "five"}
 	s3 := make([]int, 0, 6)
@@ -444,5 +446,5 @@ func main() {
 	longslice := make([]int, 100, 100)
 
 	runtime.Breakpoint()
-	fmt.Println(i1, i2, i3, p1, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice, enum1, enum2, enum3, enum4, enum5, enum6, zeropoint4, mlarge, messageVar, iface7, issue4072)
+	fmt.Println(i1, i2, i3, p1, upConst, upPtr, pp1, amb1, s1, s3, a0, a1, p2, p3, s2, as1, str1, f1, fn1, fn2, nilslice, nilptr, ch1, chnil, m1, mnil, m2, m3, m4, m5, upnil, up1, i4, i5, i6, err1, err2, errnil, iface1, iface2, ifacenil, arr1, parr, cpx1, const1, iface3, iface4, recursive1, recursive1.x, iface5, iface2fn1, iface2fn2, bencharr, benchparr, mapinf, mainMenu, b, b2, sd, anonstruct1, anonstruct2, anoniface1, anonfunc, mapanonstruct1, ifacearr, efacearr, ni8, ni16, ni32, ni64, pinf, ninf, nan, zsvmap, zsslice, zsvar, tm, rettm, errtypednil, emptyslice, emptymap, byteslice, bytestypeslice, runeslice, bytearray, bytetypearray, runearray, longstr, nilstruct, as2, as2.NonPointerReceiverMethod, s4, iface2map, issue1578, ll, unread, w2, w3, w4, w5, longarr, longslice, val, m6, m7, cl, tim1, tim2, typedstringvar, namedA1, namedA2, astructName1(namedA2), badslice, tim3, int3chan, longbyteslice, enum1, enum2, enum3, enum4, enum5, enum6, zeropoint4, mlarge, messageVar, iface7, issue4072)
 }

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -643,7 +643,7 @@ func (scope *EvalScope) setValue(dstv, srcv *Variable, srcExpr string) error {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		n, _ := constant.Int64Val(srcv.Value)
 		return dstv.writeUint(uint64(n), dstv.RealType.Size())
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		n, _ := constant.Uint64Val(srcv.Value)
 		return dstv.writeUint(n, dstv.RealType.Size())
 	case reflect.Bool:
@@ -1542,7 +1542,7 @@ func (scope *EvalScope) evalTypeCast(op *evalop.TypeCast, stack *evalStack) {
 		switch argv.Kind {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			// ok
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			// ok
 		default:
 			stack.err = converr
@@ -1581,7 +1581,7 @@ func (scope *EvalScope) evalTypeCast(op *evalop.TypeCast, stack *evalStack) {
 			v.Value = constant.MakeUint64(convertInt(uint64(n), false, ttyp.Size()))
 			stack.push(v)
 			return
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			n, _ := constant.Uint64Val(argv.Value)
 			v.Value = constant.MakeUint64(convertInt(n, false, ttyp.Size()))
 			stack.push(v)
@@ -1608,7 +1608,7 @@ func (scope *EvalScope) evalTypeCast(op *evalop.TypeCast, stack *evalStack) {
 			v.Value = constant.MakeInt64(int64(convertInt(uint64(n), true, ttyp.Size())))
 			stack.push(v)
 			return
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			n, _ := constant.Uint64Val(argv.Value)
 			v.Value = constant.MakeInt64(int64(convertInt(n, true, ttyp.Size())))
 			stack.push(v)

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -764,7 +764,15 @@ func newVariable(name string, addr uint64, dwarfType godwarf.Type, bi *BinaryInf
 		v.RealType = &godwarf.IntType{BasicType: t.BasicType}
 		v.Kind = reflect.Int
 	case *godwarf.UintType:
-		v.Kind = reflect.Uint
+		// Most unsigned DWARF types are represented as reflect.Uint regardless of
+		// size; uintptr is special because eval and Go treat it as reflect.Uintptr.
+		if rk := t.Common().ReflectKind; rk == reflect.Uintptr {
+			v.Kind = reflect.Uintptr
+		} else if t.Name == "uintptr" {
+			v.Kind = reflect.Uintptr
+		} else {
+			v.Kind = reflect.Uint
+		}
 	case *godwarf.FloatType:
 		switch t.ByteSize {
 		case 4:
@@ -1109,7 +1117,10 @@ func (a *Ancestor) Stack(n int) ([]Stackframe, error) {
 			r[i] = Stackframe{Err: pcsVar.Children[i].Unreadable}
 			continue
 		}
-		if pcsVar.Children[i].Kind != reflect.Uint {
+		switch pcsVar.Children[i].Kind {
+		case reflect.Uint, reflect.Uintptr:
+			// ok — runtime ancestor PCs may be uintptr-typed.
+		default:
 			return nil, fmt.Errorf("wrong type for pcs item %d: %v", i, pcsVar.Children[i].Kind)
 		}
 		pc, _ := constant.Int64Val(pcsVar.Children[i].Value)

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -951,6 +951,12 @@ func getEvalExpressionTestCases() []varTest {
 		{`*(*uint)(unsafe.Pointer(p1))`, false, `1`, `1`, "uint", nil},
 		{`*(*uint)(unsafe.Pointer(&i1))`, false, `1`, `1`, "uint", nil},
 
+		// Regression: uintptr-typed operands use reflect.Uintptr — eval must permit
+		// the same casts as Go (combined with uintptr Kind in variables.go).
+		{`int(upConst)`, false, `123`, `123`, "int", nil},
+		{`uint(upConst)`, false, `123`, `123`, "uint", nil},
+		{`(*int)(upPtr)`, false, `(*int)(0x…`, `(*int)(0x…`, "*int", nil},
+
 		// Malformed values
 		{`badslice`, false, `(unreadable non-zero length array with nil base)`, `(unreadable non-zero length array with nil base)`, "[]int", nil},
 	}


### PR DESCRIPTION
Combines superseded PRs [#4329](https://github.com/go-delve/delve/pull/4329), [#4330](https://github.com/go-delve/delve/pull/4330), and [#4331](https://github.com/go-delve/delve/pull/4331):

- **`evalTypeCast`**: treat `reflect.Uintptr` like other unsigned widths for pointer casts, `UintType` casts, and `IntType` casts.
- **`setValue`**: allow assignment into `reflect.Uintptr` destinations (same as other unsigned ints).
- **`variables`**: mark DWARF `uintptr` locals/globals as `reflect.Uintptr`; accept `uintptr` PC words when decoding ancestor stack `pcs`.

**Regression tests** (via `getEvalExpressionTestCases` / `TestEvalExpression`): `_fixtures/testvariables2.go` adds `upConst` and `upPtr`; expressions `int(upConst)`, `uint(upConst)`, and `(*int)(upPtr)` guard the cast paths once `uintptr` values carry `reflect.Uintptr`.

Closing #4329, #4330, and #4331 in favor of this single PR.