### PR TITLE
proc: add test for accessing global C variables

### DIFF
--- a/_fixtures/dwzcompression.go
+++ b/_fixtures/dwzcompression.go
@@ -1,6 +1,7 @@
 package main
 
 // #include <stdio.h>
+// int globalvar = 10;
 // void fortytwo()
 // {
 //      fprintf(stdin, "42");

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -2111,3 +2111,15 @@ func TestEmbeddedStructMethodsAndFieldLookup(t *testing.T) {
 		}
 	})
 }
+
+func TestCGlobal(t *testing.T) {
+	skipOn(t, "not working on freebsd", "freebsd")
+	withTestProcess("dwzcompression", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+		setFunctionBreakpoint(p, t, "C.fortytwo")
+		assertNoError(grp.Continue(), t, "first Continue()")
+		val := evalVariable(p, t, "globalvar")
+		if val.RealType == nil {
+			t.Errorf("Can't find type for \"stdin\" global variable")
+		}
+	})
+}


### PR DESCRIPTION
It turns out that we only test this functionality accidentally through
TestDWZCompression which will soon stop working because dwz doesn't
work with 1.25 and later.

Make a copy of the test that doesn't use dwz compression.
