### PR TITLE
dwarf/frame: check the error after executing an opcode

### DIFF
--- a/pkg/dwarf/frame/table.go
+++ b/pkg/dwarf/frame/table.go
@@ -175,7 +175,7 @@ func executeDwarfProgramUntilPC(fde *FrameDescriptionEntry, pc uint64) *FrameCon
 }
 
 func (frame *FrameContext) executeDwarfProgram() {
-	for frame.buf.Len() > 0 {
+	for frame.buf.Len() > 0 && frame.err == nil {
 		executeDwarfInstruction(frame)
 	}
 }
@@ -188,7 +188,7 @@ func (frame *FrameContext) ExecuteUntilPC(instructions []byte) error {
 	// We only need to execute the instructions until
 	// ctx.loc > ctx.address (which is the address we
 	// are currently at in the traced process).
-	for frame.address >= frame.loc && frame.buf.Len() > 0 {
+	for frame.address >= frame.loc && frame.buf.Len() > 0 && frame.err == nil {
 		executeDwarfInstruction(frame)
 	}
 	return frame.err


### PR DESCRIPTION
executeDwarfInstruction will return immediately when there is a previous error. In the execution loop, if we don't check the error, nothing changes after each iteration and we get an infinite loop. Check the error after executing every opcode and break in case of error.