### PR TITLE
debugger: close resumeNotify early with the halt command

### DIFF
--- a/_fixtures/cgotest.go
+++ b/_fixtures/cgotest.go
@@ -6,10 +6,17 @@ char* foo(void) { return "hello, world!"; }
 */
 import "C"
 
-import "fmt"
-import "runtime"
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+)
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "sleep" {
+		time.Sleep(10 * time.Second)
+	}
 	runtime.GOMAXPROCS(runtime.NumCPU())
 	fmt.Println(C.GoString(C.foo()))
 }

--- a/_fixtures/fake-debuginfod-find/debuginfod-find
+++ b/_fixtures/fake-debuginfod-find/debuginfod-find
@@ -6,7 +6,7 @@ fi
 
 for i in $(seq 1 100000 1000000); do
 	echo "Downloading $i..." >&2
-	sleep 1
+	sleep 0.6
 done
 
 echo "i-dont-actually-have-a-path-im-a-fake-stub-sorry"

--- a/pkg/proc/debuginfod/debuginfod.go
+++ b/pkg/proc/debuginfod/debuginfod.go
@@ -11,7 +11,7 @@ import (
 )
 
 const debuginfodFind = "debuginfod-find"
-const notificationThrottle time.Duration = 1 * time.Second
+const notificationThrottle time.Duration = 500 * time.Millisecond
 
 func execFind(ctx context.Context, notify func(string), args ...string) (string, error) {
 	if _, err := exec.LookPath(debuginfodFind); err != nil {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -1101,6 +1101,11 @@ func (d *Debugger) Command(command *api.DebuggerCommand, resumeNotify chan struc
 			}
 		}
 		d.recordMutex.Unlock()
+
+		if resumeNotify != nil {
+			close(resumeNotify)
+			resumeNotify = nil
+		}
 	}
 
 	withBreakpointInfo := true

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -145,7 +145,10 @@ func (s *RPCServer) Command(command api.DebuggerCommand, cb service.RPCCallback)
 }
 
 func (s *RPCServer) eventsFn(event *proc.Event) {
-	s.eventsChan <- event
+	select {
+	case s.eventsChan <- event:
+	default:
+	}
 }
 
 type GetBufferedTracepointsIn struct {

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3419,26 +3419,32 @@ func TestCancelDownload(t *testing.T) {
 	}
 	fakedebuginfodDir, _ := filepath.Abs(filepath.Join(protest.FindFixturesDir(), "fake-debuginfod-find"))
 	t.Setenv("PATH", os.ExpandEnv(fakedebuginfodDir+":$PATH"))
-	withTestClient2("cgotest", t, func(c service.Client) {
-		_, err := c.CreateBreakpoint(&api.Breakpoint{FunctionName: "main.main"})
-		assertNoError(err, t, "CreateBreakpoint")
-		eventReceived := false
+	withTestClient2Extended("cgotest", t, 0, [3]string{}, []string{"sleep"}, func(c service.Client, fixture protest.Fixture) {
+		eventReceivedCount := 0
+		const eventReceivedCountCancelThreshold = 3
 		c.SetEventsFn(func(ev *api.Event) {
 			switch ev.Kind {
 			case api.EventBinaryInfoDownload:
-				eventReceived = true
+				eventReceivedCount++
 				t.Logf("download event: %q %q", ev.BinaryInfoDownloadEventDetails.ImagePath, ev.BinaryInfoDownloadEventDetails.Progress)
-				assertNoError(c.CancelDownloads(), t, "CancelDownloads")
+				if eventReceivedCount >= eventReceivedCountCancelThreshold {
+					t.Logf("stop download\n")
+					assertNoError(c.CancelDownloads(), t, "CancelDownloads")
+				}
 			}
 		})
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			c.Halt()
+		}()
 		t0 := time.Now()
 		state := <-c.Continue()
 		assertNoError(state.Err, t, "Continue")
-		if !eventReceived {
-			t.Errorf("Download event was not received")
+		if eventReceivedCount < eventReceivedCountCancelThreshold {
+			t.Errorf("Too few download events received %d", eventReceivedCount)
 		}
 		if time.Since(t0) > 3*time.Second {
-			t.Errorf("Continue took to long, we probably couldn't cancel the download")
+			t.Errorf("Continue took to long, we probably couldn't cancel the download (%v)", time.Since(t0))
 		}
 	})
 }


### PR DESCRIPTION
When we receive an halt command we wait to close the resumeNotify
channel until we acquire the target mutex, which is only possible after
the previous continue command has completed.

This means that upon receiving an halt command, we will not be able to
serve any other request, including asynchronous requests, until the
previous continue command is completed.

This breaks the intended use of the GetEvents request. The one that is
in-flight when we receive the halt command will terminate but any
subsequent GetEvents command will not be able to run until continue
finishes.

With the way the eventsChan in rpc2/server.go is used, this can also
lead to a deadlock (continue gets blocked on sending to eventsChan
through the eventsFn callback, and the eventsChan never gets drained
because GetEvents can't run).

To resolve this problem we close the resumeNotify channel early for
halt commands.

Additionally we drop events in rpc2/server.go if the eventsChan is
filled up, so that improper use of the API does not ever lead to a
deadlock.
