### PR TITLE
service/dap: print "ps aux" before exiting tests

### DIFF
--- a/_scripts/test_linux.sh
+++ b/_scripts/test_linux.sh
@@ -9,7 +9,7 @@ apt-get -qq update
 if [ "$arch" = "ppc64le" ]; then
 	apt-get install --no-upgrade -y wget jq
 else
-	apt-get install --no-upgrade -y gcc wget jq lsof
+	apt-get install --no-upgrade -y gcc wget jq lsof procps
 fi
 
 

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -54,7 +54,8 @@ var testBackend string
 
 func TestMain(m *testing.M) {
 	logOutputVal := ""
-	if _, isTeamCityTest := os.LookupEnv("TEAMCITY_VERSION"); isTeamCityTest {
+	_, isTeamCityTest := os.LookupEnv("TEAMCITY_VERSION")
+	if isTeamCityTest {
 		logOutputVal = "debugger,dap"
 	}
 	var logOutput string
@@ -63,6 +64,17 @@ func TestMain(m *testing.M) {
 	logflags.Setup(logOutput != "", logOutput, "")
 	protest.DefaultTestBackend(&testBackend)
 	protest.RunTestsWithFixtures(m)
+	if runtime.GOOS == "linux" && runtime.GOARCH == "386" && isTeamCityTest {
+		fmt.Printf("=== Output of ps aux ===\n")
+		cmd := exec.Command("ps", "aux")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if err != nil {
+			fmt.Printf("error: %v\n", err)
+		}
+		fmt.Printf("=== Done ===\n")
+	}
 }
 
 // name is for _fixtures/<name>.go


### PR DESCRIPTION
The tests on linux/386 occasionally fail with a "Test I/O incomplete
1m0s after exiting" error. See if we can use the list of running
processes to determine which test is at fault.
