### PR TITLE
proc/test: disable DWARF compression on riscv64 to work around flate hang

### DIFF
--- a/pkg/proc/stepping_test.go
+++ b/pkg/proc/stepping_test.go
@@ -1049,7 +1049,6 @@ func TestRangeOverFuncNext(t *testing.T) {
 		})
 
 		t.Run("TestPanickyIterator2", func(t *testing.T) {
-			skipOn(t, "flaky stepping timeout", "riscv64")
 			testseq2intl(t, fixture, grp, p, nil, []seqTest{
 				funcBreak(t, "main.TestPanickyIterator2"),
 				{contContinue, 125},
@@ -1604,7 +1603,6 @@ func TestRangeOverFuncNextInlined(t *testing.T) {
 		})
 
 		t.Run("TestPanickyIterator2", func(t *testing.T) {
-			skipOn(t, "flaky stepping timeout", "riscv64")
 			testseq2intl(t, fixture, grp, p, nil, []seqTest{
 				funcBreak(t, "main.TestPanickyIterator2"),
 				{contContinue, 125},

--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -187,6 +187,11 @@ func BuildFixture(t testing.TB, name string, flags BuildFlags) Fixture {
 			buildFlags = append(buildFlags, "-ldflags=-compressdwarf=false")
 		}
 	}
+	// Disable DWARF compression on riscv64 due to flate decompressor hangs
+	// in CI: https://delve.teamcity.com/buildConfiguration/Delve_AggregatorBuild/78674
+	if runtime.GOARCH == "riscv64" {
+		buildFlags = append(buildFlags, "-ldflags=-compressdwarf=false")
+	}
 	if flags&Trimpath != 0 {
 		buildFlags = append(buildFlags, "-trimpath")
 	}

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -278,7 +278,6 @@ func TestVariableEvaluation2(t *testing.T) {
 }
 
 func TestSetVariable(t *testing.T) {
-	skipOn(t, "flaky timeout during process initialization", "riscv64")
 	const errorPrefix = "ERROR:"
 	var testcases = []struct {
 		name     string

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -114,6 +114,7 @@ func multiLineVar(v *proc.Variable) string {
 }
 
 func TestVariableEvaluation(t *testing.T) {
+	skipOn(t, "flaky timeout during process initialization", "riscv64")
 	protest.AllowRecording(t)
 	testcases := []struct {
 		name        string

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -114,7 +114,6 @@ func multiLineVar(v *proc.Variable) string {
 }
 
 func TestVariableEvaluation(t *testing.T) {
-	skipOn(t, "flaky timeout during process initialization", "riscv64")
 	protest.AllowRecording(t)
 	testcases := []struct {
 		name        string


### PR DESCRIPTION
On riscv64, the Go stdlib compress/flate decompressor seems to hang in an
infinite loop when decompressing DWARF sections from test fixture binaries.

Stack trace shows the hang occurs in:
  compress/flate.(*decompressor).huffSym
  compress/flate.(*decompressor).huffmanBlock
  compress/flate.(*decompressor).Read
  debug/elf.(*File).DWARF
  github.com/go-delve/delve/pkg/proc.loadBinaryInfoElf

The goroutine is stuck in huffSym's infinite loop trying to decode a
Huffman-encoded symbol. This suggests either:
1. The Go linker on riscv64 generates corrupted compressed DWARF data
2. There's a bug in the flate decompressor on riscv64
3. Something else yet unidentified

Workaround: disable DWARF compression for all test fixtures built on
riscv64 by adding -ldflags=-compressdwarf=false. This allows tests to
run successfully by avoiding the decompression code path entirely.

This is fine for now as riscv64 is still an experimental arch but will need 
to be resolved before promoting.

This should fix the TestVariableEvaluation, TestSetVariable, and
TestPanickyIterator2 timeouts on riscv64.