### PR TITLE
proc: fix infinite loop in mapIteratorSwiss.next

### DIFF
--- a/pkg/proc/eval.go
+++ b/pkg/proc/eval.go
@@ -2883,6 +2883,10 @@ func (v *Variable) sliceAccess(idx int) (*Variable, error) {
 }
 
 func (v *Variable) mapAccess(idx *Variable) (*Variable, error) {
+	// TODO(aarzilli): here if the memory is corrupt we could end up looking at
+	// a lot of memory, and taking a long time. However there is also no
+	// obvious limit that we can impose.
+	// Maybe this isn't necessary, segfaults may stop us quickly enough.
 	it := v.mapIterator(0)
 	if it == nil {
 		return nil, fmt.Errorf("can not access unreadable map: %v", v.Unreadable)

--- a/pkg/proc/mapiter.go
+++ b/pkg/proc/mapiter.go
@@ -508,12 +508,17 @@ func (it *mapIteratorSwiss) next() bool {
 		return false
 	}
 	for it.dirIdx < it.dirLen {
+		if it.maxNumGroups > 0 && it.groupIdx+it.groupCount >= it.maxNumGroups {
+			it.v.Unreadable = fmt.Errorf("max number of groups exceeded: %d", it.groupCount)
+			return false
+		}
 		if it.tab == nil {
 			it.loadCurrentTable()
 			if it.tab == nil {
 				return false
 			}
 			if it.tab.index != it.dirIdx {
+				it.groupCount++ // count this as visiting a group so that maxNumGroups is held even if memory is corrupted and there are no real tables.
 				it.nextTable()
 				continue
 			}
@@ -521,6 +526,7 @@ func (it *mapIteratorSwiss) next() bool {
 
 		for ; it.groupIdx < uint64(it.tab.groups.Len); it.nextGroup() {
 			if it.maxNumGroups > 0 && it.groupIdx+it.groupCount >= it.maxNumGroups {
+				it.v.Unreadable = fmt.Errorf("max number of groups exceeded: %d", it.groupCount)
 				return false
 			}
 			if it.group == nil {
@@ -642,9 +648,15 @@ func (it *mapIteratorSwiss) loadCurrentTable() {
 	}
 
 	// convert the type of groups from *group to *[len]group so that it's easier to use
-	r.groups.DwarfType = pointerTo(fakeArrayType(groupsLengthMask+1, it.groupType), it.v.bi.Arch)
+	fat := fakeArrayType(groupsLengthMask+1, it.groupType)
+	r.groups.DwarfType = pointerTo(fat, it.v.bi.Arch)
 	r.groups.RealType = r.groups.DwarfType
 	r.groups = r.groups.maybeDereference()
+	if r.groups.stride != fat.(*godwarf.ArrayType).StrideBitSize/8 {
+		// This discrpancy indicates an overflow in the multiplication of the
+		// element type size and the number of elements in fakeArrayType.
+		it.v.Unreadable = fmt.Errorf("impossible table lenght in swiss table: %d", groupsLengthMask)
+	}
 
 	if r.groups.Addr == 0 {
 		it.v.Unreadable = errSwissTableNilGroups

--- a/pkg/proc/variables.go
+++ b/pkg/proc/variables.go
@@ -173,7 +173,7 @@ type LoadConfig struct {
 	//
 	// When this happens delve will have to scan many empty buckets to find the
 	// few entries in the map.
-	// MaxMapBuckets can be set to avoid annoying slowdowns␣while reading
+	// MaxMapBuckets can be set to avoid annoying slowdowns while reading
 	// very sparse maps.
 	//
 	// Since there is no good way for a user of delve to specify the value of


### PR DESCRIPTION
Fixes a bug found by the fuzzer in
https://github.com/go-delve/delve/actions/runs/32555989728.

If the table length is too large (because of memory corruption) the
multiplication between that value and the size of the group struct can
overflow. If the overflow is just right the resulting stride will be
zero, causing the loop in mapIteratorSwiss.next to never progress.

Also changes said loop to respect maxNumGroups even when we can't load
any tables but dirLen is large. This is unrelated to the fuzzer bug, it
was merely spotted during the investigation.

We might need some other mechanism to stop the search in mapAccess
early if the table is enormous, or appears to be because of memory
corruption, but doesn't cause an integer overflow. However there are no
obvious limits to impose there so leave it for now.
