### PR TITLE
build: ignore unsupported windows/arm64 architecture in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,9 @@ builds:
         goarch: "386"
       - goos: windows
         goarch: ppc64le
+      # windows/arm64 is not yet stable, enable once no longer gated by the exp.winarm64 build tag.
+      - goos: windows
+        goarch: arm64
     ldflags:
       - -X main.Build={{.FullCommit}}
 


### PR DESCRIPTION
See also: https://github.com/go-delve/delve/pull/4281

---

### Context

The current release pipeline fails when trying to compile Delve for `windows/arm64`.
Delve restricts this architecture behind an experimental build tag (`exp.winarm64`), causing standard compilation steps to pick up the sentinel error file (`support_sentinel_windows.go`) and crash the pipeline.

### Changes

* Updated `.goreleaser.yaml` to add `windows/arm64` to the `ignore` list.

    This aligns the matrix behavior with other unsupported architectures already listed under the `ignore` block (such as `windows/386` and `windows/ppc64le`), hopefully fixing the release/snapshot pipelines.

Fixes [#4380](https://github.com/go-delve/delve/issues/4380)