### PR TITLE
proc: add test for struct literals with embedded field selectors

### DIFF
--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1423,6 +1423,7 @@ func TestCallFunction(t *testing.T) {
 		{`mul2ptr(&main.a2struct{Y: 3})`, []string{":int:6"}, nil, 1},
 		{`mul2ptr(&main.a2struct{1})`, []string{":int:2"}, nil, 1},
 		{`m[main.intpair{3, 1}]`, []string{`:string:"three,one"`}, nil, 0},
+		{`main.Derived{ x: 1, y: 2 }`, []string{`:main.Derived:main.Derived {x: 1, Base: main.Base {y: 2}}`}, nil, 0},
 	}
 
 	withTestProcessArgs("fncall", t, ".", nil, protest.AllNonOptimized, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {


### PR DESCRIPTION
Because we implemented struct literals through assignment we always
supported this even though Go only started in 1.27. Add an explicit
test for this.

Updates #4360
