### PR TITLE
proc: export LoadFullValue as return-by-value helper

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -520,7 +520,7 @@ func evalBreakpointCondition(tgt *Target, thread Thread, cond ast.Expr) (bool, e
 		}
 		return true, errors.New("condition expression not boolean")
 	}
-	v.loadValue(loadFullValue)
+	v.loadValue(LoadFullValue())
 	if v.Unreadable != nil {
 		if stack.disabledErrors {
 			return false, nil

--- a/pkg/proc/core/core_test.go
+++ b/pkg/proc/core/core_test.go
@@ -491,7 +491,7 @@ mainSearch:
 	}
 
 	scope := proc.FrameToScope(p, p.Memory(), nil, p.CurrentThread().ThreadID(), *mainFrame)
-	loadConfig := proc.LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1}
+	loadConfig := proc.LoadFullValue()
 	v1, err := scope.EvalExpression("t", loadConfig)
 	assertNoError(err, t, "EvalVariable(t)")
 	assertNoError(v1.Unreadable, t, "unreadable variable 't'")

--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -1223,7 +1223,7 @@ func (stack *evalStack) executeOp() {
 			stack.err = errors.New("internal debugger error: expected boolean")
 			return
 		}
-		x.loadValue(loadFullValue)
+		x.loadValue(LoadFullValue())
 		stack.push(newConstant(x.Value, scope.BinInfo, scope.Mem))
 
 	case *evalop.Pop:
@@ -1503,7 +1503,7 @@ func (scope *EvalScope) evalJump(op *evalop.Jump, stack *evalStack) {
 		}
 		return
 	}
-	x.loadValue(loadFullValue)
+	x.loadValue(LoadFullValue())
 	if x.Unreadable != nil {
 		stack.err = x.Unreadable
 		return
@@ -1658,7 +1658,7 @@ func (scope *EvalScope) evalTypeCast(op *evalop.TypeCast, stack *evalStack) {
 		}
 	}
 
-	cfg := loadFullValue
+	cfg := LoadFullValue()
 	if scope.loadCfg != nil {
 		cfg = *scope.loadCfg
 	}
@@ -1909,7 +1909,7 @@ func capBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 	case reflect.Slice:
 		return newConstant(constant.MakeInt64(arg.Cap), arg.bi, arg.mem), nil
 	case reflect.Chan:
-		arg.loadValue(loadFullValue)
+		arg.loadValue(LoadFullValue())
 		if arg.Unreadable != nil {
 			return nil, arg.Unreadable
 		}
@@ -1942,7 +1942,7 @@ func lenBuiltin(args []*Variable, nodeargs []ast.Expr) (*Variable, error) {
 		}
 		return newConstant(constant.MakeInt64(arg.Len), arg.bi, arg.mem), nil
 	case reflect.Chan:
-		arg.loadValue(loadFullValue)
+		arg.loadValue(LoadFullValue())
 		if arg.Unreadable != nil {
 			return nil, arg.Unreadable
 		}
@@ -2066,7 +2066,7 @@ func minmaxBuiltin(name string, op token.Token, args []*Variable, nodeargs []ast
 		if args[i].Kind == reflect.String {
 			args[i].loadValue(loadFullValueLongerStrings)
 		} else {
-			args[i].loadValue(loadFullValue)
+			args[i].loadValue(LoadFullValue())
 		}
 
 		if args[i].Unreadable != nil {
@@ -2131,7 +2131,7 @@ func (scope *EvalScope) evalTypeAssert(op *evalop.TypeAssert, stack *evalStack) 
 		stack.err = fmt.Errorf("expression %q not an interface", astutil.ExprToString(op.Node.X))
 		return
 	}
-	xv.loadInterface(0, false, loadFullValue)
+	xv.loadInterface(0, false, LoadFullValue())
 	if xv.Unreadable != nil {
 		stack.err = xv.Unreadable
 		return
@@ -2229,7 +2229,7 @@ func (scope *EvalScope) evalIndex(op *evalop.Index, stack *evalStack) {
 		return
 
 	case reflect.Map:
-		idxev.loadValue(loadFullValue)
+		idxev.loadValue(LoadFullValue())
 		if idxev.Unreadable != nil {
 			stack.err = idxev.Unreadable
 			return
@@ -2495,14 +2495,14 @@ func (scope *EvalScope) evalBinary(binop *evalop.Binary, stack *evalStack) {
 	xv := stack.pop()
 
 	if xv.Kind != reflect.String { // delay loading strings until we use them
-		xv.loadValue(loadFullValue)
+		xv.loadValue(LoadFullValue())
 	}
 	if xv.Unreadable != nil {
 		stack.err = xv.Unreadable
 		return
 	}
 	if yv.Kind != reflect.String { // delay loading strings until we use them
-		yv.loadValue(loadFullValue)
+		yv.loadValue(LoadFullValue())
 	}
 	if yv.Unreadable != nil {
 		stack.err = yv.Unreadable
@@ -2888,7 +2888,7 @@ func (v *Variable) mapAccess(idx *Variable) (*Variable, error) {
 		return nil, fmt.Errorf("can not access unreadable map: %v", v.Unreadable)
 	}
 
-	lcfg := loadFullValue
+	lcfg := LoadFullValue()
 	if idx.Kind == reflect.String && int64(len(constant.StringVal(idx.Value))) == idx.Len && idx.Len > int64(lcfg.MaxStringLen) {
 		// If the index is a string load as much of the keys to at least match the length of the index.
 		//TODO(aarzilli): when struct literals are implemented this needs to be

--- a/pkg/proc/fncall.go
+++ b/pkg/proc/fncall.go
@@ -844,7 +844,7 @@ func funcCallStep(callScope *EvalScope, stack *evalStack, thread Thread) bool {
 			archoff = 40
 		}
 		// get error from top of the stack and return it to user
-		errvar, err := readStackVariable(p, thread, regs, archoff, "string", loadFullValue)
+		errvar, err := readStackVariable(p, thread, regs, archoff, "string", LoadFullValue())
 		if err != nil {
 			fncall.err = fmt.Errorf("could not get precheck error reason: %v", err)
 			break
@@ -1101,7 +1101,7 @@ func (scope *EvalScope) convertAllocToString(stack *evalStack) {
 	mallocv := stack.pop()
 	v := stack.pop()
 
-	mallocv.loadValue(loadFullValue)
+	mallocv.loadValue(LoadFullValue())
 
 	if mallocv.Unreadable != nil {
 		stack.err = mallocv.Unreadable

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/go-delve/delve/service/api"
 )
 
-var normalLoadConfig = proc.LoadConfig{true, 1, 64, 64, -1, 0}
+var normalLoadConfig = proc.LoadFullValue()
 var testBackend, buildMode string
 
 func init() {

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -250,7 +250,7 @@ func (t *Target) IsCgo() bool {
 	scope := globalScope(t, t.BinInfo(), t.BinInfo().Images[0], t.Memory())
 	iscgov, err := scope.findGlobal("runtime", "iscgo")
 	if err == nil {
-		iscgov.loadValue(loadFullValue)
+		iscgov.loadValue(LoadFullValue())
 		if iscgov.Unreadable == nil {
 			t.iscgo = new(bool)
 			*t.iscgo = constant.BoolVal(iscgov.Value)
@@ -376,7 +376,7 @@ func setAsyncPreemptOff(p *Target, v int64) {
 		logger.Warnf("could not find asyncpreemptoff field: %v", err)
 		return
 	}
-	asyncpreemptoffv.loadValue(loadFullValue)
+	asyncpreemptoffv.loadValue(LoadFullValue())
 	if asyncpreemptoffv.Unreadable != nil {
 		logger.Warnf("asyncpreemptoff field unreadable: %v", asyncpreemptoffv.Unreadable)
 		return

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -189,8 +189,13 @@ type LoadConfig struct {
 }
 
 var loadSingleValue = LoadConfig{false, 0, 64, 0, 0, 0}
-var loadFullValue = LoadConfig{true, 1, 64, 64, -1, 0}
 var loadFullValueLongerStrings = LoadConfig{true, 1, 1024 * 1024, 64, -1, 0}
+
+// LoadFullValue returns a LoadConfig that follows pointers and loads a
+// moderate amount of nested data (the default used throughout Delve).
+func LoadFullValue() LoadConfig {
+	return LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1}
+}
 
 // G status, from: src/runtime/runtime2.go
 const (
@@ -576,7 +581,7 @@ func (g *G) Labels() map[string]string {
 				labels = map[string]string{}
 				switch labelMap.Kind {
 				case reflect.Map:
-					labelMap.loadValue(loadFullValue)
+					labelMap.loadValue(LoadFullValue())
 					for i := range labelMap.Children {
 						if i%2 == 0 {
 							k := labelMap.Children[i]
@@ -602,7 +607,7 @@ func (g *G) Labels() map[string]string {
 							if err != nil {
 								break
 							}
-							v.loadValue(loadFullValue)
+							v.loadValue(LoadFullValue())
 							if len(v.Children) == 2 {
 								// Skip invalid key-value pairs caused by corrupted or incompatible label structures
 								// (e.g., labels set by some libraries: https://github.com/timandy/routine/blob/v1.1.4/goid.go#L50).
@@ -1022,7 +1027,7 @@ func (v *Variable) loadFieldNamed(name string) *Variable {
 	if err != nil {
 		return nil
 	}
-	v.loadValue(loadFullValue)
+	v.loadValue(LoadFullValue())
 	if v.Unreadable != nil {
 		return nil
 	}
@@ -1371,7 +1376,7 @@ func (v *Variable) loadValueInternal(recurseLevel int, cfg LoadConfig) {
 		sv := v.clone()
 		sv.RealType = godwarf.ResolveTypedef(&(sv.RealType.(*godwarf.ChanType).TypedefType))
 		sv = sv.maybeDereference()
-		sv.loadValueInternal(0, loadFullValue)
+		sv.loadValueInternal(0, LoadFullValue())
 		v.Children = sv.Children
 		v.Len = sv.Len
 		v.Base = sv.Addr

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -20,13 +20,7 @@ import (
 	protest "github.com/go-delve/delve/pkg/proc/test"
 )
 
-var pnormalLoadConfig = proc.LoadConfig{
-	FollowPointers:     true,
-	MaxVariableRecurse: 1,
-	MaxStringLen:       64,
-	MaxArrayValues:     64,
-	MaxStructFields:    -1,
-}
+var pnormalLoadConfig = proc.LoadFullValue()
 
 var pshortLoadConfig = proc.LoadConfig{
 	MaxStringLen:    64,

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cosiner/argv"
 	"github.com/go-delve/delve/pkg/config"
 	"github.com/go-delve/delve/pkg/locspec"
+	"github.com/go-delve/delve/pkg/proc"
 	"github.com/go-delve/delve/pkg/proc/debuginfod"
 	"github.com/go-delve/delve/service"
 	"github.com/go-delve/delve/service/api"
@@ -93,7 +94,10 @@ var (
 	// * Follows pointers
 	// * Loads more array values
 	// * Does not limit struct fields
-	longLoadConfig = api.LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1}
+	longLoadConfig = func() api.LoadConfig {
+		c := proc.LoadFullValue()
+		return *api.LoadConfigFromProc(&c)
+	}()
 	// ShortLoadConfig loads less information, not following pointers
 	// and limiting struct fields loaded to 3.
 	ShortLoadConfig = api.LoadConfig{MaxStringLen: 64, MaxStructFields: 3}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-delve/delve/pkg/config"
 	"github.com/go-delve/delve/pkg/goversion"
 	"github.com/go-delve/delve/pkg/locspec"
+	"github.com/go-delve/delve/pkg/proc"
 	"github.com/go-delve/delve/pkg/terminal/colorize"
 	"github.com/go-delve/delve/pkg/terminal/starbind"
 	"github.com/go-delve/delve/service"
@@ -618,7 +619,8 @@ func (t *Term) handleExit() (int, error) {
 // loadConfig returns an api.LoadConfig with the parameters specified in
 // the configuration file.
 func (t *Term) loadConfig() api.LoadConfig {
-	r := api.LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1}
+	full := proc.LoadFullValue()
+	r := *api.LoadConfigFromProc(&full)
 
 	if t.conf != nil && t.conf.MaxStringLen != nil {
 		r.MaxStringLen = *t.conf.MaxStringLen

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1329,7 +1329,7 @@ func (d *Debugger) collectBreakpointInformation(apiThread *api.Thread, thread pr
 		bpi.Variables = make([]api.Variable, len(bp.Variables))
 	}
 	for i := range bp.Variables {
-		v, err := s.EvalExpression(bp.Variables[i], proc.LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1})
+		v, err := s.EvalExpression(bp.Variables[i], proc.LoadFullValue())
 		if err != nil {
 			bpi.Variables[i] = api.Variable{Name: bp.Variables[i], Unreadable: fmt.Sprintf("eval error: %v", err)}
 		} else {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -209,7 +209,8 @@ type StacktraceOut struct {
 func (s *RPCServer) Stacktrace(arg StacktraceIn, out *StacktraceOut) error {
 	cfg := arg.Cfg
 	if cfg == nil && arg.Full {
-		cfg = &api.LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1}
+		full := proc.LoadFullValue()
+		cfg = api.LoadConfigFromProc(&full)
 	}
 	if arg.Defers {
 		arg.Opts |= api.StacktraceReadDefers
@@ -553,7 +554,8 @@ type EvalOut struct {
 func (s *RPCServer) Eval(arg EvalIn, out *EvalOut) error {
 	cfg := arg.Cfg
 	if cfg == nil {
-		cfg = &api.LoadConfig{FollowPointers: true, MaxVariableRecurse: 1, MaxStringLen: 64, MaxArrayValues: 64, MaxStructFields: -1}
+		full := proc.LoadFullValue()
+		cfg = api.LoadConfigFromProc(&full)
 	}
 	pcfg := *api.LoadConfigToProc(cfg)
 	v, err := s.debugger.EvalVariableInScope(arg.Scope.GoroutineID, arg.Scope.Frame, arg.Scope.DeferredCall, arg.Expr, pcfg)

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -30,13 +30,10 @@ import (
 	"github.com/go-delve/delve/service/rpccommon"
 )
 
-var normalLoadConfig = api.LoadConfig{
-	FollowPointers:     true,
-	MaxVariableRecurse: 1,
-	MaxStringLen:       64,
-	MaxArrayValues:     64,
-	MaxStructFields:    -1,
-}
+var normalLoadConfig = func() api.LoadConfig {
+	c := proc.LoadFullValue()
+	return *api.LoadConfigFromProc(&c)
+}()
 
 var testBackend, buildMode string
 


### PR DESCRIPTION
Replace the unexported mutable loadFullValue var with LoadFullValue() so callers get a fresh copy, and deduplicate matching LoadConfig literals across proc, debugger, rpc2, terminal, and tests.