### PR TITLE
proc: do not nest memCache objects

### DIFF
--- a/pkg/proc/mem.go
+++ b/pkg/proc/mem.go
@@ -94,6 +94,7 @@ func cacheMemory(mem MemoryReadWriter, addr uint64, size int) MemoryReadWriter {
 		if cacheMem.contains(addr, size) {
 			return mem
 		}
+		return &memCache{false, addr, make([]byte, size), cacheMem.mem}
 	case *compositeMemory:
 		return mem
 	}

--- a/pkg/proc/proc_general_test.go
+++ b/pkg/proc/proc_general_test.go
@@ -120,6 +120,16 @@ func TestReadCStringValue(t *testing.T) {
 	}
 }
 
+func TestMemCacheDoesNotNest(t *testing.T) {
+	const base = 0x5000
+	dm := &dummyMem{t: t, mem: make([]byte, 1000), base: base}
+	mem1 := cacheMemory(dm, base, 10)
+	mem2 := cacheMemory(mem1, base+20, 10)
+	if mem2.(*memCache).mem != dm {
+		t.Errorf("cacheMemory nested memCaches")
+	}
+}
+
 func assertNoError(err error, t testing.TB, s string) {
 	if err != nil {
 		_, file, line, _ := runtime.Caller(1)


### PR DESCRIPTION
This addresses #4416. With the way we use memCache it is rare that we
are going to use anything but the topmost memCache object so we should
avoid nesting them completely.

If #4416 is actually caused by some infinite recursion in our code this
will not fix it but hopefully it will give us a better stacktrace to
analyze.

Fixes #4416
