### PR TITLE
proc: do not call debuginfod-find right after attach

### DIFF
--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -118,6 +118,7 @@ type BinaryInfo struct {
 	debugPinnerFn *Function
 	logger        logflags.Logger
 	eventsFn      func(*Event)
+	attaching     bool
 
 	cancelDownloadsMu sync.Mutex
 	cancelDownloads   func()
@@ -132,6 +133,8 @@ var (
 	// ErrNoDebugInfoFound is returned when Delve cannot open the debug_info
 	// section or find an external debug info file.
 	ErrNoDebugInfoFound = errors.New("could not open debug info")
+
+	ErrDebuginfodSkippedOnAttach = errors.New("debuginfod call skipped on attach")
 )
 
 var (
@@ -870,8 +873,8 @@ type ElfDynamicSection struct {
 }
 
 // NewBinaryInfo returns an initialized but unloaded BinaryInfo struct.
-func NewBinaryInfo(goos, goarch string) *BinaryInfo {
-	r := &BinaryInfo{GOOS: goos, logger: logflags.DebuggerLogger()}
+func NewBinaryInfo(goos, goarch string, attaching bool) *BinaryInfo {
+	r := &BinaryInfo{GOOS: goos, logger: logflags.DebuggerLogger(), attaching: attaching}
 
 	// TODO: find better way to determine proc arch (perhaps use executable file info).
 	switch goarch {
@@ -1676,6 +1679,9 @@ func (bi *BinaryInfo) openSeparateDebugInfo(image *Image, exe *elf.File, debugIn
 				})
 			}
 		}
+		if bi.attaching {
+			return nil, nil, ErrDebuginfodSkippedOnAttach
+		}
 		debugFilePath, err = debuginfod.GetDebuginfo(bi.downloadsCtx, notify, image.BuildID)
 		if err != nil {
 			return nil, nil, ErrNoDebugInfoFound
@@ -1751,6 +1757,9 @@ func loadBinaryInfoElf(bi *BinaryInfo, image *Image, path string, addr uint64, w
 			}
 			err := loadBinaryInfoGoRuntimeElf(bi, image, path, elfFile)
 			if err != nil {
+				if serr == ErrDebuginfodSkippedOnAttach {
+					return serr
+				}
 				return fmt.Errorf("could not read debug info (%v) and could not read go symbol table (%v)", dwerr, err)
 			}
 			image.IsGo = true

--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -155,9 +155,9 @@ func readLinuxOrPlatformIndependentCore(corePath, exePath string) (*process, pro
 		if err != nil {
 			return nil, nil, err
 		}
-		bi = proc.NewBinaryInfo(goos, goarch)
+		bi = proc.NewBinaryInfo(goos, goarch, false)
 	} else if goarch, ok := supportedLinuxMachines[machineType]; ok {
-		bi = proc.NewBinaryInfo("linux", goarch)
+		bi = proc.NewBinaryInfo("linux", goarch, false)
 	} else {
 		return nil, nil, errors.New("unsupported machine type")
 	}

--- a/pkg/proc/core/windows_amd64_minidump.go
+++ b/pkg/proc/core/windows_amd64_minidump.go
@@ -36,7 +36,7 @@ func readAMD64Minidump(minidumpPath, exePath string) (*process, proc.Thread, err
 	p := &process{
 		mem:         memory,
 		Threads:     map[int]*thread{},
-		bi:          proc.NewBinaryInfo("windows", "amd64"),
+		bi:          proc.NewBinaryInfo("windows", "amd64", false),
 		entryPoint:  entryPoint,
 		breakpoints: proc.NewBreakpointMap(),
 		pid:         int(mdmp.Pid),

--- a/pkg/proc/dwarf_expr_test.go
+++ b/pkg/proc/dwarf_expr_test.go
@@ -41,7 +41,7 @@ func fakeBinaryInfo(t *testing.T, dwb *dwarfbuilder.Builder) (*proc.BinaryInfo, 
 	dwdata, err := dwarf.New(abbrev, aranges, frame, info, line, pubnames, ranges, str)
 	assertNoError(err, t, "creating dwarf")
 
-	bi := proc.NewBinaryInfo("linux", "amd64")
+	bi := proc.NewBinaryInfo("linux", "amd64", false)
 	bi.LoadImageFromData(dwdata, frame, line, loc)
 
 	return bi, dwdata

--- a/pkg/proc/gdbserial/gdbserver.go
+++ b/pkg/proc/gdbserial/gdbserver.go
@@ -225,7 +225,7 @@ type gdbRegnames struct {
 // If process is not nil it is the stub's process and will be killed after
 // Detach.
 // Use Listen, Dial or Connect to complete connection.
-func newProcess(process *os.Process) *gdbProcess {
+func newProcess(process *os.Process, attaching bool) *gdbProcess {
 	logger := logflags.GdbWireLogger()
 	p := &gdbProcess{
 		conn: gdbConn{
@@ -237,7 +237,7 @@ func newProcess(process *os.Process) *gdbProcess {
 			goos:                runtime.GOOS,
 		},
 		threads:        make(map[int]*gdbThread),
-		bi:             proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH),
+		bi:             proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH, attaching),
 		regnames:       new(gdbRegnames),
 		breakpoints:    proc.NewBreakpointMap(),
 		gcmdok:         true,
@@ -573,7 +573,7 @@ func LLDBLaunch(cmd []string, wd string, flags proc.LaunchFlags, debugInfoDirs [
 		return nil, err
 	}
 
-	p := newProcess(process.Process)
+	p := newProcess(process.Process, false)
 	p.conn.isDebugserver = isDebugserver
 
 	var grp *proc.TargetGroup
@@ -655,7 +655,7 @@ func LLDBAttach(pid int, path string, waitFor *proc.WaitFor, debugInfoDirs []str
 		return nil, err
 	}
 
-	p := newProcess(process.Process)
+	p := newProcess(process.Process, true)
 	p.conn.isDebugserver = isDebugserver
 
 	var grp *proc.TargetGroup

--- a/pkg/proc/gdbserial/rr.go
+++ b/pkg/proc/gdbserial/rr.go
@@ -175,7 +175,7 @@ func Replay(tracedir string, quiet, deleteOnDetach bool, debugInfoDirs []string,
 		return nil, init.err
 	}
 
-	p := newProcess(rrcmd.Process)
+	p := newProcess(rrcmd.Process, false)
 	p.tracedir = tracedir
 	p.conn.useXcmd = true // 'rr' does not support the 'M' command which is what we would usually use to write memory, this is only important during function calls, in any other situation writing memory will fail anyway.
 	p.conn.newRRCmdStyle = rrVersion.AfterOrEqual(goversion.GoVersion{Major: 5, Minor: 8, Rev: 0})

--- a/pkg/proc/native/proc.go
+++ b/pkg/proc/native/proc.go
@@ -54,7 +54,7 @@ func newProcess(pid int) *nativeProcess {
 		firstStart:   true,
 		os:           new(osProcessDetails),
 		ptraceThread: newPtraceThread(),
-		bi:           proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH),
+		bi:           proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH, pid != 0),
 	}
 	return dbp
 }
@@ -68,7 +68,7 @@ func newChildProcess(dbp *nativeProcess, pid int) *nativeProcess {
 		firstStart:   true,
 		os:           new(osProcessDetails),
 		ptraceThread: dbp.ptraceThread.acquire(),
-		bi:           proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH),
+		bi:           proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH, false),
 	}
 }
 

--- a/pkg/proc/proc_general_test.go
+++ b/pkg/proc/proc_general_test.go
@@ -141,7 +141,7 @@ func assertNoError(err error, t testing.TB, s string) {
 func TestDwarfVersion(t *testing.T) {
 	// Tests that we correctly read the version of compilation units
 	fixture := protest.BuildFixture(t, "math", 0)
-	bi := NewBinaryInfo(runtime.GOOS, runtime.GOARCH)
+	bi := NewBinaryInfo(runtime.GOOS, runtime.GOARCH, false)
 	// Use a fake entry point so LoadBinaryInfo does not error in case the binary is PIE.
 	const fakeEntryPoint = 1
 	assertNoError(bi.LoadBinaryInfo(fixture.Path, fakeEntryPoint, nil), t, "LoadBinaryInfo")
@@ -158,7 +158,7 @@ func TestRegabiFlagSentinel(t *testing.T) {
 		t.Skip("irrelevant before Go 1.17 or on non-amd64 architectures")
 	}
 	fixture := protest.BuildFixture(t, "math", 0)
-	bi := NewBinaryInfo(runtime.GOOS, runtime.GOARCH)
+	bi := NewBinaryInfo(runtime.GOOS, runtime.GOARCH, false)
 	// Use a fake entry point so LoadBinaryInfo does not error in case the binary is PIE.
 	const fakeEntryPoint = 1
 	assertNoError(bi.LoadBinaryInfo(fixture.Path, fakeEntryPoint, nil), t, "LoadBinaryInfo")

--- a/pkg/proc/proc_linux_test.go
+++ b/pkg/proc/proc_linux_test.go
@@ -57,11 +57,11 @@ func TestGnuDebuglink(t *testing.T) {
 	run("objcopy", "--add-gnu-debuglink="+debuglinkDwoPath, debuglinkPath)
 
 	// open original executable
-	normalBinInfo := proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH)
+	normalBinInfo := proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH, false)
 	assertNoError(normalBinInfo.LoadBinaryInfo(fixture.Path, 0, []string{"/debugdir"}), t, "LoadBinaryInfo (normal exe)")
 
 	// open .gnu_debuglink executable
-	debuglinkBinInfo := proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH)
+	debuglinkBinInfo := proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH, false)
 	assertNoError(debuglinkBinInfo.LoadBinaryInfo(debuglinkPath, 0, []string{"/debugdir"}), t, "LoadBinaryInfo (gnu_debuglink exe)")
 
 	if len(normalBinInfo.Functions) != len(debuglinkBinInfo.Functions) {

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -4697,7 +4697,7 @@ func TestIssue2319(t *testing.T) {
 	fixture := protest.BuildFixture(t, "issue2319/", protest.BuildModeExternalLinker)
 
 	// Load up the binary and make sure there are no crashes.
-	bi := proc.NewBinaryInfo("linux", "amd64")
+	bi := proc.NewBinaryInfo("linux", "amd64", false)
 	assertNoError(bi.LoadBinaryInfo(fixture.Path, 0, nil), t, "LoadBinaryInfo")
 }
 
@@ -6147,7 +6147,7 @@ func TestDelveCatch(t *testing.T) {
 
 func TestTrimpathDetection(t *testing.T) {
 	f1 := protest.BuildFixture(t, "math", 0)
-	bi1 := proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH)
+	bi1 := proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH, false)
 	assertNoError(bi1.LoadBinaryInfo(f1.Path, 0x10000, nil), t, "LoadBinaryInfo")
 	if bi1.Images[0].Trimpath {
 		t.Error("expected trimpath used to be false, was true")
@@ -6157,7 +6157,7 @@ func TestTrimpathDetection(t *testing.T) {
 	buildinfo, _ := buildinfo.ReadFile(f2.Path)
 	fmt.Printf("%#v\n", buildinfo)
 
-	b2 := proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH)
+	b2 := proc.NewBinaryInfo(runtime.GOOS, runtime.GOARCH, false)
 	assertNoError(b2.LoadBinaryInfo(f2.Path, 0x10000, nil), t, "LoadBinaryInfo")
 	if !b2.Images[0].Trimpath {
 		t.Error("expected trimpath used to be true, was false")

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -78,6 +78,8 @@ func (grp *TargetGroup) Continue() error {
 			grp.finishManualStop()
 		}
 	}()
+	hadAttaching := grp.targets[0].BinInfo().attaching
+	grp.targets[0].BinInfo().attaching = false
 	for {
 		err := grp.manageUnsatisfiableBreakpoints()
 		if err != nil {
@@ -153,6 +155,21 @@ func (grp *TargetGroup) Continue() error {
 			it.Reset()
 			for it.Next() {
 				it.Target.ClearSteppingBreakpoints()
+			}
+		}
+
+		if hadAttaching {
+			hadAttaching = false
+			if valid, _ := grp.targets[0].Valid(); valid {
+				bi := grp.targets[0].BinInfo()
+				for i := 1; i < len(bi.Images); i++ {
+					if bi.Images[i].loadErr == ErrDebuginfodSkippedOnAttach {
+						err := loadBinaryInfo(bi, bi.Images[i], bi.Images[i].Path, bi.Images[i].addr)
+						if err != nil {
+							bi.Images[i].loadErr = err
+						}
+					}
+				}
 			}
 		}
 
@@ -625,6 +642,7 @@ func (grp *TargetGroup) StepOut() error {
 // threads will remain stopped.
 func (grp *TargetGroup) StepInstruction(skipCalls bool) (err error) {
 	dbp := grp.Selected
+	dbp.BinInfo().attaching = false
 	thread := dbp.CurrentThread()
 	g := dbp.SelectedGoroutine()
 	if g != nil {

--- a/pkg/proc/variables_fuzz_test.go
+++ b/pkg/proc/variables_fuzz_test.go
@@ -48,7 +48,7 @@ func FuzzEvalExpression(f *testing.F) {
 	if os.IsNotExist(err) {
 		f.Skip("not setup")
 	}
-	bi := proc.NewBinaryInfo("linux", "amd64")
+	bi := proc.NewBinaryInfo("linux", "amd64", false)
 	assertNoError(bi.LoadBinaryInfo(fuzzExecutable, 0, nil), f, "LoadBinaryInfo")
 	fh, err := os.Open(fuzzInfoPath)
 	assertNoError(err, f, "Open fuzzInfoPath")


### PR DESCRIPTION
Calling debuginfod-find can lead to minute long pauses, if we do it
while we are executing the Attach constructors we have no way of
notifying the user about this and the user has no way of aborting the
operation.

This means that delve will appear to be stuck somewhere, for long
periods of time.

This change disables debuginfod calls immediately after attach (to an
existing process). The libraries that weren't loaded this way will be
loaded after the next continue when clients can set up a notification
channel and disable them with CancelDownloads.

A followup commit will extend the functionality of
DownloadLibraryDebugInfo, so that it too can print notifications, and
also call it automatically from the client after an attach.
