### PR TITLE
proc: decode AVX-512 ZMM16-ZMM31 from XSAVE

### DIFF
--- a/pkg/proc/amd64util/xsave.go
+++ b/pkg/proc/amd64util/xsave.go
@@ -13,11 +13,13 @@ import (
 // Manual, Volume 1: Basic Architecture.
 type AMD64Xstate struct {
 	AMD64PtraceFpRegs
-	Xsave       []byte // raw xsave area
-	AvxState    bool   // contains AVX state
-	YmmSpace    [256]byte
-	Avx512State bool // contains AVX512 state
-	ZmmSpace    [512]byte
+	Xsave        []byte // raw xsave area
+	AvxState     bool   // contains AVX state
+	YmmSpace     [256]byte
+	Avx512State  bool // contains AVX512 state
+	ZmmSpace     [512]byte
+	Hi16ZmmState bool // contains ZMM16 through ZMM31
+	Hi16ZmmSpace [1024]byte
 
 	zmmHi256offset int
 }
@@ -70,6 +72,13 @@ func (xstate *AMD64Xstate) Decode() []proc.Register {
 		}
 	}
 
+	if xstate.Hi16ZmmState {
+		for i := 0; i < len(xstate.Hi16ZmmSpace); i += 64 {
+			n := i / 64
+			regs = proc.AppendBytesRegister(regs, fmt.Sprintf("XMM%d", n+16), xstate.Hi16ZmmSpace[i:i+64])
+		}
+	}
+
 	return regs
 }
 
@@ -89,7 +98,7 @@ type xstate_bv uint64
 
 func (s xstate_bv) hasAVX() bool       { return s&(1<<2) != 0 }
 func (s xstate_bv) hasZMM_Hi256() bool { return s&(1<<6) != 0 }
-func (s xstate_bv) hasHi16_ZMM() bool  { return s&(1<<7) != 0 } //lint:ignore U1000 future use
+func (s xstate_bv) hasHi16_ZMM() bool  { return s&(1<<7) != 0 }
 func (s xstate_bv) hasPKRU() bool      { return s&(1<<9) != 0 }
 
 // AMD64XstateRead reads a byte array containing an XSAVE area into regset.
@@ -97,8 +106,8 @@ func (s xstate_bv) hasPKRU() bool      { return s&(1<<9) != 0 }
 // contents of the legacy region of the XSAVE area.
 // See Section 13.1 (and following) of Intel® 64 and IA-32 Architectures
 // Software Developer’s Manual, Volume 1: Basic Architecture.
-// If xstateZMMHi256Offset is zero, it will be guessed.
-func AMD64XstateRead(xstateargs []byte, readLegacy bool, regset *AMD64Xstate, xstateZMMHi256Offset int) error {
+// If either component offset is zero, it will be guessed.
+func AMD64XstateRead(xstateargs []byte, readLegacy bool, regset *AMD64Xstate, xstateZMMHi256Offset, xstateHi16ZMMOffset int) error {
 	if _XSAVE_HEADER_START+_XSAVE_HEADER_LEN >= len(xstateargs) {
 		return nil
 	}
@@ -118,19 +127,13 @@ func AMD64XstateRead(xstateargs []byte, readLegacy bool, regset *AMD64Xstate, xs
 		return nil
 	}
 
-	if !xstate_bv.hasAVX() {
-		return nil
+	if xstate_bv.hasAVX() {
+		avxstate := xstateargs[_XSAVE_EXTENDED_REGION_START:]
+		regset.AvxState = true
+		copy(regset.YmmSpace[:], avxstate[:len(regset.YmmSpace)])
 	}
 
-	avxstate := xstateargs[_XSAVE_EXTENDED_REGION_START:]
-	regset.AvxState = true
-	copy(regset.YmmSpace[:], avxstate[:len(regset.YmmSpace)])
-
-	if !xstate_bv.hasZMM_Hi256() {
-		return nil
-	}
-
-	if xstateZMMHi256Offset == 0 {
+	if xstateZMMHi256Offset == 0 && (xstate_bv.hasZMM_Hi256() || (xstate_bv.hasHi16_ZMM() && xstateHi16ZMMOffset == 0)) {
 		// Guess ZMM_Hi256 component offset
 		// ref: https://github.com/bminor/binutils-gdb/blob/df89bdf0baf106c3b0a9fae53e4e48607a7f3f87/gdb/i387-tdep.c#L916
 		if xcr0.hasPKRU() && len(xstateargs) == 2440 {
@@ -142,15 +145,24 @@ func AMD64XstateRead(xstateargs []byte, readLegacy bool, regset *AMD64Xstate, xs
 		}
 	}
 
-	regset.zmmHi256offset = xstateZMMHi256Offset
+	if xstate_bv.hasZMM_Hi256() {
+		regset.zmmHi256offset = xstateZMMHi256Offset
 
-	avx512state := xstateargs[xstateZMMHi256Offset:]
-	regset.Avx512State = true
-	copy(regset.ZmmSpace[:], avx512state[:len(regset.ZmmSpace)])
+		avx512state := xstateargs[xstateZMMHi256Offset:]
+		regset.Avx512State = true
+		copy(regset.ZmmSpace[:], avx512state[:len(regset.ZmmSpace)])
+	}
 
-	// TODO(aarzilli): if xstate_bv.hasHi16_ZMM() is set then xstateargs[1664:2688]
-	// contains ZMM16 through ZMM31, those aren't just the higher 256bits, it's
-	// the full register so each is 64 bytes (512bits)
+	if xstate_bv.hasHi16_ZMM() {
+		if xstateHi16ZMMOffset == 0 {
+			xstateHi16ZMMOffset = xstateZMMHi256Offset + len(regset.ZmmSpace)
+		}
+		if xstateHi16ZMMOffset < 0 || xstateHi16ZMMOffset > len(xstateargs)-len(regset.Hi16ZmmSpace) {
+			return fmt.Errorf("Hi16_ZMM state at offset %d exceeds XSAVE area of %d bytes", xstateHi16ZMMOffset, len(xstateargs))
+		}
+		regset.Hi16ZmmState = true
+		copy(regset.Hi16ZmmSpace[:], xstateargs[xstateHi16ZMMOffset:])
+	}
 
 	return nil
 }

--- a/pkg/proc/amd64util/xsave_test.go
+++ b/pkg/proc/amd64util/xsave_test.go
@@ -1,0 +1,113 @@
+package amd64util
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/go-delve/delve/pkg/proc"
+)
+
+func TestAMD64XstateReadHi16ZMM(t *testing.T) {
+	const offset = 704
+	xsave := make([]byte, offset+16*64)
+	binary.LittleEndian.PutUint64(xsave[_XSAVE_HEADER_START:], 1<<7)
+	want := fillHi16ZMM(xsave[offset:])
+
+	var xstate AMD64Xstate
+	if err := AMD64XstateRead(xsave, false, &xstate, 0, offset); err != nil {
+		t.Fatal(err)
+	}
+
+	regs := xstate.Decode()
+	for i := range 16 {
+		name := fmt.Sprintf("XMM%d", i+16)
+		got := registerBytes(regs, name)
+		if !bytes.Equal(got, want[i]) {
+			t.Errorf("%s = %x, want %x", name, got, want[i])
+		}
+	}
+}
+
+func TestAMD64XstateReadHi16ZMMAbsent(t *testing.T) {
+	const offset = 704
+	xsave := make([]byte, offset+16*64)
+	fillHi16ZMM(xsave[offset:])
+
+	var xstate AMD64Xstate
+	if err := AMD64XstateRead(xsave, false, &xstate, 0, offset); err != nil {
+		t.Fatal(err)
+	}
+	if got := registerBytes(xstate.Decode(), "XMM16"); got != nil {
+		t.Errorf("XMM16 = %x, want absent", got)
+	}
+}
+
+func TestAMD64XstateReadHi16ZMMTruncated(t *testing.T) {
+	const offset = 704
+	xsave := make([]byte, offset+16*64-1)
+	binary.LittleEndian.PutUint64(xsave[_XSAVE_HEADER_START:], 1<<7)
+
+	var xstate AMD64Xstate
+	if err := AMD64XstateRead(xsave, false, &xstate, 0, offset); err == nil {
+		t.Fatal("AMD64XstateRead returned nil error for truncated Hi16_ZMM state")
+	}
+}
+
+func TestAMD64XstateReadHi16ZMMGuessesCoreOffset(t *testing.T) {
+	tests := []struct {
+		name   string
+		size   int
+		offset int
+		pkru   bool
+	}{
+		{name: "Intel", size: 2688, offset: 1664},
+		{name: "AMD", size: 2440, offset: 1408, pkru: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			xsave := make([]byte, tc.size)
+			binary.LittleEndian.PutUint64(xsave[_XSAVE_HEADER_START:], 1<<7)
+			if tc.pkru {
+				binary.LittleEndian.PutUint64(xsave[_I386_LINUX_XSAVE_XCR0_OFFSET:], 1<<9)
+			}
+			want := fillHi16ZMM(xsave[tc.offset:])
+
+			var xstate AMD64Xstate
+			if err := AMD64XstateRead(xsave, false, &xstate, 0, 0); err != nil {
+				t.Fatal(err)
+			}
+			got16 := registerBytes(xstate.Decode(), "XMM16")
+			if !bytes.Equal(got16, want[0]) {
+				t.Errorf("XMM16 = %x, want %x", got16, want[0])
+			}
+			got31 := registerBytes(xstate.Decode(), "XMM31")
+			if !bytes.Equal(got31, want[15]) {
+				t.Errorf("XMM31 = %x, want %x", got31, want[15])
+			}
+		})
+	}
+}
+
+func fillHi16ZMM(dst []byte) [16][]byte {
+	var values [16][]byte
+	for i := range values {
+		values[i] = make([]byte, 64)
+		for j := range values[i] {
+			values[i][j] = byte(i + j)
+		}
+		copy(dst[i*64:], values[i])
+	}
+	return values
+}
+
+func registerBytes(regs []proc.Register, name string) []byte {
+	for _, reg := range regs {
+		if reg.Name == name {
+			return reg.Reg.Bytes
+		}
+	}
+	return nil
+}

--- a/pkg/proc/core/linux_core.go
+++ b/pkg/proc/core/linux_core.go
@@ -363,7 +363,7 @@ func readNote(r io.ReadSeeker, machineType elf.Machine) (*note, error) {
 	case _NT_X86_XSTATE:
 		if machineType == _EM_X86_64 {
 			var fpregs amd64util.AMD64Xstate
-			if err := amd64util.AMD64XstateRead(desc, true, &fpregs, 0); err != nil {
+			if err := amd64util.AMD64XstateRead(desc, true, &fpregs, 0, 0); err != nil {
 				return nil, err
 			}
 			note.Desc = &fpregs

--- a/pkg/proc/native/cpuid/xsave_x86.go
+++ b/pkg/proc/native/cpuid/xsave_x86.go
@@ -58,3 +58,28 @@ func AMD64XstateZMMHi256Offset() int {
 	})
 	return xstateZMMHi256Offset
 }
+
+var xstateHi16ZMMOffset int
+var loadXstateHi16ZMMOffsetOnce sync.Once
+
+// AMD64XstateHi16ZMMOffset probes Hi16_ZMM offset of the current CPU. Beware
+// that core dumps may be generated from a different CPU.
+func AMD64XstateHi16ZMMOffset() int {
+	loadXstateHi16ZMMOffsetOnce.Do(func() {
+		// See Intel 64 and IA-32 Architecture Software Developer's Manual, Vol. 1
+		// chapter 13.2 and Vol. 2A CPUID instruction for a description of all the
+		// magic constants.
+
+		_, _, cx, _ := cpuid(0x01, 0x00)
+
+		if cx&(1<<26) == 0 { // Vol. 2A, Table 3-10, XSAVE enabled bit check
+			// XSAVE not supported by this processor
+			xstateHi16ZMMOffset = 0
+			return
+		}
+
+		_, bx, _, _ := cpuid(0x0d, 0x07) // Hi16_ZMM is component #7
+		xstateHi16ZMMOffset = int(bx)
+	})
+	return xstateHi16ZMMOffset
+}

--- a/pkg/proc/native/ptrace_freebsd_amd64.go
+++ b/pkg/proc/native/ptrace_freebsd_amd64.go
@@ -74,7 +74,7 @@ func ptraceGetRegset(id int) (*amd64util.AMD64Xstate, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, cpuid.AMD64XstateZMMHi256Offset())
+	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, cpuid.AMD64XstateZMMHi256Offset(), cpuid.AMD64XstateHi16ZMMOffset())
 	return &regset, err
 }
 

--- a/pkg/proc/native/ptrace_linux_386.go
+++ b/pkg/proc/native/ptrace_linux_386.go
@@ -39,7 +39,7 @@ func ptraceGetRegset(tid int) (regset amd64util.AMD64Xstate, err error) {
 	}
 
 	regset.Xsave = xstateargs[:iov.Len]
-	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, cpuid.AMD64XstateZMMHi256Offset())
+	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, cpuid.AMD64XstateZMMHi256Offset(), cpuid.AMD64XstateHi16ZMMOffset())
 	return
 }
 

--- a/pkg/proc/native/ptrace_linux_amd64.go
+++ b/pkg/proc/native/ptrace_linux_amd64.go
@@ -38,6 +38,6 @@ func ptraceGetRegset(tid int) (regset amd64util.AMD64Xstate, err error) {
 	}
 
 	regset.Xsave = xstateargs[:iov.Len]
-	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, cpuid.AMD64XstateZMMHi256Offset())
+	err = amd64util.AMD64XstateRead(regset.Xsave, false, &regset, cpuid.AMD64XstateZMMHi256Offset(), cpuid.AMD64XstateHi16ZMMOffset())
 	return
 }


### PR DESCRIPTION
previously, zmm16 through zmm31 were ignored. This adds decoding support plus a bunch of synthetic tests.