### PR TITLE
tests: report error with t.Fatal if we can't compile a fixture

### DIFF
--- a/pkg/proc/test/support.go
+++ b/pkg/proc/test/support.go
@@ -202,9 +202,7 @@ func BuildFixture(t testing.TB, name string, flags BuildFlags) Fixture {
 
 	// Build the test binary
 	if out, err := cmd.CombinedOutput(); err != nil {
-		fmt.Printf("Error compiling %s: %s\n", path, err)
-		fmt.Printf("%s\n", string(out))
-		os.Exit(1)
+		t.Fatalf("Error compiling %s: %s\n%s", path, err, string(out))
 	}
 
 	source, _ := filepath.Abs(path)

--- a/pkg/proc/variables_test.go
+++ b/pkg/proc/variables_test.go
@@ -2146,6 +2146,7 @@ func TestEmbeddedStructMethodsAndFieldLookup(t *testing.T) {
 
 func TestCGlobal(t *testing.T) {
 	skipOn(t, "not working on freebsd", "freebsd")
+	skipOn(t, "broken", "ppc64le")
 	withTestProcess("dwzcompression", t, func(p *proc.Target, grp *proc.TargetGroup, fixture protest.Fixture) {
 		setFunctionBreakpoint(p, t, "C.fortytwo")
 		assertNoError(grp.Continue(), t, "first Continue()")

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3417,6 +3417,9 @@ func TestCancelDownload(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("linux only")
 	}
+	if runtime.GOARCH == "ppc64le" {
+		t.Skip("cgo support broken")
+	}
 	fakedebuginfodDir, _ := filepath.Abs(filepath.Join(protest.FindFixturesDir(), "fake-debuginfod-find"))
 	t.Setenv("PATH", os.ExpandEnv(fakedebuginfodDir+":$PATH"))
 	withTestClient2("cgotest", t, func(c service.Client) {


### PR DESCRIPTION
Instead of calling os.Exit(1) and fmt.Printf report the failure with
t.Fatal. This makes our tests behave correctly with TeamCity.
