### PR TITLE
*: add scripts to setup / run eval fuzzer and run in CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,28 @@
+name: FuzzEvalExpression
+
+on:
+  schedule:
+    # Daily 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}'
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.27'
+
+      - name: Run timed fuzz
+        run: _scripts/fuzz_eval_expression.sh fuzz

--- a/_scripts/fuzz_eval_expression.sh
+++ b/_scripts/fuzz_eval_expression.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Run FuzzEvalExpression setup, then either the seed corpus (seed) or a
+# timed continuous fuzz (fuzz). Intended for CI; linux/amd64 only.
+set -euo pipefail
+
+mode="${1:-}"
+if [[ "$mode" != "seed" && "$mode" != "fuzz" ]]; then
+	echo "usage: $0 <seed|fuzz>" >&2
+	exit 2
+fi
+
+if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+	echo "fuzz_eval_expression: skipping (requires linux/amd64, got $(uname -s)/$(uname -m))"
+	exit 0
+fi
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+echo "fuzz_eval_expression: setup"
+go test ./pkg/proc -count=1 -run=FuzzEvalExpression -fuzzevalexpressionsetup
+
+case "$mode" in
+seed)
+	echo "fuzz_eval_expression: seed"
+	go test ./pkg/proc -count=1 -run=FuzzEvalExpression
+	;;
+fuzz)
+	echo "fuzz_eval_expression: fuzz (2m)"
+	go test ./pkg/proc -count=1 -run=NONE -fuzz=FuzzEvalExpression \
+		-fuzztime=2m -fuzzminimizetime=0 -v
+	;;
+esac

--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -87,8 +87,17 @@ fi
 set +e
 go run _scripts/make.go test
 x=$?
+
+fuzz_x=0
+if [ "$arch" = "amd64" ]; then
+	_scripts/fuzz_eval_expression.sh seed
+	fuzz_x=$?
+fi
+
 if [ "$version" = "gotip" ]; then
 	exit 0
+elif [ "$x" -ne 0 ]; then
+	exit "$x"
 else
-	exit $x
+	exit "$fuzz_x"
 fi


### PR DESCRIPTION
We have a fuzz test for eval, but never ended up running them in CI. This adds a short fuzz run on PRs and a longer, scheduled fuzz run nightly.