### PR TITLE
terminal,service,proc: add set next statement (jump) command

### DIFF
--- a/Documentation/cli/README.md
+++ b/Documentation/cli/README.md
@@ -12,6 +12,7 @@ Command | Description
 --------|------------
 [call](#call) | Resumes process, injecting a function call (EXPERIMENTAL!!!)
 [continue](#continue) | Run until breakpoint or program termination.
+[jump](#jump) | Set the next instruction to be executed (EXPERIMENTAL!!!).
 [next](#next) | Step over to next source line.
 [next-instruction](#next-instruction) | Single step a single cpu instruction, skipping function calls.
 [rebuild](#rebuild) | Rebuild the target executable and restarts it. It does not work if the executable was not built by delve.
@@ -492,6 +493,23 @@ Prints the help message.
 Type "help" followed by the name of a command for more information about it.
 
 Aliases: h
+
+## jump
+Set the next instruction to be executed (EXPERIMENTAL!!!).
+
+	jump <linespec>
+
+Sets the next instruction to be executed to the location given by &lt;linespec>,
+without executing any of the instructions in between (also known as "set next
+statement"). The target must be inside the current function.
+
+WARNING: this is unsafe. Even with optimizations disabled the compiler
+reorders instructions and inserts hidden initialization, so skipping over code
+can skip setup that later instructions rely on.
+
+See also: "help locspec".
+
+Aliases: j
 
 ## libraries
 List loaded dynamic libraries.

--- a/Documentation/cli/starlark.md
+++ b/Documentation/cli/starlark.md
@@ -65,6 +65,7 @@ process_pid() | Equivalent to API call [ProcessPid](https://pkg.go.dev/github.co
 recorded() | Equivalent to API call [Recorded](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Recorded)
 restart(Position, ResetArgs, NewArgs, Rerecord, Rebuild, NewRedirects) | Equivalent to API call [Restart](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Restart)
 set_expr(Scope, Symbol, Value) | Equivalent to API call [Set](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Set)
+set_execution_point(Addr) | Equivalent to API call [SetExecutionPoint](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.SetExecutionPoint)
 stacktrace(Id, Depth, Full, Defers, Opts, Cfg, Skip) | Equivalent to API call [Stacktrace](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.Stacktrace)
 state(NonBlocking) | Equivalent to API call [State](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.State)
 toggle_breakpoint(Id, Name) | Equivalent to API call [ToggleBreakpoint](https://pkg.go.dev/github.com/go-delve/delve/service/rpc2#RPCServer.ToggleBreakpoint)

--- a/_fixtures/setnextstatement.go
+++ b/_fixtures/setnextstatement.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+func demo() {
+	n := 0
+	n++
+	n++
+	fmt.Println(n)
+}
+
+func other() {
+	fmt.Println("other")
+}
+
+func main() {
+	demo()
+	other()
+}

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -352,6 +352,40 @@ func (t *Target) SwitchThread(tid int) error {
 	return fmt.Errorf("thread %d does not exist", tid)
 }
 
+// SetNextExecutionPoint sets the program counter of the current thread to
+// addr without executing any of the instructions in between, also known as
+// "set next statement" or "jump". addr must be inside the function the
+// current thread is stopped in: jumping to a different function would leave
+// the stack frame set up for the old function and corrupt execution.
+//
+// Even with optimizations disabled the compiler reorders instructions and
+// inserts hidden initialization, so skipping over code can skip setup that
+// later instructions rely on.
+func (t *Target) SetNextExecutionPoint(addr uint64) error {
+	if ok, err := t.Valid(); !ok {
+		return err
+	}
+
+	thread := t.CurrentThread()
+	regs, err := thread.Registers()
+	if err != nil {
+		return err
+	}
+
+	currentFn := t.BinInfo().PCToFunc(regs.PC())
+	destFn := t.BinInfo().PCToFunc(addr)
+	if currentFn == nil || destFn == nil || currentFn != destFn {
+		return errors.New("can not set the next execution point outside of the current function")
+	}
+
+	if err := setPC(thread, addr); err != nil {
+		return err
+	}
+
+	t.selectedGoroutine, _ = GetG(t.CurrentThread())
+	return nil
+}
+
 // setAsyncPreemptOff enables or disables async goroutine preemption by
 // writing the value 'v' to runtime.debug.asyncpreemptoff.
 // A value of '1' means off, a value of '0' means on.

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -227,6 +227,19 @@ Current limitations:
 - calling a function will resume execution of all goroutines.
 - only supported on linux's native backend.
 `},
+		{aliases: []string{"jump", "j"}, group: runCmds, cmdFn: setNextStatement, helpMsg: `Set the next instruction to be executed (EXPERIMENTAL!!!).
+
+	jump <linespec>
+
+Sets the next instruction to be executed to the location given by <linespec>,
+without executing any of the instructions in between (also known as "set next
+statement"). The target must be inside the current function.
+
+WARNING: this is unsafe. Even with optimizations disabled the compiler
+reorders instructions and inserts hidden initialization, so skipping over code
+can skip setup that later instructions rely on.
+
+See also: "help locspec".`},
 		{aliases: []string{"threads"}, group: goroutineCmds, cmdFn: threads, helpMsg: "Print out info for every traced thread."},
 		{aliases: []string{"thread", "tr"}, group: goroutineCmds, cmdFn: thread, helpMsg: `Switch to the specified thread.
 
@@ -1512,6 +1525,29 @@ func stepInstruction(t *Term, ctx callContext, frame int, skipCalls bool) error 
 	}
 	printcontext(t, state)
 	printPos(t, state.CurrentThread, printPosShowArrow|printPosStepInstruction)
+	return nil
+}
+
+func setNextStatement(t *Term, ctx callContext, args string) error {
+	if args == "" {
+		return errors.New("jump requires a location")
+	}
+
+	locs, _, err := t.client.FindLocation(ctx.Scope, args, false, t.substitutePathRules())
+	if err != nil {
+		return err
+	}
+	if len(locs) != 1 {
+		return errors.New("can not jump to a location that resolves to multiple addresses")
+	}
+
+	state, err := t.client.SetExecutionPoint(locs[0].PC)
+	if err != nil {
+		return err
+	}
+
+	printcontext(t, state)
+	printPos(t, state.CurrentThread, printPosShowArrow)
 	return nil
 }
 

--- a/pkg/terminal/starbind/starlark_mapping.go
+++ b/pkg/terminal/starbind/starlark_mapping.go
@@ -1654,6 +1654,37 @@ func (env *Env) starlarkPredeclare() (starlark.StringDict, map[string]string) {
 		return env.interfaceToStarlarkValue(&rpcRet), nil
 	})
 	doc["set_expr"] = "builtin set_expr(Scope, Symbol, Value)\n\nset_expr sets the value of a variable. Only numerical types and\npointers are currently supported."
+	r["set_execution_point"] = starlark.NewBuiltin("set_execution_point", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		if err := isCancelled(thread); err != nil {
+			return starlark.None, decorateError(thread, err)
+		}
+		var rpcArgs rpc2.SetExecutionPointIn
+		var rpcRet rpc2.SetExecutionPointOut
+		if len(args) > 0 && args[0] != starlark.None {
+			err := unmarshalStarlarkValue(args[0], &rpcArgs.Addr, "Addr")
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
+		for _, kv := range kwargs {
+			var err error
+			switch kv[0].(starlark.String) {
+			case "Addr":
+				err = unmarshalStarlarkValue(kv[1], &rpcArgs.Addr, "Addr")
+			default:
+				err = fmt.Errorf("unknown argument %q", kv[0])
+			}
+			if err != nil {
+				return starlark.None, decorateError(thread, err)
+			}
+		}
+		err := env.ctx.Client().CallAPI("SetExecutionPoint", &rpcArgs, &rpcRet)
+		if err != nil {
+			return starlark.None, err
+		}
+		return env.interfaceToStarlarkValue(&rpcRet), nil
+	})
+	doc["set_execution_point"] = "builtin set_execution_point(Addr)\n\nset_execution_point sets the next instruction to be executed by the current\nthread to the instruction at arg.Addr, without executing any of the\ninstructions in between (also known as \"set next statement\" or \"jump\"). The\ntarget address must be inside the function the current thread is stopped in."
 	r["stacktrace"] = starlark.NewBuiltin("stacktrace", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		if err := isCancelled(thread); err != nil {
 			return starlark.None, decorateError(thread, err)

--- a/service/client.go
+++ b/service/client.go
@@ -72,6 +72,9 @@ type Client interface {
 	GetBreakpointByName(name string) (*api.Breakpoint, error)
 	// CreateBreakpoint creates a new breakpoint.
 	CreateBreakpoint(*api.Breakpoint) (*api.Breakpoint, error)
+	// SetExecutionPoint sets the next instruction to be executed by the current
+	// thread to the instruction at the given address ("set next statement").
+	SetExecutionPoint(addr uint64) (*api.DebuggerState, error)
 	// CreateBreakpointWithExpr creates a new breakpoint and sets an expression to restore it after it is disabled.
 	CreateBreakpointWithExpr(*api.Breakpoint, string, [][2]string, bool) (*api.Breakpoint, error)
 	// CreateWatchpoint creates a new watchpoint.

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -822,6 +822,17 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string,
 	return createdBp, nil
 }
 
+// SetExecutionPoint sets the next instruction to be executed by the current
+// thread to addr, without executing any of the instructions in between (also
+// known as "set next statement" or "jump"). The target address must be inside
+// the function the current thread is stopped in.
+func (d *Debugger) SetExecutionPoint(addr uint64) error {
+	d.targetMutex.Lock()
+	defer d.targetMutex.Unlock()
+
+	return d.target.Selected.SetNextExecutionPoint(addr)
+}
+
 func (d *Debugger) convertBreakpoint(lbp *proc.LogicalBreakpoint) *api.Breakpoint {
 	abp := api.ConvertLogicalBreakpoint(lbp)
 	bps := []*proc.Breakpoint{}

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -294,6 +294,15 @@ func (c *RPCClient) CreateBreakpoint(breakPoint *api.Breakpoint) (*api.Breakpoin
 	return &out.Breakpoint, err
 }
 
+// SetExecutionPoint sets the next instruction to be executed by the current
+// thread to the instruction at addr, without executing any of the
+// instructions in between (also known as "set next statement" or "jump").
+func (c *RPCClient) SetExecutionPoint(addr uint64) (*api.DebuggerState, error) {
+	var out SetExecutionPointOut
+	err := c.call("SetExecutionPoint", SetExecutionPointIn{Addr: addr}, &out)
+	return &out.State, err
+}
+
 // CreateBreakpointWithExpr is like CreateBreakpoint but will also set a
 // location expression to be used to restore the breakpoint after it is
 // disabled.

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -292,6 +292,31 @@ func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpoi
 	return nil
 }
 
+type SetExecutionPointIn struct {
+	// Addr is the address of the instruction to jump to.
+	Addr uint64
+}
+
+type SetExecutionPointOut struct {
+	State api.DebuggerState
+}
+
+// SetExecutionPoint sets the next instruction to be executed by the current
+// thread to the instruction at arg.Addr, without executing any of the
+// instructions in between (also known as "set next statement" or "jump"). The
+// target address must be inside the function the current thread is stopped in.
+func (s *RPCServer) SetExecutionPoint(arg SetExecutionPointIn, out *SetExecutionPointOut) error {
+	if err := s.debugger.SetExecutionPoint(arg.Addr); err != nil {
+		return err
+	}
+	state, err := s.debugger.State(false)
+	if err != nil {
+		return err
+	}
+	out.State = *state
+	return nil
+}
+
 type CreateEBPFTracepointIn struct {
 	FunctionName string
 }

--- a/service/rpccommon/suitablemethods.go
+++ b/service/rpccommon/suitablemethods.go
@@ -59,6 +59,7 @@ func suitableMethods2(s *rpc2.RPCServer, methods map[string]*methodType) {
 	methods["RPCServer.Recorded"] = &methodType{method: reflect.ValueOf(s.Recorded)}
 	methods["RPCServer.Restart"] = &methodType{method: reflect.ValueOf(s.Restart)}
 	methods["RPCServer.Set"] = &methodType{method: reflect.ValueOf(s.Set)}
+	methods["RPCServer.SetExecutionPoint"] = &methodType{method: reflect.ValueOf(s.SetExecutionPoint)}
 	methods["RPCServer.Stacktrace"] = &methodType{method: reflect.ValueOf(s.Stacktrace)}
 	methods["RPCServer.State"] = &methodType{method: reflect.ValueOf(s.State)}
 	methods["RPCServer.StopRecording"] = &methodType{method: reflect.ValueOf(s.StopRecording)}

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -322,6 +322,53 @@ func TestClientServer_step(t *testing.T) {
 	})
 }
 
+func TestClientServer_setNextStatement(t *testing.T) {
+	// Setting the execution point writes to the PC register, which is not
+	// possible on an immutable recording, so this test does not allow
+	// recording and is skipped on the rr backend.
+	withTestClient2Extended("setnextstatement", t, 0, [3]string{}, nil, func(c service.Client, fixture protest.Fixture) {
+		scope := api.EvalScope{GoroutineID: -1}
+
+		findPC := func(line int) uint64 {
+			locs, _, err := c.FindLocation(scope, fmt.Sprintf("%s:%d", fixture.Source, line), false, nil)
+			assertNoError(err, t, fmt.Sprintf("FindLocation(:%d)", line))
+			if len(locs) != 1 {
+				t.Fatalf("FindLocation(:%d) returned %d locations", line, len(locs))
+			}
+			return locs[0].PC
+		}
+
+		// Stop on the second increment (line 8) inside main.demo.
+		_, err := c.CreateBreakpoint(&api.Breakpoint{Addr: findPC(8)})
+		assertNoError(err, t, "CreateBreakpoint()")
+		state := <-c.Continue()
+		assertNoError(state.Err, t, "Continue()")
+		if state.CurrentThread.Line != 8 {
+			t.Fatalf("expected to stop at line 8, stopped at %d", state.CurrentThread.Line)
+		}
+
+		// Jumping backwards within the same function is allowed.
+		line6PC := findPC(6)
+		state, err = c.SetExecutionPoint(line6PC)
+		assertNoError(err, t, "SetExecutionPoint(:6)")
+		if state.CurrentThread.Line != 6 {
+			t.Fatalf("expected execution point at line 6, got line %d", state.CurrentThread.Line)
+		}
+		if state.CurrentThread.PC != line6PC {
+			t.Fatalf("expected PC %#x, got %#x", line6PC, state.CurrentThread.PC)
+		}
+
+		// Jumping into a different function (main.other) must be rejected.
+		_, err = c.SetExecutionPoint(findPC(13))
+		if err == nil {
+			t.Fatal("expected SetExecutionPoint into a different function to fail")
+		}
+		if !strings.Contains(err.Error(), "outside of the current function") {
+			t.Fatalf("unexpected error jumping across functions: %v", err)
+		}
+	})
+}
+
 func TestClientServer_stepout(t *testing.T) {
 	protest.AllowRecording(t)
 	withTestClient2("testnextprog", t, func(c service.Client) {


### PR DESCRIPTION
Adds a "jump" (alias "j") command and a SetExecutionPoint RPC method that set the next instruction to be executed by the current thread to a given location, without executing any of the instructions in between.

The target must be inside the function the current thread is stopped in as jumping to a different function would leave the stack frame set up for the old function and corrupt execution.

Fixes #1045