### PR TITLE
tests: regenerate capslock

### DIFF
--- a/_scripts/capslock_darwin_amd64-output.txt
+++ b/_scripts/capslock_darwin_amd64-output.txt
@@ -4,7 +4,7 @@ For additional debugging signals, use verbose mode with -output=verbose
 To get machine-readable full analysis output, use -output=json
 
 Analyzed packages:
-  github.com/cilium/ebpf v0.11.0
+  github.com/cilium/ebpf v0.22.0
   github.com/cosiner/argv v0.1.0
   github.com/cpuguy83/go-md2man/v2 v2.0.6
   github.com/derekparker/trie/v3 v3.2.0
@@ -15,13 +15,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 1 references

--- a/_scripts/capslock_darwin_arm64-output.txt
+++ b/_scripts/capslock_darwin_arm64-output.txt
@@ -14,12 +14,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 1 references

--- a/_scripts/capslock_linux_386-output.txt
+++ b/_scripts/capslock_linux_386-output.txt
@@ -4,7 +4,7 @@ For additional debugging signals, use verbose mode with -output=verbose
 To get machine-readable full analysis output, use -output=json
 
 Analyzed packages:
-  github.com/cilium/ebpf v0.11.0
+  github.com/cilium/ebpf v0.22.0
   github.com/cosiner/argv v0.1.0
   github.com/cpuguy83/go-md2man/v2 v2.0.6
   github.com/derekparker/trie/v3 v3.2.0
@@ -15,13 +15,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 1 references

--- a/_scripts/capslock_linux_amd64-output.txt
+++ b/_scripts/capslock_linux_amd64-output.txt
@@ -4,7 +4,7 @@ For additional debugging signals, use verbose mode with -output=verbose
 To get machine-readable full analysis output, use -output=json
 
 Analyzed packages:
-  github.com/cilium/ebpf v0.11.0
+  github.com/cilium/ebpf v0.22.0
   github.com/cosiner/argv v0.1.0
   github.com/cpuguy83/go-md2man/v2 v2.0.6
   github.com/derekparker/trie/v3 v3.2.0
@@ -15,13 +15,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 1 references

--- a/_scripts/capslock_linux_arm64-output.txt
+++ b/_scripts/capslock_linux_arm64-output.txt
@@ -14,12 +14,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 1 references

--- a/_scripts/capslock_linux_ppc64le-output.txt
+++ b/_scripts/capslock_linux_ppc64le-output.txt
@@ -14,12 +14,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 1 references

--- a/_scripts/capslock_linux_riscv64-output.txt
+++ b/_scripts/capslock_linux_riscv64-output.txt
@@ -14,12 +14,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 1 references

--- a/_scripts/capslock_windows_amd64-output.txt
+++ b/_scripts/capslock_windows_amd64-output.txt
@@ -4,7 +4,7 @@ For additional debugging signals, use verbose mode with -output=verbose
 To get machine-readable full analysis output, use -output=json
 
 Analyzed packages:
-  github.com/cilium/ebpf v0.11.0
+  github.com/cilium/ebpf v0.22.0
   github.com/cosiner/argv v0.1.0
   github.com/cpuguy83/go-md2man/v2 v2.0.6
   github.com/derekparker/trie/v3 v3.2.0
@@ -17,13 +17,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 2 references

--- a/_scripts/capslock_windows_arm64-output.txt
+++ b/_scripts/capslock_windows_arm64-output.txt
@@ -16,12 +16,12 @@ Analyzed packages:
   github.com/rivo/uniseg v0.2.0
   github.com/russross/blackfriday/v2 v2.1.0
   github.com/spf13/cobra v1.10.2
-  github.com/spf13/pflag v1.0.9
+  github.com/spf13/pflag v1.0.10
   go.starlark.net v0.0.0-20231101134539-556fd59b42f6
   go.yaml.in/yaml/v3 v3.0.4
-  golang.org/x/arch v0.11.0
-  golang.org/x/sync v0.8.0
-  golang.org/x/sys v0.26.0
+  golang.org/x/arch v0.28.0
+  golang.org/x/sync v0.22.0
+  golang.org/x/sys v0.46.0
   golang.org/x/telemetry v0.0.0-20241106142447-58a1122356f5
 
 ARBITRARY_EXECUTION: 2 references

--- a/_scripts/gen-capslock-all.go
+++ b/_scripts/gen-capslock-all.go
@@ -22,7 +22,7 @@ var platforms = []Platform{
 	{GOOS: "linux", GOARCH: "amd64"},
 	{GOOS: "linux", GOARCH: "386"},
 	{GOOS: "linux", GOARCH: "arm64"},
-	{GOOS: "linux", GOARCH: "riscv64"},
+	{GOOS: "linux", GOARCH: "riscv64", BuildTags: "exp.linuxriscv64"},
 	{GOOS: "linux", GOARCH: "ppc64le", BuildTags: "exp.linuxppc64le"},
 	{GOOS: "darwin", GOARCH: "amd64"},
 	{GOOS: "darwin", GOARCH: "arm64"},
@@ -106,13 +106,12 @@ func main() {
 func generateCapslock(platform Platform) error {
 	outputFile := fmt.Sprintf("_scripts/capslock_%s_%s-output.txt", platform.GOOS, platform.GOARCH)
 
-	args := []string{"run", "github.com/google/capslock/cmd/capslock@latest"}
+	args := []string{}
 	if platform.BuildTags != "" {
 		args = append(args, "-buildtags", platform.BuildTags)
 	}
 	args = append(args, "-packages", "./cmd/dlv")
-
-	cmd := exec.Command("go", args...)
+	cmd := exec.Command("capslock", args...)
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("GOOS=%s", platform.GOOS),
 		fmt.Sprintf("GOARCH=%s", platform.GOARCH),


### PR DESCRIPTION
Disable capslock if it isn't built with an updated version of
x/go/tools because it currently crashes.
