### PR TITLE
tests: fix TestWaitForSearchPastSeenProcess flake

### DIFF
--- a/pkg/proc/native/waitfor_test.go
+++ b/pkg/proc/native/waitfor_test.go
@@ -49,6 +49,8 @@ func TestWaitForSearchPastSeenProcess(t *testing.T) {
 		_ = cmd.Wait()
 	})
 
+	time.Sleep(10 * time.Millisecond)
+
 	pid, err = waitForSearchProcess(strings.Join(cmd.Args, " "), seen)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
TestWaitForSearchPastSeenProcess seems to flake on linux, especially on
linux/386 which runs on a virtual machine. This is probably because of
a race condition with the kernel listing new processes through procfs.

Add a small sleep to see if this fixes it.
