### PR TITLE
ci: upgrade actions, pin them, and pin GoReleaser version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,24 +35,24 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # full history required for goreleaser release notes
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version: stable
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5  # v3.10.1
 
       - name: Run goreleaser (release)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
-          version: ~> v2
+          version: v2.17.1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,16 +60,16 @@ jobs:
 
       - name: Run goreleaser (snapshot)
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7.2.3
         with:
-          version: ~> v2
+          version: v2.17.1
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload snapshot artifacts
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: snapshot-dist
           path: dist/

--- a/.github/workflows/test-windows-arm64.yml
+++ b/.github/workflows/test-windows-arm64.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Run tests
         run: _scripts/test_windows.ps1 -version go${{ matrix.go-version }} -arch arm64 -binDir $env:RUNNER_TOOL_CACHE


### PR DESCRIPTION
## Summary

* upgrade `actions/checkout` from v4 and v5 to v7.0.1;
* upgrade `actions/setup-go` from v5 to v7.0.0;
* keep `sigstore/cosign-installer` on v3 and pin it to v3.10.1;
* upgrade `goreleaser/goreleaser-action` from v6 to v7.2.3;
* upgrade `actions/upload-artifact` from v4 to v7.0.1;
* pin every action to its full commit SHA; and
* pin the GoReleaser executable to v2.17.1 instead of the floating `~> v2` constraint.

## Motivation

Newer actions versions use the Node 24 action runtime, avoiding the Node 20 deprecation path.

The GoReleaser workflow previously requested `~> v2`, allowing a future GoReleaser v2 release to be selected automatically.
Pinning the exact version ensures that release and snapshot jobs use the same known GoReleaser implementation until the repository deliberately upgrades it.

The cosign-installer action remains on v3 because v4 installs Cosign v3 by default.
Cosign v3 requires migrating the existing detached certificate and signature output to a Sigstore bundle, which should be handled as a separate release-workflow change.

## Scope

This change:

* updates and pins the CI actions and the GoReleaser executable;
* does not change build targets, archives, checksums, signing, or publication configuration;
* is independent of the immutable-release upload failure.

This patch is a follow-up to: https://github.com/go-delve/delve/issues/4407.
This makes the release process more resilient to unreviewed tooling changes and action-runtime deprecations.