### PR TITLE
service/dap: send ExitedEvent before TerminatedEvent

### DIFF
--- a/cmd/dlv/dlv_test.go
+++ b/cmd/dlv/dlv_test.go
@@ -549,6 +549,10 @@ func TestRemoteDAPClient(t *testing.T) {
 	client := newDAPRemoteClient(t, listenAddr, false, false)
 	client.ContinueRequest(1)
 	client.ExpectContinueResponse(t)
+	ee := client.ExpectExitedEvent(t)
+	if ee.Body.ExitCode != 0 {
+		t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+	}
 	client.ExpectTerminatedEvent(t)
 
 	client.DisconnectRequest()
@@ -567,6 +571,9 @@ func closeDAPRemoteMultiClient(t *testing.T, c *daptest.Client, expectStatus str
 	c.DisconnectRequest()
 	c.ExpectOutputEventClosingClient(t, expectStatus)
 	c.ExpectDisconnectResponse(t)
+	if expectStatus == "exited" {
+		c.ExpectExitedEvent(t)
+	}
 	c.ExpectTerminatedEvent(t)
 	c.Close()
 	time.Sleep(10 * time.Millisecond)
@@ -620,6 +627,10 @@ func TestRemoteDAPClientMulti(t *testing.T) {
 	dapclient2.CheckStopLocation(t, 1, "main.main", 5)
 	dapclient2.ContinueRequest(1)
 	dapclient2.ExpectContinueResponse(t)
+	ee := dapclient2.ExpectExitedEvent(t)
+	if ee.Body.ExitCode != 0 {
+		t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+	}
 	dapclient2.ExpectTerminatedEvent(t)
 	closeDAPRemoteMultiClient(t, dapclient2, "exited")
 

--- a/service/dap/command.go
+++ b/service/dap/command.go
@@ -172,7 +172,7 @@ func (s *Session) examineMemory(goid, frame int, argstr string) (string, error) 
 		}
 
 		switch val.Kind {
-		case reflect.Ptr: // "-x &myVar" or "-x myPtrVar"
+		case reflect.Pointer: // "-x &myVar" or "-x myPtrVar"
 			if len(val.Children) < 1 {
 				return fmt.Errorf("bug? invalid pointer: %#v", val).Error(), nil
 			}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1253,6 +1253,10 @@ func (s *Session) onLaunchRequest(request *dap.LaunchRequest) {
 
 			close(s.noDebugProcess.exited)
 			s.logToConsole(proc.ErrProcessExited{Pid: cmd.ProcessState.Pid(), Status: cmd.ProcessState.ExitCode()}.Error())
+			s.send(&dap.ExitedEvent{
+				Event: *s.newEvent("exited"),
+				Body:  dap.ExitedEventBody{ExitCode: cmd.ProcessState.ExitCode()},
+			})
 			s.send(&dap.TerminatedEvent{Event: *s.newEvent("terminated")})
 		}()
 		return
@@ -1463,15 +1467,22 @@ func (s *Session) onDisconnectRequest(request *dap.DisconnectRequest) {
 		// terminate the debuggee should clean up only the client connection and pointer to debugger,
 		// but not the entire server.
 		status := "halted"
+		var exitState *api.DebuggerState
+		var exitErr error
 		if s.isRunningCmd() {
 			status = "running"
 		} else if state, err := s.debugger.State(false); processExited(state, err) {
 			status = "exited"
+			exitState = state
+			exitErr = err
 			s.preTerminatedWG.Wait()
 		}
 
 		s.logToConsole(fmt.Sprintf("Closing client session, but leaving multi-client DAP server at %s with debuggee %s", s.config.Listener.Addr().String(), status))
 		s.send(&dap.DisconnectResponse{Response: *s.newResponse(request.Request)})
+		if status == "exited" {
+			s.sendExitedEvent(exitState, exitErr)
+		}
 		s.send(&dap.TerminatedEvent{Event: *s.newEvent("terminated")})
 		s.conn.Close()
 		s.disconnected = true
@@ -2904,7 +2915,7 @@ func (s *Session) childrenToDAPVariables(v *fullyQualifiedVariable) []dap.Variab
 				cfqname = ""
 			case v.Kind == reflect.Interface:
 				cfqname = fmt.Sprintf("%s.(%s)", v.fullyQualifiedNameOrExpr, c.Name) // c is data
-			case v.Kind == reflect.Ptr:
+			case v.Kind == reflect.Pointer:
 				cfqname = fmt.Sprintf("(*%v)", v.fullyQualifiedNameOrExpr) // c is the nameless pointer value
 			case v.Kind == reflect.Complex64 || v.Kind == reflect.Complex128:
 				cfqname = "" // complex children are not struct fields and can't be accessed directly
@@ -3109,7 +3120,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		value = fmt.Sprintf("%s = %#x", value, n)
 	case reflect.UnsafePointer:
 		// Skip child reference
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v.DwarfType != nil && len(v.Children) > 0 && v.Children[0].Addr != 0 && v.Children[0].Kind != reflect.Invalid {
 			if v.Children[0].OnlyAddr { // Not loaded
 				if v.Addr == 0 {
@@ -3345,8 +3356,8 @@ func (s *Session) doCall(goid, frame int, expr string) (*api.DebuggerState, []*p
 	}, nil, s.conn.closedChan, s.convertDebuggerEvent)
 	if processExited(state, err) {
 		s.preTerminatedWG.Wait()
-		e := &dap.TerminatedEvent{Event: *s.newEvent("terminated")}
-		s.send(e)
+		s.sendExitedEvent(state, err)
+		s.send(&dap.TerminatedEvent{Event: *s.newEvent("terminated")})
 		return nil, nil, errors.New("terminated")
 	}
 	if err != nil {
@@ -3500,7 +3511,10 @@ func (s *Session) onRestartRequest(request *dap.RestartRequest) {
 	discardedBreakpoints, err := s.debugger.Restart(false, "", resetArgs, newArgs, [3]string{}, rebuild)
 	if err != nil {
 		s.sendErrorResponse(request.Request, FailedToLaunch, "Failed to restart", err.Error())
-		if _, err := s.debugger.State(false); validBefore && err != nil {
+		if state, err := s.debugger.State(false); validBefore && err != nil {
+			if processExited(state, err) {
+				s.sendExitedEvent(state, err)
+			}
 			s.send(&dap.TerminatedEvent{Event: *s.newEvent("terminated")})
 		}
 		return
@@ -4202,6 +4216,24 @@ func processExited(state *api.DebuggerState, err error) bool {
 	return isexited || err == nil && state.Exited
 }
 
+func exitCode(state *api.DebuggerState, err error) int {
+	var errProcessExited proc.ErrProcessExited
+	if errors.As(err, &errProcessExited) {
+		return errProcessExited.Status
+	}
+	if state != nil {
+		return state.ExitStatus
+	}
+	return 0
+}
+
+func (s *Session) sendExitedEvent(state *api.DebuggerState, err error) {
+	s.send(&dap.ExitedEvent{
+		Event: *s.newEvent("exited"),
+		Body:  dap.ExitedEventBody{ExitCode: exitCode(state, err)},
+	})
+}
+
 func (s *Session) setRunningCmd(running bool) {
 	s.runningMu.Lock()
 	defer s.runningMu.Unlock()
@@ -4268,6 +4300,7 @@ func (s *Session) runUntilStopAndNotify(command string, allowNextStateChange *sy
 
 	if processExited(state, err) {
 		s.preTerminatedWG.Wait()
+		s.sendExitedEvent(state, err)
 		s.send(&dap.TerminatedEvent{Event: *s.newEvent("terminated")})
 		return
 	}

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -213,6 +213,10 @@ func TestStopWithTarget(t *testing.T) {
 		"disconnect after  exit": func(c *daptest.Client, forceStop chan struct{}) {
 			c.ContinueRequest(1)
 			c.ExpectContinueResponse(t)
+			ee := c.ExpectExitedEvent(t)
+			if ee.Body.ExitCode != 0 {
+				t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+			}
 			c.ExpectTerminatedEvent(t)
 			c.DisconnectRequest()
 		},
@@ -274,6 +278,10 @@ func TestSessionStop(t *testing.T) {
 		"disconnect after exit": func(s *Session, c *daptest.Client, serveDone chan struct{}) {
 			c.ContinueRequest(1)
 			c.ExpectContinueResponse(t)
+			ee := c.ExpectExitedEvent(t)
+			if ee.Body.ExitCode != 0 {
+				t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+			}
 			c.ExpectTerminatedEvent(t)
 			c.DisconnectRequest()
 			<-serveDone
@@ -477,6 +485,10 @@ func TestLaunchStopOnEntry(t *testing.T) {
 		contResp := client.ExpectContinueResponse(t)
 		if contResp.RequestSeq != 12 || !contResp.Body.AllThreadsContinued {
 			t.Errorf("\ngot %#v\nwant RequestSeq=12 Body.AllThreadsContinued=true", contResp)
+		}
+		ee := client.ExpectExitedEvent(t)
+		if ee.Body.ExitCode != 0 {
+			t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
 		}
 		client.ExpectTerminatedEvent(t)
 
@@ -752,6 +764,10 @@ func TestLaunchWithFollowExec(t *testing.T) {
 		if contResp.RequestSeq != 10 || !contResp.Body.AllThreadsContinued {
 			t.Errorf("\ngot %#v\nwant RequestSeq=10 Body.AllThreadsContinued=true", contResp)
 		}
+		ee := client.ExpectExitedEvent(t)
+		if ee.Body.ExitCode != 0 {
+			t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+		}
 		client.ExpectTerminatedEvent(t)
 
 		// 11 >> disconnect, << disconnect
@@ -873,6 +889,10 @@ func TestContinueOnEntry(t *testing.T) {
 		client.ExpectConfigurationDoneResponse(t)
 		// "Continue" happens behind the scenes on another goroutine
 
+		ee := client.ExpectExitedEvent(t)
+		if ee.Body.ExitCode != 0 {
+			t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+		}
 		client.ExpectTerminatedEvent(t)
 
 		// 6 >> threads, << threads
@@ -1010,6 +1030,10 @@ func TestPreSetBreakpoint(t *testing.T) {
 		}
 		// "Continue" is triggered after the response is sent
 
+		ee := client.ExpectExitedEvent(t)
+		if ee.Body.ExitCode != 0 {
+			t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+		}
 		client.ExpectTerminatedEvent(t)
 
 		// Pause request after termination should result in an error.
@@ -4025,6 +4049,10 @@ func TestHitConditionBreakpoints(t *testing.T) {
 					client.ContinueRequest(1)
 					client.ExpectContinueResponse(t)
 
+					ee := client.ExpectExitedEvent(t)
+					if ee.Body.ExitCode != 0 {
+						t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+					}
 					client.ExpectTerminatedEvent(t)
 				},
 				disconnect: false,
@@ -4895,6 +4923,10 @@ func TestEvaluateCallRequest(t *testing.T) {
 
 					// Call can exit.
 					client.EvaluateRequest("call callexit()", 1000, "this context will be ignored")
+					ee := client.ExpectExitedEvent(t)
+					if ee.Body.ExitCode != 0 {
+						t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+					}
 					client.ExpectTerminatedEvent(t)
 					if res := client.ExpectVisibleErrorResponse(t); res.Body.Error == nil || !strings.Contains(res.Body.Error.Format, "terminated") {
 						t.Errorf("\ngot %#v\nwant Format=.*terminated.*", res)
@@ -5680,6 +5712,7 @@ func runDebugSessionWithBPs(t *testing.T, client *daptest.Client, cmd string, cm
 	}
 
 	if cmd == "launch" { // Let the program run to completion
+		client.ExpectExitedEvent(t)
 		client.ExpectTerminatedEvent(t)
 	}
 	client.DisconnectRequestWithKillOption(true)
@@ -5819,6 +5852,10 @@ func TestExitNonZeroStatus(t *testing.T) {
 		client.ConfigurationDoneRequest()
 		client.ExpectConfigurationDoneResponse(t)
 
+		ee := client.ExpectExitedEvent(t)
+		if ee.Body.ExitCode != 2 {
+			t.Errorf("\ngot ExitCode=%d, want 2", ee.Body.ExitCode)
+		}
 		client.ExpectTerminatedEvent(t)
 
 		client.DisconnectRequest()
@@ -5868,6 +5905,10 @@ func runNoDebugSession(t *testing.T, client *daptest.Client, launchRequest func(
 	client.ExpectLaunchResponse(t)
 
 	client.ExpectOutputEventProcessExited(t, exitStatus)
+	ee := client.ExpectExitedEvent(t)
+	if ee.Body.ExitCode != exitStatus {
+		t.Errorf("\ngot ExitCode=%d, want %d", ee.Body.ExitCode, exitStatus)
+	}
 	client.ExpectTerminatedEvent(t)
 	client.DisconnectRequestWithKillOption(true)
 	client.ExpectDisconnectResponse(t)
@@ -5920,6 +5961,7 @@ func TestNoDebug_AcceptNoRequestsButDisconnect(t *testing.T) {
 				if !ok {
 					t.Errorf("\ngot %#v\nwant Output=%q\n", m, wants)
 				}
+			case *dap.ExitedEvent:
 			case *dap.TerminatedEvent:
 				terminated = true
 			case *dap.DisconnectResponse:
@@ -6472,6 +6514,7 @@ func main() {
 					})
 					client.ExpectRestartResponse(t)
 					client.ExpectErrorResponse(t)
+					client.ExpectExitedEvent(t)
 					client.ExpectTerminatedEvent(t)
 				},
 				disconnect: false,
@@ -8180,10 +8223,11 @@ func TestRedirect(t *testing.T) {
 				default:
 					t.Errorf("\ngot %#v\nwant Category='stdout' or 'stderr'", m)
 				}
+			case *dap.ExitedEvent:
 			case *dap.TerminatedEvent:
 				break terminatedPoint
 			default:
-				t.Errorf("\n got %#v, want *dap.OutputEvent or *dap.TerminateResponse", m)
+				t.Errorf("\n got %#v, want *dap.OutputEvent, *dap.ExitedEvent, or *dap.TerminatedEvent", m)
 			}
 		}
 
@@ -8242,16 +8286,16 @@ func TestBreakpointAfterDisconnect(t *testing.T) {
 	var port int
 	portChan := make(chan int, 1)
 	go func() {
-		var portLine string
+		var portLine strings.Builder
 		buf := make([]byte, 256)
 		for {
 			n, err := stdout.Read(buf)
 			if err != nil {
 				return
 			}
-			portLine += string(buf[:n])
-			if strings.Contains(portLine, "LISTENING:") {
-				parts := strings.Split(portLine, "LISTENING:")
+			portLine.WriteString(string(buf[:n]))
+			if strings.Contains(portLine.String(), "LISTENING:") {
+				parts := strings.Split(portLine.String(), "LISTENING:")
 				if len(parts) > 1 {
 					portStr := strings.TrimSpace(strings.Split(parts[1], "\n")[0])
 					if p, err := strconv.Atoi(portStr); err == nil {
@@ -8341,6 +8385,10 @@ func TestRedirects(t *testing.T) {
 
 		client.ContinueRequest(1)
 		client.ExpectContinueResponse(t)
+		ee := client.ExpectExitedEvent(t)
+		if ee.Body.ExitCode != 0 {
+			t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+		}
 		client.ExpectTerminatedEvent(t)
 
 		buf, err := os.ReadFile(outfile)
@@ -8363,6 +8411,10 @@ func TestRedirects(t *testing.T) {
 
 		client.ContinueRequest(1)
 		client.ExpectContinueResponse(t)
+		ee = client.ExpectExitedEvent(t)
+		if ee.Body.ExitCode != 0 {
+			t.Errorf("\ngot ExitCode=%d, want 0", ee.Body.ExitCode)
+		}
 		client.ExpectTerminatedEvent(t)
 
 		buf2, err := os.ReadFile(outfile)


### PR DESCRIPTION
The DAP server was only sending TerminatedEvent when the debuggee process exited, but per the DAP spec, an ExitedEvent with the process exit code should precede TerminatedEvent as TerminatedEvent means the debugging session has terminated, not necessarily that the debugee has exited. This adds ExitedEvent in all process exit paths: normal exit, call injection failure, noDebug mode, multi-client disconnect, and restart failure.

Tests are updated to expect the new event and assert correct exit codes.