### PR TITLE
ci: upgrade GitHub Actions and pin GoReleaser

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,6 +10,9 @@ concurrency:
   group: '${{ github.workflow }}'
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest
@@ -17,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.27'
 

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -18,7 +18,7 @@ jobs:
       # Needed by score-push to publish the score for the README badge.
       id-token: write
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: getplumber/plumber@40bd6b5bb8ff4f0944feacaeb41dea6bce08d62d # v0.4.28
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,24 +80,24 @@ jobs:
           esac
 
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # full history required for goreleaser release notes
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Run goreleaser (release)
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: ~> v2
+          version: v2.17.1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -105,16 +105,16 @@ jobs:
 
       - name: Run goreleaser (snapshot)
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: ~> v2
+          version: v2.17.1
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload snapshot artifacts
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: snapshot-dist
           path: dist/

--- a/.github/workflows/test-windows-arm64.yml
+++ b/.github/workflows/test-windows-arm64.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run tests
         run: _scripts/test_windows.ps1 -version go${{ matrix.go-version }} -arch arm64 -binDir $env:RUNNER_TOOL_CACHE


### PR DESCRIPTION
This upgrades the GitHub Actions we use to current versions so CI is on the Node 24 runtime, and pins GoReleaser itself to v2.17.1 instead of the floating ~> v2 constraint. Cosign installer stays on v3 so we don't have to migrate signing output to Sigstore bundles here.

fuzz.yml still had floating v5 tags after the earlier SHA pinning, so that is pinned too, along with checkout in plumber.yml. The fuzz workflow also now declares contents: read.

This is #4410 rebased onto current master.