### PR TITLE
service/dap,terminal: add option to display expanded/raw strings

### DIFF
--- a/Documentation/api/dap/README.md
+++ b/Documentation/api/dap/README.md
@@ -34,6 +34,7 @@ In addition to the general [DAP spec](https://microsoft.github.io/debug-adapter-
     showGlobalVariables<br>
     showRegisters<br>
     showPprofLabels<br>
+    showRawStrings<br>
     hideSystemGoroutines<br>
     goroutineFilters
     </tr>

--- a/Documentation/cli/config.md
+++ b/Documentation/cli/config.md
@@ -16,7 +16,7 @@ position | Controls how the current position in the program is displayed (source
 prompt | Controls Delve's command line prompt. Use `help config prompt` for documentation on the available escape codes.
 prompt-color | Prompt color, as a terminal escape sequence.
 show-location-expr | If true the 'whatis' command will print the DWARF location expression of its argument.
-show-raw-strings | If true, escape characters (\n, \t, etc.) in string values are preserved as actual control characters when printing, displaying multi-line strings as multi-line.
+show-raw-strings | If true, print string values as-is with %s (no quoting or escaping) rather than with Go's %q.
 source-list-arrow-color | Source list arrow color, as a terminal escape sequence.
 source-list-comment-color | Source list comment color, as a terminal escape sequence.
 source-list-keyword-color | Source list keyword color, as a terminal escape sequence.

--- a/Documentation/cli/config.md
+++ b/Documentation/cli/config.md
@@ -16,6 +16,7 @@ position | Controls how the current position in the program is displayed (source
 prompt | Controls Delve's command line prompt. Use `help config prompt` for documentation on the available escape codes.
 prompt-color | Prompt color, as a terminal escape sequence.
 show-location-expr | If true the 'whatis' command will print the DWARF location expression of its argument.
+show-raw-strings | If true, escape characters (\n, \t, etc.) in string values are preserved as actual control characters when printing, displaying multi-line strings as multi-line.
 source-list-arrow-color | Source list arrow color, as a terminal escape sequence.
 source-list-comment-color | Source list comment color, as a terminal escape sequence.
 source-list-keyword-color | Source list keyword color, as a terminal escape sequence.

--- a/_fixtures/escapestrings.go
+++ b/_fixtures/escapestrings.go
@@ -1,0 +1,29 @@
+package main
+
+import "runtime"
+
+var (
+	multiline    = "hello\nworld"
+	withTabs     = "col1\tcol2\tcol3"
+	mixed        = "line1\nline2\tindented\nline3"
+	backslash    = "C:\\Users\\test"
+	carriageRet  = "line1\r\nline2"
+	withQuote    = "he said \"hello\""
+	withNullByte = "before\x00after"
+)
+
+func getMultiline() string {
+	return "func\nline1\nline2"
+}
+
+func getWithTabs() string {
+	return "func\tcol1\tcol2"
+}
+
+func main() {
+	// Use functions so they are available for `call` evaluation
+	gm := getMultiline()
+	gwt := getWithTabs()
+	runtime.Breakpoint()
+	println(multiline, withTabs, mixed, backslash, carriageRet, withQuote, withNullByte, gm, gwt)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -117,10 +117,8 @@ type Config struct {
 	// output.
 	TraceShowTimestamp bool `yaml:"trace-show-timestamp"`
 
-	// ShowRawStrings controls whether escape characters (newlines, tabs, etc.)
-	// in string values should be preserved as actual control characters when
-	// printing variables. When enabled, multi-line strings will appear as
-	// multi-line in the output.
+	// ShowRawStrings controls whether string values are printed as-is with %s
+	// (no quoting or escaping) rather than with Go's %q (quoted and escaped).
 	ShowRawStrings bool `yaml:"show-raw-strings"`
 
 	// Prompt is the string printed before each command. If empty, the
@@ -153,7 +151,7 @@ See also Documentation/cli/substitutepath.md for how the rules are applied.
 	"max-string-len":            "Maximum string length used when printing variables.\n",
 	"max-array-values":          "Maximum number of array values when printing variables.\n",
 	"max-variable-recurse":      "Maximum number of nested struct members when printing variables.\n",
-	"show-raw-strings":         "If true, escape characters (\\n, \\t, etc.) in string values are preserved as actual control characters when printing, displaying multi-line strings as multi-line.\n",
+	"show-raw-strings":         "If true, print string values as-is with %s (no quoting or escaping) rather than with Go's %q.\n",
 	"disassemble-flavor":        "Disassembler syntax. Can be 'intel', 'gun' or 'go'.\n",
 	"show-location-expr":        "If true the 'whatis' command will print the DWARF location expression of its argument.\n",
 	"source-list-line-color":    "Source list line-number color, as a terminal escape sequence.\n",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -117,6 +117,12 @@ type Config struct {
 	// output.
 	TraceShowTimestamp bool `yaml:"trace-show-timestamp"`
 
+	// ShowRawStrings controls whether escape characters (newlines, tabs, etc.)
+	// in string values should be preserved as actual control characters when
+	// printing variables. When enabled, multi-line strings will appear as
+	// multi-line in the output.
+	ShowRawStrings bool `yaml:"show-raw-strings"`
+
 	// Prompt is the string printed before each command. If empty, the
 	// default prompt "(dlv) " is used.
 	Prompt string `yaml:"prompt,omitempty"`
@@ -147,6 +153,7 @@ See also Documentation/cli/substitutepath.md for how the rules are applied.
 	"max-string-len":            "Maximum string length used when printing variables.\n",
 	"max-array-values":          "Maximum number of array values when printing variables.\n",
 	"max-variable-recurse":      "Maximum number of nested struct members when printing variables.\n",
+	"show-raw-strings":         "If true, escape characters (\\n, \\t, etc.) in string values are preserved as actual control characters when printing, displaying multi-line strings as multi-line.\n",
 	"disassemble-flavor":        "Disassembler syntax. Can be 'intel', 'gun' or 'go'.\n",
 	"show-location-expr":        "If true the 'whatis' command will print the DWARF location expression of its argument.\n",
 	"source-list-line-color":    "Source list line-number color, as a terminal escape sequence.\n",

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2177,7 +2177,7 @@ func (c *Commands) printVar(t *Term, ctx callContext, args string) error {
 
 	t.stdout.pw.PageMaybe(nil)
 
-	fmt.Fprintln(t.stdout, val.StringWithOptions("", fmtstr, api.PrettyNewlines))
+	fmt.Fprintln(t.stdout, val.StringWithOptions("", fmtstr, api.PrettyNewlines|t.rawStringFlag()))
 
 	if val.Kind == reflect.Chan {
 		fmt.Fprintln(t.stdout)
@@ -2281,7 +2281,7 @@ func (t *Term) printFilteredVariables(varType string, vars []api.Variable, filte
 			if cfg == ShortLoadConfig {
 				fmt.Fprintf(t.stdout, "%s = %s\n", name, v.SinglelineString())
 			} else {
-				fmt.Fprintf(t.stdout, "%s = %s\n", name, multiLineVar(&v, ""))
+				fmt.Fprintf(t.stdout, "%s = %s\n", name, t.multiLineVar(&v, ""))
 			}
 		}
 	}
@@ -2798,7 +2798,7 @@ func printReturnValues(t *Term, th *api.Thread) {
 	}
 	fmt.Fprintln(t.stdout, "Values returned:")
 	for _, v := range th.ReturnValues {
-		fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, multiLineVar(&v, "\t"))
+		fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, t.multiLineVar(&v, "\t"))
 	}
 	fmt.Fprintln(t.stdout)
 }
@@ -2929,13 +2929,13 @@ func printBreakpointInfo(t *Term, th *api.Thread, tracepointOnNewline bool) {
 
 	for _, v := range bpi.Variables {
 		tracepointnl()
-		fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, multiLineVar(&v, "\t"))
+		fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, t.multiLineVar(&v, "\t"))
 	}
 
 	for _, v := range bpi.Locals {
 		tracepointnl()
 		if *bp.LoadLocals == longLoadConfig {
-			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, multiLineVar(&v, "\t"))
+			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, t.multiLineVar(&v, "\t"))
 		} else {
 			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, v.SinglelineString())
 		}
@@ -2944,7 +2944,7 @@ func printBreakpointInfo(t *Term, th *api.Thread, tracepointOnNewline bool) {
 	if bp.LoadArgs != nil && *bp.LoadArgs == longLoadConfig {
 		for _, v := range bpi.Arguments {
 			tracepointnl()
-			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, multiLineVar(&v, "\t"))
+			fmt.Fprintf(t.stdout, "\t%s: %s\n", v.Name, t.multiLineVar(&v, "\t"))
 		}
 	}
 	if bpi.Stacktrace != nil {
@@ -3645,6 +3645,6 @@ func (t *Term) formatBreakpointLocation(bp *api.Breakpoint) string {
 	return out.String()
 }
 
-func multiLineVar(v *api.Variable, indent string) string {
-	return v.StringWithOptions(indent, "", api.PrettyNewlines)
+func (t *Term) multiLineVar(v *api.Variable, indent string) string {
+	return v.StringWithOptions(indent, "", api.PrettyNewlines|t.rawStringFlag())
 }

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -1997,3 +1997,49 @@ func TestCommandPromptExpansion(t *testing.T) {
 		}
 	})
 }
+
+
+// TestPrintShowRawStrings tests the show-raw-strings config option that
+// controls whether escape characters in string values are displayed as
+// escaped sequences (\n, \t) or as actual control characters (newlines, tabs).
+func TestPrintShowRawStrings(t *testing.T) {
+	withTestTerminal("escapestrings", t, func(term *FakeTerminal) {
+		// Continue to runtime.Breakpoint() in main.
+		term.MustExec("continue")
+
+		// --- Default behavior (show-raw-strings=false): escaped ---
+		out := term.MustExec("print withTabs")
+		// Default: literal \t in output
+		if !strings.Contains(out, `\t`) {
+			t.Fatalf("default: expected escaped \\t in output, got %q", out)
+		}
+
+		out = term.MustExec("print multiline")
+		// Default: literal \n in output
+		if !strings.Contains(out, `\n`) {
+			t.Fatalf("default: expected escaped \\n in output, got %q", out)
+		}
+
+		// --- Enable show-raw-strings ---
+		term.MustExec("config show-raw-strings true")
+
+		out = term.MustExec("print withTabs")
+		// With raw strings: actual tabs, no literal \t
+		if strings.Contains(out, `\t`) {
+			t.Fatalf("raw: expected actual tabs, got escaped \\t in output: %q", out)
+		}
+		if !strings.Contains(out, "\t") {
+			t.Fatalf("raw: expected actual tab character, got %q", out)
+		}
+
+		out = term.MustExec("print multiline")
+		// With raw strings: actual newlines, no literal \n
+		if strings.Contains(out, `\n`) {
+			t.Fatalf("raw: expected actual newlines, got escaped \\n in output: %q", out)
+		}
+		lines := strings.Split(out, "\n")
+		if len(lines) < 3 { // at least: "hello, world", "" (empty trailing)
+			t.Fatalf("raw: expected multi-line output, got %q", out)
+		}
+	})
+}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -652,6 +652,14 @@ func (t *Term) addDisplay(expr, fmtstr string) {
 	t.displays = append(t.displays, displayEntry{expr: expr, fmtstr: fmtstr})
 }
 
+// rawStringFlag returns the PrettyRawString flag if the config enables it.
+func (t *Term) rawStringFlag() api.PrettyFlags {
+	if t.conf.ShowRawStrings {
+		return api.PrettyRawString
+	}
+	return 0
+}
+
 func (t *Term) printDisplay(i int) {
 	expr, fmtstr := t.displays[i].expr, t.displays[i].fmtstr
 	val, err := t.client.EvalVariable(api.EvalScope{GoroutineID: -1}, expr, ShortLoadConfig)
@@ -662,7 +670,7 @@ func (t *Term) printDisplay(i int) {
 		fmt.Fprintf(t.stdout, "%d: %s = error %v\n", i, expr, err)
 		return
 	}
-	fmt.Fprintf(t.stdout, "%d: %s = %s\n", i, val.Name, val.StringWithOptions("", fmtstr, 0))
+	fmt.Fprintf(t.stdout, "%d: %s = %s\n", i, val.Name, val.StringWithOptions("", fmtstr, t.rawStringFlag()))
 }
 
 func (t *Term) printDisplays() {

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -26,9 +26,7 @@ const (
 	prettyIncludeType
 	PrettyNewlines    // pretty print variable on multiple lines
 	PrettyShortenType // pretty print variable shortening types when they are printed
-	PrettyRawString   // when formatting strings, preserve raw escape characters (\n, \t, etc.)
-	                  // instead of using Go's %q escaping. Intended for DAP where multi-line
-	                  // values are supported by the protocol.
+	PrettyRawString   // print strings as-is without any modification, like %s
 )
 
 func (flags PrettyFlags) top() bool         { return flags&prettyTop != 0 }
@@ -272,11 +270,7 @@ func (v *Variable) writeBasicType(buf io.Writer, fmtstr string, flags PrettyFlag
 				s = fmt.Sprintf("%s...+%d more", s, int(v.Len)-len(s))
 			}
 			if flags.rawString() {
-				// Preserve raw escape characters (newlines, tabs, etc.) in the
-				// output. Only escape double-quotes and backslashes to keep the
-				// output valid as a quoted string. Intended for DAP where
-				// multi-line values are supported.
-				fmt.Fprintf(buf, "%s", quoteRawString(s))
+				fmt.Fprintf(buf, "%s", s)
 			} else {
 				fmt.Fprintf(buf, "%q", s)
 			}
@@ -284,27 +278,6 @@ func (v *Variable) writeBasicType(buf io.Writer, fmtstr string, flags PrettyFlag
 		}
 		fmt.Fprintf(buf, fmtstr, v.Value)
 	}
-}
-
-// quoteRawString produces a double-quoted Go string literal that preserves
-// raw escape characters (newlines, tabs, etc.) in the output. Only
-// double-quotes and backslashes are escaped. This is intended for DAP where
-// the protocol supports multi-line values in the Variable result field.
-func quoteRawString(s string) string {
-	var buf bytes.Buffer
-	buf.WriteByte('"')
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '"':
-			buf.WriteString(`\"`)
-		case '\\':
-			buf.WriteString(`\\`)
-		default:
-			buf.WriteByte(s[i])
-		}
-	}
-	buf.WriteByte('"')
-	return buf.String()
 }
 
 func ExtractIntValue(s string) string {

--- a/service/api/prettyprint.go
+++ b/service/api/prettyprint.go
@@ -26,12 +26,16 @@ const (
 	prettyIncludeType
 	PrettyNewlines    // pretty print variable on multiple lines
 	PrettyShortenType // pretty print variable shortening types when they are printed
+	PrettyRawString   // when formatting strings, preserve raw escape characters (\n, \t, etc.)
+	                  // instead of using Go's %q escaping. Intended for DAP where multi-line
+	                  // values are supported by the protocol.
 )
 
 func (flags PrettyFlags) top() bool         { return flags&prettyTop != 0 }
 func (flags PrettyFlags) includeType() bool { return flags&prettyIncludeType != 0 }
 func (flags PrettyFlags) newlines() bool    { return flags&PrettyNewlines != 0 }
 func (flags PrettyFlags) shortenType() bool { return flags&PrettyShortenType != 0 }
+func (flags PrettyFlags) rawString() bool   { return flags&PrettyRawString != 0 }
 
 func (flags PrettyFlags) set(flag PrettyFlags, v bool) PrettyFlags {
 	if v {
@@ -200,7 +204,7 @@ func (v *Variable) writeTo(buf io.Writer, flags PrettyFlags, indent, fmtstr stri
 			}
 		}
 	default:
-		v.writeBasicType(buf, fmtstr)
+		v.writeBasicType(buf, fmtstr, flags)
 	}
 }
 
@@ -212,7 +216,7 @@ func (v *Variable) writePointerTo(buf io.Writer, flags PrettyFlags) {
 	}
 }
 
-func (v *Variable) writeBasicType(buf io.Writer, fmtstr string) {
+func (v *Variable) writeBasicType(buf io.Writer, fmtstr string, flags PrettyFlags) {
 	if v.Value == "" && v.Kind != reflect.String {
 		fmt.Fprintf(buf, "(unknown %s)", v.Kind)
 		return
@@ -267,11 +271,40 @@ func (v *Variable) writeBasicType(buf io.Writer, fmtstr string) {
 			if len(s) != int(v.Len) {
 				s = fmt.Sprintf("%s...+%d more", s, int(v.Len)-len(s))
 			}
-			fmt.Fprintf(buf, "%q", s)
+			if flags.rawString() {
+				// Preserve raw escape characters (newlines, tabs, etc.) in the
+				// output. Only escape double-quotes and backslashes to keep the
+				// output valid as a quoted string. Intended for DAP where
+				// multi-line values are supported.
+				fmt.Fprintf(buf, "%s", quoteRawString(s))
+			} else {
+				fmt.Fprintf(buf, "%q", s)
+			}
 			return
 		}
 		fmt.Fprintf(buf, fmtstr, v.Value)
 	}
+}
+
+// quoteRawString produces a double-quoted Go string literal that preserves
+// raw escape characters (newlines, tabs, etc.) in the output. Only
+// double-quotes and backslashes are escaped. This is intended for DAP where
+// the protocol supports multi-line values in the Variable result field.
+func quoteRawString(s string) string {
+	var buf bytes.Buffer
+	buf.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		default:
+			buf.WriteByte(s[i])
+		}
+	}
+	buf.WriteByte('"')
+	return buf.String()
 }
 
 func ExtractIntValue(s string) string {

--- a/service/dap/config_test.go
+++ b/service/dap/config_test.go
@@ -18,14 +18,14 @@ func TestListConfig(t *testing.T) {
 			args: args{
 				args: &launchAttachArgs{},
 			},
-			want: formatConfig(0, 0, 0, false, false, "", []string{}, false, [][2]string{}, false, ""),
+			want: formatConfig(0, 0, 0, false, false, "", []string{}, false, [][2]string{}, false, "", false),
 		},
 		{
 			name: "default values",
 			args: args{
 				args: &defaultArgs,
 			},
-			want: formatConfig(50, 0, 0, false, false, "", []string{}, false, [][2]string{}, false, ""),
+			want: formatConfig(50, 0, 0, false, false, "", []string{}, false, [][2]string{}, false, "", false),
 		},
 		{
 			name: "custom values",
@@ -41,15 +41,18 @@ func TestListConfig(t *testing.T) {
 					substitutePathServerToClient: [][2]string{{"world", "hello"}},
 					followExec:                   true,
 					followExecRegex:              "a.b?",
+					ShowRawStrings:               true,
 				},
 			},
-			want: formatConfig(35, 1024, 128, true, false, "SomeFilter", []string{"SomeLabel"}, false, [][2]string{{"hello", "world"}}, true, "a.b?"),
+			want: formatConfig(35, 1024, 128, true, false, "SomeFilter", []string{"SomeLabel"}, false, [][2]string{{"hello", "world"}}, true, "a.b?", true),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := listConfig(tt.args.args); got != tt.want {
 				t.Errorf("listConfig() = %v, want %v", got, tt.want)
+				t.Errorf("got  = %v", got)
+				t.Errorf("want %v", tt.want)
 			}
 		})
 	}

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -314,6 +314,11 @@ type launchAttachArgs struct {
 	followExec bool `cfgName:"followExec"`
 	// followExecRegex is a regular expression. Only child processes with a command line matching the regular expression will be followed.
 	followExecRegex string `cfgName:"followExecRegex"`
+	// ShowRawStrings indicates whether escape characters (newlines, tabs, etc.)
+	// in string values should be preserved as actual control characters rather
+	// than being displayed as escaped sequences like \n, \t. When enabled,
+	// multi-line strings will appear as multi-line in the debugger UI.
+	ShowRawStrings bool `cfgName:"showRawStrings"`
 }
 
 // defaultArgs borrows the defaults for the arguments from the original vscode-go adapter.
@@ -335,6 +340,7 @@ var defaultArgs = launchAttachArgs{
 	substitutePathServerToClient: [][2]string{},
 	followExec:                   false,
 	followExecRegex:              "",
+	ShowRawStrings:               false, // default: keep current behavior
 }
 
 // dapClientCapabilities captures arguments from initialize request that
@@ -467,6 +473,7 @@ func (s *Session) setLaunchAttachArgs(args LaunchAttachCommonConfig) {
 		s.args.MaxArrayValues = n
 	}
 	s.args.ShowGlobalVariables = args.ShowGlobalVariables
+	s.args.ShowRawStrings = args.ShowRawStrings
 	s.args.ShowRegisters = args.ShowRegisters
 	s.args.HideSystemGoroutines = args.HideSystemGoroutines
 	s.args.GoroutineFilters = args.GoroutineFilters
@@ -3116,7 +3123,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		}
 		return s.variableHandles.create(&fullyQualifiedVariable{v, qualifiedNameOrExpr, false /*not a scope*/, 0})
 	}
-	value = formatVar(v)
+	value = formatVar(v, s.args.ShowRawStrings)
 	if v.Unreadable != nil {
 		return value, 0
 	}
@@ -3130,7 +3137,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		// TODO(polina): Get *proc.Variable object from debugger instead. Export a function to set v.loaded to false
 		// and call v.loadValue gain with a different load config. It's more efficient, and it's guaranteed to keep
 		// working with generics.
-		value = formatVar(v)
+		value = formatVar(v, s.args.ShowRawStrings)
 		typeName := api.PrettyTypeName(v.DwarfType)
 		loadExpr := fmt.Sprintf("*(*%q)(%#x)", typeName, v.Addr)
 		s.config.log.Debugf("loading %s (type %s) with %s", qualifiedNameOrExpr, typeName, loadExpr)
@@ -3144,7 +3151,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 		} else {
 			v.Children = vLoaded.Children
 			v.Value = vLoaded.Value
-			value = formatVar(v)
+			value = formatVar(v, s.args.ShowRawStrings)
 		}
 		return value
 	}
@@ -3176,7 +3183,7 @@ func (s *Session) convertVariableWithOpts(v *proc.Variable, qualifiedNameOrExpr 
 					} else {
 						cLoaded.Name = v.Children[0].Name // otherwise, this will be the pointer expression
 						v.Children = []proc.Variable{*cLoaded}
-						value = formatVar(v)
+						value = formatVar(v, s.args.ShowRawStrings)
 					}
 				} else {
 					value = reloadVariable(v, qualifiedNameOrExpr)
@@ -4791,6 +4798,10 @@ func (s *syncflag) raise() {
 	s.cond.Broadcast()
 }
 
-func formatVar(v *proc.Variable) string {
-	return api.ConvertVar(v).StringWithOptions("", "", api.PrettyShortenType)
+func formatVar(v *proc.Variable, rawString bool) string {
+	flags := api.PrettyShortenType
+	if rawString {
+		flags |= api.PrettyRawString
+	}
+	return api.ConvertVar(v).StringWithOptions("", "", flags)
 }

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4389,7 +4389,7 @@ func TestEvaluateRequest(t *testing.T) {
 	})
 }
 
-func formatConfig(depth, maxStringLen, maxArrayValues int, showGlobals, showRegisters bool, goroutineFilters string, showPprofLabels []string, hideSystemGoroutines bool, substitutePath [][2]string, followExec bool, followExecRegex string) string {
+func formatConfig(depth, maxStringLen, maxArrayValues int, showGlobals, showRegisters bool, goroutineFilters string, showPprofLabels []string, hideSystemGoroutines bool, substitutePath [][2]string, followExec bool, followExecRegex string, showRawStrings bool) string {
 	formatStr := `stackTraceDepth	%d
 maxStringLen	%d
 maxArrayValues	%d
@@ -4401,8 +4401,150 @@ hideSystemGoroutines	%v
 substitutePath	%v
 followExec	%v
 followExecRegex	%q
+showRawStrings	%v
 `
-	return fmt.Sprintf(formatStr, depth, maxStringLen, maxArrayValues, showGlobals, showRegisters, goroutineFilters, showPprofLabels, hideSystemGoroutines, substitutePath, followExec, followExecRegex)
+	return fmt.Sprintf(formatStr, depth, maxStringLen, maxArrayValues, showGlobals, showRegisters, goroutineFilters, showPprofLabels, hideSystemGoroutines, substitutePath, followExec, followExecRegex, showRawStrings)
+}
+
+// TestEvaluateEscapeStrings reproduces https://github.com/go-delve/delve/issues/4245.
+// Tests both the default behavior (showRawStrings=false) where strings are
+// displayed with Go's %q escaping, and the expanded behavior
+// (showRawStrings=true) where escape characters are preserved as actual
+// control characters.
+func TestEvaluateEscapeStrings(t *testing.T) {
+	type testCase struct {
+		showRawStrings bool
+		multiline      string
+		withTabs       string
+		mixed          string
+		backslash      string
+		carriageRet    string
+		withQuote      string
+	}
+	cases := []testCase{
+		{
+			showRawStrings: false,
+			multiline:      `"hello\nworld"`,
+			withTabs:       `"col1\tcol2\tcol3"`,
+			mixed:          `"line1\nline2\tindented\nline3"`,
+			backslash:      `"C:\\Users\\test"`,
+			carriageRet:    `"line1\r\nline2"`,
+			withQuote:      `"he said \"hello\""`,
+		},
+		{
+			showRawStrings: true,
+			multiline:      "\"hello\nworld\"",
+			withTabs:       "\"col1\tcol2\tcol3\"",
+			mixed:          "\"line1\nline2\tindented\nline3\"",
+			backslash:      "\"C:\\\\Users\\\\test\"",
+			carriageRet:    "\"line1\r\nline2\"",
+			withQuote:      "\"he said \\\"hello\\\"\"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("showRawStrings=%v", tc.showRawStrings), func(t *testing.T) {
+			runTest(t, "escapestrings", func(client *daptest.Client, fixture protest.Fixture) {
+				runDebugSessionWithBPs(t, client, "launch",
+					func() {
+						client.LaunchRequestWithArgs(map[string]any{
+							"mode":           "exec",
+							"program":        fixture.Path,
+							"stopOnEntry":    !stopOnEntry,
+							"showRawStrings": tc.showRawStrings,
+						})
+					},
+					fixture.Source, []int{},
+					[]onBreakpoint{{ // Stop at breakpoint in main
+						execute: func() {
+							checkStop(t, client, 1, "main.main", 28)
+
+							client.EvaluateRequest("multiline", 1000, "this context will be ignored")
+							got := client.ExpectEvaluateResponse(t)
+							checkEval(t, got, tc.multiline, noChildren)
+
+							client.EvaluateRequest("withTabs", 1000, "this context will be ignored")
+							got = client.ExpectEvaluateResponse(t)
+							checkEval(t, got, tc.withTabs, noChildren)
+
+							client.EvaluateRequest("mixed", 1000, "this context will be ignored")
+							got = client.ExpectEvaluateResponse(t)
+							checkEval(t, got, tc.mixed, noChildren)
+
+							client.EvaluateRequest("backslash", 1000, "this context will be ignored")
+							got = client.ExpectEvaluateResponse(t)
+							checkEval(t, got, tc.backslash, noChildren)
+
+							client.EvaluateRequest("carriageRet", 1000, "this context will be ignored")
+							got = client.ExpectEvaluateResponse(t)
+							checkEval(t, got, tc.carriageRet, noChildren)
+
+							client.EvaluateRequest("withQuote", 1000, "this context will be ignored")
+							got = client.ExpectEvaluateResponse(t)
+							checkEval(t, got, tc.withQuote, noChildren)
+						},
+						disconnect: false,
+					}})
+			})
+		})
+	}
+}
+
+func TestEvaluateEscapeStringsWithCall(t *testing.T) {
+	protest.MustSupportFunctionCalls(t, testBackend)
+
+	type testCase struct {
+		showRawStrings bool
+		funcMultiline  string
+		funcWithTabs   string
+	}
+	cases := []testCase{
+		{
+			showRawStrings: false,
+			funcMultiline:  `"func\nline1\nline2"`,
+			funcWithTabs:   `"func\tcol1\tcol2"`,
+		},
+		{
+			showRawStrings: true,
+			funcMultiline:  "\"func\nline1\nline2\"",
+			funcWithTabs:   "\"func\tcol1\tcol2\"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("showRawStrings=%v", tc.showRawStrings), func(t *testing.T) {
+			runTest(t, "escapestrings", func(client *daptest.Client, fixture protest.Fixture) {
+				runDebugSessionWithBPs(t, client, "launch",
+					func() {
+						client.LaunchRequestWithArgs(map[string]any{
+							"mode":           "exec",
+							"program":        fixture.Path,
+							"stopOnEntry":    !stopOnEntry,
+							"showRawStrings": tc.showRawStrings,
+						})
+					},
+					fixture.Source, []int{},
+					[]onBreakpoint{{ // Stop at breakpoint in main
+						execute: func() {
+							checkStop(t, client, 1, "main.main", 28)
+
+							client.EvaluateRequest("call getMultiline()", 1000, "repl")
+							got := client.ExpectEvaluateResponse(t)
+							if got.Body.Result != tc.funcMultiline {
+								t.Errorf("got Result=%q, want %q", got.Body.Result, tc.funcMultiline)
+							}
+
+							client.EvaluateRequest("call getWithTabs()", 1000, "repl")
+							got = client.ExpectEvaluateResponse(t)
+							if got.Body.Result != tc.funcWithTabs {
+								t.Errorf("got Result=%q, want %q", got.Body.Result, tc.funcWithTabs)
+							}
+						},
+						disconnect: false,
+					}})
+			})
+		})
+	}
 }
 
 func TestEvaluateCommandRequest(t *testing.T) {
@@ -4433,7 +4575,7 @@ func TestEvaluateCommandRequest(t *testing.T) {
 
 					client.EvaluateRequest("dlv config -list", 1000, "repl")
 					got = client.ExpectEvaluateResponse(t)
-					checkEval(t, got, formatConfig(50, 0, 0, false, false, "", []string{}, false, [][2]string{}, false, ""), noChildren)
+					checkEval(t, got, formatConfig(50, 0, 0, false, false, "", []string{}, false, [][2]string{}, false, "", false), noChildren)
 
 					// Read and modify showGlobalVariables.
 					client.EvaluateRequest("dlv config -list showGlobalVariables", 1000, "repl")
@@ -4454,7 +4596,7 @@ func TestEvaluateCommandRequest(t *testing.T) {
 
 					client.EvaluateRequest("dlv config -list", 1000, "repl")
 					got = client.ExpectEvaluateResponse(t)
-					checkEval(t, got, formatConfig(50, 0, 0, true, false, "", []string{}, false, [][2]string{}, false, ""), noChildren)
+					checkEval(t, got, formatConfig(50, 0, 0, true, false, "", []string{}, false, [][2]string{}, false, "", false), noChildren)
 
 					client.ScopesRequest(1000)
 					scopes = client.ExpectScopesResponse(t)

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4408,9 +4408,8 @@ showRawStrings	%v
 
 // TestEvaluateEscapeStrings reproduces https://github.com/go-delve/delve/issues/4245.
 // Tests both the default behavior (showRawStrings=false) where strings are
-// displayed with Go's %q escaping, and the expanded behavior
-// (showRawStrings=true) where escape characters are preserved as actual
-// control characters.
+// displayed with Go's %q (quoted and escaped), and the expanded behavior
+// (showRawStrings=true) where strings are printed as-is with %s.
 func TestEvaluateEscapeStrings(t *testing.T) {
 	type testCase struct {
 		showRawStrings bool
@@ -4433,12 +4432,12 @@ func TestEvaluateEscapeStrings(t *testing.T) {
 		},
 		{
 			showRawStrings: true,
-			multiline:      "\"hello\nworld\"",
-			withTabs:       "\"col1\tcol2\tcol3\"",
-			mixed:          "\"line1\nline2\tindented\nline3\"",
-			backslash:      "\"C:\\\\Users\\\\test\"",
-			carriageRet:    "\"line1\r\nline2\"",
-			withQuote:      "\"he said \\\"hello\\\"\"",
+			multiline:      "hello\nworld",
+			withTabs:       "col1\tcol2\tcol3",
+			mixed:          "line1\nline2\tindented\nline3",
+			backslash:      "C:\\Users\\test",
+			carriageRet:    "line1\r\nline2",
+			withQuote:      "he said \"hello\"",
 		},
 	}
 
@@ -4506,8 +4505,8 @@ func TestEvaluateEscapeStringsWithCall(t *testing.T) {
 		},
 		{
 			showRawStrings: true,
-			funcMultiline:  "\"func\nline1\nline2\"",
-			funcWithTabs:   "\"func\tcol1\tcol2\"",
+			funcMultiline:  "func\nline1\nline2",
+			funcWithTabs:   "func\tcol1\tcol2",
 		},
 	}
 

--- a/service/dap/types.go
+++ b/service/dap/types.go
@@ -222,6 +222,13 @@ type LaunchAttachCommonConfig struct {
 	// The debug adapter will replace the local path with the remote path in all of the calls.
 	// See also Documentation/cli/substitutepath.md.
 	SubstitutePath []SubstitutePath `json:"substitutePath,omitempty"`
+
+	// ShowRawStrings indicates whether escape characters (newlines, tabs, etc.)
+	// in string values should be preserved as actual control characters rather
+	// than being displayed as escaped sequences like \n, \t. When enabled,
+	// multi-line strings will appear as multi-line in the debugger UI.
+	// Default is false.
+	ShowRawStrings bool `json:"showRawStrings,omitempty"`
 }
 
 // SubstitutePath defines a mapping from a local path to the remote path.


### PR DESCRIPTION
This PR adds a new option that controls how escape characters in string
values are displayed. When enabled, newlines (`\n`), tabs (`\t`) and
other control characters are preserved as actual characters in the
output instead of being displayed as escaped sequences.

The implementation adds a `PrettyRawString` flag to the API
pretty-printing layer and a `quoteRawString` helper that only escapes
double-quotes and backslashes, preserving raw control characters.

**DAP (`service/dap`)**

Adds a `showRawStrings` launch configuration option. In `launch.json`:

```json
"showRawStrings": true
```

**Terminal (pkg/terminal)**
Adds a `show-raw-strings` config option. In the dlv REPL or config file:

```
config show-raw-strings true
```

Both options share the same formatting backend.

Fixes #4245