### PR TITLE
pkg/proc: add GOEXPERIMENT=mapsplitgroup support

### DIFF
--- a/pkg/proc/mapiter.go
+++ b/pkg/proc/mapiter.go
@@ -322,7 +322,32 @@ type mapIteratorSwiss struct {
 	keyTypeIsPtr, elemTypeIsPtr bool
 	tableType, groupType        *godwarf.StructType
 
-	tableFieldIndex, tableFieldGroups, groupsFieldLengthMask, groupsFieldData, groupFieldCtrl, groupFieldSlots, slotFieldKey, slotFieldElem *godwarf.StructField
+	tableFieldIndex, tableFieldGroups, groupsFieldLengthMask, groupsFieldData, groupFieldCtrl *godwarf.StructField
+
+	// GOEXPERIMENT=nomapsplitgroup
+	//
+	// Interleaved slot layout (KVKVKVKV):
+	//
+	// type group struct {
+	//     ctrl  uint64
+	//     slots [abi.MapGroupSlots]struct {
+	//         key  keyType
+	//         elem elemType
+	//     }
+	// }
+	groupFieldSlots, slotFieldKey, slotFieldElem *godwarf.StructField
+
+	// GOEXPERIMENT=mapsplitgroup
+	//
+	// Split layout (KKKKVVVV):
+	//
+	// type group struct {
+	//     ctrl  uint64
+	//     keys  [abi.MapGroupSlots]keyType
+	//     elems [abi.MapGroupSlots]elemType
+	// }
+	mapsplitgroup                   bool
+	groupFieldKeys, groupFieldElems *godwarf.StructField
 
 	dirIdx int64
 	tab    *swissTable
@@ -343,8 +368,13 @@ type swissTable struct {
 }
 
 type swissGroup struct {
-	slots *Variable
 	ctrls []byte
+
+	// GOEXPERIMENT=nomapsplitgroup
+	slots *Variable
+
+	// GOEXPERIMENT=mapsplitgroup
+	keys, elems *Variable
 }
 
 var (
@@ -405,36 +435,54 @@ func (it *mapIteratorSwiss) loadTypes() {
 		switch field.Name {
 		case "ctrl":
 			it.groupFieldCtrl = field
+		// GOEXPERIMENT=nomapsplitgroup
 		case "slots":
 			it.groupFieldSlots = field
+		// GOEXPERIMENT=mapsplitgroup
+		case "keys":
+			it.groupFieldKeys = field
+		case "elems":
+			it.groupFieldElems = field
 		}
 	}
-	if it.groupFieldCtrl == nil || it.groupFieldSlots == nil {
+	if it.groupFieldCtrl == nil {
+		it.v.Unreadable = errSwissMapBadGroupTypeErr
+		return
+	}
+	// Either slots or keys+elems must exist.
+	it.mapsplitgroup = it.groupFieldKeys != nil && it.groupFieldElems != nil
+	if !it.mapsplitgroup && it.groupFieldSlots == nil {
+		it.v.Unreadable = errSwissMapBadGroupTypeErr
+		return
+	}
+	if it.mapsplitgroup && it.groupFieldSlots != nil {
 		it.v.Unreadable = errSwissMapBadGroupTypeErr
 		return
 	}
 
-	slotsType, ok := godwarf.ResolveTypedef(it.groupFieldSlots.Type).(*godwarf.ArrayType)
-	if !ok {
-		it.v.Unreadable = errSwissMapBadGroupTypeErr
-		return
-	}
-	slotType, ok := slotsType.Type.(*godwarf.StructType)
-	if !ok {
-		it.v.Unreadable = errSwissMapBadGroupTypeErr
-		return
-	}
-	for _, field := range slotType.Field {
-		switch field.Name {
-		case "key":
-			it.slotFieldKey = field
-		case "elem":
-			it.slotFieldElem = field
+	if !it.mapsplitgroup {
+		slotsType, ok := godwarf.ResolveTypedef(it.groupFieldSlots.Type).(*godwarf.ArrayType)
+		if !ok {
+			it.v.Unreadable = errSwissMapBadGroupTypeErr
+			return
 		}
-	}
-	if it.slotFieldKey == nil || it.slotFieldElem == nil {
-		it.v.Unreadable = errSwissMapBadGroupTypeErr
-		return
+		slotType, ok := slotsType.Type.(*godwarf.StructType)
+		if !ok {
+			it.v.Unreadable = errSwissMapBadGroupTypeErr
+			return
+		}
+		for _, field := range slotType.Field {
+			switch field.Name {
+			case "key":
+				it.slotFieldKey = field
+			case "elem":
+				it.slotFieldElem = field
+			}
+		}
+		if it.slotFieldKey == nil || it.slotFieldElem == nil {
+			it.v.Unreadable = errSwissMapBadGroupTypeErr
+			return
+		}
 	}
 
 	if it.dirLen <= 0 {
@@ -482,20 +530,31 @@ func (it *mapIteratorSwiss) next() bool {
 				}
 			}
 
-			for ; it.slotIdx < uint32(it.group.slots.Len); it.slotIdx++ {
+			var slotsLen uint32
+			if it.mapsplitgroup {
+				slotsLen = uint32(it.group.keys.Len)
+			} else {
+				slotsLen = uint32(it.group.slots.Len)
+			}
+			for ; it.slotIdx < slotsLen; it.slotIdx++ {
 				if it.slotIsEmptyOrDeleted(it.slotIdx) {
 					continue
 				}
 
-				cur, err := it.group.slots.sliceAccess(int(it.slotIdx))
-				if err != nil {
-					it.v.Unreadable = fmt.Errorf("error accessing swiss map in table %d, group %d, slot %d", it.dirIdx, it.groupIdx, it.slotIdx)
-					return false
-				}
-
 				var err1, err2 error
-				it.curKey, err1 = cur.toField(it.slotFieldKey)
-				it.curValue, err2 = cur.toField(it.slotFieldElem)
+				if it.mapsplitgroup {
+					it.curKey, err1 = it.group.keys.sliceAccess(int(it.slotIdx))
+					it.curValue, err2 = it.group.elems.sliceAccess(int(it.slotIdx))
+				} else {
+					cur, err := it.group.slots.sliceAccess(int(it.slotIdx))
+					if err != nil {
+						it.v.Unreadable = fmt.Errorf("error accessing swiss map in table %d, group %d, slot %d", it.dirIdx, it.groupIdx, it.slotIdx)
+						return false
+					}
+
+					it.curKey, err1 = cur.toField(it.slotFieldKey)
+					it.curValue, err2 = cur.toField(it.slotFieldElem)
+				}
 				if err1 != nil || err2 != nil {
 					it.v.Unreadable = fmt.Errorf("error accessing swiss map slot: %v %v", err1, err2)
 					return false
@@ -602,13 +661,10 @@ func (it *mapIteratorSwiss) loadCurrentGroup() {
 		it.v.Unreadable = fmt.Errorf("could not load swiss map group: %v", err)
 		return
 	}
+
 	g := &swissGroup{}
+
 	var err2 error
-	g.slots, err2 = group.toField(it.groupFieldSlots)
-	if err2 != nil {
-		it.v.Unreadable = fmt.Errorf("could not load swiss map group slots: %v", err2)
-		return
-	}
 	ctrl, err2 := group.toField(it.groupFieldCtrl)
 	if err2 != nil {
 		it.v.Unreadable = fmt.Errorf("could not load swiss map group ctrl: %v", err2)
@@ -620,6 +676,26 @@ func (it *mapIteratorSwiss) loadCurrentGroup() {
 		it.v.Unreadable = err
 		return
 	}
+
+	if it.mapsplitgroup {
+		g.keys, err2 = group.toField(it.groupFieldKeys)
+		if err2 != nil {
+			it.v.Unreadable = fmt.Errorf("could not load swiss map group keys: %v", err2)
+			return
+		}
+		g.elems, err2 = group.toField(it.groupFieldElems)
+		if err2 != nil {
+			it.v.Unreadable = fmt.Errorf("could not load swiss map group elems: %v", err2)
+			return
+		}
+	} else {
+		g.slots, err2 = group.toField(it.groupFieldSlots)
+		if err2 != nil {
+			it.v.Unreadable = fmt.Errorf("could not load swiss map group slots: %v", err2)
+			return
+		}
+	}
+
 	it.group = g
 }
 

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -2055,8 +2055,8 @@ func TestBuildFixtureGoExperiment(t *testing.T) {
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) {
 		t.Skip("noswissmap experiment does not exist before Go 1.24")
 	}
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 27) {
-		t.Skip("noswissmap experiment removed in Go 1.27")
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 26) {
+		t.Skip("noswissmap experiment removed in Go 1.26")
 	}
 
 	// Regression test: BuildFixture must not return a binary cached under a

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -1962,19 +1962,16 @@ func TestSetupRangeFramesCrash(t *testing.T) {
 	}
 }
 
-func TestClassicMap(t *testing.T) {
+func TestMapImplementationVariants(t *testing.T) {
 	// This test replicates some of the tests in TestEvalExpression to check
-	// that we still support non-swiss maps on versions of Go where the default
-	// map backend is swisstables.
+	// that we support other implementation variants for the standard library
+	// map, specifically the classic (non-swiss) implementation and the
+	// splitmap and nosplitmap experiments (one of those is the default).
 	protest.AllowRecording(t)
 
 	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 24) {
 		t.Skip("N/A")
 	}
-	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 27) {
-		t.Skip("noswissmap experiment removed in Go 1.27")
-	}
-	t.Setenv("GOEXPERIMENT", "noswissmap")
 
 	testcases := []varTest{
 		{"m1[\"Malone\"]", false, "main.astruct {A: 2, B: 3}", "main.astruct {A: 2, B: 3}", "main.astruct", nil},
@@ -1990,44 +1987,66 @@ func TestClassicMap(t *testing.T) {
 		{"mnil == m1", false, "", "", "", errors.New("can not compare map variables")},
 		{"mnil == nil", false, "true", "true", "", nil},
 		{"m2", true, "map[int]*main.astruct [1: *{A: 10, B: 11}, ]", "map[int]*main.astruct [...]", "map[int]*main.astruct", nil},
-
-		// Check that the fixture binary actually uses the classic map
-		// implementation: runtime.hmap does not exist in swissmap binaries.
-		{`**(**runtime.hmap)(uintptr(&m1))`, false, `…`, `…`, "runtime.hmap", nil},
+		{`zsvmap["testkey"]`, false, "struct {} {}", "struct {} {}", "struct {}", nil},
 	}
 
-	withTestProcess("testvariables2", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
-		assertNoError(grp.Continue(), t, "Continue() returned an error")
-		for _, tc := range testcases {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Logf("%q", tc.name)
-				variable, err := evalVariableWithCfg(p, tc.name, pnormalLoadConfig)
-				if tc.err == nil {
-					assertNoError(err, t, fmt.Sprintf("EvalExpression(%s) returned an error", tc.name))
-					assertVariable(t, variable, tc)
-					variable, err := evalVariableWithCfg(p, tc.name, pshortLoadConfig)
-					assertNoError(err, t, fmt.Sprintf("EvalExpression(%s, pshortLoadConfig) returned an error", tc.name))
-					assertVariable(t, variable, tc.alternateVarTest())
-				} else {
+	helper := func(t *testing.T, testcases []varTest) {
+		t.Helper()
+		withTestProcess("testvariables2", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
+			assertNoError(grp.Continue(), t, "Continue() returned an error")
+			for _, tc := range testcases {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Logf("%q", tc.name)
+					variable, err := evalVariableWithCfg(p, tc.name, pnormalLoadConfig)
+					if tc.err == nil {
+						assertNoError(err, t, fmt.Sprintf("EvalExpression(%s) returned an error", tc.name))
+						assertVariable(t, variable, tc)
+						variable, err := evalVariableWithCfg(p, tc.name, pshortLoadConfig)
+						assertNoError(err, t, fmt.Sprintf("EvalExpression(%s, pshortLoadConfig) returned an error", tc.name))
+						assertVariable(t, variable, tc.alternateVarTest())
+					} else {
 
-					if err == nil {
-						t.Fatalf("Expected error %s, got no error (%s)", tc.err.Error(), tc.name)
-					}
-					switch e := tc.err.(type) {
-					case *altError:
-						if !slices.Contains(e.errs, err.Error()) {
-							t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
+						if err == nil {
+							t.Fatalf("Expected error %s, got no error (%s)", tc.err.Error(), tc.name)
 						}
-					default:
-						if tc.err.Error() != "*" && tc.err.Error() != err.Error() {
-							t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
+						switch e := tc.err.(type) {
+						case *altError:
+							if !slices.Contains(e.errs, err.Error()) {
+								t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
+							}
+						default:
+							if tc.err.Error() != "*" && tc.err.Error() != err.Error() {
+								t.Fatalf("Unexpected error. Expected %s got %s", tc.err.Error(), err.Error())
+							}
 						}
-					}
 
-				}
-			})
-		}
-	})
+					}
+				})
+			}
+		})
+	}
+
+	if goversion.VersionAfterOrEqual(runtime.Version(), 1, 27) {
+		t.Run("MapSplitGroup", func(t *testing.T) {
+			t.Setenv("GOEXPERIMENT", "mapsplitgroup")
+			helper(t, testcases)
+		})
+		t.Run("NoMapSplitGroup", func(t *testing.T) {
+			t.Setenv("GOEXPERIMENT", "nomapsplitgroup")
+			helper(t, testcases)
+		})
+	}
+
+	if !goversion.VersionAfterOrEqual(runtime.Version(), 1, 26) {
+		t.Run("ClassicMaps", func(t *testing.T) {
+			t.Setenv("GOEXPERIMENT", "noswissmap")
+			helper(t, append(testcases,
+				// Check that the fixture binary actually uses the classic map
+				// implementation: runtime.hmap does not exist in swissmap binaries.
+				varTest{`**(**runtime.hmap)(uintptr(&m1))`, false, `…`, `…`, "runtime.hmap", nil}))
+		})
+	}
+
 }
 
 func TestCallFunctionRegisterArg(t *testing.T) {


### PR DESCRIPTION
This is the same as #4274 but with a test added. I've checked it against the implementation that was merged and it seems to be still matching.