### PR TITLE
proc: fix panic on follow-exec process exit

### DIFF
--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -421,7 +421,9 @@ func (dbp *nativeProcess) execPtraceFunc(fn func()) {
 }
 
 func (dbp *nativeProcess) postExit() {
-	dbp.exited.Store(true)
+	if dbp.exited.Swap(true) {
+		return
+	}
 	dbp.ptraceThread.release()
 	dbp.bi.Close()
 	if dbp.ctty != nil {

--- a/pkg/proc/native/syscall_windows.go
+++ b/pkg/proc/native/syscall_windows.go
@@ -138,6 +138,7 @@ type _DEBUG_EVENT struct {
 //sys	_ResumeThread(threadid syscall.Handle) (prevsuspcount uint32, err error) [failretval==0xffffffff] = kernel32.ResumeThread
 //sys	_ContinueDebugEvent(processid uint32, threadid uint32, continuestatus uint32) (err error) = kernel32.ContinueDebugEvent
 //sys	_WriteProcessMemory(process syscall.Handle, baseaddr uintptr, buffer *byte, size uintptr, byteswritten *uintptr) (err error) = kernel32.WriteProcessMemory
+//sys	_FlushInstructionCache(process syscall.Handle, baseaddr uintptr, size uintptr) (err error) = kernel32.FlushInstructionCache
 //sys	_ReadProcessMemory(process syscall.Handle, baseaddr uintptr, buffer *byte, size uintptr, bytesread *uintptr) (err error) = kernel32.ReadProcessMemory
 //sys	_DebugBreakProcess(process syscall.Handle) (err error) = kernel32.DebugBreakProcess
 //sys	_WaitForDebugEvent(debugevent *_DEBUG_EVENT, milliseconds uint32) (err error) = kernel32.WaitForDebugEvent

--- a/pkg/proc/native/threads_windows.go
+++ b/pkg/proc/native/threads_windows.go
@@ -115,6 +115,10 @@ func (t *nativeThread) WriteMemory(addr uint64, data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	// On ARM64 the instruction and data caches are not coherent,
+	// WriteProcessMemory only updates the data cache so we must flush
+	// the instruction cache explicitly. On x86/amd64 this is a no-op.
+	_ = _FlushInstructionCache(t.dbp.os.hProcess, uintptr(addr), uintptr(len(data)))
 	return int(count), nil
 }
 

--- a/pkg/proc/native/zsyscall_windows.go
+++ b/pkg/proc/native/zsyscall_windows.go
@@ -48,6 +48,7 @@ var (
 	procResumeThread               = modkernel32.NewProc("ResumeThread")
 	procContinueDebugEvent         = modkernel32.NewProc("ContinueDebugEvent")
 	procWriteProcessMemory         = modkernel32.NewProc("WriteProcessMemory")
+	procFlushInstructionCache      = modkernel32.NewProc("FlushInstructionCache")
 	procReadProcessMemory          = modkernel32.NewProc("ReadProcessMemory")
 	procDebugBreakProcess          = modkernel32.NewProc("DebugBreakProcess")
 	procWaitForDebugEvent          = modkernel32.NewProc("WaitForDebugEvent")
@@ -128,6 +129,18 @@ func _ContinueDebugEvent(processid uint32, threadid uint32, continuestatus uint3
 
 func _WriteProcessMemory(process syscall.Handle, baseaddr uintptr, buffer *byte, size uintptr, byteswritten *uintptr) (err error) {
 	r1, _, e1 := syscall.Syscall6(procWriteProcessMemory.Addr(), 5, uintptr(process), uintptr(baseaddr), uintptr(unsafe.Pointer(buffer)), uintptr(size), uintptr(unsafe.Pointer(byteswritten)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _FlushInstructionCache(process syscall.Handle, baseaddr uintptr, size uintptr) (err error) {
+	r1, _, e1 := syscall.Syscall(procFlushInstructionCache.Addr(), 3, uintptr(process), uintptr(baseaddr), uintptr(size))
 	if r1 == 0 {
 		if e1 != 0 {
 			err = errnoErr(e1)


### PR DESCRIPTION
- Make `postExit` idempotent to prevent double-release of the `ptraceThread` refcount
- Flush instruction cache after writing memory on Windows to fix intermittent missed breakpoints on ARM64

### Fix 1: postExit double-release

In `trapWaitInternal`, a process leader can have `postExit` called via the ESRCH path (when `resumeWithSig` fails because the thread is gone), and then called again when the actual exit event arrives. The double-release drops the `ptraceThread` refcount too low, closing `ptraceChan` while another process in the follow-exec group still needs it. The next ptrace operation on that process panics with "send on closed channel".

Uses atomic `Swap` instead of `Store` so the second call is a no-op.

Observed on linux/riscv64 with Go 1.27rc1 as a panic in `TestLaunchWithFollowExec`.

### Fix 2: FlushInstructionCache on Windows

On ARM64 the instruction and data caches are not coherent. `WriteProcessMemory` only updates the data cache, so breakpoint instructions written by the debugger may not be visible to the instruction fetch unit. This causes intermittent missed breakpoints on Windows/ARM64 — the CPU executes the original instruction from stale I-cache instead of the BRK that was written.

Calls `FlushInstructionCache` after every `WriteProcessMemory` to ensure I-cache coherency. On x86/amd64 this is a documented no-op.

Fixes #3183