### PR TITLE
proc/test: include GOEXPERIMENT in the fixture cache key 

### DIFF
--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2051,6 +2051,24 @@ func TestStepParked(t *testing.T) {
 	})
 }
 
+func TestBuildFixtureGoExperiment(t *testing.T) {
+	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) {
+		t.Skip("noswissmap experiment does not exist before Go 1.24")
+	}
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 27) {
+		t.Skip("noswissmap experiment removed in Go 1.27")
+	}
+
+	// Regression test: BuildFixture must not return a binary cached under a
+	// different GOEXPERIMENT, since the experiment changes the built binary.
+	defaultFixture := protest.BuildFixture(t, "testvariables2", 0)
+	t.Setenv("GOEXPERIMENT", "noswissmap")
+	experimentFixture := protest.BuildFixture(t, "testvariables2", 0)
+	if defaultFixture.Path == experimentFixture.Path {
+		t.Fatalf("BuildFixture returned the same binary %q for different GOEXPERIMENT values", defaultFixture.Path)
+	}
+}
+
 func TestUnsupportedArch(t *testing.T) {
 	ver, _ := goversion.Parse(runtime.Version())
 	if ver.Major < 0 || !ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 6, Rev: -1}) || ver.AfterOrEqual(goversion.GoVersion{Major: 1, Minor: 7, Rev: -1}) {

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -41,6 +41,10 @@ type Fixture struct {
 type fixtureKey struct {
 	Name  string
 	Flags BuildFlags
+	// GoExperiment is the value of GOEXPERIMENT during compilation.
+	//
+	// Track this as it some tests use different GOEXPERIMENT values.
+	GoExperiment string
 }
 
 // Fixtures is a map of fixtureKey{ Fixture.Name, buildFlags } to Fixture.
@@ -107,7 +111,7 @@ func BuildFixture(t testing.TB, name string, flags BuildFlags) Fixture {
 	if !runningWithFixtures {
 		panic("RunTestsWithFixtures not called")
 	}
-	fk := fixtureKey{name, flags}
+	fk := fixtureKey{Name: name, Flags: flags, GoExperiment: os.Getenv("GOEXPERIMENT")}
 	fixturesmu.Lock()
 	if f, ok := fixtures[fk]; ok {
 		fixturesmu.Unlock()

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1984,6 +1984,10 @@ func TestClassicMap(t *testing.T) {
 		{"mnil == m1", false, "", "", "", errors.New("can not compare map variables")},
 		{"mnil == nil", false, "true", "true", "", nil},
 		{"m2", true, "map[int]*main.astruct [1: *{A: 10, B: 11}, ]", "map[int]*main.astruct [...]", "map[int]*main.astruct", nil},
+
+		// Check that the fixture binary actually uses the classic map
+		// implementation: runtime.hmap does not exist in swissmap binaries.
+		{`**(**runtime.hmap)(uintptr(&m1))`, false, `…`, `…`, "runtime.hmap", nil},
 	}
 
 	withTestProcess("testvariables2", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {


### PR DESCRIPTION
BuildFixture used to cache built fixtures by (name, flags),
but `TestClassicMap` builds testvariables2 under
`GOEXPERIMENT=noswissmap`, which produces a
different binary.

Whichever test built the fixture first determined the
binary every other test got.

If we try to parallelize the tests (upcoming work),
`TestClassicMap` runs first and populates the cache
with a `noswissmap` binary, breaking `TestEvalExpression`'s
`swissmap` type assertions.

So earlier, the fully-serial `TestClassicMap`
would incorrectly use the cached `swissmap` binary
and does not actually exercise classic maps.