### PR TITLE
proc,service: emit events while calling DownloadLibraryDebugInfo

### DIFF
--- a/cmd/dlv/cmds/commands.go
+++ b/cmd/dlv/cmds/commands.go
@@ -291,7 +291,7 @@ or later, -gcflags="-N -l" on earlier versions of Go.`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			os.Exit(execute(0, args, conf, "", debugger.ExecutingExistingFile, args, buildFlags))
+			os.Exit(execute(0, args, conf, "", debugger.ExecutingExistingFile, args, buildFlags, false))
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
@@ -437,7 +437,7 @@ https://github.com/mozilla/rr
 			Run: func(cmd *cobra.Command, args []string) {
 				backend = "rr"
 				rrDelOnDetach = false
-				os.Exit(execute(0, []string{}, conf, args[0], debugger.ExecutingOther, args, buildFlags))
+				os.Exit(execute(0, []string{}, conf, args[0], debugger.ExecutingOther, args, buildFlags, false))
 			},
 			ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 				if len(args) > 2 {
@@ -664,7 +664,7 @@ func debugCmd(cmd *cobra.Command, args []string) {
 		}
 		defer gobuild.Remove(debugname)
 		processArgs := append([]string{debugname}, targetArgs...)
-		return execute(0, processArgs, conf, "", debugger.ExecutingGeneratedFile, dlvArgs, buildFlags)
+		return execute(0, processArgs, conf, "", debugger.ExecutingGeneratedFile, dlvArgs, buildFlags, false)
 	}()
 	os.Exit(status)
 }
@@ -839,7 +839,7 @@ func traceCmd(cmd *cobra.Command, args []string, conf *config.Config) int {
 		cfg := &config.Config{
 			TraceShowTimestamp: traceShowTimestamp,
 		}
-		t := terminal.New(client, cfg)
+		t := terminal.New(client, cfg, false)
 		t.SetTraceNonInteractive()
 		t.TraceVerbosity = traceVerbose
 		t.RedirectTo(os.Stderr)
@@ -938,7 +938,7 @@ func testCmd(cmd *cobra.Command, args []string) {
 			workingDir = getPackageDir(dlvArgs)
 		}
 
-		return execute(0, processArgs, conf, "", debugger.ExecutingGeneratedTest, dlvArgs, buildFlags)
+		return execute(0, processArgs, conf, "", debugger.ExecutingGeneratedTest, dlvArgs, buildFlags, false)
 	}()
 	os.Exit(status)
 }
@@ -972,11 +972,11 @@ func attachCmd(_ *cobra.Command, args []string) {
 		}
 		args = args[1:]
 	}
-	os.Exit(execute(pid, args, conf, "", debugger.ExecutingOther, args, buildFlags))
+	os.Exit(execute(pid, args, conf, "", debugger.ExecutingOther, args, buildFlags, true))
 }
 
 func coreCmd(_ *cobra.Command, args []string) {
-	os.Exit(execute(0, []string{args[0]}, conf, args[1], debugger.ExecutingOther, args, buildFlags))
+	os.Exit(execute(0, []string{args[0]}, conf, args[1], debugger.ExecutingOther, args, buildFlags, false))
 }
 
 func connectCmd(_ *cobra.Command, args []string) {
@@ -994,7 +994,7 @@ func connectCmd(_ *cobra.Command, args []string) {
 		logflags.Close()
 		os.Exit(1)
 	}
-	ec := connect(addr, nil, conf)
+	ec := connect(addr, nil, conf, false)
 	logflags.Close()
 	os.Exit(ec)
 }
@@ -1032,7 +1032,7 @@ func splitArgs(cmd *cobra.Command, args []string) ([]string, []string) {
 	return args, []string{}
 }
 
-func connect(addr string, clientConn net.Conn, conf *config.Config) int {
+func connect(addr string, clientConn net.Conn, conf *config.Config, isAttachCmd bool) int {
 	// Create and start a terminal - attach to running instance
 	var client *rpc2.RPCClient
 	if clientConn == nil {
@@ -1055,7 +1055,7 @@ func connect(addr string, clientConn net.Conn, conf *config.Config) int {
 			}
 		}
 	}
-	term := terminal.New(client, conf)
+	term := terminal.New(client, conf, isAttachCmd)
 	term.InitFile = initFile
 	status, err := term.Run()
 	if err != nil {
@@ -1064,7 +1064,7 @@ func connect(addr string, clientConn net.Conn, conf *config.Config) int {
 	return status
 }
 
-func execute(attachPid int, processArgs []string, conf *config.Config, coreFile string, kind debugger.ExecuteKind, dlvArgs []string, buildFlags string) int {
+func execute(attachPid int, processArgs []string, conf *config.Config, coreFile string, kind debugger.ExecuteKind, dlvArgs []string, buildFlags string, isAttachCmd bool) int {
 	if err := logflags.Setup(logFlag, logOutput, logDest); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return 1
@@ -1217,7 +1217,7 @@ func execute(attachPid int, processArgs []string, conf *config.Config, coreFile 
 		return 0
 	}
 
-	return connect(listener.Addr().String(), clientConn, conf)
+	return connect(listener.Addr().String(), clientConn, conf, isAttachCmd)
 }
 
 func parseRedirects(redirects []string) ([3]string, error) {

--- a/pkg/proc/bininfo.go
+++ b/pkg/proc/bininfo.go
@@ -1155,8 +1155,18 @@ func (bi *BinaryInfo) AddImage(path string, addr uint64) error {
 	return err
 }
 
+// ResetDownloadsContext resets the downloads context. If the context was
+// cancelled before this BinaryInfo object will be able to do downloads
+// again.
+func (bi *BinaryInfo) ResetDownloadsContext() {
+	bi.cancelDownloadsMu.Lock()
+	bi.downloadsCtx, bi.cancelDownloads = context.WithCancel(context.Background())
+	bi.cancelDownloadsMu.Unlock()
+}
+
 // LoadImageBinaryInfoAgain loads the n-th image debug symbols if they weren't already loaded.
 func (bi *BinaryInfo) LoadImageBinaryInfoAgain(n int) error {
+	bi.attaching = false
 	if n < 0 || n >= len(bi.Images) || bi.Images[n].loadErr == nil {
 		return nil
 	}

--- a/pkg/proc/target_group.go
+++ b/pkg/proc/target_group.go
@@ -651,6 +651,7 @@ const (
 	EventBinaryInfoDownload
 	EventBreakpointMaterialized
 	EventProcessSpawned
+	EventDownloadLibraryInfoDone
 )
 
 // BinaryInfoDownloadEventDetails describes the details of a BinaryInfoDownloadEvent

--- a/pkg/terminal/command.go
+++ b/pkg/terminal/command.go
@@ -2724,11 +2724,10 @@ func libraries(t *Term, ctx callContext, args string) error {
 			if err != nil {
 				return err
 			}
-			t.client.DownloadLibraryDebugInfo(n)
+			return t.client.DownloadLibraryDebugInfo(n)
 		default:
 			return errors.New("wrong arguments")
 		}
-		return nil
 	}
 
 	libs, _, err := t.client.ListDynamicLibraries()

--- a/pkg/terminal/command_test.go
+++ b/pkg/terminal/command_test.go
@@ -152,7 +152,7 @@ func withTestTerminalBuildFlags(name string, t testing.TB, buildFlags test.Build
 
 	ft := &FakeTerminal{
 		t:    t,
-		Term: New(client, &config.Config{}),
+		Term: New(client, &config.Config{}, false),
 	}
 	fn(ft)
 }
@@ -1340,7 +1340,7 @@ func TestClearCondBreakpoint(t *testing.T) {
 func TestBreakpointEditing(t *testing.T) {
 	term := &FakeTerminal{
 		t:    t,
-		Term: New(nil, &config.Config{}),
+		Term: New(nil, &config.Config{}, false),
 	}
 	_ = term
 
@@ -1997,7 +1997,6 @@ func TestCommandPromptExpansion(t *testing.T) {
 		}
 	})
 }
-
 
 // TestPrintShowRawStrings tests the show-raw-strings config option that
 // controls whether escape characters in string values are displayed as

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -166,6 +166,7 @@ func New(client service.Client, conf *config.Config, isAttachCmd bool) *Term {
 				if !firstEventBinaryInfoDownload {
 					fmt.Fprintf(t.stdout, "\n")
 				}
+				firstEventBinaryInfoDownload = true
 			case api.EventBreakpointMaterialized:
 				bp := event.BreakpointMaterializedEventDetails.Breakpoint
 				file := t.formatPath(bp.File)

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -73,6 +73,9 @@ type Term struct {
 
 	substitutePathRulesCache [][2]string
 
+	// isAttachCmd is true if this terminal was stated by 'dlv attach...'
+	isAttachCmd bool
+
 	// quitContinue is set to true by exitCommand to signal that the process
 	// should be resumed before quitting.
 	quitContinue bool
@@ -104,7 +107,7 @@ type displayEntry struct {
 }
 
 // New returns a new Term.
-func New(client service.Client, conf *config.Config) *Term {
+func New(client service.Client, conf *config.Config, isAttachCmd bool) *Term {
 	cmds := DebugCommands(client)
 	if conf != nil && conf.Aliases != nil {
 		cmds.Merge(conf.Aliases)
@@ -120,6 +123,8 @@ func New(client service.Client, conf *config.Config) *Term {
 		line:   liner.NewLiner(),
 		cmds:   cmds,
 		stdout: &transcriptWriter{pw: &pagingWriter{w: os.Stdout}},
+
+		isAttachCmd: isAttachCmd,
 	}
 	t.line.SetCtrlZStop(true)
 
@@ -154,7 +159,7 @@ func New(client service.Client, conf *config.Config) *Term {
 				}
 				fmt.Fprintf(t.stdout, "Downloading debug info for %s: %s (press ^C to cancel)", event.BinaryInfoDownloadEventDetails.ImagePath, event.BinaryInfoDownloadEventDetails.Progress)
 				firstEventBinaryInfoDownload = false
-			case api.EventStopped:
+			case api.EventStopped, api.EventDownloadLibraryInfoDone:
 				t.downloadsMu.Lock()
 				t.downloadsInProgress = false
 				t.downloadsMu.Unlock()
@@ -415,6 +420,10 @@ func (t *Term) Run() (int, error) {
 	// Ensure that the target process is neither running nor recording by
 	// making a blocking call.
 	_, _ = t.client.GetState()
+
+	if t.isAttachCmd {
+		t.client.DownloadLibraryDebugInfo(-1)
+	}
 
 	for {
 		locs = nil

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -751,6 +751,7 @@ const (
 	EventBinaryInfoDownload
 	EventBreakpointMaterialized
 	EventProcessSpawned
+	EventDownloadLibraryInfoDone
 )
 
 // BinaryInfoDownloadEventDetails describes the details of a BinaryInfoDownloadEvent

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -458,6 +458,8 @@ type DebuggerCommand struct {
 
 	// If WithEvents is set events are generated that should be read by calling
 	// GetEvents.
+	// A client specifying this is responsible for calling GetEvents repeatedly
+	// until an EventStopped is seen.
 	WithEvents bool
 
 	// UnsafeCall disables parameter escape checking for function calls.
@@ -746,12 +748,12 @@ type Event struct {
 type EventKind uint8
 
 const (
-	EventResumed EventKind = iota
-	EventStopped
-	EventBinaryInfoDownload
-	EventBreakpointMaterialized
-	EventProcessSpawned
-	EventDownloadLibraryInfoDone
+	EventResumed                 EventKind = iota // The target process has resumed
+	EventStopped                                  // The target process stopped, there will be no more events until Command is called again
+	EventBinaryInfoDownload                       // Delve is downloading the debug symbols for a library, using debuginfod
+	EventBreakpointMaterialized                   // A previously suspended breakpoint has been materialized
+	EventProcessSpawned                           // A new child process has been spawned
+	EventDownloadLibraryInfoDone                  // The DownloadLibraryDebugInfo call has finished its work
 )
 
 // BinaryInfoDownloadEventDetails describes the details of a BinaryInfoDownloadEvent

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2664,10 +2664,31 @@ func (d *Debugger) CancelDownloads() bool {
 }
 
 // DownloadLibraryDebugInfo attempts to download the specified library's debug info.
-func (d *Debugger) DownloadLibraryDebugInfo(n int) error {
+func (d *Debugger) DownloadLibraryDebugInfo(n int, eventsFn func(*proc.Event)) error {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
-	return d.target.Selected.BinInfo().LoadImageBinaryInfoAgain(n)
+	if eventsFn != nil {
+		defer eventsFn(&proc.Event{Kind: proc.EventDownloadLibraryInfoDone})
+	}
+	d.target.SetEventsFn(eventsFn)
+	bi := d.target.Selected.BinInfo()
+	bi.ResetDownloadsContext()
+	if n > 0 {
+		return bi.LoadImageBinaryInfoAgain(n)
+	}
+	hadErrors := false
+	for i := range bi.Images {
+		if bi.Images[i].LoadError() != nil {
+			err := bi.LoadImageBinaryInfoAgain(i)
+			if err != nil {
+				hadErrors = true
+			}
+		}
+	}
+	if hadErrors {
+		return errors.New("errors downloading debuginfo")
+	}
+	return nil
 }
 
 func guessSubstitutePath(args *api.GuessSubstitutePathIn, bins [][]proc.Function, fileForFunc func(int, *proc.Function) string) map[string]string {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -2676,17 +2676,18 @@ func (d *Debugger) DownloadLibraryDebugInfo(n int, eventsFn func(*proc.Event)) e
 	if n > 0 {
 		return bi.LoadImageBinaryInfoAgain(n)
 	}
-	hadErrors := false
+	tried, succeeded := 0, 0
 	for i := range bi.Images {
 		if bi.Images[i].LoadError() != nil {
+			tried++
 			err := bi.LoadImageBinaryInfoAgain(i)
-			if err != nil {
-				hadErrors = true
+			if err == nil {
+				succeeded++
 			}
 		}
 	}
-	if hadErrors {
-		return errors.New("errors downloading debuginfo")
+	if tried != succeeded {
+		return fmt.Errorf("downloaded %d/%d libraries", succeeded, tried)
 	}
 	return nil
 }

--- a/service/rpc2/client.go
+++ b/service/rpc2/client.go
@@ -169,7 +169,7 @@ func (c *RPCClient) drainEvents() <-chan struct{} {
 			}
 			for _, event := range out.Events {
 				c.eventsFn(&event)
-				if event.Kind == api.EventStopped {
+				if event.Kind == api.EventStopped || event.Kind == api.EventDownloadLibraryInfoDone {
 					return
 				}
 			}
@@ -715,7 +715,7 @@ func (c *RPCClient) CancelDownloads() error {
 
 func (c *RPCClient) DownloadLibraryDebugInfo(n int) error {
 	out := DownloadLibraryDebugInfoOut{}
-	return c.call("DownloadLibraryDebugInfo", DownloadLibraryDebugInfoIn{n}, out)
+	return c.callWhileDrainingEvents("DownloadLibraryDebugInfo", DownloadLibraryDebugInfoIn{n, c.eventsFn != nil}, &out)
 }
 
 func (c *RPCClient) TypeInfo(name string) (*api.TypeInfo, error) {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -1252,14 +1252,21 @@ func (s *RPCServer) CancelDownloads(arg CancelDownloadsIn, cb service.RPCCallbac
 }
 
 type DownloadLibraryDebugInfoIn struct {
-	N int
+	N          int
+	WithEvents bool
 }
 
 type DownloadLibraryDebugInfoOut struct {
 }
 
-func (s *RPCServer) DownloadLibraryDebugInfo(arg DownloadLibraryDebugInfoIn, out DownloadLibraryDebugInfoOut) error {
-	return s.debugger.DownloadLibraryDebugInfo(arg.N)
+func (s *RPCServer) DownloadLibraryDebugInfo(arg DownloadLibraryDebugInfoIn, cb service.RPCCallback) {
+	close(cb.SetupDoneChan())
+	eventsFn := s.eventsFn
+	if !arg.WithEvents {
+		eventsFn = nil
+	}
+	err := s.debugger.DownloadLibraryDebugInfo(arg.N+1, eventsFn)
+	cb.Return(new(DownloadLibraryDebugInfoOut), err)
 }
 
 type TypeInfoIn struct {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -1252,7 +1252,11 @@ func (s *RPCServer) CancelDownloads(arg CancelDownloadsIn, cb service.RPCCallbac
 }
 
 type DownloadLibraryDebugInfoIn struct {
-	N          int
+	N int
+	// WithEvents specifies that download events, similar to the ones produced
+	// by Command are emitted.
+	// A client specifying WithEvents is responsible for repeatedly calling
+	// GetEvents until a EventDownloadLibraryInfoDone is seen.
 	WithEvents bool
 }
 

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3499,6 +3499,93 @@ func TestCancelDownload(t *testing.T) {
 	})
 }
 
+func TestCancelDownloadAfterAttach(t *testing.T) {
+	if testBackend == "rr" {
+		return
+	}
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	if runtime.GOARCH == "ppc64le" {
+		t.Skip("cgo support broken")
+	}
+
+	fakedebuginfodDir, _ := filepath.Abs(filepath.Join(protest.FindFixturesDir(), "fake-debuginfod-find"))
+	t.Setenv("PATH", os.ExpandEnv(fakedebuginfodDir+":$PATH"))
+
+	listener, clientConn := service.ListenerPipe()
+	defer listener.Close()
+	var buildFlags protest.BuildFlags
+	if buildMode == "pie" {
+		buildFlags |= protest.BuildModePIE
+	}
+	fixture := protest.BuildFixture(t, "cgotest", buildFlags)
+
+	cmd := exec.Command(fixture.Path, "sleep")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	assertNoError(cmd.Start(), t, "starting fixture")
+	defer cmd.Process.Kill()
+
+	time.Sleep(500 * time.Millisecond)
+
+	t0 := time.Now()
+	server := rpccommon.NewServer(&service.Config{
+		Listener:   listener,
+		APIVersion: 2,
+		Debugger: debugger.Config{
+			AttachPid:  cmd.Process.Pid,
+			WorkingDir: ".",
+			Backend:    testBackend,
+		},
+	})
+	if err := server.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	client := rpc2.NewClientFromConn(clientConn)
+	defer server.Stop()
+
+	if time.Since(t0) > 3*time.Second {
+		t.Fatalf("Attach took too long, debuginfo downloads were probably performed (%v)", time.Since(t0))
+	}
+
+	libs, _, err := client.ListDynamicLibraries()
+	assertNoError(err, t, "ListDynamicLibraries")
+	debuginfodSkipFound := false
+	for _, lib := range libs {
+		if strings.Contains(lib.LoadError, "debuginfod") {
+			debuginfodSkipFound = true
+		}
+	}
+	if !debuginfodSkipFound {
+		t.Logf("%#v", libs)
+		t.Fatal("Could not find library with skipped debuginfod download")
+	}
+
+	eventReceived := false
+	client.SetEventsFn(func(ev *api.Event) {
+		switch ev.Kind {
+		case api.EventBinaryInfoDownload:
+			eventReceived = true
+			client.CancelDownloads()
+		}
+	})
+
+	t0 = time.Now()
+	client.DownloadLibraryDebugInfo(-1)
+
+	if !eventReceived {
+		t.Errorf("Download did not start")
+	}
+	if time.Since(t0) > 3*time.Second {
+		t.Fatalf("DownloadLibraryDebugInfo took too long, we were unable to cancel debuginfo downloads (%v)", time.Since(t0))
+	}
+
+	client.Detach(true)
+}
+
 func TestEvalNonunicodeString(t *testing.T) {
 	// Non-unicode strings can not be sent through json encoding without being
 	// altered, check that our workaround works.

--- a/service/test/integration2_test.go
+++ b/service/test/integration2_test.go
@@ -3501,7 +3501,7 @@ func TestCancelDownload(t *testing.T) {
 
 func TestCancelDownloadAfterAttach(t *testing.T) {
 	if testBackend == "rr" {
-		return
+		t.Skip("N/A")
 	}
 	if runtime.GOOS != "linux" {
 		t.Skip("linux only")


### PR DESCRIPTION
Emit download events produced after calling DownloadLibraryDebugInfo,
fix a bug where the download context wasn't reset.

When -1 is passed to DownloadLibraryDebugInfo download all libraries
that weren't downloaded previously.

Automatically call DownloadLibraryDebugInfo(-1) client side after an
attach.
