### PR TITLE
dap: add types command to list program types

### DIFF
--- a/service/dap/command.go
+++ b/service/dap/command.go
@@ -80,6 +80,12 @@ Type "help" followed by the name of a command for more information about it.`
 
 If regex is specified only the source files matching it will be returned.`
 
+	msgTypes = `Print list of types.
+
+	dlv types [<regex>]
+
+If regex is specified only the types matching it will be returned.`
+
 	msgTarget = `Manages child process debugging.
 
         target follow-exec [-on [regex]] [-off]
@@ -120,6 +126,7 @@ func debugCommands(s *Session) []command {
 		{aliases: []string{"help", "h"}, cmdFn: s.helpMessage, helpMsg: msgHelp},
 		{aliases: []string{"config"}, cmdFn: s.evaluateConfig, helpMsg: msgConfig},
 		{aliases: []string{"sources", "s"}, cmdFn: s.sources, helpMsg: msgSources},
+		{aliases: []string{"types"}, cmdFn: s.types, helpMsg: msgTypes},
 		{aliases: []string{"target"}, cmdFn: s.targetCmd, helpMsg: msgTarget},
 		{aliases: []string{"examinemem", "x"}, cmdFn: s.examineMemory, helpMsg: msgExamineMemory},
 	}
@@ -250,6 +257,15 @@ func (s *Session) sources(_, _ int, filter string) (string, error) {
 	}
 	sort.Strings(sources)
 	return strings.Join(sources, "\n"), nil
+}
+
+func (s *Session) types(_, _ int, filter string) (string, error) {
+	types, err := s.debugger.Types(filter)
+	if err != nil {
+		return "", err
+	}
+	// Debugger.Types already sorts and deduplicates its result.
+	return strings.Join(types, "\n"), nil
 }
 
 func (s *Session) targetCmd(_, _ int, argstr string) (string, error) {

--- a/service/dap/server_test.go
+++ b/service/dap/server_test.go
@@ -4653,6 +4653,25 @@ func TestEvaluateCommandRequest(t *testing.T) {
 						t.Errorf("\ngot: %#v, want sources=\"\"", got)
 					}
 
+					// Test types.
+					client.EvaluateRequest("dlv types", 1000, "repl")
+					got = client.ExpectEvaluateResponse(t)
+					if !strings.Contains(got.Body.Result, "main.FooBar") {
+						t.Errorf("\ngot: %#v, want types contains main.FooBar", got)
+					}
+
+					client.EvaluateRequest("dlv types ^main\\.FooBar2$", 1000, "repl")
+					got = client.ExpectEvaluateResponse(t)
+					if got.Body.Result != "main.FooBar2" {
+						t.Errorf("\ngot: %#v, want types=%q", got, "main.FooBar2")
+					}
+
+					client.EvaluateRequest("dlv types nonexistenttype", 1000, "repl")
+					got = client.ExpectEvaluateResponse(t)
+					if got.Body.Result != "" {
+						t.Errorf("\ngot: %#v, want types=\"\"", got)
+					}
+
 					// Test target.
 					client.EvaluateRequest("dlv target list", 1000, "repl")
 					got = client.ExpectEvaluateResponse(t)


### PR DESCRIPTION
Mirror the existing sources command so `dlv types [<regex>]` works from a DAP session the same way it does in the command-line REPL. The handler delegates to Debugger.Types, which already filters, sorts, and deduplicates its result.

Fixes #3729