### PR TITLE
proc: fix test for go1.27 regexp refactor

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4427,6 +4427,10 @@ func TestIssue1795(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 13) {
 		t.Skip("Test not relevant to Go < 1.13")
 	}
+	var doExecuteName = "regexp.(*Regexp).doExecute"
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 27) {
+		doExecuteName = "regexp.(*Regexp).find"
+	}
 	skipOn(t, "broken", "ppc64le")
 	withTestProcessArgs("issue1795", t, ".", []string{}, protest.EnableInlining|protest.EnableOptimization, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		assertNoError(grp.Continue(), t, "Continue()")
@@ -4435,14 +4439,14 @@ func TestIssue1795(t *testing.T) {
 		assertLineNumber(p, t, 13, "wrong line number after Next,")
 	})
 	withTestProcessArgs("issue1795", t, ".", []string{}, protest.EnableInlining|protest.EnableOptimization, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
-		setFunctionBreakpoint(p, t, "regexp.(*Regexp).doExecute")
+		setFunctionBreakpoint(p, t, doExecuteName)
 		assertNoError(grp.Continue(), t, "Continue()")
 		assertLineNumber(p, t, 12, "wrong line number after Continue (1),")
 		assertNoError(grp.Continue(), t, "Continue()")
 		frames, err := proc.ThreadStacktrace(p, p.CurrentThread(), 40)
 		assertNoError(err, t, "ThreadStacktrace()")
 		logStacktrace(t, p, frames)
-		if err := checkFrame(frames[0], "regexp.(*Regexp).doExecute", "", 0, false); err != nil {
+		if err := checkFrame(frames[0], doExecuteName, "", 0, false); err != nil {
 			t.Errorf("Wrong frame 0: %v", err)
 		}
 		if err := checkFrame(frames[1], "regexp.(*Regexp).doMatch", "", 0, true); err != nil {


### PR DESCRIPTION
Fix a test broken by renames in go1.27
