### PR TITLE
service/test: skip waitreason test on development versions

### DIFF
--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3138,6 +3138,10 @@ func TestClientServer_breakpointOnFuncWithABIWrapper(t *testing.T) {
 }
 
 func TestClientServer_chanGoroutines(t *testing.T) {
+	ver, _ := goversion.Parse(runtime.Version())
+	if ver.IsDevelBuild() {
+		t.Skip("skip on development version")
+	}
 	withTestClient2("changoroutines", t, func(c service.Client) {
 		ver := c.GetVersion()
 		goVer := goversion.ParseProducer(ver.TargetGoVersion)


### PR DESCRIPTION
There is no point in updating the code for this early because the list
of waitreasons could change late in the development cycle and then the
test wouldn't catch it.

Disable the test on development builds so that it reminds us of making
an update after the rc comes out.
