### PR TITLE
ci: fail early when a release is already published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,51 @@ jobs:
           echo "::error::A tag must be specified for non-dry-run releases"
           exit 1
 
+      - name: Reject existing published release
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          response_file="${RUNNER_TEMP}/release-preflight.json"
+          encoded_tag="$(jq -rn --arg tag "${RELEASE_TAG}" '$tag | @uri')"
+
+          status="$(
+            curl \
+              --silent \
+              --show-error \
+              --output "${response_file}" \
+              --write-out '%{http_code}' \
+              --header 'Accept: application/vnd.github+json' \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header 'X-GitHub-Api-Version: 2026-03-10' \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${encoded_tag}"
+          )"
+
+          case "${status}" in
+            200)
+              echo \
+                "::error title=Release already published::"\
+                "${RELEASE_TAG} already has a published GitHub Release. "\
+                "Immutable releases cannot accept new assets. Push a new "\
+                "tag and let GoReleaser create and publish the release."
+              exit 1
+              ;;
+            404)
+              # No published release exists; an existing draft is intentionally allowed.
+              ;;
+            *)
+              echo \
+                "::error title=Release preflight failed::"\
+                "GitHub returned HTTP ${status} while checking ${RELEASE_TAG}."
+              cat "${response_file}"
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Add a preflight check that aborts a release run when the target tag already has a published GitHub Release.

## Motivation

GitHub does not allow assets to be added to a published immutable release.
Previously, this condition was discovered only after GoReleaser had built, archived, checksummed, and signed all artifacts, when the upload stage failed with HTTP 422 errors.

The new check reports the release-ordering problem before the build steps begin.

## Scope

This change:

* runs only for tag-triggered and non-dry-run releases;
* does not create, modify, publish, or delete any release;
* does not prevent a maintainer from publishing a release manually;
* makes that mistake fail immediately with an actionable explanation;
* leaves snapshot builds unchanged.

This patch is a follow-up to: https://github.com/go-delve/delve/issues/4407.
This makes the release process more resilient to release-ordering mistakes by replacing a late, ambiguous upload failure with an early diagnostic.