### PR TITLE
proc: advance through FreeBSD process snapshots

### DIFF
--- a/pkg/proc/native/proc_freebsd.go
+++ b/pkg/proc/native/proc_freebsd.go
@@ -173,20 +173,19 @@ func waitForSearchProcess(pfx string, seen map[int]struct{}) (int, error) {
 	var cnt C.uint
 	procs := C.procstat_getprocs(ps, C.KERN_PROC_PROC, 0, &cnt)
 	defer C.procstat_freeprocs(ps, procs)
-	proc := procs
 	for i := 0; i < int(cnt); i++ {
-		if _, isseen := seen[int(proc.ki_pid)]; isseen {
+		proc := (*C.struct_kinfo_proc)(unsafe.Pointer(uintptr(unsafe.Pointer(procs)) + uintptr(i)*unsafe.Sizeof(*procs)))
+		pid := int(proc.ki_pid)
+		if _, isseen := seen[pid]; isseen {
 			continue
 		}
-		seen[int(proc.ki_pid)] = struct{}{}
+		seen[pid] = struct{}{}
 
 		argv := strings.Join(getCmdLineInternal(ps, proc), " ")
 		log.Debugf("waitfor: new process %q", argv)
 		if strings.HasPrefix(argv, pfx) {
-			return int(proc.ki_pid), nil
+			return pid, nil
 		}
-
-		proc = (*C.struct_kinfo_proc)(unsafe.Pointer(uintptr(unsafe.Pointer(proc)) + unsafe.Sizeof(*proc)))
 	}
 	return 0, nil
 }

--- a/pkg/proc/native/waitfor_test.go
+++ b/pkg/proc/native/waitfor_test.go
@@ -1,0 +1,59 @@
+package native
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+const waitForHelperEnv = "DELVE_WAITFOR_HELPER"
+
+func TestWaitForSearchPastSeenProcess(t *testing.T) {
+	switch runtime.GOOS {
+	case "freebsd", "linux", "windows":
+		// waitForSearchProcess is only implemented on these operating systems.
+	default:
+		t.Skipf("not implemented on %s", runtime.GOOS)
+	}
+
+	if os.Getenv(waitForHelperEnv) == "1" {
+		// Stay alive until the parent finds and kills us, with an orphan timeout.
+		time.Sleep(30 * time.Second)
+		return
+	}
+
+	// Populate seen with the current process snapshot.
+	seen := make(map[int]struct{})
+	prefix := fmt.Sprintf("delve-impossible-process-%d", os.Getpid())
+	pid, err := waitForSearchProcess(prefix, seen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != 0 {
+		t.Fatalf("unexpectedly found process %d", pid)
+	}
+
+	// Start a process that was not present in the initial snapshot.
+	uniqueArg := fmt.Sprintf("waitfor-child-%d", os.Getpid())
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWaitForSearchPastSeenProcess$", uniqueArg)
+	cmd.Env = append(os.Environ(), waitForHelperEnv+"=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	pid, err = waitForSearchProcess(strings.Join(cmd.Args, " "), seen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pid != cmd.Process.Pid {
+		t.Fatalf("expected PID %d, got %d", cmd.Process.Pid, pid)
+	}
+}


### PR DESCRIPTION
`waitForSearchProcess` advanced its process pointer only after processing an entry. When an entry was already present in `seen`, `continue` skipped that update, causing the remaining iterations to repeatedly inspect the same process and miss newer entries.

Compute each entry from the process-array base and loop index so every iteration advances. Add a FreeBSD regression test that populates `seen`, starts a new process, and verifies that a second scan reaches it.

Tested on FreeBSD 14.3 amd64 under QEMU/KVM:

```
go test ./pkg/proc/native -run TestWaitForSearchPastSeenProcess -count=100
go test ./pkg/proc/native ./pkg/proc
```