### PR TITLE
terminal: extend frame pointer unwinding blocking branch to fix TestScopePrefix index panic on windows/arm64

### DIFF
--- a/pkg/proc/stack.go
+++ b/pkg/proc/stack.go
@@ -588,11 +588,13 @@ func (it *stackIterator) advanceRegs() (callFrameRegs op.DwarfRegisters, ret uin
 			stable = (bp != 0 && bp+2*ptrSize == cfa)
 
 			// Disable hybrid FP unwinding on Windows when DW_AT_producer is missing
-			// or unparsable (otherwise canUseFP could activate despite the Go 1.24/1.25
-			// guard), and for Go 1.24/1.25 due to test failures. See golang/go#63630.
+			// or unparsable (otherwise canUseFP could activate despite the Go 1.24+
+			// guard), and for Go 1.24 and later due to test failures. See
+			// golang/go#63630. Open-ended since the upstream issue is still
+			// unresolved as of Go 1.27.
 			if it.bi.GOOS == "windows" {
 				ver := goversion.ParseProducer(it.bi.Producer())
-				if ver.Major < 1 || !ver.IsDevelBuild() && ver.Major == 1 && (ver.Minor == 24 || ver.Minor == 25) {
+				if ver.Major < 1 || !ver.IsDevelBuild() && ver.Major == 1 && ver.Minor >= 24 {
 					stable = false
 				}
 			}

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -463,6 +463,9 @@ func TestScopePrefix(t *testing.T) {
 			if err != nil {
 				t.Fatalf("could not parse value %q of i for goroutine %d frame %d: %v", out, gid, fid, err)
 			}
+			if ival < 0 || ival >= len(seen) {
+				t.Fatalf("value of i (%d) for goroutine %d frame %d out of expected range [0,%d); raw output %q; stack: %q; goroutines: %q", ival, gid, fid, len(seen), out, stackOut, goroutinesOut)
+			}
 			seen[ival] = true
 		}
 


### PR DESCRIPTION
TestScopePrefix intermittently panics with an index-out-of-range on windows/arm64 CI when the evaluated value of `i` is garbage (likely a stack/pointer address) instead of the expected 0-9, indicating a race in stack unwinding on that backend. Guard the index and fail with the raw eval output, stack, and goroutines listing so the next occurrence is diagnosable instead of a bare panic.