### PR TITLE
proc: fix C frame attribution for noreturn calls in stack unwinding

### DIFF
--- a/_fixtures/cgocoreassert.go
+++ b/_fixtures/cgocoreassert.go
@@ -1,0 +1,25 @@
+package main
+
+/*
+#include <stdio.h>
+#include <assert.h>
+
+void test1(void) {
+    assert(0);
+}
+
+void test2(void) {
+    int val = 2;
+    test1();
+}
+
+void test3(void) {
+    int val = 3;
+    test2();
+}
+*/
+import "C"
+
+func main() {
+	C.test3()
+}

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -319,6 +319,58 @@ func TestCore(t *testing.T) {
 	logRegisters(t, regs, p.BinInfo().Arch)
 }
 
+// TestCoreCGOAssert verifies that C function frames appear in core dump backtraces.
+// Issue #3322: the crash frame (C.test1) is missing when assert() crashes in CGO code.
+func TestCoreCGOAssert(t *testing.T) {
+	t.Parallel()
+	mustSupportCore(t)
+
+	grp, _ := withCoreFile(t, "cgocoreassert", "")
+	p := grp.Selected
+
+	gs, _, err := proc.GoroutinesInfo(p, 0, 0)
+	if err != nil || len(gs) == 0 {
+		t.Fatalf("GoroutinesInfo() = %v, %v; wanted at least one goroutine", gs, err)
+	}
+
+	// Find the goroutine running main.main and check its stack for C frames.
+	var mainStack []proc.Stackframe
+	for _, g := range gs {
+		stack, err := proc.GoroutineStacktrace(p, g, 20, 0)
+		if err != nil {
+			t.Errorf("Stacktrace() on goroutine %v = %v", g, err)
+			continue
+		}
+		for _, frame := range stack {
+			if frame.Call.Fn != nil && frame.Call.Fn.Name == "main.main" {
+				mainStack = stack
+				break
+			}
+		}
+		if mainStack != nil {
+			break
+		}
+	}
+	if mainStack == nil {
+		t.Fatal("could not find main goroutine")
+	}
+
+	found := make(map[string]bool)
+	for _, frame := range mainStack {
+		if frame.Call.Fn != nil {
+			found[frame.Call.Fn.Name] = true
+		}
+	}
+
+	// Issue #3322: C.test1 (where assert(0) is called) is missing from the
+	// backtrace. C.test2 and C.test3 are resolved correctly.
+	for _, name := range []string{"C.test1", "C.test2", "C.test3"} {
+		if !found[name] {
+			t.Errorf("C function frame %q missing from backtrace (issue #3322)", name)
+		}
+	}
+}
+
 func TestCoreFpRegisters(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS != "linux" || runtime.GOARCH == "386" {

--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -283,6 +283,15 @@ func (it *stackIterator) Next() bool {
 		logger.Debugf("%s", w.String())
 	}
 
+	// Adjust return addresses that land on a C function entry due to noreturn calls (e.g. assert).
+	if !it.top && !it.sigret && it.pc > 0 {
+		if fn := it.bi.PCToFunc(it.pc); fn != nil && it.pc == fn.Entry && !fn.cu.isgo {
+			if pfn := it.bi.PCToFunc(it.pc - 1); pfn != nil && pfn != fn {
+				it.pc--
+			}
+		}
+	}
+
 	callFrameRegs, ret, retaddr := it.advanceRegs()
 	it.frame = it.newStackframe(ret, retaddr)
 


### PR DESCRIPTION
When a C function's last instruction is a call to a noreturn function (e.g. assert), the return address lands exactly at the next function's entry point, causing the caller to disappear from the backtrace. Adjust the PC back so the frame is attributed to the correct function.

Fixes #3322

before:
```
(dlv) bt
[...]
12  0x0000000000487aa0 in C.test2
    at ./_fixtures/cgocoreassert.go:11
13  0x00007ffd75ba1f80 in ???
    at ?:-1
14  0x0000000000487acb in C.test3
    at ./_fixtures/cgocoreassert.go:18
15  0x0000000000487adf in C._cgo_ee046dc4d12f_Cfunc_test3
    at /tmp/go-build/cgo-gcc-prolog:48
16  0x0000000000481804 in runtime.asmcgocall
    at /usr/lib/golang/src/runtime/asm_amd64.s:995
17  0x0000000000000000 in ???
    at ?:-1
18  0x000000000047b3ff in runtime.cgocall
    at /usr/lib/golang/src/runtime/cgocall.go:185
19  0x000000000048799a in main._Cfunc_test3
    at _cgo_gotypes.go:46
20  0x00000000004879cf in main.main
    at ./_fixtures/cgocoreassert.go:24
[...]
```

after:
```
(dlv) bt
[...]
12  0x0000000000487a9f in C.test1
    at ./_fixtures/cgocoreassert.go:8
13  0x0000000000487ab4 in C.test2
    at ./_fixtures/cgocoreassert.go:13
14  0x0000000000487acb in C.test3
    at ./_fixtures/cgocoreassert.go:18
15  0x0000000000487adf in C._cgo_ee046dc4d12f_Cfunc_test3
    at /tmp/go-build/cgo-gcc-prolog:48
16  0x0000000000481804 in runtime.asmcgocall
    at /usr/lib/golang/src/runtime/asm_amd64.s:995
17  0x0000000000000000 in ???
    at ?:-1
18  0x000000000047b3ff in runtime.cgocall
    at /usr/lib/golang/src/runtime/cgocall.go:185
19  0x000000000048799a in main._Cfunc_test3
    at _cgo_gotypes.go:46
20  0x00000000004879cf in main.main
    at ./_fixtures/cgocoreassert.go:24
[...]
```

