### PR TITLE
build: pin github actions to commit shas and declare workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,22 +35,22 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0  # full history required for goreleaser release notes
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: stable
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - name: Run goreleaser (release)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: ~> v2
           args: release --clean
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run goreleaser (snapshot)
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: ~> v2
           args: release --snapshot --clean
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload snapshot artifacts
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: snapshot-dist
           path: dist/

--- a/.github/workflows/test-windows-arm64.yml
+++ b/.github/workflows/test-windows-arm64.yml
@@ -10,6 +10,9 @@ concurrency:
   group: '${{ github.ref }}-${{ github.workflow}}'
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   test-windows-arm64:
     runs-on: windows-11-arm

--- a/.github/workflows/test-windows-arm64.yml
+++ b/.github/workflows/test-windows-arm64.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Run tests
         run: _scripts/test_windows.ps1 -version go${{ matrix.go-version }} -arch arm64 -binDir $env:RUNNER_TOOL_CACHE


### PR DESCRIPTION
Hi, drive-by CI hardening in two commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v6` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. The spot that matters here is `release.yml`: goreleaser and the cosign installer run with `contents: write` and the keyless signing identity, so a re-pointed tag there means a compromised release could ship signed. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). All shas were resolved from the upstream repos and cross checked against their release tags. The pins stay maintainable: a dependabot config with the `github-actions` ecosystem bumps them automatically, one small block.

**Commit 2 adds `permissions: contents: read` to the windows arm64 test workflow**, the only one without a block. The job never uses the token, so the scope is exact. `release.yml` already declares scoped permissions (nicely done) and is untouched.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v6`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on master. I will also open a PR which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.