### PR TITLE
dwarf/frame: add DW_CFA_GNU_args_size opcode

### DIFF
--- a/pkg/dwarf/frame/table.go
+++ b/pkg/dwarf/frame/table.go
@@ -88,6 +88,7 @@ const (
 	DW_CFA_val_offset_sf                   // op1: ULEB128, op2: SLEB128
 	DW_CFA_val_expression                  // op1: ULEB128, op2: BLOCK
 	DW_CFA_lo_user            = 0x1c       // op1: BLOCK
+	DW_CFA_GNU_args_size      = 0x2e       // op1: ULEB128
 	DW_CFA_hi_user            = 0x3f       // op1: ULEB128 register, op2: BLOCK
 	DW_CFA_advance_loc        = (0x1 << 6) // High 2 bits: 0x1, low 6: delta
 	DW_CFA_offset             = (0x2 << 6) // High 2 bits: 0x2, low 6: register
@@ -143,6 +144,7 @@ var fnlookup = map[byte]instruction{
 	DW_CFA_val_expression:     valexpression,
 	DW_CFA_lo_user:            louser,
 	DW_CFA_hi_user:            hiuser,
+	DW_CFA_GNU_args_size:      argssize,
 }
 
 func executeCIEInstructions(cie *CommonInformationEntry) *FrameContext {
@@ -461,4 +463,8 @@ func louser(frame *FrameContext) {
 
 func hiuser(frame *FrameContext) {
 	frame.buf.Next(1)
+}
+
+func argssize(frame *FrameContext) {
+	leb128.DecodeUnsigned(frame.buf)
 }

--- a/pkg/dwarf/frame/table_test.go
+++ b/pkg/dwarf/frame/table_test.go
@@ -1,0 +1,63 @@
+package frame
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func TestExecuteDwarfProgram(t *testing.T) {
+	// DW_CFA_advance_loc: 5
+	// DW_CFA_def_cfa_offset: 16
+	// DW_CFA_offset: r6 (rbp) at cfa-16
+	// DW_CFA_advance_loc: 3
+	// DW_CFA_def_cfa_register: r6 (rbp)
+	// DW_CFA_advance_loc: 5
+	// DW_CFA_offset: r3 (rbx) at cfa-24
+	// DW_CFA_advance_loc: 42
+	// DW_CFA_GNU_args_size: 32
+	// DW_CFA_advance_loc1: 66
+	// DW_CFA_def_cfa: r7 (rsp) ofs 8
+	instructions, _ := hex.DecodeString("450e108602430d064583036a2e2002420c0708")
+	frame := &FrameContext{
+		Regs:            make(map[uint64]DWRule),
+		initialRegs:     make(map[uint64]DWRule),
+		codeAlignment:   1,
+		dataAlignment:   -8,
+		buf:             bytes.NewBuffer(instructions),
+		rememberedState: newStateStack(),
+	}
+
+	frame.executeDwarfProgram()
+	if frame.err != nil {
+		t.Fatalf("Failed to execute DWARF program: %v", frame.err)
+	}
+
+	if frame.CFA.Rule != RuleCFA {
+		t.Fatalf("Rule CFA expect: %v, got: %v", RuleCFA, frame.CFA.Rule)
+	}
+
+	if frame.CFA.Reg != 7 {
+		t.Fatalf("CFA reg expect: %v, got: %v", 7, frame.CFA.Reg)
+	}
+
+	if frame.CFA.Offset != 8 {
+		t.Fatalf("CFA offset expect: %v, got: %v", 8, frame.CFA.Offset)
+	}
+
+	if frame.Regs[6].Rule != RuleOffset {
+		t.Fatalf("Rule r6 expect: %v, got: %v", RuleOffset, frame.Regs[6].Rule)
+	}
+
+	if frame.Regs[6].Offset != -16 {
+		t.Fatalf("Reg r6 offset expect: %v, got: %v", -16, frame.Regs[6].Offset)
+	}
+
+	if frame.Regs[3].Rule != RuleOffset {
+		t.Fatalf("Rule r3 expect: %v, got: %v", RuleOffset, frame.Regs[3].Rule)
+	}
+
+	if frame.Regs[3].Offset != -24 {
+		t.Fatalf("Reg r3 offset expect: %v, got: %v", -24, frame.Regs[3].Offset)
+	}
+}


### PR DESCRIPTION
This opcode is used by C++ for fixing the stack when unwinding exception. When backtracing the stack, we don't need to care about it. So just read it and ignore.