### PR TITLE
pkg/proc: Defer pointer cast to syscall invoking function

### DIFF
--- a/pkg/proc/native/syscall_windows.go
+++ b/pkg/proc/native/syscall_windows.go
@@ -136,7 +136,7 @@ type _DEBUG_EVENT struct {
 	U              [160]byte
 }
 
-//sys	_NtQueryInformationThread(threadHandle syscall.Handle, infoclass int32, info uintptr, infolen uint32, retlen *uint32) (status _NTSTATUS) = ntdll.NtQueryInformationThread
+//sys	_NtQueryInformationThread(threadHandle syscall.Handle, infoclass int32, info *_THREAD_BASIC_INFORMATION, infolen uint32, retlen *uint32) (status _NTSTATUS) = ntdll.NtQueryInformationThread
 //sys	_GetThreadContext(thread syscall.Handle, context *_CONTEXT) (err error) = kernel32.GetThreadContext
 //sys	_SetThreadContext(thread syscall.Handle, context *_CONTEXT) (err error) = kernel32.SetThreadContext
 //sys	_SuspendThread(threadid syscall.Handle) (prevsuspcount uint32, err error) [failretval==0xffffffff] = kernel32.SuspendThread

--- a/pkg/proc/native/threads_windows_amd64.go
+++ b/pkg/proc/native/threads_windows_amd64.go
@@ -24,7 +24,7 @@ func registers(t *nativeThread) (proc.Registers, error) {
 	}
 
 	var threadInfo _THREAD_BASIC_INFORMATION
-	status := _NtQueryInformationThread(t.os.hThread, _ThreadBasicInformation, uintptr(unsafe.Pointer(&threadInfo)), uint32(unsafe.Sizeof(threadInfo)), nil)
+	status := _NtQueryInformationThread(t.os.hThread, _ThreadBasicInformation, &threadInfo, uint32(unsafe.Sizeof(threadInfo)), nil)
 	if !_NT_SUCCESS(status) {
 		return nil, fmt.Errorf("NtQueryInformationThread failed: it returns 0x%x", status)
 	}

--- a/pkg/proc/native/zsyscall_windows.go
+++ b/pkg/proc/native/zsyscall_windows.go
@@ -177,8 +177,8 @@ func _WriteProcessMemory(process syscall.Handle, baseaddr uintptr, buffer *byte,
 	return
 }
 
-func _NtQueryInformationThread(threadHandle syscall.Handle, infoclass int32, info uintptr, infolen uint32, retlen *uint32) (status _NTSTATUS) {
-	r0, _, _ := syscall.SyscallN(procNtQueryInformationThread.Addr(), uintptr(threadHandle), uintptr(infoclass), uintptr(info), uintptr(infolen), uintptr(unsafe.Pointer(retlen)))
+func _NtQueryInformationThread(threadHandle syscall.Handle, infoclass int32, info *_THREAD_BASIC_INFORMATION, infolen uint32, retlen *uint32) (status _NTSTATUS) {
+	r0, _, _ := syscall.SyscallN(procNtQueryInformationThread.Addr(), uintptr(threadHandle), uintptr(infoclass), uintptr(unsafe.Pointer(info)), uintptr(infolen), uintptr(unsafe.Pointer(retlen)))
 	status = _NTSTATUS(r0)
 	return
 }


### PR DESCRIPTION
Previously, the logic in `registers(*nativeThread)` would
create a pointer to a stack variable `threadInfo`, immediately
convert it to a `uintptr` and pass that `uintptr` down to
`_NtQueryInformationThread` which would invoke `SyscallN`.

This meant that if the call to `_NtQueryInformationThread`
forced growth of the stack (due to running out of space),
the uintptr (interpreted as a pointer) would be logically
dangling. And the syscall would successfully write to that memory.

After the syscall finished, the `status` would be a success,
but the subsequent read from the local's field
`threadInfo.TebBaseAddress` would not actually be the
correct value, because the write happened at the old address.

This PR changes the signature of _NtQueryInformationThread
to take `*_THREAD_BASIC_INFORMATION` and regenerates the syscall
wrapper. With this change, the `*T` -> `unsafe.Pointer` -> `uintptr`
conversion happens within the `SyscallN` call expression,
which is correctly handled by the compiler.

One downstream impact of this is that it fixes flakiness
in TestCallFunction on Windows with addr=0x1488
which seems to correspond to

```
// Offsets into Thread Environment Block (pointer in GS)
#define TEB_TlsSlots 0x1480
```

in the runtime assembly stubs.
