### PR TITLE
release: make interrupted draft uploads rerunnable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,6 +71,11 @@ signs:
     output: true
 
 release:
+  # Reuse a draft left behind by an interrupted release run.
+  use_existing_draft: true
+  # When retrying a partial draft, replace same-name artifacts that were
+  # successfully uploaded before the previous run was interrupted.
+  replace_existing_artifacts: true
   github:
     owner: go-delve
     name: delve


### PR DESCRIPTION
## Summary

Configure GoReleaser to reuse an existing draft release and replace same-name assets when retrying a partially completed upload.

## Motivation

A release run can be interrupted after GoReleaser has created its draft or uploaded only some of the artifacts.
Without explicit retry behavior, rerunning the workflow may encounter the existing draft or duplicate asset names instead of continuing the release.

With this configuration, a rerun can target the draft left by the interrupted run and replace artifacts that were uploaded before the failure.

## Scope

This change improves recovery from transient failures during the draft upload phase, including runner interruptions, network failures, and partial GitHub API failures.

It does not:

* modify or recover published immutable releases;
* address releases that were manually published too early;
* change the normal successful sequence of creating a draft, uploading assets, and publishing it;
* require maintainers to create draft releases manually.

This patch is a follow-up to: https://github.com/go-delve/delve/issues/4407.
This makes the release process more resilient by making the pre-publication upload phase safely rerunnable.